### PR TITLE
feat: add Espanso text expander

### DIFF
--- a/docs/espanso-usage.md
+++ b/docs/espanso-usage.md
@@ -196,7 +196,7 @@ Use regex for more flexible matching:
 
 Both X11 and Wayland support are enabled by default on Linux. The module:
 - Configures `x11Support = true` and `waylandSupport = true`
-- Sets `package-wayland = pkgs.espanso-wayland`
+- Sets `packageWayland = pkgs.espanso-wayland`
 - Creates a wrapper script that checks `$WAYLAND_DISPLAY` at runtime
 - Automatically launches the correct binary based on your graphical session
 
@@ -228,7 +228,7 @@ Override the espanso package if needed:
 {
   services.espanso = {
     package = pkgs.espanso;  # X11 variant
-    package-wayland = pkgs.espanso-wayland;  # Wayland variant
+    packageWayland = pkgs.espanso-wayland;  # Wayland variant
   };
 }
 ```

--- a/docs/espanso-usage.md
+++ b/docs/espanso-usage.md
@@ -194,7 +194,11 @@ Use regex for more flexible matching:
 
 ### Default Behavior (Recommended)
 
-Both X11 and Wayland support are enabled by default on Linux. The module automatically selects the correct variant based on your graphical session.
+Both X11 and Wayland support are enabled by default on Linux. The module:
+- Configures `x11Support = true` and `waylandSupport = true`
+- Sets `package-wayland = pkgs.espanso-wayland`
+- Creates a wrapper script that checks `$WAYLAND_DISPLAY` at runtime
+- Automatically launches the correct binary based on your graphical session
 
 ### Optimizing Closure Size
 

--- a/docs/espanso-usage.md
+++ b/docs/espanso-usage.md
@@ -1,0 +1,326 @@
+# Espanso Text Expander Module
+
+## Overview
+
+The espanso module provides declarative configuration for the cross-platform text expander. It leverages Home Manager's `services.espanso` module with sensible defaults and common match patterns.
+
+## Quick Start
+
+### Enable in Home Manager Configuration
+
+The module is auto-imported when included in your Home Manager modules list:
+
+```nix
+{
+  imports = [
+    config.flake.homeManagerModules.apps.espanso
+  ];
+}
+```
+
+This automatically enables espanso with:
+- Both X11 and Wayland support (auto-detection based on `$WAYLAND_DISPLAY`)
+- Notifications disabled (less intrusive)
+- Common date/time triggers (`:date`, `:time`, `:now`, `:isodate`)
+- Development snippets (`:shebang`, `:todo`, `:fixme`)
+
+### Default Triggers
+
+Once enabled, the following triggers are available:
+
+| Trigger | Output | Example |
+|---------|--------|---------|
+| `:date` | Current date | `2025-10-08` |
+| `:time` | Current time | `14:30` |
+| `:now` | Date and time | `2025-10-08 14:30` |
+| `:isodate` | ISO 8601 format | `2025-10-08T14:30:00+0000` |
+| `:shebang` | Bash shebang | `#!/usr/bin/env bash` |
+| `:shebangnix` | Nix-shell shebang | `#!/usr/bin/env nix-shell`<br>`#!nix-shell -i bash` |
+| `:todo` | TODO comment | `# TODO: ` |
+| `:fixme` | FIXME comment | `# FIXME: ` |
+
+## Customization
+
+### Adding Custom Matches
+
+Extend the default matches with your own patterns:
+
+```nix
+{
+  services.espanso.matches = {
+    # Add to existing matches
+    email = {
+      matches = [
+        {
+          trigger = ":email";
+          replace = "your.email@example.com";
+        }
+        {
+          trigger = ":work";
+          replace = "work.email@company.com";
+        }
+      ];
+    };
+
+    # Code snippets
+    coding = {
+      matches = [
+        {
+          trigger = ":func";
+          replace = "function $1() {\n  $0\n}";
+        }
+        {
+          trigger = ":lambda";
+          replace = "lambda x: x";
+        }
+      ];
+    };
+  };
+}
+```
+
+### App-Specific Configurations
+
+Configure espanso behavior per application:
+
+```nix
+{
+  services.espanso.configs = {
+    # Global settings
+    default = {
+      show_notifications = true;  # Override default
+    };
+
+    # VSCode-specific
+    vscode = {
+      filter_title = "Visual Studio Code$";
+      backend = "Clipboard";  # Better compatibility
+    };
+
+    # Terminal-specific
+    terminal = {
+      filter_class = "Alacritty|kitty|wezterm";
+      backend = "Inject";
+    };
+  };
+}
+```
+
+### Advanced Variables
+
+Espanso supports various variable types:
+
+```nix
+{
+  services.espanso.matches.advanced = {
+    matches = [
+      # Form with user input
+      {
+        trigger = ":greet";
+        replace = "Hello {{name}}!";
+        vars = [
+          {
+            name = "name";
+            type = "form";
+            params = {
+              layout = "Name: [[name]]";
+            };
+          }
+        ];
+      }
+
+      # Shell command output
+      {
+        trigger = ":ip";
+        replace = "{{output}}";
+        vars = [
+          {
+            name = "output";
+            type = "shell";
+            params = {
+              cmd = "curl -s ifconfig.me";
+            };
+          }
+        ];
+      }
+
+      # Clipboard content
+      {
+        trigger = ":clip";
+        replace = "{{clipboard}}";
+        vars = [
+          {
+            name = "clipboard";
+            type = "clipboard";
+          }
+        ];
+      }
+    ];
+  };
+}
+```
+
+### Regex Triggers
+
+Use regex for more flexible matching:
+
+```nix
+{
+  services.espanso.matches.regex = {
+    matches = [
+      {
+        regex = ":hi(?P<person>\\w+)";
+        replace = "Hello {{person}}!";
+      }
+      {
+        regex = ":math(?P<expr>[0-9+\\-*/]+)";
+        replace = "{{result}}";
+        vars = [
+          {
+            name = "result";
+            type = "shell";
+            params = {
+              cmd = "echo \"{{expr}}\" | bc";
+            };
+          }
+        ];
+      }
+    ];
+  };
+}
+```
+
+## Display Server Configuration
+
+### Default Behavior (Recommended)
+
+Both X11 and Wayland support are enabled by default on Linux. The module automatically selects the correct variant based on your graphical session.
+
+### Optimizing Closure Size
+
+If you only use one display server, disable the unused support:
+
+```nix
+{
+  # Wayland-only
+  services.espanso = {
+    x11Support = false;
+    waylandSupport = true;
+  };
+
+  # X11-only
+  services.espanso = {
+    x11Support = true;
+    waylandSupport = false;
+  };
+}
+```
+
+### Custom Package
+
+Override the espanso package if needed:
+
+```nix
+{
+  services.espanso = {
+    package = pkgs.espanso;  # X11 variant
+    package-wayland = pkgs.espanso-wayland;  # Wayland variant
+  };
+}
+```
+
+## Service Management
+
+The module automatically configures systemd user service (Linux) or launchd agent (macOS):
+
+```bash
+# Check service status
+systemctl --user status espanso
+
+# Restart service
+systemctl --user restart espanso
+
+# View logs
+journalctl --user -u espanso -f
+```
+
+## Configuration Files
+
+Generated YAML files are located at:
+- `~/.config/espanso/config/*.yml` - Configuration files
+- `~/.config/espanso/match/*.yml` - Match files
+
+These are managed declaratively via Nix. Manual edits will be overwritten on Home Manager activation.
+
+## Troubleshooting
+
+### Espanso Not Triggering
+
+1. Verify service is running: `systemctl --user status espanso`
+2. Check logs: `journalctl --user -u espanso`
+3. Test with `:espanso` trigger (built-in test)
+4. Ensure correct backend for your application (try `backend = "Clipboard"`)
+
+### Wayland Clipboard Issues
+
+For multi-user setups on Wayland, you may need additional permissions:
+
+```bash
+# Find Wayland directory
+echo $XDG_RUNTIME_DIR
+
+# Grant permissions (example for user 'username')
+sudo usermod -a -G username espanso
+chmod g+rwx $XDG_RUNTIME_DIR
+chmod g+w $XDG_RUNTIME_DIR/wayland-0
+```
+
+### Application Compatibility
+
+Some applications require clipboard backend:
+
+```nix
+{
+  services.espanso.configs.incompatible-app = {
+    filter_title = "AppName$";
+    backend = "Clipboard";
+  };
+}
+```
+
+## Integration with This Repository
+
+### In Dendritic Configuration
+
+Import in your home-manager configuration:
+
+```nix
+# In configurations/homeManager/<username>/default.nix
+{
+  imports = [
+    config.flake.homeManagerModules.apps.espanso
+  ];
+
+  # Override defaults as needed
+  services.espanso.matches.personal = {
+    matches = [
+      # Your custom matches
+    ];
+  };
+}
+```
+
+### Module Location
+
+The espanso module is auto-discovered from:
+- Source: `modules/hm-apps/espanso.nix`
+- Export: `flake.homeManagerModules.apps.espanso`
+
+## References
+
+- **Official Documentation**: https://espanso.org/docs/
+- **Configuration Guide**: https://espanso.org/docs/configuration/basics/
+- **Matches Guide**: https://espanso.org/docs/matches/basics/
+- **Variables Reference**: https://espanso.org/docs/matches/extensions/
+- **nixpkgs Package**: `pkgs/by-name/es/espanso/package.nix`
+- **Home Manager Module**: `/home/vx/git/home-manager/modules/services/espanso.nix`

--- a/modules/hm-apps/espanso.nix
+++ b/modules/hm-apps/espanso.nix
@@ -18,7 +18,7 @@
 
   Display Server Support:
     * Both X11 and Wayland support enabled by default on Linux.
-    * Module sets x11Support=true, waylandSupport=true, and package-wayland=pkgs.espanso-wayland.
+    * Module sets x11Support=true, waylandSupport=true, and packageWayland=pkgs.espanso-wayland.
     * Home Manager creates a wrapper that checks $WAYLAND_DISPLAY and launches the correct binary.
     * To reduce closure size, disable unused support:
       services.espanso.x11Support = false;  # Wayland-only
@@ -52,7 +52,7 @@
         waylandSupport = lib.mkDefault isLinux;
 
         # Ensure Wayland package is available when waylandSupport is enabled
-        package-wayland = lib.mkDefault (if isLinux then pkgs.espanso-wayland else null);
+        packageWayland = lib.mkDefault (if isLinux then pkgs.espanso-wayland else null);
 
         # Default configuration
         configs = {

--- a/modules/hm-apps/espanso.nix
+++ b/modules/hm-apps/espanso.nix
@@ -1,0 +1,127 @@
+/*
+  Package: espanso
+  Description: Cross-platform text expander written in Rust.
+  Homepage: https://espanso.org
+  Documentation: https://espanso.org/docs/
+  Repository: https://github.com/espanso/espanso
+
+  Summary:
+    * Detects when you type a keyword (trigger) and replaces it with predefined text (expansion) while typing.
+    * Supports variables (date, shell, clipboard), forms, regex triggers, and app-specific configurations.
+    * Works on X11 and Wayland (auto-detection based on $WAYLAND_DISPLAY).
+
+  Configuration:
+    * Uses Home Manager's services.espanso module with declarative configs and matches.
+    * Configs: general espanso settings (notifications, backend, app filters).
+    * Matches: trigger definitions with variables and expansions.
+    * Auto-generates YAML files to ~/.config/espanso/.
+
+  Display Server Support:
+    * Both X11 and Wayland support enabled by default on Linux.
+    * Automatically switches between variants based on graphical session.
+    * To reduce closure size, disable unused support:
+      services.espanso.x11Support = false;  # Wayland-only
+      services.espanso.waylandSupport = false;  # X11-only
+
+  Example Usage:
+    * Default setup provides common date/time variables and basic expansions.
+    * Add custom matches via services.espanso.matches attribute set.
+    * Create app-specific configs via services.espanso.configs.
+
+  Common Patterns:
+    * Date/time: ":now" → "2025-10-08 14:30"
+    * Email: ":email" → "user@example.com"
+    * Code snippets: ":shebang" → "#!/usr/bin/env bash"
+    * Forms: interactive prompts for dynamic content
+    * Regex: pattern-based replacements with capture groups
+*/
+
+{
+  flake.homeManagerModules.apps.espanso =
+    { lib, ... }:
+    {
+      services.espanso = {
+        enable = true;
+
+        # Default configuration
+        configs = {
+          default = {
+            show_notifications = false;
+            # Uncomment for clipboard backend (better compatibility with some apps)
+            # backend = "Clipboard";
+          };
+        };
+
+        # Default matches with common patterns
+        matches = {
+          # Base expansions with date/time variables
+          base = {
+            matches = [
+              {
+                trigger = ":date";
+                replace = "{{currentdate}}";
+              }
+              {
+                trigger = ":time";
+                replace = "{{currenttime}}";
+              }
+              {
+                trigger = ":now";
+                replace = "{{currentdate}} {{currenttime}}";
+              }
+              {
+                trigger = ":isodate";
+                replace = "{{isodate}}";
+              }
+            ];
+
+            global_vars = [
+              {
+                name = "currentdate";
+                type = "date";
+                params = {
+                  format = "%Y-%m-%d";
+                };
+              }
+              {
+                name = "currenttime";
+                type = "date";
+                params = {
+                  format = "%H:%M";
+                };
+              }
+              {
+                name = "isodate";
+                type = "date";
+                params = {
+                  format = "%Y-%m-%dT%H:%M:%S%z";
+                };
+              }
+            ];
+          };
+
+          # Development/coding snippets
+          dev = {
+            matches = [
+              {
+                trigger = ":shebang";
+                replace = "#!/usr/bin/env bash";
+              }
+              {
+                trigger = ":shebangnix";
+                replace = "#!/usr/bin/env nix-shell\n#!nix-shell -i bash";
+              }
+              {
+                trigger = ":todo";
+                replace = "# TODO: ";
+              }
+              {
+                trigger = ":fixme";
+                replace = "# FIXME: ";
+              }
+            ];
+          };
+        };
+      };
+    };
+}

--- a/modules/hm-apps/espanso.nix
+++ b/modules/hm-apps/espanso.nix
@@ -18,7 +18,8 @@
 
   Display Server Support:
     * Both X11 and Wayland support enabled by default on Linux.
-    * Automatically switches between variants based on graphical session.
+    * Module sets x11Support=true, waylandSupport=true, and package-wayland=pkgs.espanso-wayland.
+    * Home Manager creates a wrapper that checks $WAYLAND_DISPLAY and launches the correct binary.
     * To reduce closure size, disable unused support:
       services.espanso.x11Support = false;  # Wayland-only
       services.espanso.waylandSupport = false;  # X11-only
@@ -38,10 +39,20 @@
 
 {
   flake.homeManagerModules.apps.espanso =
-    { lib, ... }:
+    { lib, pkgs, ... }:
+    let
+      isLinux = pkgs.stdenv.hostPlatform.isLinux;
+    in
     {
       services.espanso = {
         enable = true;
+
+        # Enable both X11 and Wayland support on Linux for auto-detection
+        x11Support = lib.mkDefault isLinux;
+        waylandSupport = lib.mkDefault isLinux;
+
+        # Ensure Wayland package is available when waylandSupport is enabled
+        package-wayland = lib.mkDefault (if isLinux then pkgs.espanso-wayland else null);
 
         # Default configuration
         configs = {

--- a/modules/system76/home-manager-apps.nix
+++ b/modules/system76/home-manager-apps.nix
@@ -9,6 +9,7 @@ let
     "docker-compose"
     "dua"
     "element-desktop"
+    "espanso"
     # "evince"
     "fd"
     "feh"


### PR DESCRIPTION
## Summary

Add comprehensive espanso text expander integration with Home Manager module and enable it for system76 host.

### Changes

- ✨ New Home Manager module at `modules/hm-apps/espanso.nix`
- 📚 Comprehensive documentation at `docs/espanso-usage.md`
- ⚙️ Enabled espanso for system76 host configuration

### Features

**Auto-enabled configuration with sensible defaults:**
- Both X11 and Wayland support (auto-detection via `$WAYLAND_DISPLAY`)
- Notifications disabled by default (less intrusive)
- Common date/time triggers included
- Development snippets for bash/nix

**Default Triggers:**
| Trigger | Output | Example |
|---------|--------|---------|
| `:date` | Current date | `2025-10-08` |
| `:time` | Current time | `14:30` |
| `:now` | Date and time | `2025-10-08 14:30` |
| `:isodate` | ISO 8601 format | `2025-10-08T14:30:00+0000` |
| `:shebang` | Bash shebang | `#!/usr/bin/env bash` |
| `:shebangnix` | Nix-shell shebang | `#!/usr/bin/env nix-shell`<br>`#!nix-shell -i bash` |
| `:todo` | TODO comment | `# TODO: ` |
| `:fixme` | FIXME comment | `# FIXME: ` |

### Documentation

The comprehensive `docs/espanso-usage.md` includes:
- Quick start guide
- Customization examples (matches, configs, variables)
- Advanced patterns (regex, forms, shell commands)
- Display server configuration (X11/Wayland)
- Service management
- Troubleshooting guide

### Validation

```bash
# Module is properly exported
nix eval .#homeManagerModules.apps --apply builtins.attrNames | grep espanso

# Enabled for system76
nix eval .#nixosConfigurations.system76.config.home-manager.extraAppImports --apply 'x: builtins.elem "espanso" x'
# => true

# Configuration check
nix flake check --accept-flake-config
```

### Architecture

Follows dendritic pattern:
- Module auto-discovered via import-tree
- Exported to `flake.homeManagerModules.apps.espanso`
- Uses Home Manager's `services.espanso` module (mature, feature-complete)
- Extensible design for custom matches and configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)