### PR TITLE
feat: centralize MCP server catalog

### DIFF
--- a/docs/espanso-usage.md
+++ b/docs/espanso-usage.md
@@ -19,6 +19,7 @@ The module is auto-imported when included in your Home Manager modules list:
 ```
 
 This automatically enables espanso with:
+
 - Both X11 and Wayland support (auto-detection based on `$WAYLAND_DISPLAY`)
 - Notifications disabled (less intrusive)
 - Common date/time triggers (`:date`, `:time`, `:now`, `:isodate`)
@@ -28,16 +29,16 @@ This automatically enables espanso with:
 
 Once enabled, the following triggers are available:
 
-| Trigger | Output | Example |
-|---------|--------|---------|
-| `:date` | Current date | `2025-10-08` |
-| `:time` | Current time | `14:30` |
-| `:now` | Date and time | `2025-10-08 14:30` |
-| `:isodate` | ISO 8601 format | `2025-10-08T14:30:00+0000` |
-| `:shebang` | Bash shebang | `#!/usr/bin/env bash` |
+| Trigger       | Output            | Example                                             |
+| ------------- | ----------------- | --------------------------------------------------- |
+| `:date`       | Current date      | `2025-10-08`                                        |
+| `:time`       | Current time      | `14:30`                                             |
+| `:now`        | Date and time     | `2025-10-08 14:30`                                  |
+| `:isodate`    | ISO 8601 format   | `2025-10-08T14:30:00+0000`                          |
+| `:shebang`    | Bash shebang      | `#!/usr/bin/env bash`                               |
 | `:shebangnix` | Nix-shell shebang | `#!/usr/bin/env nix-shell`<br>`#!nix-shell -i bash` |
-| `:todo` | TODO comment | `# TODO: ` |
-| `:fixme` | FIXME comment | `# FIXME: ` |
+| `:todo`       | TODO comment      | `# TODO: `                                          |
+| `:fixme`      | FIXME comment     | `# FIXME: `                                         |
 
 ## Customization
 
@@ -195,6 +196,7 @@ Use regex for more flexible matching:
 ### Default Behavior (Recommended)
 
 Both X11 and Wayland support are enabled by default on Linux. The module:
+
 - Configures `x11Support = true` and `waylandSupport = true`
 - Sets `package-wayland = pkgs.espanso-wayland`
 - Creates a wrapper script that checks `$WAYLAND_DISPLAY` at runtime
@@ -251,6 +253,7 @@ journalctl --user -u espanso -f
 ## Configuration Files
 
 Generated YAML files are located at:
+
 - `~/.config/espanso/config/*.yml` - Configuration files
 - `~/.config/espanso/match/*.yml` - Match files
 
@@ -317,6 +320,7 @@ Import in your home-manager configuration:
 ### Module Location
 
 The espanso module is auto-discovered from:
+
 - Source: `modules/hm-apps/espanso.nix`
 - Export: `flake.homeManagerModules.apps.espanso`
 

--- a/lib/mcp-servers.nix
+++ b/lib/mcp-servers.nix
@@ -1,0 +1,190 @@
+{
+  lib,
+  defaultTimeoutMs ? 60000,
+  defaultVariants ? { },
+  ...
+}:
+
+let
+  mkNpx = args: {
+    type = "stdio";
+    command = "npx";
+    inherit args;
+    startup_timeout_ms = defaultTimeoutMs;
+  };
+
+  mkNpxPackage =
+    name:
+    mkNpx [
+      "-y"
+      name
+    ];
+
+  mkNpxRemote =
+    url:
+    mkNpx [
+      "mcp-remote"
+      url
+    ];
+
+  serverCatalog = {
+    sequential-thinking = {
+      default = "stdio";
+      variants = {
+        stdio = mkNpxPackage "@modelcontextprotocol/server-sequential-thinking";
+      };
+    };
+
+    memory = {
+      default = "stdio";
+      variants = {
+        stdio = mkNpxPackage "@modelcontextprotocol/server-memory";
+      };
+    };
+
+    time = {
+      default = "stdio";
+      variants = {
+        stdio = {
+          type = "stdio";
+          command = "uvx";
+          args = [ "mcp-server-time" ];
+          startup_timeout_ms = defaultTimeoutMs;
+        };
+      };
+    };
+
+    cfdocs = {
+      default = "stdio";
+      variants = {
+        stdio = mkNpxRemote "https://docs.mcp.cloudflare.com/sse";
+      };
+    };
+
+    cfbuilds = {
+      default = "stdio";
+      variants = {
+        stdio = mkNpxRemote "https://builds.mcp.cloudflare.com/sse";
+      };
+    };
+
+    cfobservability = {
+      default = "stdio";
+      variants = {
+        stdio = mkNpxRemote "https://observability.mcp.cloudflare.com/sse";
+      };
+    };
+
+    cfradar = {
+      default = "stdio";
+      variants = {
+        stdio = mkNpxRemote "https://radar.mcp.cloudflare.com/sse";
+      };
+    };
+
+    cfcontainers = {
+      default = "stdio";
+      variants = {
+        stdio = mkNpxRemote "https://containers.mcp.cloudflare.com/sse";
+      };
+    };
+
+    cfbrowser = {
+      default = "stdio";
+      variants = {
+        stdio = mkNpxRemote "https://browser.mcp.cloudflare.com/sse";
+      };
+    };
+
+    cfgraphql = {
+      default = "stdio";
+      variants = {
+        stdio = mkNpxRemote "https://graphql.mcp.cloudflare.com/sse";
+      };
+    };
+
+    deepwiki = {
+      default = "remote";
+      variants = {
+        remote = mkNpxRemote "https://mcp.deepwiki.com/mcp";
+        http = {
+          type = "http";
+          url = "https://mcp.deepwiki.com/mcp";
+          startup_timeout_ms = defaultTimeoutMs;
+        };
+      };
+    };
+  };
+
+  catalogHas = name: builtins.hasAttr name serverCatalog;
+
+  getServerEntry =
+    name:
+    if catalogHas name then
+      serverCatalog.${name}
+    else
+      builtins.throw "Unknown MCP server `" + name + "` requested; update modules/lib/mcp-servers.nix.";
+
+  defaultVariantFor =
+    name:
+    let
+      entry = getServerEntry name;
+      userDefault = lib.attrByPath [ name ] null defaultVariants;
+    in
+    if userDefault != null then
+      userDefault
+    else
+      entry.default or (lib.head (lib.attrNames entry.variants));
+
+  getVariant =
+    name: variant:
+    let
+      entry = getServerEntry name;
+    in
+    if builtins.hasAttr variant entry.variants then
+      entry.variants.${variant}
+    else
+      let
+        known = lib.concatStringsSep ", " (lib.attrNames entry.variants);
+      in
+      builtins.throw (
+        "Unknown variant `" + variant + "` for MCP server `" + name + "`. Known variants: " + known
+      );
+
+  resolvedServers =
+    selections:
+    let
+      resolveValue =
+        name: value:
+        if value == null || (lib.isBool value && !value) then
+          null
+        else if lib.isBool value && value then
+          getVariant name (defaultVariantFor name)
+        else if lib.isString value then
+          getVariant name value
+        else if lib.isAttrs value then
+          if catalogHas name then
+            let
+              variant = lib.attrByPath [ "variant" ] value (defaultVariantFor name);
+              overrides = lib.removeAttrs value [ "variant" ];
+              base = getVariant name variant;
+            in
+            lib.recursiveUpdate base overrides
+          else
+            value
+        else
+          builtins.throw "Unsupported selection value for MCP server `" + name + "`.";
+    in
+    lib.filterAttrs (_: v: v != null) (lib.mapAttrs resolveValue selections);
+
+  dropType = servers: lib.mapAttrs (_: server: lib.removeAttrs server [ "type" ]) servers;
+
+in
+{
+  inherit serverCatalog;
+  definitions = lib.mapAttrs (_: entry: entry.variants) serverCatalog;
+
+  select = resolvedServers;
+  selectWithoutType = selections: dropType (resolvedServers selections);
+  removeType = dropType;
+}

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -25,90 +25,24 @@
 
       context7ApiKey = if hasSecret "context7/api-key" then getSecret "context7/api-key" else null;
 
-      baseServers = {
-        sequential-thinking = {
-          type = "stdio";
-          command = "npx";
-          args = [
-            "-y"
-            "@modelcontextprotocol/server-sequential-thinking"
-          ];
-          startup_timeout_ms = defaultTimeoutMs;
+      mcp = import ../../lib/mcp-servers.nix {
+        inherit lib defaultTimeoutMs;
+        defaultVariants = {
+          deepwiki = "http";
         };
-        time = {
-          type = "stdio";
-          command = "uvx";
-          args = [ "mcp-server-time" ];
-          startup_timeout_ms = defaultTimeoutMs;
-        };
-        cfdocs = {
-          type = "stdio";
-          command = "npx";
-          args = [
-            "mcp-remote"
-            "https://docs.mcp.cloudflare.com/sse"
-          ];
-          startup_timeout_ms = defaultTimeoutMs;
-        };
-        cfbuilds = {
-          type = "stdio";
-          command = "npx";
-          args = [
-            "mcp-remote"
-            "https://builds.mcp.cloudflare.com/sse"
-          ];
-          startup_timeout_ms = defaultTimeoutMs;
-        };
-        cfobservability = {
-          type = "stdio";
-          command = "npx";
-          args = [
-            "mcp-remote"
-            "https://observability.mcp.cloudflare.com/sse"
-          ];
-          startup_timeout_ms = defaultTimeoutMs;
-        };
-        cfradar = {
-          type = "stdio";
-          command = "npx";
-          args = [
-            "mcp-remote"
-            "https://radar.mcp.cloudflare.com/sse"
-          ];
-          startup_timeout_ms = defaultTimeoutMs;
-        };
-        cfcontainers = {
-          type = "stdio";
-          command = "npx";
-          args = [
-            "mcp-remote"
-            "https://containers.mcp.cloudflare.com/sse"
-          ];
-          startup_timeout_ms = defaultTimeoutMs;
-        };
-        cfbrowser = {
-          type = "stdio";
-          command = "npx";
-          args = [
-            "mcp-remote"
-            "https://browser.mcp.cloudflare.com/sse"
-          ];
-          startup_timeout_ms = defaultTimeoutMs;
-        };
-        cfgraphql = {
-          type = "stdio";
-          command = "npx";
-          args = [
-            "mcp-remote"
-            "https://graphql.mcp.cloudflare.com/sse"
-          ];
-          startup_timeout_ms = defaultTimeoutMs;
-        };
-        deepwiki = {
-          type = "http";
-          url = "https://mcp.deepwiki.com/mcp";
-          startup_timeout_ms = defaultTimeoutMs;
-        };
+      };
+
+      claudeMcpServers = mcp.select {
+        sequential-thinking = true;
+        time = true;
+        cfdocs = true;
+        cfbuilds = true;
+        cfobservability = true;
+        cfradar = true;
+        cfcontainers = true;
+        cfbrowser = true;
+        cfgraphql = true;
+        deepwiki = true;
       };
 
       # Only include context7 if a valid API key exists
@@ -126,7 +60,7 @@
         };
       };
 
-      defaultServers = baseServers // context7mcp;
+      defaultServers = claudeMcpServers // context7mcp;
 
       # Claude Code settings.json configuration
       claudeSettings = {

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -89,8 +89,8 @@
         sequential-thinking = true;
         memory = true;
         time = true;
-          cfdocs = true;
-          cfbindings = false;
+        cfdocs = true;
+        cfbindings = false;
         cfbuilds = true;
         cfobservability = true;
         cfradar = true;

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -89,8 +89,8 @@
         sequential-thinking = true;
         memory = true;
         time = true;
-        cfdocs = true;
-        # cfbindings intentionally disabled at user request.
+          cfdocs = true;
+          cfbindings = false;
         cfbuilds = true;
         cfobservability = true;
         cfradar = true;

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -79,6 +79,26 @@
           }
         else
           { };
+
+      mcp = import ../../lib/mcp-servers.nix {
+        inherit lib;
+        defaultTimeoutMs = 60000;
+      };
+
+      codexMcpServers = mcp.selectWithoutType {
+        sequential-thinking = true;
+        memory = true;
+        time = true;
+        cfdocs = true;
+        # cfbindings intentionally disabled at user request.
+        cfbuilds = true;
+        cfobservability = true;
+        cfradar = true;
+        cfcontainers = false; # conflicts w/ builtin review command
+        cfbrowser = true;
+        cfgraphql = true;
+        deepwiki = true;
+      };
     in
     {
       programs.codex = {
@@ -106,105 +126,7 @@
           tools = {
             web_search = true;
           };
-          mcp_servers = context7Server // {
-            memory = {
-              command = "npx";
-              args = [
-                "-y"
-                "@modelcontextprotocol/server-memory"
-              ];
-              startup_timeout_ms = 60000;
-            };
-            sequential-thinking = {
-              command = "npx";
-              args = [
-                "-y"
-                "@modelcontextprotocol/server-sequential-thinking"
-              ];
-              startup_timeout_ms = 60000;
-            };
-            time = {
-              command = "uvx";
-              args = [ "mcp-server-time" ];
-              startup_timeout_ms = 60000;
-            };
-            # Cloudflare MCP servers – https://github.com/cloudflare/mcp-server-cloudflare#cloudflare-mcp-server
-            cfdocs = {
-              command = "npx";
-              args = [
-                "mcp-remote"
-                "https://docs.mcp.cloudflare.com/sse"
-              ];
-              startup_timeout_ms = 60000;
-            };
-            # cfbindings disabled at user request.
-            # cfbindings = {
-            #   command = "npx";
-            #   args = [
-            #     "mcp-remote"
-            #     "https://bindings.mcp.cloudflare.com/sse"
-            #   ];
-            #   startup_timeout_ms = 60000;
-            # };
-            cfbuilds = {
-              command = "npx";
-              args = [
-                "mcp-remote"
-                "https://builds.mcp.cloudflare.com/sse"
-              ];
-              startup_timeout_ms = 60000;
-            };
-            cfobservability = {
-              command = "npx";
-              args = [
-                "mcp-remote"
-                "https://observability.mcp.cloudflare.com/sse"
-              ];
-              startup_timeout_ms = 60000;
-            };
-            cfradar = {
-              command = "npx";
-              args = [
-                "mcp-remote"
-                "https://radar.mcp.cloudflare.com/sse"
-              ];
-              startup_timeout_ms = 60000;
-            };
-            # Disabled because it conflicts with Codex CLI review feature.
-            # cfcontainers disabled at user request.
-            # cfcontainers = {
-            #   command = "npx";
-            #   args = [
-            #     "mcp-remote"
-            #     "https://containers.mcp.cloudflare.com/sse"
-            #   ];
-            #   startup_timeout_ms = 60000;
-            # };
-            cfbrowser = {
-              command = "npx";
-              args = [
-                "mcp-remote"
-                "https://browser.mcp.cloudflare.com/sse"
-              ];
-              startup_timeout_ms = 60000;
-            };
-            cfgraphql = {
-              command = "npx";
-              args = [
-                "mcp-remote"
-                "https://graphql.mcp.cloudflare.com/sse"
-              ];
-              startup_timeout_ms = 60000;
-            };
-            deepwiki = {
-              command = "npx";
-              args = [
-                "mcp-remote"
-                "https://mcp.deepwiki.com/mcp"
-              ];
-              startup_timeout_ms = 60000;
-            };
-          };
+          mcp_servers = context7Server // codexMcpServers;
           profiles = {
             gpt-5-codex = {
               model = "gpt-5-codex";


### PR DESCRIPTION
## Summary
- centralize MCP server definitions with reusable selection helpers and richer validation errors
- refactor Codex and Claude Code modules to enable servers via booleans using the shared catalog
- document catalog usage and align espanso module/docs with the Home Manager `package-wayland` option

## Testing
- nix fmt
- nix flake check --accept-flake-config
- nix develop -c pre-commit run --all-files
