### PR TITLE
fix: replace hardcoded path with portable GitHub URL for nix-logseq-git-flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -516,14 +516,17 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1760276024,
-        "narHash": "sha256-BWuaU4ssYjcc4X2tm1q8oo4sKZ4HRF3ame2wuxMY2bc=",
-        "path": "/home/vx/git/nix-logseq-git-flake",
-        "type": "path"
+        "lastModified": 1766370716,
+        "narHash": "sha256-6B8h0a1Ab2mKfboJ/blyDcmAMR1XJkfqCy+nDMAj1Us=",
+        "owner": "Bad3r",
+        "repo": "nix-logseq-git-flake",
+        "rev": "1205c52382bd760d17d0abb4870d5b60f303c48e",
+        "type": "github"
       },
       "original": {
-        "path": "/home/vx/git/nix-logseq-git-flake",
-        "type": "path"
+        "owner": "Bad3r",
+        "repo": "nix-logseq-git-flake",
+        "type": "github"
       }
     },
     "nixos-facter-modules": {

--- a/flake.nix
+++ b/flake.nix
@@ -45,7 +45,7 @@
     };
 
     nix-logseq-git-flake = {
-      url = "path:/home/vx/git/nix-logseq-git-flake";
+      url = "github:Bad3r/nix-logseq-git-flake";
     };
 
     # nix-on-droid = {

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,7 @@
     };
 
     nix-logseq-git-flake = {
+      # GitHub URL for portability; use --override-input for local dev
       url = "github:Bad3r/nix-logseq-git-flake";
     };
 


### PR DESCRIPTION
## Summary

Replaces hardcoded local path with portable GitHub URL for nix-logseq-git-flake input.

**Note:** Based on #27 for clean cherry-pick, but functionally independent.

## Changes

- **a65e4337a**: Replace `path:/home/vx/git/...` with `github:Bad3r/nix-logseq-git-flake`
- Update flake.lock from local path (Oct 12) to GitHub (Dec 22, latest)
- Add comment explaining flake input limitations and local dev workflow

## Rationale

Flake inputs are resolved before Nix evaluation, so `metaOwner` and environment variables cannot be used in input URLs. The GitHub URL provides portability while the `--override-input` flag supports local development.

**Before:**
```nix
nix-logseq-git-flake.url = "path:/home/vx/git/nix-logseq-git-flake";
```

**After:**
```nix
nix-logseq-git-flake.url = "github:Bad3r/nix-logseq-git-flake";
# For local development:
# nix build --override-input nix-logseq-git-flake "path:$HOME/git/nix-logseq-git-flake"
```

## Test Plan

- [x] Builds successfully
- [x] Pre-commit hooks pass
- [x] Portable across systems (no hardcoded username)

## Merge Requirements

**Note:** Based on #27 to avoid conflicts, but can be rebased to main independently after #27 merges.

## Verification

Build artifacts: /tmp/branch-split-verification/branch4*