### PR TITLE
fix(stylix): remove redundant targets and _module.check workaround

### DIFF
--- a/docs/stylix-integration.md
+++ b/docs/stylix-integration.md
@@ -1,0 +1,187 @@
+# Stylix Integration
+
+This document covers how Stylix theming integrates with the Dendritic Pattern and the key constraints module authors must understand.
+
+## Overview
+
+[Stylix](https://github.com/danth/stylix) provides automatic, consistent theming across NixOS and Home Manager applications using base16 color schemes. This repository integrates Stylix at both the system (NixOS) and user (Home Manager) levels.
+
+The integration is configured in:
+
+- `modules/theming/stylix.nix` — NixOS-level Stylix configuration
+- Individual app modules — may interact with Stylix targets
+
+## Key Concept: NixOS vs Home Manager Targets
+
+Stylix exposes `stylix.targets.<app>.enable` options, but **these targets exist in different contexts**:
+
+| Context      | Example Targets                                            | Where Defined             |
+| ------------ | ---------------------------------------------------------- | ------------------------- |
+| NixOS        | `console`, `grub`, `plymouth`, `gtk`, `lightdm`, `nixvim`  | System-level applications |
+| Home Manager | `dunst`, `rofi`, `mpv`, `alacritty`, `kitty`, `fzf`, `bat` | User-level applications   |
+
+**Critical Rule**: A NixOS module cannot set Home Manager-only targets, and vice versa. Attempting to do so results in undefined option errors.
+
+To inspect available targets in each context:
+
+```bash
+# NixOS targets
+nix eval .#nixosConfigurations.system76.options.stylix.targets --apply builtins.attrNames
+
+# Home Manager targets (via the HM module system)
+# These are only available within Home Manager module evaluation
+```
+
+## The autoEnable Mechanism
+
+Stylix provides `stylix.autoEnable` (default: `true`) which automatically enables theming for all detected applications. When `autoEnable` is true:
+
+1. Stylix checks if an application's program option is enabled (e.g., `programs.fzf.enable`)
+2. If enabled, Stylix automatically sets `stylix.targets.<app>.enable = true`
+
+**Important**: Stylix's `autoEnable` does **not** detect whether an application is installed via `environment.systemPackages`. It only responds to program-specific options like `programs.<app>.enable`.
+
+### Priority and Overrides
+
+Stylix sets target enables with a specific priority. Using `lib.mkDefault true` in app modules can accidentally override user preferences:
+
+```nix
+# BAD: This overrides user's stylix.autoEnable = false setting
+stylix.targets.fzf.enable = lib.mkDefault true;
+
+# GOOD: Let Stylix's autoEnable handle it automatically
+# (simply omit the line)
+```
+
+## Best Practices for Module Authors
+
+### NixOS App Modules (`modules/apps/`)
+
+1. **Do NOT set `stylix.targets.*` options** — these are typically Home Manager targets
+2. Focus on `environment.systemPackages` and system-level configuration
+3. Let Home Manager modules handle user-level theming
+
+```nix
+# Correct NixOS app module
+{
+  flake.nixosModules.apps.dunst =
+    { pkgs, lib, config, ... }:
+    let
+      cfg = config.programs.dunst.extended;
+    in
+    {
+      options.programs.dunst.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable dunst notification daemon.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ pkgs.dunst ];
+        # NO stylix.targets.dunst.enable here — it's HM-only
+      };
+    };
+}
+```
+
+### Home Manager Modules (`modules/hm-apps/`)
+
+1. **Do NOT manually set `stylix.targets.*`** — let `autoEnable` handle it
+2. Only set targets if you need to **disable** theming for a specific app
+3. If you must set a target, use appropriate priority
+
+```nix
+# Correct HM app module — let autoEnable work
+{
+  flake.homeManagerModules.apps.fzf =
+    { lib, ... }:
+    {
+      programs.fzf.enable = true;
+      # Stylix will automatically enable stylix.targets.fzf
+      # because programs.fzf.enable = true
+    };
+}
+
+# Only if you need to DISABLE theming:
+{
+  flake.homeManagerModules.apps.some-app =
+    { lib, ... }:
+    {
+      programs.some-app.enable = true;
+      stylix.targets.some-app.enable = false;  # Explicitly disable
+    };
+}
+```
+
+## Common Pitfalls
+
+### Pitfall 1: Setting HM Targets in NixOS Modules
+
+```nix
+# WRONG — dunst target only exists in Home Manager
+flake.nixosModules.apps.dunst = { ... }: {
+  stylix.targets.dunst.enable = lib.mkDefault true;  # ERROR: undefined option
+};
+```
+
+This causes evaluation errors unless `_module.check = false` is set, which masks the problem.
+
+### Pitfall 2: Redundant Target Enables
+
+```nix
+# WRONG — redundant and potentially buggy
+flake.homeManagerModules.apps.fzf = { lib, ... }: {
+  programs.fzf.enable = true;
+  stylix.targets.fzf.enable = lib.mkDefault true;  # Redundant!
+};
+```
+
+Stylix already enables this automatically. The `lib.mkDefault` can override user's `stylix.autoEnable = false`.
+
+### Pitfall 3: Using \_module.check = false
+
+Never use `_module.check = false` to silence option errors. This masks real problems:
+
+```nix
+# WRONG — hides undefined option errors
+configurations.nixos.myhost.module = {
+  _module.check = false;  # Don't do this
+  imports = [ ... ];
+};
+```
+
+Instead, fix the root cause by ensuring options are only set in their valid context.
+
+## Debugging Stylix Issues
+
+### Check Which Targets Exist
+
+```bash
+# List NixOS stylix targets
+nix eval .#nixosConfigurations.system76.options.stylix.targets \
+  --apply builtins.attrNames 2>/dev/null | tr ',' '\n' | tr -d '[]" '
+```
+
+### Verify Target State
+
+```bash
+# Check if a specific target is enabled in the final config
+nix eval .#nixosConfigurations.system76.config.stylix.targets.console.enable
+```
+
+### Trace autoEnable Behavior
+
+If theming isn't applying, verify:
+
+1. `stylix.autoEnable` is `true` (or not explicitly `false`)
+2. The corresponding `programs.<app>.enable` is `true`
+3. The target exists in the current context (NixOS vs HM)
+
+## Related Documentation
+
+- `docs/dendritic-pattern-reference.md` — module discovery and aggregator patterns
+- `docs/home-manager-aggregator.md` — how Home Manager modules are composed
+- `docs/apps-module-style-guide.md` — per-app module authoring conventions
+- [Stylix Documentation](https://danth.github.io/stylix/) — upstream reference

--- a/modules/apps/dunst.nix
+++ b/modules/apps/dunst.nix
@@ -45,9 +45,6 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        # Enable Stylix theming for dunst
-        stylix.targets.dunst.enable = lib.mkDefault true;
-
         environment.systemPackages = [ cfg.package ];
       };
     };

--- a/modules/apps/google-chrome-dev.nix
+++ b/modules/apps/google-chrome-dev.nix
@@ -20,6 +20,9 @@
     * `google-chrome-unstable` - Launch Chrome Dev (the binary is named google-chrome-unstable).
     * `google-chrome-unstable --enable-features=WebGPU` - Test WebGPU support.
     * `google-chrome-unstable --user-data-dir=/tmp/chrome-test` - Isolated testing profile.
+
+  Local Workarounds:
+    * Removes duplicate desktop file with broken /usr/bin path (upstream: browser-previews#44).
 */
 { inputs, ... }:
 let
@@ -51,7 +54,13 @@ let
         # Must be unconditional so the package option can resolve
         nixpkgs.overlays = [
           (_final: prev: {
-            google-chrome-dev = packageFor prev.stdenv.hostPlatform.system;
+            google-chrome-dev = (packageFor prev.stdenv.hostPlatform.system).overrideAttrs (oldAttrs: {
+              postInstall = (oldAttrs.postInstall or "") + ''
+                # Workaround for upstream browser-previews#44:
+                # Remove unpatched duplicate desktop file with broken /usr/bin path
+                rm -f $out/share/applications/com.google.Chrome.unstable.desktop
+              '';
+            });
           })
         ];
 

--- a/modules/apps/i3status-rust.nix
+++ b/modules/apps/i3status-rust.nix
@@ -44,9 +44,6 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        # Enable Stylix theming for i3status-rust
-        stylix.targets.i3status-rust.enable = lib.mkDefault true;
-
         environment.systemPackages = [ cfg.package ];
       };
     };

--- a/modules/apps/mangohud.nix
+++ b/modules/apps/mangohud.nix
@@ -44,9 +44,6 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        # Enable Stylix theming for mangohud
-        stylix.targets.mangohud.enable = lib.mkDefault true;
-
         environment.systemPackages = [ cfg.package ];
       };
     };
@@ -70,9 +67,6 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        # Enable Stylix theming for mangohud (HM)
-        stylix.targets.mangohud.enable = lib.mkDefault true;
-
         programs.mangohud.enable = true;
       };
     };

--- a/modules/apps/mpv.nix
+++ b/modules/apps/mpv.nix
@@ -78,9 +78,6 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        # Enable Stylix theming for mpv
-        stylix.targets.mpv.enable = lib.mkDefault true;
-
         environment.systemPackages = [ cfg.package ] ++ cfg.extraScripts ++ cfg.extraPackages;
       };
     };

--- a/modules/apps/rofi.nix
+++ b/modules/apps/rofi.nix
@@ -45,9 +45,6 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        # Enable Stylix theming for rofi
-        stylix.targets.rofi.enable = lib.mkDefault true;
-
         environment.systemPackages = [ cfg.package ];
       };
     };

--- a/modules/base/console.nix
+++ b/modules/base/console.nix
@@ -1,9 +1,5 @@
-{ lib, ... }:
-{
+_: {
   flake.nixosModules.base = {
-    # Enable Stylix theming for console
-    stylix.targets.console.enable = lib.mkDefault true;
-
     console.keyMap = "us";
   };
 }

--- a/modules/hm-apps/alacritty.nix
+++ b/modules/hm-apps/alacritty.nix
@@ -39,9 +39,6 @@
       };
 
       config = lib.mkIf cfg.enable {
-        # Enable Stylix theming for alacritty
-        stylix.targets.alacritty.enable = lib.mkDefault true;
-
         home.packages = [ pkgs.alacritty ];
       };
     };

--- a/modules/hm-apps/bat.nix
+++ b/modules/hm-apps/bat.nix
@@ -30,12 +30,8 @@
     * `git diff | bat --diff` — Colorize Git diff output with syntax-aware highlighting.
 */
 
-{ lib, ... }:
-{
+_: {
   flake.homeManagerModules.apps.bat = {
-    # Enable Stylix theming for bat
-    stylix.targets.bat.enable = lib.mkDefault true;
-
     programs.bat = {
       enable = true;
 

--- a/modules/hm-apps/fzf.nix
+++ b/modules/hm-apps/fzf.nix
@@ -27,9 +27,6 @@
   flake.homeManagerModules.apps.fzf =
     { pkgs, lib, ... }:
     {
-      # Enable Stylix theming for fzf
-      stylix.targets.fzf.enable = lib.mkDefault true;
-
       programs.fzf = {
         enable = true;
 

--- a/modules/hm-apps/lazygit.nix
+++ b/modules/hm-apps/lazygit.nix
@@ -32,31 +32,26 @@
 */
 
 {
-  flake.homeManagerModules.apps.lazygit =
-    { lib, ... }:
-    {
-      # Enable Stylix theming for lazygit
-      stylix.targets.lazygit.enable = lib.mkDefault true;
+  flake.homeManagerModules.apps.lazygit = {
+    programs.lazygit = {
+      enable = true;
 
-      programs.lazygit = {
-        enable = true;
-
-        # Custom settings can be added here
-        # settings = {
-        #   gui = {
-        #     theme = {
-        #       activeBorderColor = ["#88c0d0" "bold"];
-        #       inactiveBorderColor = ["#4c566a"];
-        #       selectedLineBgColor = ["#3b4252"];
-        #     };
-        #   };
-        #   git = {
-        #     paging = {
-        #       colorArg = "always";
-        #       pager = "delta --dark --paging=never";
-        #     };
-        #   };
-        # };
-      };
+      # Custom settings can be added here
+      # settings = {
+      #   gui = {
+      #     theme = {
+      #       activeBorderColor = ["#88c0d0" "bold"];
+      #       inactiveBorderColor = ["#4c566a"];
+      #       selectedLineBgColor = ["#3b4252"];
+      #     };
+      #   };
+      #   git = {
+      #     paging = {
+      #       colorArg = "always";
+      #       pager = "delta --dark --paging=never";
+      #     };
+      #   };
+      # };
     };
+  };
 }

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -30,8 +30,6 @@
     {
       imports = [ inputs.nixvim.homeModules.nixvim ];
 
-      stylix.targets.nixvim.enable = mkDefault true;
-
       programs.nixvim = {
         enable = true;
 

--- a/modules/hm-apps/vscode.nix
+++ b/modules/hm-apps/vscode.nix
@@ -22,12 +22,9 @@
     * `code --install-extension ms-python.python` — Install extensions
 */
 
-{ lib, pkgs, ... }:
+{ pkgs, ... }:
 {
   flake.homeManagerModules.apps.vscode = {
-    # Enable Stylix theming for VSCode
-    stylix.targets.vscode.enable = lib.mkDefault true;
-
     programs.vscode = {
       enable = true;
 

--- a/modules/hm-apps/wezterm.nix
+++ b/modules/hm-apps/wezterm.nix
@@ -22,12 +22,7 @@
 */
 
 {
-  flake.homeManagerModules.apps.wezterm =
-    { lib, ... }:
-    {
-      # Enable Stylix theming for wezterm
-      stylix.targets.wezterm.enable = lib.mkDefault true;
-
-      programs.wezterm.enable = true;
-    };
+  flake.homeManagerModules.apps.wezterm = {
+    programs.wezterm.enable = true;
+  };
 }

--- a/modules/hm-apps/zathura.nix
+++ b/modules/hm-apps/zathura.nix
@@ -38,9 +38,6 @@
       };
 
       config = lib.mkIf cfg.enable {
-        # Enable Stylix theming for zathura
-        stylix.targets.zathura.enable = lib.mkDefault true;
-
         home.packages = [ pkgs.zathura ];
       };
     };

--- a/modules/shell/starship.nix
+++ b/modules/shell/starship.nix
@@ -22,9 +22,6 @@
 { lib, ... }:
 {
   flake.homeManagerModules.base = {
-    # Enable Stylix theming for Starship
-    stylix.targets.starship.enable = lib.mkDefault true;
-
     programs.starship = {
       enable = true;
 

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -25,12 +25,6 @@ let
 in
 {
   configurations.nixos.system76.module = {
-    # Defer option checking to allow Stylix options to be defined after
-    # app modules try to use them. The imports list is processed in order,
-    # but contributions from other files (via the aggregator) are merged
-    # before imports are resolved.
-    _module.check = false;
-
     # NOTE: All modules/system76/*.nix files are auto-imported by import-tree
     # and contribute to this aggregator via flake-parts. Only actual NixOS
     # modules (exported via flake.nixosModules.* or from external inputs)

--- a/modules/terminal/kitty.nix
+++ b/modules/terminal/kitty.nix
@@ -2,9 +2,6 @@
   flake.homeManagerModules.gui =
     { lib, ... }:
     {
-      # Enable Stylix theming for kitty
-      stylix.targets.kitty.enable = lib.mkDefault true;
-
       programs.kitty = {
         enable = true;
         # Ensure kitty is set as default terminal in user session

--- a/modules/terminal/wezterm.nix
+++ b/modules/terminal/wezterm.nix
@@ -1,10 +1,5 @@
 {
-  flake.homeManagerModules.gui =
-    { lib, ... }:
-    {
-      # Enable Stylix theming for wezterm
-      stylix.targets.wezterm.enable = lib.mkDefault true;
-
-      programs.wezterm.enable = true;
-    };
+  flake.homeManagerModules.gui = {
+    programs.wezterm.enable = true;
+  };
 }

--- a/modules/web-browsers/firefox.nix
+++ b/modules/web-browsers/firefox.nix
@@ -20,9 +20,6 @@ _: {
       };
 
       config = {
-        # Enable Stylix theming for Firefox
-        stylix.targets.firefox.enable = lib.mkDefault true;
-
         programs.firefox = {
           enable = true;
           package = pkgs.firefox;

--- a/modules/window-manager/i3-config.nix
+++ b/modules/window-manager/i3-config.nix
@@ -455,8 +455,6 @@
           bars.default = i3statusBarConfig;
         };
 
-        stylix.targets.i3.enable = lib.mkDefault true;
-
         xdg.configFile = {
           "i3status-rust/config.toml".source =
             config.xdg.configFile."i3status-rust/config-default.toml".source;


### PR DESCRIPTION
## Summary

- Remove all `stylix.targets.*.enable = lib.mkDefault true` lines from NixOS and HM modules
- Remove `_module.check = false` workaround from `imports.nix`
- Let Stylix's built-in `autoEnable` mechanism handle target activation
- Add comprehensive Stylix integration documentation
- Fix duplicate desktop file issue in google-chrome-dev package

## Root Cause Analysis

**NixOS app modules** (dunst, mpv, rofi, mangohud, i3status-rust) were setting Stylix targets that **only exist in Home Manager context**:

```
NixOS stylix.targets: chromium, console, feh, fish, font-packages, fontconfig, 
                      glance, gnome, grub, gtk, kmscon, lightdm, nixvim, plymouth, qt...

Missing (HM-only): dunst, mpv, rofi, mangohud, i3status-rust
```

With `_module.check = false`, these undefined option assignments were silently ignored.

**HM modules** had redundant lines that were actually buggy:
- Stylix `autoEnable` already defaults to `true` for all affected targets
- Our `lib.mkDefault true` would override user's `stylix.autoEnable = false` setting

## Changes

| Category | Files | Effect |
|----------|-------|--------|
| NixOS app modules | 5 | Removed no-op lines targeting HM-only targets |
| HM modules | 14 | Removed redundant/buggy lines |
| imports.nix | 1 | Removed `_module.check = false` |
| Documentation | 1 | Added `docs/stylix-integration.md` |
| google-chrome-dev | 1 | Remove broken duplicate desktop file |

## Documentation Added

New `docs/stylix-integration.md` covers:
- NixOS vs Home Manager target separation
- The `autoEnable` mechanism and priority behavior
- Best practices for module authors
- Common pitfalls that led to the `_module.check` workaround

## Additional Fix: google-chrome-dev Desktop Files

Applied local workaround for [browser-previews#44](https://github.com/nix-community/browser-previews/issues/44):
- The upstream package ships two desktop files but only patches one
- `com.google.Chrome.unstable.desktop` has broken `/usr/bin` path
- Added `postInstall` override to remove the broken file

## Verification

- ✅ Pre-commit hooks pass
- ✅ Flake check passes
- ✅ NixOS configuration builds successfully
- ✅ Stylix theming works via autoEnable

## Test Plan

- [ ] Verify themed applications still receive Stylix colors
- [ ] Verify `stylix.autoEnable = false` properly disables theming
- [ ] Verify only one Chrome entry appears in application menu
- [ ] Review documentation for accuracy

Fixes #32
Fixes #33
Fixes #35