### PR TITLE
feat(agents): centralize commit skill rendering and codex packaging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,9 +195,9 @@ PR body should include:
 
 | Trigger            | Command                                  | Preconditions                                   | Post-check                                                         |
 | ------------------ | ---------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------ |
-| Start work         | `nix develop`                            | Clean tree; network available for substituters. | Dev tools available (`treefmt`, `lefthook`, etc.).                 |
+| Start work         | `nix develop`                            | Clean tree; network available for substituters. | Dev tools available (`treefmt`, `pre-commit`, etc.).               |
 | Format sources     | `nix fmt`                                | Run at repo root.                               | No remaining formatting diffs in `git status`.                     |
-| Run hooks          | `nix develop -c lefthook run pre-commit` | Dev shell ready; workspace writable.            | Exit code 0; review reported TODOs/failures.                       |
+| Run hooks          | `nix develop -c pre-commit run --all-files --hook-stage manual` | Dev shell ready; workspace writable.            | Exit code 0; review reported TODOs/failures.                       |
 | Generate artifacts | `nix develop -c write-files`             | Dev shell ready; managed files may update.      | Review diffs in `.actrc`, `.gitignore`, `.sops.yaml`, `README.md`. |
 
 ### Validation and Builds

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -140,44 +140,8 @@ _: {
       claudeJsonConfigFile = pkgs.writeText "claude-json-config.json" (builtins.toJSON claudeJsonConfig);
 
       # ── Commit Skill ──────────────────────────────────────────────────────
-      # Claude Code frontmatter + dynamic context + shared rules + workflow
-      commitSkillMd = ''
-        ---
-        name: commit
-        description: >
-          This skill should be used when the user invokes /commit to create a git commit.
-          It supports continuation commits on non-main branches and isolated worktree
-          commits when branch protection or user intent requires a new branch.
-        disable-model-invocation: true
-        allowed-tools: Bash(git status*), Bash(git diff*), Bash(git log*), Bash(git add *), Bash(git commit *), Bash(git worktree *), Bash(git for-each-ref *), Bash(git rev-parse *), Bash(git branch *), Bash(git push *), Bash(mkdir *), Bash(gh repo view *), Bash(gh pr *), Bash(gh label *), Read, Grep, Glob
-        argument-hint: "[optional commit message]"
-        ---
-
-        # Git Commit Skill
-
-        Create a well-formatted git commit following all project safety rules and Conventional Commits format, with automatic selection between continuation and worktree-isolated modes.
-
-        ## Current Git State
-
-        Working tree status:
-        !`git status --short`
-
-        Already staged changes:
-        !`git diff --staged --stat`
-
-        Recent commits (for style reference):
-        !`git log --oneline -5`
-
-        ${skillsLib.commitRules}
-
-        ### If `$ARGUMENTS` is provided
-
-        Use the provided text as the commit message directly. Still run through the pre-commit checklist and staging rules before committing.
-
-        ### If no arguments provided
-
-        ${skillsLib.commitWorkflow}
-      '';
+      commitSkill = skillsLib.skillDefs.commit;
+      commitSkillMd = skillsLib.renderClaudeSkillMd commitSkill;
 
     in
     {

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -43,6 +43,7 @@ _: {
       codexPkg = lib.attrByPath [ "programs" "codex" "extended" "package" ] pkgs.codex osConfig;
       homeDir = config.home.homeDirectory;
       configDir = "${config.xdg.configHome}/codex";
+      agentsDir = "${config.xdg.configHome}/agents";
       tomlFormat = pkgs.formats.toml { };
 
       # MCP servers via centralized catalog
@@ -58,8 +59,8 @@ _: {
       # Base settings (everything except projects — those are merged at runtime)
       baseSettings = {
         # Core settings
-        model = "gpt-5.2-codex";
-        profile = "gpt-5.2-codex";
+        model = "gpt-5.3-codex";
+        profile = "default";
         approval_policy = "never";
         sandbox_mode = "danger-full-access";
         personality = "pragmatic";
@@ -107,13 +108,19 @@ _: {
 
         # Feature flags
         features = {
-          shell_snapshot = true;
+          apply_patch_freeform = true;
           apps = true;
+          child_agents_md = true;
+          collab = true;
+          memory_tool = true;
+          shell_snapshot = true;
+          skill_env_var_dependency_prompt = true;
+          sqlite = true;
           steer = true;
           undo = true;
           unified_exec = true;
           use_linux_sandbox_bwrap = false;
-          responses_websockets = true;
+          responses_websockets = false; # 10/02/26 doesnt work as expected
         };
 
         # Shell environment
@@ -136,8 +143,8 @@ _: {
 
         # Profiles
         profiles = {
-          "gpt-5.2-codex" = {
-            model = "gpt-5.2-codex";
+          default = {
+            model = "gpt-5.3-codex";
             approval_policy = "never";
             model_supports_reasoning_summaries = true;
             model_reasoning_effort = "xhigh";
@@ -157,53 +164,67 @@ _: {
       };
 
       # ── Commit Skill ──────────────────────────────────────────────────────
-      # Codex SKILL.md with YAML frontmatter + shared rules from skillsLib
-      commitSkillMd = ''
-        ---
-        name: commit
-        description: >
-          Execute safe git commit workflows using either continuation on the current
-          non-main branch or isolated branch/worktree creation when required.
-        metadata:
-          short-description: Dual-mode git commit workflow with branch protection
-        ---
-
-        # Git Commit Skill
-
-        ${skillsLib.commitRules}
-        ${skillsLib.commitWorkflow}
-      '';
+      commitSkill = skillsLib.skillDefs.commit;
+      commitSkillDir = skillsLib.mkCodexSkillDir pkgs commitSkill;
 
       baseConfigFile = tomlFormat.generate "codex-config-base" baseSettings;
       nixProjectsFile = tomlFormat.generate "codex-nix-projects" nixProjectSettings;
+      tomlMergePython = pkgs.python3.withPackages (ps: [ ps.tomlkit ]);
 
-      yq = lib.getExe pkgs.yq-go;
-
-      # Wrapper that merges split config files before launching codex.
-      # Reads base settings + nix projects + user-managed projects, deep-merges
-      # them into config.toml, then execs the real binary.
+      # Wrapper that assembles config.toml before launching codex.
+      # Uses parser-based TOML merge with precedence:
+      # base settings < nix-managed projects < user-managed projects.
       codexWrapped = pkgs.writeShellScriptBin "codex" ''
-        cfgDir="''${CODEX_HOME:-${configDir}}"
-        base="$cfgDir/config.base.toml"
-        nixProjects="$cfgDir/projects.nix.toml"
-        userProjects="$cfgDir/trusted-projects.toml"
-        out="$cfgDir/config.toml"
+                cfgDir="''${CODEX_HOME:-${configDir}}"
+                base="$cfgDir/config.base.toml"
+                nixProjects="$cfgDir/projects.nix.toml"
+                userProjects="$cfgDir/trusted-projects.toml"
+                out="$cfgDir/config.toml"
 
-        if [ -f "$base" ] && [ -f "$nixProjects" ]; then
-          if [ -f "$userProjects" ] && grep -q '[^[:space:]#]' "$userProjects" 2>/dev/null; then
-            ${yq} eval-all -p toml -o toml \
-              'select(fi == 0) * select(fi == 1) * select(fi == 2)' \
-              "$base" "$nixProjects" "$userProjects" > "$out.tmp" && mv "$out.tmp" "$out" \
-              || echo "codex-wrapper: config merge failed, using existing config" >&2
-          else
-            ${yq} eval-all -p toml -o toml \
-              'select(fi == 0) * select(fi == 1)' \
-              "$base" "$nixProjects" > "$out.tmp" && mv "$out.tmp" "$out" \
-              || echo "codex-wrapper: config merge failed, using existing config" >&2
-          fi
-        fi
+                if [ -f "$base" ]; then
+                  if ${tomlMergePython}/bin/python - "$base" "$nixProjects" "$userProjects" "$out.tmp" <<'PY'
+        from pathlib import Path
+        import sys
+        import tomllib
+        import tomlkit
 
-        exec ${codexPkg}/bin/codex "$@"
+
+        def load_toml(path_str: str) -> dict:
+            path = Path(path_str)
+            if not path.exists():
+                return {}
+            raw = path.read_text(encoding="utf-8")
+            if not raw.strip():
+                return {}
+            return tomllib.loads(raw)
+
+
+        def deep_merge(base: dict, override: dict) -> dict:
+            for key, value in override.items():
+                current = base.get(key)
+                if isinstance(current, dict) and isinstance(value, dict):
+                    deep_merge(current, value)
+                else:
+                    base[key] = value
+            return base
+
+
+        base_path, nix_projects_path, user_projects_path, out_path = sys.argv[1:5]
+        merged = {}
+        for path in (base_path, nix_projects_path, user_projects_path):
+            deep_merge(merged, load_toml(path))
+
+        Path(out_path).write_text(tomlkit.dumps(merged), encoding="utf-8")
+        PY
+                  then
+                    [ -s "$out.tmp" ] && mv "$out.tmp" "$out" \
+                      || echo "codex-wrapper: config assembly failed, using existing config" >&2
+                  else
+                    echo "codex-wrapper: config merge failed, using existing config" >&2
+                  fi
+                fi
+
+                exec ${codexPkg}/bin/codex "$@"
       '';
     in
     {
@@ -234,6 +255,28 @@ _: {
                         fi
           '';
 
+          # Codex discovers user skills in ~/.agents/skills
+          activation.codexAgentsHomeLink = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+            agentsHome="${homeDir}/.agents"
+            legacyBackupBase="${homeDir}/.agents.pre-xdg-migration"
+
+            # If ~/.agents is a real directory, migrate its contents into
+            # ~/.config/agents and archive the legacy directory before linking.
+            if [ -d "$agentsHome" ] && [ ! -L "$agentsHome" ]; then
+              run mkdir -p "${agentsDir}"
+              run cp -a "$agentsHome/." "${agentsDir}/"
+
+              backupPath="$legacyBackupBase"
+              if [ -e "$backupPath" ]; then
+                backupPath="''${legacyBackupBase}-$(date +%s)"
+              fi
+              run mv "$agentsHome" "$backupPath"
+            fi
+
+            run mkdir -p "${agentsDir}/skills"
+            run ln -sfnT "${agentsDir}" "$agentsHome"
+          '';
+
           sessionVariables = {
             CODEX_HOME = lib.mkDefault configDir;
             CODEX_DISABLE_UPDATE_CHECK = "1";
@@ -247,8 +290,8 @@ _: {
           # Nix-managed trusted projects (read-only symlink to store)
           "codex/projects.nix.toml".source = nixProjectsFile;
 
-          # Commit skill (user-scoped, discovered by SkillsManager at ~/.config/codex/skills/)
-          "codex/skills/commit/SKILL.md".text = commitSkillMd;
+          # Commit skill (user-scoped, discovered by SkillsManager at ~/.agents/skills/)
+          "agents/skills/commit".source = commitSkillDir;
         };
       };
     };

--- a/modules/home-manager/nixos.nix
+++ b/modules/home-manager/nixos.nix
@@ -176,6 +176,7 @@ in
 
       config.home-manager = {
         useGlobalPkgs = true;
+        useUserPackages = true;
         extraSpecialArgs = {
           hasGlobalPkgs = true;
           inherit inputs metaOwner;

--- a/modules/integrations/skills.nix
+++ b/modules/integrations/skills.nix
@@ -97,7 +97,7 @@ let
     - Never run `git add -A` or `git add .`; stage explicit file paths only.
     - Never run `git push --force` to `main` or `master`.
     - Never use `--no-verify` or `--no-gpg-sign`.
-    - Never run `rm` or `rm -rf`; use recoverable deletion tooling when deletion is required.
+    - Never run `rm` or `rm -rf`; use recoverable deletion tool `rip` when deletion is required.
 
     After a pre-commit hook failure, never run `git commit --amend` unless the user explicitly asks to amend the previous commit.
 
@@ -150,11 +150,6 @@ let
     git log --oneline -5
     ```
 
-    Verify and enforce:
-
-    1. Refuse to commit secrets or credentials (`.env`, keys, tokens, certificates, credential dumps).
-    2. Flag generated or managed artifacts when their source definitions were not updated.
-
     ## Stage Changes Intentionally
 
     Use atomic staging rules:
@@ -169,7 +164,7 @@ let
 
     Use Conventional Commits format: `type(scope): summary`.
 
-    Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`.
+    Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`, `docs`.
 
     Choose scope from the primary module/directory/domain affected. Keep summary concise and focused on intent.
 

--- a/modules/integrations/skills.nix
+++ b/modules/integrations/skills.nix
@@ -1,197 +1,394 @@
 /*
-  Shared Skill Rules Library
+  Shared Skill Library
 
-  This module provides flake.lib.skills with tool-agnostic rule sets
-  that can be consumed by multiple AI coding tool integrations.
+  This module provides flake.lib.skills with:
+    - skillDefs: Canonical, agent-agnostic skill definitions
+    - renderCodexSkillMd: Render SKILL.md for Codex
+    - mkCodexSkillDir: Build a full Codex skill directory (SKILL.md + agents/openai.yaml)
+    - renderClaudeSkillMd: Render SKILL.md for Claude Code
 
-  Each consumer wraps these with its own tool-specific frontmatter and chrome:
-    - modules/hm-apps/claude-code.nix → ~/.claude/skills/commit/SKILL.md
-    - modules/hm-apps/codex.nix       → ~/.config/codex/skills/commit/SKILL.md
+  Consumers:
+    - modules/hm-apps/codex.nix
+    - modules/hm-apps/claude-code.nix
 */
-_: {
+{ lib, ... }:
+let
+  renderFrontmatter =
+    fields: fieldOrder:
+    let
+      orderedKeys = lib.filter (key: fields ? ${key}) fieldOrder;
+      extraKeys = lib.sort builtins.lessThan (
+        lib.filter (key: !(lib.elem key fieldOrder)) (lib.attrNames fields)
+      );
+      keys = orderedKeys ++ extraKeys;
+      lines = map (key: "${key}: ${builtins.toJSON fields.${key}}") keys;
+    in
+    ''
+      ---
+      ${lib.concatStringsSep "\n" lines}
+      ---
+    '';
+
+  renderSkillBody =
+    {
+      title,
+      intro ? "",
+      sections ? [ ],
+      body,
+    }:
+    let
+      sectionBlocks = lib.filter (section: section != "") sections;
+      sectionText = lib.concatStringsSep "\n\n" sectionBlocks;
+      introText = lib.optionalString (intro != "") "${intro}\n\n";
+      sectionsText = lib.optionalString (sectionText != "") "${sectionText}\n\n";
+    in
+    ''
+      # ${title}
+
+      ${introText}${sectionsText}${body}
+    '';
+
+  commitSelectModeSection = command: ''
+    ## Select Mode
+
+    Always execute in `worktree_atomic` mode. Interpret user intent only as post-commit actions:
+
+    1. `${command}` means commit only (no push, no PR) in a newly created worktree.
+    2. `${command} and push` means commit + push + PR + labels from a newly created worktree.
+    3. `${command} ... create pull request` means commit + push + PR + labels from a newly created worktree.
+    4. `${command} ... explicit branch` uses the provided text as the branch seed, then still creates a brand-new unique branch.
+  '';
+
+  commitSkillBody = ''
+    If the user provides an explicit commit message argument, use it after checks. If user intent is ambiguous, ask one short clarifying question before mutating state.
+    If a user requests a direct commit on `main` or `master`, refuse and continue with a new worktree branch workflow.
+    Never reuse an existing worktree path from a prior invocation.
+    Never reuse any existing local or remote branch name from a prior invocation.
+
+    ## Apply `~/trees` Naming Standard
+
+    Use this structure for all new worktrees:
+
+    ```bash
+    repo_name="$(basename "$(git rev-parse --show-toplevel)")"
+    trees_repo_dir="$HOME/trees/$repo_name"
+    ```
+
+    Always create worktrees under `"$trees_repo_dir"` and never directly under `~/trees` root.
+
+    Infer naming from existing directory names in `"$trees_repo_dir"`:
+
+    - If names follow `type-slug` (for example `feat-user-defaults`, `fix-mcp-json-schema`, `docs-documentation-audit`), use:
+      - Branch name: `type/slug`
+      - Worktree directory: `type-slug` (branch name with `/` replaced by `-`)
+    - If names follow non-type phase/task style (for example `phase-7-5-deploy-verification`), use the same hyphenated value for both branch and worktree directory.
+    - If no entries exist, default to `type/slug` branch naming and `type-slug` worktree directories.
+
+    When the user provides an explicit branch name, treat it as a seed and generate a new unique branch from it.
+    Do not infer "same feature" from changed files alone. Resolve branch seed only from explicit user branch text, explicit ticket/issue identifier, or explicit "continue branch X" wording, then generate a new unique branch name.
+
+    ## Enforce Non-Negotiable Safety Rules
+
+    Apply these rules in every mode:
+
+    - Never run `git stash drop` or `git stash clear`.
+    - Never run `git reset --hard` unless the user explicitly requests it.
+    - Never run `git clean -fd`.
+    - Never run `git add -A` or `git add .`; stage explicit file paths only.
+    - Never run `git push --force` to `main` or `master`.
+    - Never use `--no-verify` or `--no-gpg-sign`.
+    - Never run `rm` or `rm -rf`; use recoverable deletion tooling when deletion is required.
+
+    After a pre-commit hook failure, never run `git commit --amend` unless the user explicitly asks to amend the previous commit.
+
+    ## Enforce Main Branch Protection
+
+    Apply this guard before any staging or commit:
+
+    - Never run `git commit` when current branch is `main` or `master`.
+    - Never perform commit operations in-place on the primary checkout when it is on `main` or `master`.
+    - Always create a new worktree and new non-main branch first, then commit inside that new worktree.
+
+    ## Require Invocation-Local Worktree Creation
+
+    Enforce this gate before any `git add` or `git commit`:
+
+    1. Snapshot existing worktree paths at invocation start:
+
+    ```bash
+    git worktree list --porcelain
+    ```
+
+    2. Create a brand-new worktree path under `~/trees/repo-name` that did not exist at invocation start.
+    3. Re-read `git worktree list --porcelain` and verify the new path appears in the post-create list and was absent in the pre-create list.
+    4. Refuse execution if verification fails, or if the selected path existed before invocation.
+    5. Refuse execution if the command flow attempts to stage or commit before this verification passes.
+
+    ## Require Invocation-Local Branch Creation
+
+    Enforce this gate before any `git worktree add`, `git add`, or `git commit`:
+
+    1. Snapshot existing local and remote branch names at invocation start:
+
+    ```bash
+    git for-each-ref --format='%(refname:short)' refs/heads refs/remotes
+    ```
+
+    2. Build `new_branch` from branch seed using established style.
+    3. Verify `new_branch` does not exist in pre-snapshot local or remote refs.
+    4. If it exists, append deterministic suffix (`-r2`, `-r3`, ...) until unique.
+    5. Refuse execution if flow attempts to create or use a branch name that existed before invocation.
+
+    ## Run Preflight Checks
+
+    Run these checks before staging and committing:
+
+    ```bash
+    git status --short
+    git diff --staged --stat
+    git diff --stat
+    git log --oneline -5
+    ```
+
+    Verify and enforce:
+
+    1. Refuse to commit secrets or credentials (`.env`, keys, tokens, certificates, credential dumps).
+    2. Flag generated or managed artifacts when their source definitions were not updated.
+
+    ## Stage Changes Intentionally
+
+    Use atomic staging rules:
+
+    - Stage only files for one logical concern.
+    - Use explicit paths: `git add path/to/file1 path/to/file2`.
+    - Split unrelated concerns into separate commits.
+
+    If nothing is staged, inspect unstaged changes, propose the exact file list to stage, and proceed only after user confirmation.
+
+    ## Write Commit Messages
+
+    Use Conventional Commits format: `type(scope): summary`.
+
+    Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `chore`.
+
+    Choose scope from the primary module/directory/domain affected. Keep summary concise and focused on intent.
+
+    Use a heredoc for multi-line messages:
+
+    ```bash
+    git commit -m "$(cat <<'MSG'
+    type(scope): summary
+
+    Optional body with context.
+    MSG
+    )"
+    ```
+
+    ## Execute Workflow (Always Worktree-First)
+
+    1. Parse intent flags from the user request:
+       - `push_required` for push requests
+       - `pr_required` for PR requests
+       - `labels_required` when PR labels are requested
+    2. Normalize intent flags:
+       - If `push_required` is true, force `pr_required=true` and `labels_required=true`.
+       - If `pr_required` is true, force `labels_required=true`.
+    3. Resolve branch seed in this order:
+       - Explicit branch text from user input
+       - Explicit ticket/issue id from user input
+       - New seed inferred from request slug + established naming style
+    4. Select base branch in this order:
+       - User-specified base
+       - `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`
+       - Fallback `main`, then `master` if present
+    5. Compute `repo_name` and `trees_repo_dir`, then ensure `"$trees_repo_dir"` exists.
+    6. Capture pre-create worktree list.
+    7. Capture pre-create branch list (local + remote refs).
+    8. Infer naming style from `~/trees/<repo_name>` and build provisional branch/worktree names from branch seed.
+    9. Enforce invocation-local branch creation gate by suffixing until branch name is globally unique against pre-snapshot refs.
+    10. Derive `new_worktree_name` from final `new_branch` by replacing `/` with `-`.
+    11. Ensure `new_branch` is never `main` or `master`.
+    12. If `"$HOME/trees/$repo_name/$new_worktree_name"` already exists, append a deterministic suffix (`-r2`, `-r3`, ...) until unique.
+    13. Create worktree and new branch from base:
+
+    ```bash
+    git worktree add -b new-branch "$HOME/trees/$repo_name/new-worktree-name" base-branch
+    ```
+
+    14. Capture post-create worktree list and verify invocation-local creation gate passed.
+    15. Set the new worktree path as the active working directory for all subsequent commands.
+    16. Run preflight checks, stage exact files, draft/confirm message when needed, and commit.
+    17. If `push_required`, push safely with upstream tracking.
+    18. If `pr_required`, create PR with `gh pr create --fill --base base-branch --head active-branch` unless user provides custom title/body.
+    19. Because `pr_required` implies `labels_required`, always set labels immediately after PR creation:
+       - Prefer user-provided labels.
+       - Otherwise inspect `gh label list` and apply best-matching existing labels.
+    20. Return new worktree path, active branch, commit SHA, and optional push/PR outputs.
+
+    ## Handle Failures
+
+    If any command fails:
+
+    1. Stop and report the exact failed command and stderr.
+    2. Explain whether commit/push/PR happened or not.
+    3. Provide the smallest safe recovery step and continue only after confirmation when state is ambiguous.
+  '';
+
+  skillDefs = {
+    commit = {
+      id = "commit";
+      title = "Git Commit Skill";
+      body = commitSkillBody;
+      targets = {
+        codex = true;
+        claude = true;
+      };
+
+      codex = {
+        frontmatter = {
+          name = "commit";
+          description = "Execute safe Git commit workflows when the user invokes $commit or asks to commit changes. Always create a new git worktree under ~/trees/repo-name and commit there, never directly on main/master. Use for $commit, $commit and push, and $commit in a new branch then push and create a pull request with gh and labels.";
+        };
+        intro = "Create a well-formatted git commit following all project safety rules and Conventional Commits format.";
+        sections = [ (commitSelectModeSection "$commit") ];
+        interface = {
+          display_name = "Commit Workflow";
+          short_description = "Safe commit, push, branch, and PR workflow";
+          default_prompt = "Use $commit to create a fresh ~/trees worktree and brand-new branch, commit off main/master, and when pushing always create a PR and apply labels.";
+        };
+      };
+
+      claude = {
+        frontmatter = {
+          name = "commit";
+          description = "Execute safe Git commit workflows when the user invokes /commit or asks to commit changes. Always create a new git worktree under ~/trees/repo-name and commit there, never directly on main/master. Use for /commit, /commit and push, and /commit in a new branch then push and create a pull request with gh and labels.";
+          "disable-model-invocation" = true;
+          "allowed-tools" =
+            "Bash(git status*), Bash(git diff*), Bash(git log*), Bash(git add *), Bash(git commit *), Bash(git worktree *), Bash(git for-each-ref *), Bash(git rev-parse *), Bash(git branch *), Bash(git push *), Bash(mkdir *), Bash(gh repo view *), Bash(gh pr *), Bash(gh label *), Read, Grep, Glob";
+          "argument-hint" = "[optional commit message]";
+        };
+        intro = "Create a well-formatted git commit following all project safety rules and Conventional Commits format.";
+        dynamicSections = [
+          (commitSelectModeSection "/commit")
+          ''
+            ## Current Git State
+
+            Working tree status:
+            !`git status --short`
+
+            Already staged changes:
+            !`git diff --staged --stat`
+
+            Recent commits (for style reference):
+            !`git log --oneline -5`
+          ''
+          ''
+            ### If `$ARGUMENTS` is provided
+
+            Use the provided text as the commit message directly. Still run through safety checks before committing.
+          ''
+        ];
+      };
+    };
+  };
+
+  renderCodexSkillMd =
+    skillDef:
+    if !(skillDef.targets.codex or false) then
+      throw "Skill '${skillDef.id}' does not target Codex"
+    else
+      let
+        frontmatter = renderFrontmatter skillDef.codex.frontmatter [
+          "name"
+          "description"
+        ];
+        body = renderSkillBody {
+          inherit (skillDef) title;
+          intro = skillDef.codex.intro or "";
+          sections = skillDef.codex.sections or [ ];
+          inherit (skillDef) body;
+        };
+      in
+      ''
+        ${frontmatter}
+
+        ${body}
+      '';
+
+  renderCodexOpenaiYaml =
+    skillDef:
+    if !(skillDef.targets.codex or false) then
+      throw "Skill '${skillDef.id}' does not target Codex"
+    else
+      let
+        interface = skillDef.codex.interface or { };
+        requiredFields = [
+          "display_name"
+          "short_description"
+          "default_prompt"
+        ];
+        missingFields = lib.filter (field: !(interface ? ${field})) requiredFields;
+      in
+      if missingFields != [ ] then
+        throw "Skill '${skillDef.id}' missing Codex interface fields: ${lib.concatStringsSep ", " missingFields}"
+      else
+        ''
+          interface:
+            display_name: ${builtins.toJSON interface.display_name}
+            short_description: ${builtins.toJSON interface.short_description}
+            default_prompt: ${builtins.toJSON interface.default_prompt}
+        '';
+
+  mkCodexSkillDir =
+    pkgs: skillDef:
+    if !(skillDef.targets.codex or false) then
+      throw "Skill '${skillDef.id}' does not target Codex"
+    else
+      let
+        skillMdFile = pkgs.writeText "codex-skill-${skillDef.id}-SKILL.md" (renderCodexSkillMd skillDef);
+        openaiYamlFile = pkgs.writeText "codex-skill-${skillDef.id}-openai.yaml" (
+          renderCodexOpenaiYaml skillDef
+        );
+      in
+      pkgs.runCommand "codex-skill-${skillDef.id}" { } ''
+        mkdir -p "$out/agents"
+        cp ${skillMdFile} "$out/SKILL.md"
+        cp ${openaiYamlFile} "$out/agents/openai.yaml"
+      '';
+
+  renderClaudeSkillMd =
+    skillDef:
+    if !(skillDef.targets.claude or false) then
+      throw "Skill '${skillDef.id}' does not target Claude Code"
+    else
+      let
+        frontmatter = renderFrontmatter skillDef.claude.frontmatter [
+          "name"
+          "description"
+          "disable-model-invocation"
+          "allowed-tools"
+          "argument-hint"
+        ];
+        body = renderSkillBody {
+          inherit (skillDef) title;
+          intro = skillDef.claude.intro or "";
+          sections = skillDef.claude.dynamicSections or [ ];
+          inherit (skillDef) body;
+        };
+      in
+      ''
+        ${frontmatter}
+
+        ${body}
+      '';
+in
+{
   flake.lib.skills = {
-    # ════════════════════════════════════════════════════════════════════════
-    # Shared commit rules — tool-agnostic markdown
-    # No frontmatter, no dynamic injection, no argument handling.
-    # Each consumer wraps these with its own tool-specific chrome.
-    # ════════════════════════════════════════════════════════════════════════
-    commitRules = ''
-      ## Safety Rules — Absolute Prohibitions
-
-      These rules are **non-negotiable** and override all other instructions.
-
-      ### Forbidden Commands — NEVER Execute
-
-      - `git stash drop` or `git stash clear` — never delete stashes
-      - `git reset --hard` — never without explicit user approval
-      - `git clean -fd` — never execute
-      - `git add -A` or `git add .` — never bulk-stage; stage specific files by name
-      - `git push --force` to main or master — warn user and refuse
-      - `--no-verify` or `--no-gpg-sign` flags — never skip hooks or signing
-      - `rm` or `rm -rf` on any files — use `rip` instead for recoverable deletion
-
-      ### After Pre-Commit Hook Failure
-
-      When a pre-commit hook fails, the commit did **NOT** happen. Therefore:
-      - **NEVER** use `--amend` after a hook failure — it would modify the PREVIOUS commit
-      - Instead: fix the issue, re-stage files, and create a **NEW** commit
-      - Only use `--amend` when the user explicitly requests amending
-
-      ## Pre-Commit Checklist
-
-      Before staging or committing, verify:
-
-      1. **No secrets or credentials** in staged files:
-         - `.env`, `.env.*` files
-         - `credentials.json`, API keys, tokens
-         - Private keys, certificates
-         - If detected, warn the user and refuse to commit
-
-      2. **No generated artefacts** unless their source module was updated:
-         - `.actrc`, `.gitignore`, `.sops.yaml`, `README.md`
-         - These are managed by the files module — edit source definitions instead
-
-      3. **Formatting and hooks** — remind the user if not yet run:
-         - `nix fmt` for formatting
-         - `nix develop -c pre-commit run --all-files --hook-stage manual` for hooks
-
-      ## Staging Rules
-
-      - Stage **only** files directly modified for this concern
-      - Prefer `git add <specific-file> ...` — list each file by name
-      - **One commit = one logical concern**
-        - Include all files needed for that concern, even across multiple directories
-        - Separate unrelated concerns into separate commits (feature vs docs, moduleA vs moduleB)
-
-      ## Commit Message Format
-
-      Use **Conventional Commits**: `type(scope): summary`
-
-      ### Types
-
-      | Type       | When to use                                    |
-      |------------|------------------------------------------------|
-      | `feat`     | New feature                                    |
-      | `fix`      | Bug fix                                        |
-      | `docs`     | Documentation only                             |
-      | `style`    | Formatting, whitespace (no logic change)       |
-      | `refactor` | Code restructuring (no feature or fix)         |
-      | `perf`     | Performance improvement                        |
-      | `test`     | Adding or updating tests                       |
-      | `chore`    | Build, tooling, dependency changes             |
-
-      ### Scope
-
-      - Use the primary module, directory, or domain affected
-      - Examples: `apps`, `home`, `flake`, `system76`, `sops`, `scripts`
-
-      ### Message Guidelines
-
-      - Summarize the "why" not the "what" — the diff shows what changed
-      - Keep the summary line concise (1-2 sentences)
-      - Note affected hosts/modules when relevant
-      - Record validation commands run during development
-
-      ### Multi-line Messages
-
-      Always use a HEREDOC to pass commit messages:
-
-      ```bash
-      git commit -m "$(cat <<'EOF'
-      type(scope): summary line
-
-      Optional body with additional context.
-      EOF
-      )"
-      ```
-    '';
-
-    # ════════════════════════════════════════════════════════════════════════
-    # Shared commit workflow — dual-mode commit path selection
-    # Consumers may prepend tool-specific argument handling or dynamic
-    # context sections before interpolating this block.
-    # ════════════════════════════════════════════════════════════════════════
-    commitWorkflow = ''
-      ## Workflow
-
-      ### Select Mode
-
-      Choose exactly one mode before staging or committing:
-
-      1. Read the current branch: `git rev-parse --abbrev-ref HEAD`
-      2. Parse intent flags from the user request:
-         - `push_required` when the user asks to push
-         - `pr_required` when the user asks to open a pull request
-         - `labels_required` when the user asks to apply labels
-      3. Normalize flags:
-         - If `push_required=true`, force `pr_required=true` and `labels_required=true`
-         - If `pr_required=true`, force `labels_required=true`
-      4. Select mode in this precedence order:
-         - If current branch is `main` or `master`: **`worktree_atomic`**
-         - Else if the user explicitly asks for a new branch/worktree: **`worktree_atomic`**
-         - Else if the user explicitly asks to continue current/same branch: **`continue_current_branch`**
-         - Else (non-main branch): **`continue_current_branch`**
-      5. Ask one short clarifying question only if intent remains ambiguous after these rules.
-
-      ### Shared Preflight (both modes)
-
-      Run these checks before staging or committing:
-
-      ```bash
-      git status --short
-      git diff --staged --stat
-      git diff --stat
-      git log --oneline -5
-      ```
-
-      If nothing is staged, inspect unstaged changes and propose exact file paths to stage.
-
-      ### `continue_current_branch` Mode
-
-      Use this mode to keep working on the active non-main branch.
-
-      1. Refuse execution if current branch is `main` or `master`
-      2. Stage only explicit file paths for one logical concern
-      3. Draft a Conventional Commit message
-      4. Present the draft for approval if no explicit message was provided
-      5. Commit on the current branch
-      6. If `push_required=true`, run `git push -u origin <current-branch>`
-      7. If `pr_required=true`, run `gh pr create --fill --head <current-branch>`
-      8. If `labels_required=true`, apply labels with `gh pr edit --add-label ...`
-
-      ### `worktree_atomic` Mode
-
-      Use this mode for protected branches or when the user asks for explicit branch/worktree isolation.
-
-      1. Snapshot worktrees and refs before changes:
-         - `git worktree list --porcelain`
-         - `git for-each-ref --format='%(refname:short)' refs/heads refs/remotes`
-      2. Resolve base branch in this order:
-         - User-specified base
-         - `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`
-         - Fallback: `main`, then `master`
-      3. Derive `repo_name` and create worktree under `~/trees/<repo_name>/`
-      4. Choose a unique non-main branch name (append `-r2`, `-r3`, ... when needed)
-      5. If the source checkout has local edits, create a transfer stash that includes staged, unstaged, and untracked files:
-         - `git status --porcelain` (if empty, skip transfer steps)
-         - `git stash push --include-untracked -m "worktree-atomic-transfer-<timestamp>"`
-         - `transfer_stash="$(git rev-parse --verify refs/stash)"`
-      6. Create a brand-new worktree and branch:
-         - `git worktree add -b <new-branch> "$HOME/trees/<repo_name>/<worktree-name>" <base-branch>`
-      7. Verify the new worktree did not exist in the pre-snapshot and now exists in post-snapshot
-      8. If a transfer stash was created, apply it inside the new worktree with index state preserved:
-         - `git -C "$HOME/trees/<repo_name>/<worktree-name>" stash apply --index "$transfer_stash"`
-      9. Run preflight checks and commit inside the new worktree
-      10. If `push_required=true`, push with upstream tracking
-      11. If `pr_required=true`, create PR; if `labels_required=true`, apply labels
-      12. Never run `git stash drop` or `git stash clear`; keep transfer stashes unless the user explicitly requests cleanup
-
-      ### Post-Commit
-
-      Run `git status --short` after committing and report:
-      - active branch and worktree path
-      - commit SHA
-      - push/PR/labels results when requested
-    '';
+    inherit
+      skillDefs
+      renderCodexSkillMd
+      mkCodexSkillDir
+      renderClaudeSkillMd
+      ;
   };
 }

--- a/modules/system76/zsh.nix
+++ b/modules/system76/zsh.nix
@@ -3,8 +3,8 @@
     programs.zsh = {
       enable = true;
       interactiveShellInit = ''
-                # Source Home Manager session variables (for home.sessionVariables, home.sessionPath)
-                source "$HOME/.nix-profile/etc/profile.d/hm-session-vars.sh"
+                # Source Home Manager session variables from per-user profile path.
+                source "/etc/profiles/per-user/vx/etc/profile.d/hm-session-vars.sh"
 
                 # Nix CLI config: enable flakes, pipe-operators, and GitHub authentication
                 # Keep aligned with build.sh and flake.nix nixConfig


### PR DESCRIPTION
Unify canonical skill definitions in modules/integrations/skills.nix and render
tool-specific SKILL.md outputs for Codex and Claude from shared data.

Migrate Codex user skill installation to ~/.agents/skills with activation logic,
update the Codex wrapper/config defaults, and align related Home Manager docs.
