### PR TITLE
fix(security): tighten owner privilege delegation and i7z access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,12 +193,12 @@ PR body should include:
 
 ### Development Environment
 
-| Trigger            | Command                                  | Preconditions                                   | Post-check                                                         |
-| ------------------ | ---------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------ |
-| Start work         | `nix develop`                            | Clean tree; network available for substituters. | Dev tools available (`treefmt`, `pre-commit`, etc.).               |
-| Format sources     | `nix fmt`                                | Run at repo root.                               | No remaining formatting diffs in `git status`.                     |
+| Trigger            | Command                                                         | Preconditions                                   | Post-check                                                         |
+| ------------------ | --------------------------------------------------------------- | ----------------------------------------------- | ------------------------------------------------------------------ |
+| Start work         | `nix develop`                                                   | Clean tree; network available for substituters. | Dev tools available (`treefmt`, `pre-commit`, etc.).               |
+| Format sources     | `nix fmt`                                                       | Run at repo root.                               | No remaining formatting diffs in `git status`.                     |
 | Run hooks          | `nix develop -c pre-commit run --all-files --hook-stage manual` | Dev shell ready; workspace writable.            | Exit code 0; review reported TODOs/failures.                       |
-| Generate artifacts | `nix develop -c write-files`             | Dev shell ready; managed files may update.      | Review diffs in `.actrc`, `.gitignore`, `.sops.yaml`, `README.md`. |
+| Generate artifacts | `nix develop -c write-files`                                    | Dev shell ready; managed files may update.      | Review diffs in `.actrc`, `.gitignore`, `.sops.yaml`, `README.md`. |
 
 ### Validation and Builds
 

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -1,0 +1,114 @@
+# Owner No-Sudo Operations (system76)
+
+This page documents configuration-managed privileged operations that the owner user (`vx`) can execute without being prompted for a sudo password.
+
+Scope:
+
+- Host: `system76`
+- Owner profile: `lib/meta-owner-profile.nix`
+- Owner module: `modules/meta/owner.nix`
+- i7z privilege path: `modules/apps/i7z.nix`
+- Power/systemd policy: `modules/security/polkit.nix`, `modules/system76/sudo.nix`
+
+This is intentionally focused on repo-managed policy. It does not attempt to document every upstream setuid/setcap program shipped by all packages.
+
+For host-level visibility of configured wrappers:
+
+```bash
+nix eval --json .#nixosConfigurations.system76.config.security.wrappers | jq 'keys'
+```
+
+## Direct Commands (No `sudo` Prefix Required)
+
+These work because policy is delegated through `polkit` and group membership.
+
+| Command examples                                                              | Why it works                                                                                                                           | Policy source                                                            |
+| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| `poweroff`, `reboot`                                                          | Wheel members are granted login1 power actions through polkit (`org.freedesktop.login1.power-off*`, `org.freedesktop.login1.reboot*`). | `modules/security/polkit.nix`, enabled in `modules/system76/imports.nix` |
+| `systemctl poweroff`, `systemctl reboot`                                      | Same login1 polkit action family as above.                                                                                             | `modules/security/polkit.nix`                                            |
+| `systemctl start <unit>`, `systemctl stop <unit>`, `systemctl restart <unit>` | Wheel members are granted `org.freedesktop.systemd1.manage-units`.                                                                     | `modules/security/polkit.nix`, enabled in `modules/system76/imports.nix` |
+| `nmcli ...` operations that require privileged NetworkManager actions         | `networkmanager` group is granted `org.freedesktop.NetworkManager.*` actions by polkit (from the evaluated host policy).               | Evaluated `security.polkit.extraConfig`                                  |
+| `mmcli ...` operations that require ModemManager actions                      | `networkmanager` group is granted `org.freedesktop.ModemManager*` actions by polkit (from the evaluated host policy).                  | Evaluated `security.polkit.extraConfig`                                  |
+| `i7z`                                                                         | Owner-only capability wrapper (`cap_sys_rawio`) + controlled `/dev/cpu/*/msr` access.                                                  | `modules/apps/i7z.nix`                                                   |
+
+## Wrapper Commands Exposed By Host Configuration
+
+At evaluation time on this host, `security.wrappers` includes:
+
+- `chsh`
+- `dbus-daemon-launch-helper`
+- `fusermount`
+- `fusermount3`
+- `i7z`
+- `locate`
+- `mount`
+- `newgidmap`
+- `newgrp`
+- `newuidmap`
+- `passwd`
+- `pkexec`
+- `plocate`
+- `sg`
+- `su`
+- `sudo`
+- `sudoedit`
+- `umount`
+- `unix_chkpwd`
+
+Most of these come from base system behavior or package defaults. The repo-specific hardening work in this change set is focused on `i7z` and power/systemd delegation.
+
+## `sudo` Commands With No Password Prompt
+
+These still use `sudo`, but are explicitly configured as `NOPASSWD` for wheel.
+
+| Command examples         | Why it works                                           | Policy source               |
+| ------------------------ | ------------------------------------------------------ | --------------------------- |
+| `sudo systemctl suspend` | Explicit `security.sudo-rs.extraRules` NOPASSWD entry. | `modules/system76/sudo.nix` |
+| `sudo reboot`            | Explicit `security.sudo-rs.extraRules` NOPASSWD entry. | `modules/system76/sudo.nix` |
+| `sudo poweroff`          | Explicit `security.sudo-rs.extraRules` NOPASSWD entry. | `modules/system76/sudo.nix` |
+
+## i7z Security Model And Implementation Logic
+
+### Problem being solved
+
+`i7z` reads Intel MSRs and checks write permission on `/dev/cpu/*/msr` before it starts. On this host, running plain `i7z` previously failed unless elevated.
+
+### Implemented design
+
+1. Keep `i7z` executable path restricted to the owner account via `security.wrappers.i7z`.
+2. Grant `cap_sys_rawio=ep` only to that wrapper binary.
+3. Enable `hardware.cpu.x86.msr` and set device ownership to `root` with mode `0660`.
+4. Use a dedicated `msr` group instead of broad `users` group.
+5. Add only the owner user to the `msr` group.
+6. Re-apply `/dev/cpu/*/msr` owner/group/mode in an activation script so stale device-node permissions are corrected on switch/boot.
+
+### Why this design
+
+- `udev` owner assignment to a normal user is not reliable for this device class; using `owner = "root"` avoids that failure mode.
+- `i7z` requires a write-permission check to pass, so mode `0660` is required for non-root usage.
+- The dedicated `msr` group reduces exposure compared with `users` group access.
+- Owner-only wrapper execution limits who can use the capability-bearing binary.
+
+### Residual risk and boundary
+
+- `cap_sys_rawio` is a high-privilege capability. If an attacker can execute as `vx`, they can run the wrapper.
+- Risk is reduced by scope controls (owner-only wrapper, dedicated `msr` group) but not eliminated.
+
+## How To Verify Current State
+
+```bash
+# Owner and groups
+whoami
+id -nG
+
+# i7z wrapper restriction and capability
+ls -l /run/wrappers/bin/i7z
+getcap /run/wrappers/bin/i7z
+
+# MSR device permissions
+stat -c '%n %U:%G %a' /dev/cpu/0/msr
+
+# Effective polkit and sudo policy from the evaluated host config
+nix eval --json .#nixosConfigurations.system76.config.security.polkit.extraConfig | jq -r
+nix eval --json .#nixosConfigurations.system76.config.security.sudo-rs.extraRules | jq
+```

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -1,114 +1,96 @@
-# Owner No-Sudo Operations (system76)
+# Owner No-Sudo Operations
 
-This page documents configuration-managed privileged operations that the owner user (`vx`) can execute without being prompted for a sudo password.
+This page documents configuration-managed privileged operations available to the system owner user.
 
 Scope:
 
-- Host: `system76`
-- Owner profile: `lib/meta-owner-profile.nix`
-- Owner module: `modules/meta/owner.nix`
-- i7z privilege path: `modules/apps/i7z.nix`
-- Power/systemd policy: `modules/security/polkit.nix`, `modules/system76/sudo.nix`
+- Owner identity source:
+  - `lib/meta-owner-profile.nix`
+  - `modules/meta/owner.nix`
+- i7z implementation:
+  - `modules/apps/i7z.nix`
+- polkit rules:
+  - `modules/security/polkit.nix`
+- sudo-rs rules:
+  - `security.sudo-rs.extraRules`
 
-This is intentionally focused on repo-managed policy. It does not attempt to document every upstream setuid/setcap program shipped by all packages.
+## Commands That Do Not Require `sudo` (polkit)
 
-For host-level visibility of configured wrappers:
+- Power commands:
+  - `poweroff`, `reboot`
+  - `systemctl poweroff`, `systemctl reboot`
+  - Granted by polkit login1 actions for wheel group:
+    - `org.freedesktop.login1.power-off*`
+    - `org.freedesktop.login1.reboot*`
+- NetworkManager and ModemManager commands:
+  - `nmcli ...` privileged actions
+  - `mmcli ...` privileged actions
+  - Granted to `networkmanager` group by evaluated `security.polkit.extraConfig`.
+- i7z:
+  - `i7z`
+  - Executed via owner-only `security.wrappers.i7z` with `cap_sys_rawio=ep` and controlled `/dev/cpu/*/msr` access.
 
-```bash
-nix eval --json .#nixosConfigurations.system76.config.security.wrappers | jq 'keys'
-```
+## Commands That Are Passwordless With `sudo-rs`
 
-## Direct Commands (No `sudo` Prefix Required)
+- `sudo systemctl suspend`, `sudo reboot`, `sudo poweroff`
+  - Granted by one `NOPASSWD` wheel rule in `security.sudo-rs.extraRules`.
 
-These work because policy is delegated through `polkit` and group membership.
+## Wrapper Commands
 
-| Command examples                                                              | Why it works                                                                                                                           | Policy source                                                            |
-| ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| `poweroff`, `reboot`                                                          | Wheel members are granted login1 power actions through polkit (`org.freedesktop.login1.power-off*`, `org.freedesktop.login1.reboot*`). | `modules/security/polkit.nix`, enabled in `modules/system76/imports.nix` |
-| `systemctl poweroff`, `systemctl reboot`                                      | Same login1 polkit action family as above.                                                                                             | `modules/security/polkit.nix`                                            |
-| `systemctl start <unit>`, `systemctl stop <unit>`, `systemctl restart <unit>` | Wheel members are granted `org.freedesktop.systemd1.manage-units`.                                                                     | `modules/security/polkit.nix`, enabled in `modules/system76/imports.nix` |
-| `nmcli ...` operations that require privileged NetworkManager actions         | `networkmanager` group is granted `org.freedesktop.NetworkManager.*` actions by polkit (from the evaluated host policy).               | Evaluated `security.polkit.extraConfig`                                  |
-| `mmcli ...` operations that require ModemManager actions                      | `networkmanager` group is granted `org.freedesktop.ModemManager*` actions by polkit (from the evaluated host policy).                  | Evaluated `security.polkit.extraConfig`                                  |
-| `i7z`                                                                         | Owner-only capability wrapper (`cap_sys_rawio`) + controlled `/dev/cpu/*/msr` access.                                                  | `modules/apps/i7z.nix`                                                   |
-
-## Wrapper Commands Exposed By Host Configuration
-
-At evaluation time on this host, `security.wrappers` includes:
-
-- `chsh`
-- `dbus-daemon-launch-helper`
-- `fusermount`
-- `fusermount3`
-- `i7z`
-- `locate`
-- `mount`
-- `newgidmap`
-- `newgrp`
-- `newuidmap`
-- `passwd`
-- `pkexec`
-- `plocate`
-- `sg`
-- `su`
-- `sudo`
-- `sudoedit`
-- `umount`
-- `unix_chkpwd`
-
-Most of these come from base system behavior or package defaults. The repo-specific hardening work in this change set is focused on `i7z` and power/systemd delegation.
-
-## `sudo` Commands With No Password Prompt
-
-These still use `sudo`, but are explicitly configured as `NOPASSWD` for wheel.
-
-| Command examples         | Why it works                                           | Policy source               |
-| ------------------------ | ------------------------------------------------------ | --------------------------- |
-| `sudo systemctl suspend` | Explicit `security.sudo-rs.extraRules` NOPASSWD entry. | `modules/system76/sudo.nix` |
-| `sudo reboot`            | Explicit `security.sudo-rs.extraRules` NOPASSWD entry. | `modules/system76/sudo.nix` |
-| `sudo poweroff`          | Explicit `security.sudo-rs.extraRules` NOPASSWD entry. | `modules/system76/sudo.nix` |
-
-## i7z Security Model And Implementation Logic
-
-### Problem being solved
-
-`i7z` reads Intel MSRs and checks write permission on `/dev/cpu/*/msr` before it starts. On this host, running plain `i7z` previously failed unless elevated.
-
-### Implemented design
-
-1. Keep `i7z` executable path restricted to the owner account via `security.wrappers.i7z`.
-2. Grant `cap_sys_rawio=ep` only to that wrapper binary.
-3. Enable `hardware.cpu.x86.msr` and set device ownership to `root` with mode `0660`.
-4. Use a dedicated `msr` group instead of broad `users` group.
-5. Add only the owner user to the `msr` group.
-6. Re-apply `/dev/cpu/*/msr` owner/group/mode in an activation script so stale device-node permissions are corrected on switch/boot.
-
-### Why this design
-
-- `udev` owner assignment to a normal user is not reliable for this device class; using `owner = "root"` avoids that failure mode.
-- `i7z` requires a write-permission check to pass, so mode `0660` is required for non-root usage.
-- The dedicated `msr` group reduces exposure compared with `users` group access.
-- Owner-only wrapper execution limits who can use the capability-bearing binary.
-
-### Residual risk and boundary
-
-- `cap_sys_rawio` is a high-privilege capability. If an attacker can execute as `vx`, they can run the wrapper.
-- Risk is reduced by scope controls (owner-only wrapper, dedicated `msr` group) but not eliminated.
-
-## How To Verify Current State
+Inspect current wrapper set:
 
 ```bash
-# Owner and groups
-whoami
-id -nG
-
-# i7z wrapper restriction and capability
-ls -l /run/wrappers/bin/i7z
-getcap /run/wrappers/bin/i7z
-
-# MSR device permissions
-stat -c '%n %U:%G %a' /dev/cpu/0/msr
-
-# Effective polkit and sudo policy from the evaluated host config
-nix eval --json .#nixosConfigurations.system76.config.security.polkit.extraConfig | jq -r
-nix eval --json .#nixosConfigurations.system76.config.security.sudo-rs.extraRules | jq
+➜ nix eval --json .#nixosConfigurations.$(hostname).config.security.wrappers | jq 'keys'
+[
+  "chsh",
+  "dbus-daemon-launch-helper",
+  "fusermount",
+  "fusermount3",
+  "i7z",
+  "locate",
+  "mount",
+  "newgidmap",
+  "newgrp",
+  "newuidmap",
+  "passwd",
+  "pkexec",
+  "plocate",
+  "sg",
+  "su",
+  "sudo",
+  "sudoedit",
+  "umount",
+  "unix_chkpwd"
+]
 ```
+
+NOTE: most are inherited from upstream
+
+## i7z Implementation Logic
+
+- Goal:
+  - Run `i7z` without `sudo` while narrowing privilege scope.
+- Design:
+  - `security.wrappers.i7z` restricts execution to the owner account and applies `cap_sys_rawio=ep`.
+  - `hardware.cpu.x86.msr` sets `/dev/cpu/*/msr` to `root:msr 0660`.
+  - Owner account is added to `msr` group.
+  - Activation script reapplies ownership and mode on switch/boot to correct stale device-node permissions.
+- Rationale:
+  - `i7z` checks write permission on MSR devices; `0660` is required for non-root operation.
+  - Dedicated `msr` group reduces exposure compared with broad groups.
+- Residual risk:
+  - `cap_sys_rawio` remains high privilege; compromise of the owner account can abuse it.
+
+## Verification
+
+- Identity and group membership:
+  - `whoami`
+  - `id -nG`
+- i7z wrapper and capability:
+  - `ls -l /run/wrappers/bin/i7z`
+  - `getcap /run/wrappers/bin/i7z`
+- MSR device permissions:
+  - `stat -c '%n %U:%G %a' /dev/cpu/0/msr`
+- Evaluated policy:
+  - `nix eval --json .#nixosConfigurations.$(hostname).config.security.polkit.extraConfig | jq -r`
+  - `nix eval --json .#nixosConfigurations.$(hostname).config.security.sudo-rs.extraRules | jq`

--- a/modules/apps/i7z.nix
+++ b/modules/apps/i7z.nix
@@ -78,8 +78,8 @@ let
         };
 
         security.wrappers.i7z = {
-          owner = owner;
-          group = config.hardware.cpu.x86.msr.group;
+          inherit owner;
+          inherit (config.hardware.cpu.x86.msr) group;
           permissions = "u+rx,g-rwx,o-rwx";
           source = lib.getExe cfg.package;
           capabilities = "cap_sys_rawio=ep";

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -66,7 +66,8 @@ in
 
     # Security & authentication
     security.polkit.wheelPowerManagement.enable = true;
-    security.polkit.wheelSystemdManagement.enable = true;
+    # Do not grant broad systemd unit management without explicit elevation.
+    security.polkit.wheelSystemdManagement.enable = false;
 
     # Gaming & performance
     programs = {


### PR DESCRIPTION
## Summary
- harden `i7z` access by using a dedicated `msr` group, owner-only wrapper execution, and activation-time MSR node permission repair
- disable wheel-wide systemd unit management by setting `security.polkit.wheelSystemdManagement.enable = false`
- add and refine `docs/security/owner-no-sudo-operations.md` to document owner no-sudo/passwordless operations and i7z implementation logic
- keep the style cleanup in `modules/apps/i7z.nix` (`inherit` use for wrapper attrs)

## Test plan
- `statix check modules/apps/i7z.nix`
- `statix check modules/system76/imports.nix`
- `nix develop -c treefmt docs/security/owner-no-sudo-operations.md`
- `nix flake check --accept-flake-config --no-build --offline`