### PR TITLE
refactor(scripts): simplify build.sh flow and align docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ This project uses a custom build script, [`build.sh`](build.sh), for validation 
 ```bash
 ./build.sh              # validate and deploy
 ./build.sh --boot       # install for next boot only
-./build.sh --update     # update flake inputs first
+./build.sh --update     # refresh metadata + update flake inputs
 ./build.sh --offline    # Offline build
 ```
 
-The script runs a validation pipeline (format, pre-commit hooks, flake check) before deployment. It refuses to run on a dirty worktree by default; use `--allow-dirty` to override.
+The script runs a validation pipeline (format, pre-commit hooks, flake check) before deployment.
+It refuses to run on a dirty worktree by default; use `--allow-dirty` to override.
+`--update` intentionally allows dirty worktrees and does not auto-commit `flake.lock`.
 
 **Development commands:**
 

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -40,11 +40,13 @@
           ```bash
           ./build.sh              # validate and deploy
           ./build.sh --boot       # install for next boot only
-          ./build.sh --update     # update flake inputs first
+          ./build.sh --update     # refresh metadata + update flake inputs
           ./build.sh --offline    # Offline build
           ```
 
-          The script runs a validation pipeline (format, pre-commit hooks, flake check) before deployment. It refuses to run on a dirty worktree by default; use `--allow-dirty` to override.
+          The script runs a validation pipeline (format, pre-commit hooks, flake check) before deployment.
+          It refuses to run on a dirty worktree by default; use `--allow-dirty` to override.
+          `--update` intentionally allows dirty worktrees and does not auto-commit `flake.lock`.
 
           **Development commands:**
 


### PR DESCRIPTION
## Summary
- refactor `build.sh` to use `NIX_CONFIG` only and a single shared `BUILD_FLAGS` flow
- remove flake.lock auto-commit behavior from `--update` and keep update path as metadata refresh + flake update only
- remove pre-sudo check orchestration in firmware flow and rely on direct command behavior
- replace fragile kernel/NVIDIA reboot parsing with booted-vs-current generation comparison
- update `modules/readme.nix` and generated `README.md` to document current `--update` and dirty-tree behavior

## Test plan
- `bash -n build.sh`
- `./build.sh --help`
- `nix develop -c write-files`
- `git show --name-only` (verify only `README.md`, `build.sh`, `modules/readme.nix` in commit)
