### PR TITLE
feat(system76): wire codex MCP and shell app modules

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -207,12 +207,16 @@ BOOTSTRAP_SUBSTITUTERS=(
   "https://cache.garnix.io"
   "https://cache.numtide.com"
   "https://nixpkgs-unfree.cachix.org"
+  "https://nix-logseq-git-flake.cachix.org"
+  "https://attic.xuyh0120.win/lantian"
 )
 BOOTSTRAP_TRUSTED_KEYS=(
   "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
   "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
   "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
   "nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs="
+  "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo="
+  "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc="
 )
 
 configure_build_flags() {

--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -2,11 +2,12 @@
 
 Model Context Protocol (MCP) tools that may be available when configured. Use `/mcp` to check current configuration status.
 
-| Tool                  | Primary Use                                             | Access Notes                                        | Example Invocation                                 |
-| --------------------- | ------------------------------------------------------- | --------------------------------------------------- | -------------------------------------------------- |
-| `context7`            | Look up library IDs and documentation for coding tasks. | Requires network; resolves ID before fetching docs. | `context7 resolve-library-id --name <library>`     |
-| `cfdocs`              | Search Cloudflare documentation.                        | Use for Workers, R2, and other CF services.         | `cfdocs search --query "Workers KV"`               |
-| `cfbrowser`           | Render and capture live webpages.                       | Useful for verifying UI changes.                    | `cfbrowser get-url-html --url <page>`              |
-| `deepwiki`            | Browse repository knowledge bases.                      | Supply `owner/repo` to fetch docs.                  | `deepwiki read_wiki_structure --repo owner/repo`   |
-| `time`                | Convert or fetch timestamps.                            | No prerequisites.                                   | `time convert --from UTC --to America/Los_Angeles` |
-| `sequential-thinking` | Record structured reasoning steps.                      | Use for complex tasks; keeps plan visible.          | `sequentialthinking start`                         |
+| Tool                  | Primary Use                                             | Access Notes                                        | Example Invocation                                                          |
+| --------------------- | ------------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------- |
+| `context7`            | Look up library IDs and documentation for coding tasks. | Requires network; resolves ID before fetching docs. | `context7 resolve-library-id --name <library>`                              |
+| `openaiDeveloperDocs` | Search OpenAI developer docs and API references.        | Configured for Codex only via remote MCP endpoint.  | `codex mcp add openaiDeveloperDocs --url https://developers.openai.com/mcp` |
+| `cfdocs`              | Search Cloudflare documentation.                        | Use for Workers, R2, and other CF services.         | `cfdocs search --query "Workers KV"`                                        |
+| `cfbrowser`           | Render and capture live webpages.                       | Useful for verifying UI changes.                    | `cfbrowser get-url-html --url <page>`                                       |
+| `deepwiki`            | Browse repository knowledge bases.                      | Supply `owner/repo` to fetch docs.                  | `deepwiki read_wiki_structure --repo owner/repo`                            |
+| `time`                | Convert or fetch timestamps.                            | No prerequisites.                                   | `time convert --from UTC --to America/Los_Angeles`                          |
+| `sequential-thinking` | Record structured reasoning steps.                      | Use for complex tasks; keeps plan visible.          | `sequentialthinking start`                                                  |

--- a/docs/system76/system76-troubleshooting.md
+++ b/docs/system76/system76-troubleshooting.md
@@ -249,6 +249,25 @@ glmark2
 stress-ng --cpu 12 --vm 4 --vm-bytes 2G --timeout 10m
 ```
 
+## Audio
+
+Use this recovery command anytime audio disappears:
+NOTE: Do not run wpctl set-route 63 3 blindly. Use this guarded switch instead:
+
+```bash
+HP_NUMID=$(amixer -c 2 controls | sed -n "s/^numid=\([0-9]\+\),iface=CARD,name='Headphone Jack'.*/\1/p")
+HP_STATE=$(amixer -c 2 cget numid="$HP_NUMID" | sed -n "s/^  : values=//p")
+if [ "$HP_STATE" = "on" ]; then
+    wpctl set-route 63 3
+    amixer -c 2 sset Speaker off
+    amixer -c 2 sset Headphone on
+else
+    wpctl set-route 63 2
+    amixer -c 2 sset Speaker on
+    amixer -c 2 sset Headphone on
+fi
+```
+
 ---
 
 ## Quick Reference

--- a/modules/apps/actionlint.nix
+++ b/modules/apps/actionlint.nix
@@ -1,0 +1,49 @@
+/*
+  Package: actionlint
+  Description: Static checker for GitHub Actions workflow files.
+  Homepage: https://rhysd.github.io/actionlint/
+  Documentation: https://github.com/rhysd/actionlint/blob/main/docs/usage.md
+  Repository: https://github.com/rhysd/actionlint
+
+  Summary:
+    * Lints GitHub Actions workflow syntax, expressions, and runner configuration.
+    * Integrates with shellcheck and pyflakes to validate embedded scripts.
+
+  Options:
+    -config-file: Read configuration from a specific file path.
+    -format: Render diagnostics with a custom Go template (for JSON or machine output).
+    -ignore: Ignore findings matching a regular expression (repeatable).
+    -oneline: Emit one diagnostic per line for editor and CI tooling.
+    -shellcheck: Override or disable shellcheck integration.
+*/
+_:
+let
+  ActionlintModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.actionlint.extended;
+    in
+    {
+      options.programs.actionlint.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable actionlint.";
+        };
+
+        package = lib.mkPackageOption pkgs "actionlint" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.actionlint = ActionlintModule;
+}

--- a/modules/apps/fonttools.nix
+++ b/modules/apps/fonttools.nix
@@ -1,0 +1,47 @@
+/*
+  Package: fonttools
+  Description: Library and tools to manipulate font files from Python.
+  Homepage: https://github.com/fonttools/fonttools
+  Documentation: https://fonttools.readthedocs.io/
+  Repository: https://github.com/fonttools/fonttools
+
+  Summary:
+    * Provides CLI and Python APIs for inspecting, subsetting, and converting OpenType/TrueType fonts.
+    * Includes utilities like `pyftsubset`, `ttx`, and `fonttools varLib` for font engineering workflows.
+
+  Options:
+    ttx <font-file>: Convert between binary font formats and editable XML.
+    pyftsubset <font-file> --text="...": Generate minimized subset fonts for specific glyph sets.
+    fonttools varLib <designspace-file>: Build variable fonts from a designspace file.
+*/
+_:
+let
+  FonttoolsModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.fonttools.extended;
+    in
+    {
+      options.programs.fonttools.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable fonttools.";
+        };
+
+        package = lib.mkPackageOption pkgs [ "python3Packages" "fonttools" ] { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.fonttools = FonttoolsModule;
+}

--- a/modules/apps/zsh-completions.nix
+++ b/modules/apps/zsh-completions.nix
@@ -38,7 +38,79 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
+        environment = {
+          systemPackages = [ cfg.package ];
+          etc."zsh/site-functions/_build_sh".text = ''
+            #compdef build.sh
+
+            _build_sh_hosts() {
+              local flake_dir=""
+              local i word host_output
+              local -a hosts
+
+              for (( i = 1; i <= CURRENT; i++ )); do
+                word="''${words[i]}"
+                case "''${word}" in
+                  (-p|--flake-dir)
+                    if (( i < CURRENT )); then
+                      flake_dir="''${words[i+1]}"
+                    fi
+                    ;;
+                  (--flake-dir=*)
+                    flake_dir="''${word#--flake-dir=}"
+                    ;;
+                esac
+              done
+
+              if [[ -z "''${flake_dir}" ]]; then
+                flake_dir="."
+              fi
+
+              host_output="$(
+                nix eval --raw "''${flake_dir}#nixosConfigurations" \
+                  --apply 'attrs: builtins.concatStringsSep "\n" (builtins.attrNames attrs)' \
+                  2>/dev/null || true
+              )"
+
+              if [[ -n "''${host_output}" ]]; then
+                while IFS= read -r host; do
+                  [[ -n "''${host}" ]] && hosts+=("''${host}")
+                done <<< "''${host_output}"
+              fi
+
+              if (( ''${#hosts[@]} == 0 )); then
+                if command -v hostname >/dev/null 2>&1; then
+                  hosts+=("$(hostname)")
+                fi
+              fi
+
+              if (( ''${#hosts[@]} > 0 )); then
+                _describe -t hosts "flake host" hosts
+              fi
+            }
+
+            _build_sh() {
+              _arguments -s -S \
+                '(-p --flake-dir)'{-p,--flake-dir}'[set configuration directory]:directory:_files -/' \
+                '(-t --host)'{-t,--host}'[specify target hostname]:hostname:_build_sh_hosts' \
+                '(-o --offline)'{-o,--offline}'[build in offline mode]' \
+                '(-v --verbose)'{-v,--verbose}'[enable verbose output]' \
+                '--boot[install as next-boot generation]' \
+                '--allow-dirty[allow running with a dirty git worktree]' \
+                '--update[run flake metadata refresh and update before building]' \
+                '--skip-hooks[skip pre-commit validation]' \
+                '--skip-check[skip nix flake check validation]' \
+                '--skip-all[skip all validation steps]' \
+                '--skip-firmware[skip firmware refresh/check/apply after switch]' \
+                '--keep-going[continue building despite failures]' \
+                '--repair[repair corrupted store paths during build]' \
+                '--bootstrap[use extra substituters for first build]' \
+                '(-h --help)'{-h,--help}'[show help message]'
+            }
+
+            _build_sh "$@"
+          '';
+        };
       };
     };
 in

--- a/modules/base/shell-config.nix
+++ b/modules/base/shell-config.nix
@@ -24,6 +24,7 @@
 
       programs = {
         zsh.enable = true;
+        zsh.enableCompletion = true;
         # nix-index-database module disables command-not-found and provides
         # nix-index with pre-built database; shell integration replaces command-not-found
         nix-index = {

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -51,6 +51,7 @@ _: {
         "sequential-thinking"
         "memory"
         "context7"
+        "openaiDeveloperDocs"
         "cfdocs"
         "cfbrowser"
         "deepwiki"

--- a/modules/integrations/mcp-servers.nix
+++ b/modules/integrations/mcp-servers.nix
@@ -131,6 +131,11 @@ let
       url = "https://graphql.mcp.cloudflare.com/sse";
     };
 
+    openaiDeveloperDocs = {
+      source = "sse";
+      url = "https://developers.openai.com/mcp";
+    };
+
     # ──────────────────────────────────────────────────────────────────────────
     # NPX packages (fetched at runtime)
     # ──────────────────────────────────────────────────────────────────────────

--- a/modules/shell/shell-config.nix
+++ b/modules/shell/shell-config.nix
@@ -1,11 +1,3 @@
 {
-  flake.nixosModules.base =
-    { pkgs, ... }:
-    {
-      # Set dash as the default /bin/sh for better performance and POSIX compliance
-      environment.binsh = "${pkgs.dash}/bin/dash";
-
-      # Include dash in system packages
-      environment.systemPackages = [ pkgs.dash ];
-    };
+  flake.nixosModules.shell = _: { };
 }

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -18,6 +18,7 @@
   configurations.nixos.system76.module = {
     programs = {
       act.extended.enable = lib.mkOverride 1100 true;
+      actionlint.extended.enable = lib.mkOverride 1100 true;
       "aircrack-ng".extended.enable = lib.mkOverride 1100 false;
       "android-studio".extended.enable = lib.mkOverride 1100 false;
       "antigravity-fhs".extended.enable = lib.mkOverride 1100 true;
@@ -94,6 +95,7 @@
       firefox.extended.enable = lib.mkOverride 1100 true;
       floorp.extended.enable = lib.mkOverride 1100 true;
       flarectl.extended.enable = lib.mkOverride 1100 true;
+      fonttools.extended.enable = lib.mkOverride 1100 true;
       forgit.extended.enable = lib.mkOverride 1100 true;
       formatting.extended.enable = lib.mkOverride 1100 true;
       "frida-tools".extended.enable = lib.mkOverride 1100 true;
@@ -274,7 +276,7 @@
       tar.extended.enable = lib.mkOverride 1100 true;
       tealdeer.extended.enable = lib.mkOverride 1100 true;
       "telegram-desktop".extended.enable = lib.mkOverride 1100 true;
-      "teams-for-linux".extended.enable = lib.mkOverride 1100 false;
+      "teams-for-linux".extended.enable = lib.mkOverride 1100 true;
       "temurin-bin-25".extended.enable = lib.mkOverride 1100 false;
       terraform.extended.enable = lib.mkOverride 1100 false;
       tesseract.extended.enable = lib.mkOverride 1100 true;

--- a/modules/system76/cachyos-kernel.nix
+++ b/modules/system76/cachyos-kernel.nix
@@ -4,10 +4,18 @@
 
   Source: https://github.com/xddxdd/nix-cachyos-kernel
 */
-{ inputs, ... }:
+{ inputs, lib, ... }:
+let
+  cachyosSubstituter = "https://attic.xuyh0120.win/lantian";
+  cachyosPublicKey = "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc=";
+in
 {
   configurations.nixos.system76.module = {
     # Add CachyOS kernel overlay with pinned package definitions.
     nixpkgs.overlays = [ inputs.nix-cachyos-kernel.overlays.pinned ];
+
+    # Enable CachyOS kernel binary cache only for hosts using this module.
+    nix.settings.extra-substituters = lib.mkAfter [ cachyosSubstituter ];
+    nix.settings.extra-trusted-public-keys = lib.mkAfter [ cachyosPublicKey ];
   };
 }

--- a/modules/system76/hardware-config.nix
+++ b/modules/system76/hardware-config.nix
@@ -161,9 +161,5 @@ _: {
         };
       };
 
-      hardware.system76.darp6 = {
-        soundVendorId = lib.mkDefault "0x10de0083";
-        soundSubsystemId = lib.mkDefault "0x155895e2";
-      };
     };
 }

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -42,7 +42,6 @@ in
 
       # External hardware modules
       inputs.nixos-hardware.nixosModules.system76
-      inputs.nixos-hardware.nixosModules.system76-darp6
     ]
     # Optional modules (graceful degradation)
     ++ lib.optionals system76SupportExists [ config.flake.nixosModules.system76-support ]

--- a/modules/system76/zsh.nix
+++ b/modules/system76/zsh.nix
@@ -39,6 +39,14 @@
         # Mirror bash behavior: expose hostname through HOSTNAME in zsh.
         export HOSTNAME="$HOST"
 
+        # Register custom build.sh completions from zsh site-functions.
+        if (( $+functions[compdef] )); then
+          autoload -Uz _build_sh
+          compdef _build_sh build.sh
+          compdef _build_sh ./build.sh
+          compdef _build_sh "$HOME/nixos/build.sh"
+        fi
+
         setopt NO_INTERACTIVE_COMMENTS
         alias nr='nix run nixpkgs#'
         alias ns='nix shell nixpkgs#'


### PR DESCRIPTION
## Summary
- add `modules/apps/actionlint.nix` and `modules/apps/fonttools.nix` and enable them through the System76 app bundle
- wire Codex/MCP and shell-related module updates across System76, Home Manager, and shared shell config modules
- update related docs and build-script behavior for the new MCP/shell wiring

## Test plan
- `nix flake check --accept-flake-config --no-build --offline`
- `git commit` (pre-commit hooks): `deadnix`, `nix-parse`, `statix`, `treefmt`, `typos`
- `git push` (pre-push hooks): `apps-catalog-sync`, `gitleaks`, `managed-files-drift`, `vulnix`
