### PR TITLE
chore(system76): checkpoint pending updates excluding lock files

### DIFF
--- a/docs/reference/mcp-tools.md
+++ b/docs/reference/mcp-tools.md
@@ -2,12 +2,14 @@
 
 Model Context Protocol (MCP) tools that may be available when configured. Use `/mcp` to check current configuration status.
 
-| Tool                  | Primary Use                                             | Access Notes                                        | Example Invocation                                                          |
-| --------------------- | ------------------------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------- |
-| `context7`            | Look up library IDs and documentation for coding tasks. | Requires network; resolves ID before fetching docs. | `context7 resolve-library-id --name <library>`                              |
-| `openaiDeveloperDocs` | Search OpenAI developer docs and API references.        | Configured for Codex only via remote MCP endpoint.  | `codex mcp add openaiDeveloperDocs --url https://developers.openai.com/mcp` |
-| `cfdocs`              | Search Cloudflare documentation.                        | Use for Workers, R2, and other CF services.         | `cfdocs search --query "Workers KV"`                                        |
-| `cfbrowser`           | Render and capture live webpages.                       | Useful for verifying UI changes.                    | `cfbrowser get-url-html --url <page>`                                       |
-| `deepwiki`            | Browse repository knowledge bases.                      | Supply `owner/repo` to fetch docs.                  | `deepwiki read_wiki_structure --repo owner/repo`                            |
-| `time`                | Convert or fetch timestamps.                            | No prerequisites.                                   | `time convert --from UTC --to America/Los_Angeles`                          |
-| `sequential-thinking` | Record structured reasoning steps.                      | Use for complex tasks; keeps plan visible.          | `sequentialthinking start`                                                  |
+| Tool                  | Primary Use                                             | Access Notes                                                             | Example Invocation                                                          |
+| --------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------ | --------------------------------------------------------------------------- |
+| `context7`            | Look up library IDs and documentation for coding tasks. | Requires network; resolves ID before fetching docs.                      | `context7 resolve-library-id --name <library>`                              |
+| `openaiDeveloperDocs` | Search OpenAI developer docs and API references.        | Configured for Codex only via remote MCP endpoint.                       | `codex mcp add openaiDeveloperDocs --url https://developers.openai.com/mcp` |
+| `cfdocs`              | Search Cloudflare documentation.                        | Use for Workers, R2, and other CF services.                              | `cfdocs search --query "Workers KV"`                                        |
+| `cfbrowser`           | Render and capture live webpages.                       | Useful for verifying UI changes.                                         | `cfbrowser get-url-html --url <page>`                                       |
+| `chrome-devtools`     | Control and inspect a live Chrome browser session.      | Google-maintained server; isolated profile + no usage stats recommended. | `npx -y chrome-devtools-mcp@latest --isolated --no-usage-statistics`        |
+| `deepwiki`            | Browse repository knowledge bases.                      | Supply `owner/repo` to fetch docs.                                       | `deepwiki read_wiki_structure --repo owner/repo`                            |
+| `playwright`          | Automate browser interactions for UI and E2E checks.    | Runs locally via NPX package with isolated profile.                      | `npx -y @playwright/mcp@latest --isolated`                                  |
+| `time`                | Convert or fetch timestamps.                            | No prerequisites.                                                        | `time convert --from UTC --to America/Los_Angeles`                          |
+| `sequential-thinking` | Record structured reasoning steps.                      | Use for complex tasks; keeps plan visible.                               | `sequentialthinking start`                                                  |

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -30,7 +30,9 @@ _: {
         "context7"
         "cfdocs"
         "cfbrowser"
+        "chrome-devtools"
         "deepwiki"
+        "playwright"
       ];
 
       # Claude Code settings.json configuration

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -54,7 +54,9 @@ _: {
         "openaiDeveloperDocs"
         "cfdocs"
         "cfbrowser"
+        "chrome-devtools"
         "deepwiki"
+        "playwright"
       ];
 
       # Base settings (everything except projects — those are merged at runtime)

--- a/modules/integrations/mcp-servers.nix
+++ b/modules/integrations/mcp-servers.nix
@@ -37,7 +37,10 @@ let
   optionalFields = {
     nix = [ "secretEnvVar" ];
     sse = [ "timeout" ];
-    npx = [ "timeout" ];
+    npx = [
+      "timeout"
+      "args"
+    ];
   };
 
   # Validate a single catalog entry
@@ -143,6 +146,25 @@ let
       source = "npx";
       package = "mcp-deepwiki@latest";
     };
+
+    chrome-devtools = {
+      source = "npx";
+      package = "chrome-devtools-mcp@latest";
+      # Privacy + safety defaults from upstream docs.
+      args = [
+        "--isolated"
+        "--no-usage-statistics"
+      ];
+      timeout = 120;
+    };
+
+    playwright = {
+      source = "npx";
+      package = "@playwright/mcp@latest";
+      # Security-first default: use in-memory profile (no persisted browser state).
+      args = [ "--isolated" ];
+      timeout = 120;
+    };
   };
 
   # Timeout in seconds (used by Codex via startup_timeout_sec)
@@ -225,7 +247,8 @@ let
           args = [
             "-y"
             meta.package
-          ];
+          ]
+          ++ (meta.args or [ ]);
         }
         // timeouts;
       };

--- a/modules/system76/custom-packages-overlay.nix
+++ b/modules/system76/custom-packages-overlay.nix
@@ -4,6 +4,7 @@ _: {
       (final: _prev: {
         # Add custom packages to nixpkgs
         raindrop = final.callPackage ../../packages/raindrop { };
+        electron-mail = final.callPackage ../../packages/electron-mail { };
         wappalyzer-next = final.callPackage ../../packages/wappalyzer-next { };
         age-plugin-fido2prf = final.callPackage ../../packages/age-plugin-fido2prf { };
         charles = final.callPackage ../../packages/charles { };

--- a/packages/electron-mail/default.nix
+++ b/packages/electron-mail/default.nix
@@ -1,0 +1,101 @@
+{
+  appimageTools,
+  lib,
+  fetchurl,
+  nix-update-script,
+  stdenvNoCC,
+  makeWrapper,
+  undmg,
+}:
+
+let
+  pname = "electron-mail";
+  version = "5.3.6";
+
+  sources = {
+    x86_64-linux = fetchurl {
+      url = "https://github.com/vladimiry/ElectronMail/releases/download/v${version}/electron-mail-${version}-linux-x86_64.AppImage";
+      hash = "sha256-3BWrVMlSUMMmuj6EAmqVtlHGCcminuVHkyPnc3TvgpM=";
+    };
+    aarch64-darwin = fetchurl {
+      url = "https://github.com/vladimiry/ElectronMail/releases/download/v${version}/electron-mail-${version}-mac-arm64.dmg";
+      hash = "sha256-z7j5WrU1F+iX8UDLWS5sXLwHjobPKJZFKXTcHTOQ/Eo=";
+    };
+    x86_64-darwin = fetchurl {
+      url = "https://github.com/vladimiry/ElectronMail/releases/download/v${version}/electron-mail-${version}-mac-x64.dmg";
+      hash = "sha256-7i0p7mBkzViXGdUrHXTrDDGdIy81p2YIei5Qsk8G5GU=";
+    };
+  };
+
+  src = sources.${stdenvNoCC.hostPlatform.system};
+
+  appimageContents = appimageTools.extract {
+    inherit src pname version;
+  };
+
+  meta = {
+    description = "Unofficial Election-based ProtonMail desktop client";
+    mainProgram = "electron-mail";
+    homepage = "https://github.com/vladimiry/ElectronMail";
+    license = lib.licenses.gpl3;
+    maintainers = with lib.maintainers; [
+      princemachiavelli
+      BatteredBunny
+    ];
+    platforms = [
+      "x86_64-linux"
+      "aarch64-darwin"
+      "x86_64-darwin"
+    ];
+    changelog = "https://github.com/vladimiry/ElectronMail/releases/tag/v${version}";
+  };
+
+  linux = appimageTools.wrapType2 {
+    inherit
+      src
+      pname
+      version
+      meta
+      ;
+
+    extraInstallCommands = ''
+      install -m 444 -D ${appimageContents}/${pname}.desktop -t $out/share/applications
+      substituteInPlace $out/share/applications/${pname}.desktop \
+        --replace-fail 'Exec=AppRun' 'Exec=${pname}'
+      cp -r ${appimageContents}/usr/share/icons $out/share
+    '';
+
+    extraPkgs = pkgs: [
+      pkgs.libsecret
+      pkgs.libappindicator-gtk3
+    ];
+
+    passthru.updateScript = nix-update-script { };
+  };
+
+  darwin = stdenvNoCC.mkDerivation {
+    inherit
+      src
+      pname
+      version
+      meta
+      ;
+
+    sourceRoot = ".";
+    nativeBuildInputs = [
+      undmg
+      makeWrapper
+    ];
+
+    installPhase = ''
+      runHook preInstall
+
+      mkdir -p $out/Applications
+      cp -r *.app $out/Applications/
+      makeWrapper "$out/Applications/electron-mail.app/Contents/MacOS/electron-mail" $out/bin/${pname}
+
+      runHook postInstall
+    '';
+  };
+in
+if stdenvNoCC.hostPlatform.isDarwin then darwin else linux

--- a/packages/electron-mail/default.nix
+++ b/packages/electron-mail/default.nix
@@ -34,7 +34,7 @@ let
   };
 
   meta = {
-    description = "Unofficial Election-based ProtonMail desktop client";
+    description = "Unofficial Electron-based ProtonMail desktop client";
     mainProgram = "electron-mail";
     homepage = "https://github.com/vladimiry/ElectronMail";
     license = lib.licenses.gpl3;


### PR DESCRIPTION
## Summary
- update the local `electron-mail` package to `v5.3.6` via `packages/electron-mail/default.nix` and wire it in `modules/system76/custom-packages-overlay.nix`
- fix the package meta description typo (`Election-based` -> `Electron-based`)
- carry forward current MCP/Codex/Claude Home Manager and integration updates in this branch
- update MCP tooling reference docs
- intentionally exclude lock-file changes from this PR; lock-file reconciliation will follow separately

## Test plan
- `nix eval --accept-flake-config --raw .#nixosConfigurations.system76.pkgs.electron-mail.version` (expect `5.3.6`)
- `nix build --accept-flake-config .#nixosConfigurations.system76.pkgs.electron-mail`
- pre-commit hooks pass during commit (including `treefmt`, `statix`, `deadnix`, `nix-parse`, `gitleaks`, `vulnix`)
