### PR TITLE
fix(codex): replace deprecated collab feature flag

### DIFF
--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -114,7 +114,7 @@ _: {
           apply_patch_freeform = true;
           apps = true;
           child_agents_md = true;
-          collab = true;
+          multi_agent = true;
           memory_tool = true;
           shell_snapshot = true;
           skill_env_var_dependency_prompt = true;


### PR DESCRIPTION
## Summary
- replace deprecated `features.collab` with `features.multi_agent` in `modules/hm-apps/codex.nix`
- keep feature enabled explicitly to match current Codex guidance and remove runtime deprecation warnings

## Test plan
- `nix-instantiate --parse modules/hm-apps/codex.nix >/dev/null`
- commit hooks passed (`treefmt`, `nix-parse`, `deadnix`, `statix`, `gitleaks`, `vulnix`)
