### PR TITLE
feat(networking): add tailscale extended enable wiring

### DIFF
--- a/modules/apps/tailscale.nix
+++ b/modules/apps/tailscale.nix
@@ -8,11 +8,17 @@
   Summary:
     * Installs the Tailscale client and daemon used to join tailnets and route traffic over WireGuard.
     * Enables the NixOS tailscaled service so networking state is managed declaratively.
+    * Exposes common service and SSH host settings through `programs.tailscale.extended`.
 
   Options:
     tailscale up: Bring the node online and apply advertised routes or exit-node settings.
     tailscale status: Show peer connectivity, tunnel health, and route state.
     tailscale ssh <target>: Open an SSH session over the tailnet identity plane.
+    authKeyFile: Optional file path containing a reusable auth key for non-interactive node registration.
+    extraSetFlags: Additional arguments passed to `tailscale set` after daemon startup.
+    interfaceName: Override the network interface name used by tailscaled (default `tailscale0`).
+    sshHostAlias: Host alias written to `~/.ssh/hosts/<alias>` when tailscale is enabled.
+    sshHostName: HostName used in the generated SSH match block (IP or MagicDNS name).
 */
 _:
 let
@@ -35,15 +41,50 @@ let
         };
 
         package = lib.mkPackageOption pkgs "tailscale" { };
+
+        authKeyFile = lib.mkOption {
+          type = lib.types.nullOr lib.types.path;
+          default = null;
+          description = "Optional path to a Tailscale auth key file used by tailscaled.";
+        };
+
+        extraSetFlags = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = "Additional flags passed to `tailscale set` by the NixOS module.";
+        };
+
+        interfaceName = lib.mkOption {
+          type = lib.types.str;
+          default = "tailscale0";
+          description = "Network interface name used for the tailscale tunnel.";
+        };
+
+        sshHostAlias = lib.mkOption {
+          type = lib.types.str;
+          default = "tailscale";
+          description = "SSH host alias generated under `~/.ssh/hosts/` for tailscale access.";
+        };
+
+        sshHostName = lib.mkOption {
+          type = lib.types.str;
+          default = "100.64.1.5";
+          description = "SSH HostName for the tailscale host entry (IP or MagicDNS name).";
+        };
       };
 
       config = lib.mkIf cfg.enable {
         environment.systemPackages = [ cfg.package ];
 
-        services.tailscale = {
-          enable = true;
-          inherit (cfg) package;
-        };
+        services.tailscale = lib.mkMerge [
+          {
+            enable = true;
+            inherit (cfg) package interfaceName extraSetFlags;
+          }
+          (lib.mkIf (cfg.authKeyFile != null) {
+            inherit (cfg) authKeyFile;
+          })
+        ];
       };
     };
 in

--- a/modules/apps/tailscale.nix
+++ b/modules/apps/tailscale.nix
@@ -1,0 +1,52 @@
+/*
+  Package: tailscale
+  Description: Node agent for Tailscale, a mesh VPN built on WireGuard.
+  Homepage: https://tailscale.com
+  Documentation: https://tailscale.com/kb/
+  Repository: https://github.com/tailscale/tailscale
+
+  Summary:
+    * Installs the Tailscale client and daemon used to join tailnets and route traffic over WireGuard.
+    * Enables the NixOS tailscaled service so networking state is managed declaratively.
+
+  Options:
+    tailscale up: Bring the node online and apply advertised routes or exit-node settings.
+    tailscale status: Show peer connectivity, tunnel health, and route state.
+    tailscale ssh <target>: Open an SSH session over the tailnet identity plane.
+*/
+_:
+let
+  TailscaleModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.tailscale.extended;
+    in
+    {
+      options.programs.tailscale.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable tailscale.";
+        };
+
+        package = lib.mkPackageOption pkgs "tailscale" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+
+        services.tailscale = {
+          enable = true;
+          inherit (cfg) package;
+        };
+      };
+    };
+in
+{
+  flake.nixosModules.apps.tailscale = TailscaleModule;
+}

--- a/modules/networking/ssh-hosts.nix
+++ b/modules/networking/ssh-hosts.nix
@@ -9,17 +9,29 @@ _: {
     }:
     let
       tailscaleEnabled = lib.attrByPath [ "programs" "tailscale" "extended" "enable" ] false osConfig;
+      tailscaleHostAlias = lib.attrByPath [
+        "programs"
+        "tailscale"
+        "extended"
+        "sshHostAlias"
+      ] "tailscale" osConfig;
+      tailscaleHostName = lib.attrByPath [
+        "programs"
+        "tailscale"
+        "extended"
+        "sshHostName"
+      ] "100.64.1.5" osConfig;
     in
     {
       home.file = lib.mkMerge [
         (lib.mkIf tailscaleEnabled {
-          ".ssh/hosts/tailscale".text = ''
-            Host tailscale
+          ".ssh/hosts/${tailscaleHostAlias}".text = ''
+            Host ${tailscaleHostAlias}
               Port 22
               ForwardAgent yes
               ForwardX11 yes
               User ${metaOwner.username}
-              HostName 100.64.1.5
+              HostName ${tailscaleHostName}
           '';
         })
         {

--- a/modules/networking/ssh-hosts.nix
+++ b/modules/networking/ssh-hosts.nix
@@ -1,34 +1,45 @@
 _: {
   # Provide per-host SSH config via include files under ~/.ssh/hosts/*
   flake.homeManagerModules.base =
-    { metaOwner, ... }:
     {
-      home.file = {
-        ".ssh/hosts/tailscale".text = ''
-          Host tailscale
-            Port 22
-            ForwardAgent yes
-            ForwardX11 yes
-            User ${metaOwner.username}
-            HostName 100.64.1.5
-        '';
+      lib,
+      metaOwner,
+      osConfig,
+      ...
+    }:
+    let
+      tailscaleEnabled = lib.attrByPath [ "programs" "tailscale" "extended" "enable" ] false osConfig;
+    in
+    {
+      home.file = lib.mkMerge [
+        (lib.mkIf tailscaleEnabled {
+          ".ssh/hosts/tailscale".text = ''
+            Host tailscale
+              Port 22
+              ForwardAgent yes
+              ForwardX11 yes
+              User ${metaOwner.username}
+              HostName 100.64.1.5
+          '';
+        })
+        {
+          ".ssh/hosts/github.com".text = ''
+            Host github.com
+              Hostname ssh.github.com
+              Port 443
+              User git
+              IdentitiesOnly yes
+              # Reuse SSH connection for GitHub only
+              ControlMaster auto
+              ControlPersist 15m
+              ControlPath ~/.ssh/ctl-%C
+          '';
 
-        ".ssh/hosts/github.com".text = ''
-          Host github.com
-            Hostname ssh.github.com
-            Port 443
-            User git
-            IdentitiesOnly yes
-            # Reuse SSH connection for GitHub only
-            ControlMaster auto
-            ControlPersist 15m
-            ControlPath ~/.ssh/ctl-%C
-        '';
-
-        ".ssh/hosts/system76.local".text = ''
-          Host system76.local
-            IdentityFile ~/.ssh/id_ed25519
-        '';
-      };
+          ".ssh/hosts/system76.local".text = ''
+            Host system76.local
+              IdentityFile ~/.ssh/id_ed25519
+          '';
+        }
+      ];
     };
 }

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -275,6 +275,7 @@
       strace.extended.enable = lib.mkOverride 1100 true;
       sysstat.extended.enable = lib.mkOverride 1100 true;
       tar.extended.enable = lib.mkOverride 1100 true;
+      tailscale.extended.enable = lib.mkOverride 1100 true;
       tealdeer.extended.enable = lib.mkOverride 1100 true;
       "telegram-desktop".extended.enable = lib.mkOverride 1100 true;
       "teams-for-linux".extended.enable = lib.mkOverride 1100 true;


### PR DESCRIPTION
## Summary
- add `modules/apps/tailscale.nix` with `programs.tailscale.extended` options and wiring to `services.tailscale`
- enable `tailscale.extended.enable` in `modules/system76/apps-enable.nix` so System76 can toggle tailscale from one switch
- gate `~/.ssh/hosts/tailscale` generation in `modules/networking/ssh-hosts.nix` on `osConfig.programs.tailscale.extended.enable`

## Test plan
- `nix-instantiate --parse modules/apps/tailscale.nix`
- `nix-instantiate --parse modules/networking/ssh-hosts.nix`
- `nix-instantiate --parse modules/system76/apps-enable.nix`
- `nix eval --json .#nixosConfigurations.system76.options.programs.tailscale.extended.enable.type.name`
- `nix eval --json .#nixosConfigurations.system76.config.services.tailscale.enable`
- `nix eval --raw .#nixosConfigurations.system76.config.services.tailscale.package.pname`
- `nix eval --raw '.#nixosConfigurations.system76.config.home-manager.users.vx.home.file.".ssh/hosts/tailscale".text'`
- `nix flake check --accept-flake-config --no-build --offline`
