### PR TITLE
refactor(i3wm): split startup module and disable sticky keys

### DIFF
--- a/modules/apps/i3wm/config.nix
+++ b/modules/apps/i3wm/config.nix
@@ -376,26 +376,6 @@
               inherit (i3Commands) terminal;
               menu = i3Commands.launcher;
 
-              startup = lib.mkAfter [
-                {
-                  command = "${lib.getExe' pkgs.hsetroot "hsetroot"} -solid '${stylixColorsStrictWithHash.base00}'";
-                  always = true;
-                  notification = false;
-                }
-                # DPMS: Keep screens on for 1 hour (3600s) before standby/suspend/off
-                {
-                  command = "${pkgs.xset}/bin/xset dpms 3600 3600 3600";
-                  always = true;
-                  notification = false;
-                }
-                # Screen saver: Blank after 1 hour (3600s)
-                {
-                  command = "${pkgs.xset}/bin/xset s 3600 3600";
-                  always = true;
-                  notification = false;
-                }
-              ];
-
               floating = {
                 modifier = "Mod1";
                 border = 5;

--- a/modules/apps/i3wm/startup.nix
+++ b/modules/apps/i3wm/startup.nix
@@ -1,0 +1,54 @@
+# i3 startup commands configuration
+# Defines session startup commands and accessibility hardening
+{
+  flake.homeManagerModules.apps.i3-config =
+    {
+      config,
+      pkgs,
+      lib,
+      ...
+    }:
+    let
+      stylixColors = config.lib.stylix.colors.withHashtag or config.lib.stylix.colors;
+      xfconfQuery = lib.getExe' pkgs.xfconf "xfconf-query";
+    in
+    {
+      config.xsession.windowManager.i3.config.startup = lib.mkAfter [
+        {
+          command = ''
+            set_bool() {
+              ${xfconfQuery} -c "$1" -p "$2" -s false \
+                || ${xfconfQuery} -c "$1" -p "$2" -n -t bool -s false
+            }
+
+            set_bool accessibility /StickyKeys
+            set_bool accessibility /StickyKeys/LatchToLock
+            set_bool accessibility /StickyKeys/TwoKeysDisable
+            set_bool accessibility /SlowKeys
+            set_bool accessibility /BounceKeys
+            set_bool accessibility /MouseKeys
+            set_bool xfce4-session /general/StartAssistiveTechnologies
+          '';
+          always = true;
+          notification = false;
+        }
+        {
+          command = "${lib.getExe' pkgs.hsetroot "hsetroot"} -solid '${stylixColors.base00}'";
+          always = true;
+          notification = false;
+        }
+        # DPMS: Keep screens on for 1 hour (3600s) before standby/suspend/off
+        {
+          command = "${pkgs.xset}/bin/xset dpms 3600 3600 3600";
+          always = true;
+          notification = false;
+        }
+        # Screen saver: Blank after 1 hour (3600s)
+        {
+          command = "${pkgs.xset}/bin/xset s 3600 3600";
+          always = true;
+          notification = false;
+        }
+      ];
+    };
+}


### PR DESCRIPTION
## Summary
- move `xsession.windowManager.i3.config.startup` out of `modules/apps/i3wm/config.nix` into new `modules/apps/i3wm/startup.nix`
- preserve existing startup behavior (`hsetroot`, `xset dpms`, `xset s`) in the new module
- add startup-time `xfconf-query` hardening to force-disable Sticky Keys and related accessibility toggles (`/StickyKeys`, `/SlowKeys`, `/BounceKeys`, `/MouseKeys`)

## Test plan
- `nix-instantiate --parse modules/apps/i3wm/startup.nix`
- `nix-instantiate --parse modules/apps/i3wm/config.nix`
- `nix flake check --accept-flake-config --no-build --offline` (fails in this worktree: `secrets` submodule not initialized)
- pre-push hooks executed during push and passed (`apps-catalog-sync`, `gitleaks`, `managed-files-drift`, `vulnix`)
