### PR TITLE
feat(apps): add thunderbird module and Home Manager integration

### DIFF
--- a/modules/apps/thunderbird.nix
+++ b/modules/apps/thunderbird.nix
@@ -1,0 +1,48 @@
+/*
+  Package: thunderbird
+  Description: Full-featured e-mail client.
+  Homepage: https://thunderbird.net/
+  Documentation: https://support.mozilla.org/en-US/products/thunderbird
+  Repository: https://hg.mozilla.org/comm-central/
+
+  Summary:
+    * Provides a desktop mail client with integrated calendar, contacts, tasks, and feed support.
+    * Supports multiple profiles, OpenPGP key management, and add-on based customization.
+
+  Options:
+    -P <profile>: Start Thunderbird with a specific profile name.
+    --ProfileManager: Open the profile manager to create/select profiles.
+    --safe-mode: Start Thunderbird with extensions and themes disabled for troubleshooting.
+    -compose [ <options> ]: Open a new compose window with prefilled message fields.
+*/
+_:
+let
+  ThunderbirdModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.thunderbird.extended;
+    in
+    {
+      options.programs.thunderbird.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable thunderbird.";
+        };
+
+        package = lib.mkPackageOption pkgs "thunderbird" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.thunderbird = ThunderbirdModule;
+}

--- a/modules/hm-apps/thunderbird.nix
+++ b/modules/hm-apps/thunderbird.nix
@@ -1,0 +1,33 @@
+/*
+  Package: thunderbird
+  Description: Home Manager integration for Thunderbird profile and account settings.
+  Homepage: https://thunderbird.net/
+  Documentation: https://nix-community.github.io/home-manager/options.xhtml#opt-programs.thunderbird.enable
+  Repository: https://github.com/nix-community/home-manager
+
+  Notes:
+    * Enabled only when `programs.thunderbird.extended.enable` is true in the NixOS configuration.
+    * `programs.thunderbird.package` is non-nullable in Home Manager, so package delegation uses defaults.
+    * Declares a default `main` profile to support declarative Thunderbird state.
+*/
+_: {
+  flake.homeManagerModules.apps.thunderbird =
+    { osConfig, lib, ... }:
+    let
+      nixosEnabled = lib.attrByPath [ "programs" "thunderbird" "extended" "enable" ] false osConfig;
+    in
+    {
+      config = lib.mkIf nixosEnabled {
+        programs.thunderbird = {
+          enable = true;
+          profiles.main = {
+            isDefault = true;
+            withExternalGnupg = true;
+            settings = {
+              "mailnews.start_page.enabled" = false;
+            };
+          };
+        };
+      };
+    };
+}

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -287,6 +287,7 @@
       terraform.extended.enable = lib.mkOverride 1100 false;
       tesseract.extended.enable = lib.mkOverride 1100 true;
       testdisk.extended.enable = lib.mkOverride 1100 true;
+      thunderbird.extended.enable = lib.mkOverride 1100 true;
       tokei.extended.enable = lib.mkOverride 1100 true;
       tor.extended.enable = lib.mkOverride 1100 true;
       "tor-browser".extended.enable = lib.mkOverride 1100 true;

--- a/modules/system76/home-manager-apps.nix
+++ b/modules/system76/home-manager-apps.nix
@@ -56,6 +56,7 @@ let
     "starship"
     "stylix-gui"
     "tealdeer"
+    "thunderbird"
     "tree"
     "usbguard-notifier"
     "uv"


### PR DESCRIPTION
## Summary
- add a new NixOS app module for `programs.thunderbird.extended`
- add a Home Manager thunderbird module wired to the NixOS enable flag
- enable thunderbird for the system76 host and include the HM app module

## Test plan
- `git -C /home/vx/trees/nixos/feat-thunderbird-app-integration status --short`
- `nix develop -c hook-apps-catalog-sync`
- `nix eval --json .#nixosConfigurations.system76.config.programs.thunderbird.extended.enable`
- `nix flake check --accept-flake-config --no-build --offline`
