### PR TITLE
feat(mirrors): expand mirrors and align runtime paths to /data/git

### DIFF
--- a/modules/git/mirror-root.nix
+++ b/modules/git/mirror-root.nix
@@ -1,4 +1,4 @@
-# Creates and manages the shared /git directory for local mirrors.
+# Creates and manages the shared /data/git mirror root.
 {
   flake.nixosModules.mirror-root =
     {

--- a/modules/hm-apps/direnv.nix
+++ b/modules/hm-apps/direnv.nix
@@ -54,6 +54,7 @@ _: {
               # Allow direnv in home directory projects
               prefix = [
                 "~/git"
+                "/data/git"
                 "~/projects"
                 "~/src"
               ];

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -1,5 +1,5 @@
 /*
-  Syncs GitHub repositories to a flat /git/{owner}-{repo} structure.
+  Syncs GitHub repositories to a flat /data/git/{owner}-{repo} structure.
   Preserves local work via stash/backup before resetting to upstream.
 */
 {

--- a/modules/system76/mirrors.nix
+++ b/modules/system76/mirrors.nix
@@ -15,6 +15,7 @@
 
           # Nix community
           "nix-community/home-manager"
+          "nix-community/nh"
           "nix-community/nixvim"
           "nix-community/stylix"
 
@@ -22,6 +23,8 @@
           "numtide/llm-agents.nix"
           "Mic92/sops-nix"
           "cachix/git-hooks.nix"
+          "cachix/docs.cachix.org"
+          "evilmartians/lefthook"
           "hercules-ci/flake.parts-website"
           "mightyiam/files"
           "numtide/treefmt-nix"
@@ -33,6 +36,7 @@
 
           # Applications
           "logseq/logseq"
+          "s0md3v/wappalyzer-next"
         ];
       };
     };


### PR DESCRIPTION
## Summary
- expand mirrored repositories for system76 local mirror sync
- align mirror-related runtime/docs comments to `/data/git` paths
- allow `/data/git` in direnv trusted project roots

## Test plan
- `git -C /home/vx/trees/nixos/feat-mirrors-data-git-runtime status --short`
- `git -C /home/vx/trees/nixos/feat-mirrors-data-git-runtime submodule update --init --recursive`
- `nix eval --json .#nixosConfigurations.system76.config.home-manager.users.vx.programs.gitMirror.repos`
- `nix flake check --accept-flake-config --no-build --offline`
