### PR TITLE
docs(paths): migrate local mirror references to /data/git

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -236,10 +236,10 @@ PR body should include:
 
 ### Repository Maintenance
 
-| Trigger             | Command                                         | Preconditions                                  | Post-check                                 |
-| ------------------- | ----------------------------------------------- | ---------------------------------------------- | ------------------------------------------ |
-| Remove files safely | `rip <path>`                                    | File is intended for deletion.                 | Confirm expected deletion in `git status`. |
-| Mirror updates      | `nix develop -c ghq get <repo>` or `ghq update` | Shared GHQ root configured; network available. | Mirror updated under `$HOME/git/<repo>`.   |
+| Trigger             | Command                                         | Preconditions                                  | Post-check                                       |
+| ------------------- | ----------------------------------------------- | ---------------------------------------------- | ------------------------------------------------ |
+| Remove files safely | `rip <path>`                                    | File is intended for deletion.                 | Confirm expected deletion in `git status`.       |
+| Mirror updates      | `nix develop -c ghq get <repo>` or `ghq update` | Shared GHQ root configured; network available. | Mirror updated under `/data/git/{owner}-{repo}`. |
 
 ### Troubleshooting
 
@@ -313,19 +313,19 @@ Pause, summarize the issue, and ask `vx` for direction.
 
 ## Local Mirrors
 
-| Name           | Path                       | Use When                                                       |
-| -------------- | -------------------------- | -------------------------------------------------------------- |
-| Stylix         | `$HOME/git/stylix`         | Inspect source or apply local patches.                         |
-| Home Manager   | `$HOME/git/home-manager`   | Review module behavior or backport fixes.                      |
-| i3 Docs        | `$HOME/git/i3wm-docs`      | Reference i3 documentation offline.                            |
-| nixpkgs        | `$HOME/git/nixpkgs`        | Inspect/patch upstream expressions.                            |
-| nixos-hardware | `$HOME/git/nixos-hardware` | Pull hardware profiles and troubleshoot host hardware options. |
-| nixvim         | `$HOME/git/nixvim`         | Examine NixVim modules and options.                            |
-| treefmt-nix    | `$HOME/git/treefmt-nix`    | Adjust formatter behavior or pinning.                          |
-| git-hooks.nix  | `$HOME/git/git-hooks.nix`  | Update hook definitions or debug pre-commit failures.          |
-| sops-nix       | `$HOME/git/sops-nix`       | Manage encrypted secret integrations.                          |
-| import-tree    | `$HOME/git/import-tree`    | Review/extend auto-loading behavior.                           |
-| files module   | `$HOME/git/files`          | Update generated artifact sources (e.g., `.gitignore`).        |
+| Name           | Path                                   | Use When                                                       |
+| -------------- | -------------------------------------- | -------------------------------------------------------------- |
+| Stylix         | `/data/git/nix-community-stylix`       | Inspect source or apply local patches.                         |
+| Home Manager   | `/data/git/nix-community-home-manager` | Review module behavior or backport fixes.                      |
+| i3 Docs        | `/data/git/i3-i3.github.io`            | Reference i3 documentation offline.                            |
+| nixpkgs        | `/data/git/NixOS-nixpkgs`              | Inspect/patch upstream expressions.                            |
+| nixos-hardware | `/data/git/NixOS-nixos-hardware`       | Pull hardware profiles and troubleshoot host hardware options. |
+| nixvim         | `/data/git/nix-community-nixvim`       | Examine NixVim modules and options.                            |
+| treefmt-nix    | `/data/git/numtide-treefmt-nix`        | Adjust formatter behavior or pinning.                          |
+| git-hooks.nix  | `/data/git/cachix-git-hooks.nix`       | Update hook definitions or debug pre-commit failures.          |
+| sops-nix       | `/data/git/Mic92-sops-nix`             | Manage encrypted secret integrations.                          |
+| import-tree    | `/data/git/vic-import-tree`            | Review/extend auto-loading behavior.                           |
+| files module   | `/data/git/mightyiam-files`            | Update generated artifact sources (e.g., `.gitignore`).        |
 
 ## MCP Tools
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -240,7 +240,7 @@ The `build.sh` script performs full validation (format, hooks, flake check) befo
 | Trigger              | Command                                         | Preconditions                                      | Post-check                                               |
 | -------------------- | ----------------------------------------------- | -------------------------------------------------- | -------------------------------------------------------- |
 | Remove files safely  | `rip <path>`                                    | Ensure file is tracked or intended for deletion.   | Confirm `git status` shows deletion; revert if mistaken. |
-| Mirror updates (ghq) | `nix develop -c ghq get <repo>` or `ghq update` | Shared GHQ root configured; ensure network access. | Mirror updated under `$HOME/git/<repo>`.                 |
+| Mirror updates (ghq) | `nix develop -c ghq get <repo>` or `ghq update` | Shared GHQ root configured; ensure network access. | Mirror updated under `/data/git/<repo>`.                 |
 
 ### Troubleshooting
 
@@ -314,19 +314,19 @@ Pause, summarize the situation, and ask vx for direction before proceeding.
 
 ## Local Mirrors
 
-| Name           | Path                       | Use When                                                          |
-| -------------- | -------------------------- | ----------------------------------------------------------------- |
-| Stylix         | `$HOME/git/stylix`         | Inspect Stylix source or apply local patches.                     |
-| Home Manager   | `$HOME/git/home-manager`   | Review module behaviors or backport fixes.                        |
-| i3 Docs        | `$HOME/git/i3wm-docs`      | Reference i3 window manager documentation offline.                |
-| nixpkgs        | `$HOME/git/nixpkgs`        | Vendor patches or inspect upstream expressions.                   |
-| nixos-hardware | `$HOME/git/nixos-hardware` | Pull hardware profiles or troubleshoot hardware-specific options. |
-| nixvim         | `$HOME/git/nixvim`         | Examine NixVim modules and options.                               |
-| treefmt-nix    | `$HOME/git/treefmt-nix`    | Adjust formatting behavior or version pins.                       |
-| git-hooks.nix  | `$HOME/git/git-hooks.nix`  | Update hook definitions or debug pre-commit failures.             |
-| sops-nix       | `$HOME/git/sops-nix`       | Manage encrypted secrets integrations.                            |
-| import-tree    | `$HOME/git/import-tree`    | Review import-tree functionality or extend module auto-loading.   |
-| files module   | `$HOME/git/files`          | Modify sources that generate repo artefacts (e.g., `.gitignore`). |
+| Name           | Path                                   | Use When                                                          |
+| -------------- | -------------------------------------- | ----------------------------------------------------------------- |
+| Stylix         | `/data/git/nix-community-stylix`       | Inspect Stylix source or apply local patches.                     |
+| Home Manager   | `/data/git/nix-community-home-manager` | Review module behaviors or backport fixes.                        |
+| i3 Docs        | `/data/git/i3-i3.github.io`            | Reference i3 window manager documentation offline.                |
+| nixpkgs        | `/data/git/NixOS-nixpkgs`              | Vendor patches or inspect upstream expressions.                   |
+| nixos-hardware | `/data/git/NixOS-nixos-hardware`       | Pull hardware profiles or troubleshoot hardware-specific options. |
+| nixvim         | `/data/git/nix-community-nixvim`       | Examine NixVim modules and options.                               |
+| treefmt-nix    | `/data/git/numtide-treefmt-nix`        | Adjust formatting behavior or version pins.                       |
+| git-hooks.nix  | `/data/git/cachix-git-hooks.nix`       | Update hook definitions or debug pre-commit failures.             |
+| sops-nix       | `/data/git/Mic92-sops-nix`             | Manage encrypted secrets integrations.                            |
+| import-tree    | `/data/git/vic-import-tree`            | Review import-tree functionality or extend module auto-loading.   |
+| files module   | `/data/git/mightyiam-files`            | Modify sources that generate repo artefacts (e.g., `.gitignore`). |
 
 ## MCP Tools
 

--- a/docs/architecture/06-reference.md
+++ b/docs/architecture/06-reference.md
@@ -95,14 +95,14 @@ Available after `nix develop`:
 
 ## Resource Links
 
-| Resource            | Location                                 |
-| ------------------- | ---------------------------------------- |
-| NixOS manual mirror | `nixos-manual/`                          |
-| Home Manager manual | `/home/vx/git/home-manager/docs/manual/` |
-| Stylix source       | `/home/vx/git/stylix`                    |
-| nixpkgs             | `/home/vx/git/nixpkgs`                   |
-| sops-nix            | `/home/vx/git/sops-nix`                  |
-| import-tree         | `/home/vx/git/import-tree`               |
+| Resource            | Location                                            |
+| ------------------- | --------------------------------------------------- |
+| NixOS manual mirror | `nixos-manual/`                                     |
+| Home Manager manual | `/data/git/nix-community-home-manager/docs/manual/` |
+| Stylix source       | `/data/git/nix-community-stylix`                    |
+| nixpkgs             | `/data/git/NixOS-nixpkgs`                           |
+| sops-nix            | `/data/git/Mic92-sops-nix`                          |
+| import-tree         | `/data/git/vic-import-tree`                         |
 
 ## Next Steps
 

--- a/docs/guides/apps-module-style-guide.md
+++ b/docs/guides/apps-module-style-guide.md
@@ -353,10 +353,10 @@ programs = {
 
 ```bash
 # Check local mirror
-ls "~/git/home-manager/modules/programs/<tool>.nix"
+ls /data/git/nix-community-home-manager/modules/programs/<tool>.nix
 
 # Or search for the program
-grep -r "programs\.<tool>" ~/git/home-manager/modules/programs/
+grep -r "programs\.<tool>" /data/git/nix-community-home-manager/modules/programs/
 ```
 
 If HM support exists, continue to step 6. Otherwise, skip to step 8.
@@ -368,7 +368,7 @@ Create `modules/hm-apps/<tool>.nix`. HM modules **must** guard against enabling 
 **Before writing the module**, check if the HM module's package option is nullable:
 
 ```bash
-grep -A3 "package.*=" ~/git/home-manager/modules/programs/<tool>.nix
+grep -A3 "package.*=" /data/git/nix-community-home-manager/modules/programs/<tool>.nix
 # Look for: nullable = true;
 ```
 
@@ -437,7 +437,7 @@ extraAppNames = [
 
 ```bash
 # Check if stylix supports the app
-grep -r "<tool>" ~/git/stylix/modules/
+grep -r "<tool>" /data/git/nix-community-stylix/modules/
 ```
 
 ### 9. Add Stylix Configuration (if supported)
@@ -568,19 +568,19 @@ This pattern aligns with CLAUDE.md guidance: "Use `lib.hasAttrByPath` + `lib.get
 
 ### Home Manager
 
-| Check               | Command                                                                 |
-| ------------------- | ----------------------------------------------------------------------- |
-| Module exists       | `ls ~/git/home-manager/modules/programs/<tool>.nix`                     |
-| Search by name      | `grep -r "programs\.<tool>" ~/git/home-manager/modules/`                |
-| Firefox derivatives | Check `~/git/home-manager/modules/programs/firefox/mkFirefoxModule.nix` |
+| Check               | Command                                                                                   |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| Module exists       | `ls /data/git/nix-community-home-manager/modules/programs/<tool>.nix`                     |
+| Search by name      | `grep -r "programs\.<tool>" /data/git/nix-community-home-manager/modules/`                |
+| Firefox derivatives | Check `/data/git/nix-community-home-manager/modules/programs/firefox/mkFirefoxModule.nix` |
 
 ### Stylix
 
-| Check                    | Command                                   |
-| ------------------------ | ----------------------------------------- |
-| General support          | `grep -r "<tool>" ~/git/stylix/modules/`  |
-| Firefox/Floorp/LibreWolf | `cat ~/git/stylix/modules/firefox/hm.nix` |
-| Available options        | `cat ~/git/stylix/modules/<tool>/`        |
+| Check                    | Command                                                     |
+| ------------------------ | ----------------------------------------------------------- |
+| General support          | `grep -r "<tool>" /data/git/nix-community-stylix/modules/`  |
+| Firefox/Floorp/LibreWolf | `cat /data/git/nix-community-stylix/modules/firefox/hm.nix` |
+| Available options        | `cat /data/git/nix-community-stylix/modules/<tool>/`        |
 
 ### NUR Firefox Addons
 

--- a/docs/packaging/javascript-packages.md
+++ b/docs/packaging/javascript-packages.md
@@ -6,16 +6,16 @@ This guide covers packaging npm, pnpm, and bun-based JavaScript applications in 
 
 These nixpkgs packages demonstrate various patterns for packaging JavaScript applications:
 
-| Package              | Path                                                             | Pattern                                       | When to Use                                                     |
-| -------------------- | ---------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------- |
-| **Misskey**          | `$HOME/git/nixpkgs/pkgs/by-name/mi/misskey/package.nix`          | Copy entire workspace, wrap `pnpm run`        | pnpm monorepos with native modules; preserves symlink structure |
-| **cspell**           | `$HOME/git/nixpkgs/pkgs/by-name/cs/cspell/package.nix`           | `pnpmWorkspaces` filter + hoisted reinstall   | Monorepos without native modules; minimal closure               |
-| **synchrony**        | `$HOME/git/nixpkgs/pkgs/by-name/sy/synchrony/package.nix`        | Simple `cp -r node_modules`                   | Single-package pnpm projects (non-monorepo)                     |
-| **siyuan**           | `$HOME/git/nixpkgs/pkgs/by-name/si/siyuan/package.nix`           | `sourceRoot` + `postPatch` to `fetchPnpmDeps` | Monorepo subpackage with lockfile at root                       |
-| **heroic-unwrapped** | `$HOME/git/nixpkgs/pkgs/by-name/he/heroic-unwrapped/package.nix` | `npm_config_nodedir` for native modules       | Electron/native addons needing Node headers                     |
-| **tweakcc**          | `packages/tweakcc/default.nix` (local)                           | shamefully-hoist + autoPatchelfHook           | ESM apps with prebuilt native addons, external deps             |
+| Package              | Path                                                                   | Pattern                                       | When to Use                                                     |
+| -------------------- | ---------------------------------------------------------------------- | --------------------------------------------- | --------------------------------------------------------------- |
+| **Misskey**          | `/data/git/NixOS-nixpkgs/pkgs/by-name/mi/misskey/package.nix`          | Copy entire workspace, wrap `pnpm run`        | pnpm monorepos with native modules; preserves symlink structure |
+| **cspell**           | `/data/git/NixOS-nixpkgs/pkgs/by-name/cs/cspell/package.nix`           | `pnpmWorkspaces` filter + hoisted reinstall   | Monorepos without native modules; minimal closure               |
+| **synchrony**        | `/data/git/NixOS-nixpkgs/pkgs/by-name/sy/synchrony/package.nix`        | Simple `cp -r node_modules`                   | Single-package pnpm projects (non-monorepo)                     |
+| **siyuan**           | `/data/git/NixOS-nixpkgs/pkgs/by-name/si/siyuan/package.nix`           | `sourceRoot` + `postPatch` to `fetchPnpmDeps` | Monorepo subpackage with lockfile at root                       |
+| **heroic-unwrapped** | `/data/git/NixOS-nixpkgs/pkgs/by-name/he/heroic-unwrapped/package.nix` | `npm_config_nodedir` for native modules       | Electron/native addons needing Node headers                     |
+| **tweakcc**          | `packages/tweakcc/default.nix` (local)                                 | shamefully-hoist + autoPatchelfHook           | ESM apps with prebuilt native addons, external deps             |
 
-> **Note:** nixpkgs paths reference a local clone at `$HOME/git/nixpkgs`. Clone via `ghq get NixOS/nixpkgs` or adjust paths.
+> **Note:** nixpkgs paths reference a local clone at `/data/git/NixOS-nixpkgs`. Clone via `ghq get NixOS/nixpkgs` or adjust paths.
 
 ## pnpm Packages
 
@@ -392,20 +392,20 @@ cp -rL node_modules $out/lib/my-app/
 Find pnpm packages in nixpkgs:
 
 ```bash
-rg -l 'pnpmConfigHook' $HOME/git/nixpkgs/pkgs/by-name
+rg -l 'pnpmConfigHook' /data/git/NixOS-nixpkgs/pkgs/by-name
 ```
 
 Find packages with specific patterns:
 
 ```bash
 # Monorepo with workspaces
-rg 'pnpmWorkspaces' $HOME/git/nixpkgs/pkgs/by-name
+rg 'pnpmWorkspaces' /data/git/NixOS-nixpkgs/pkgs/by-name
 
 # Native module handling
-rg 'npm_config_nodedir' $HOME/git/nixpkgs/pkgs/by-name
+rg 'npm_config_nodedir' /data/git/NixOS-nixpkgs/pkgs/by-name
 
 # Hoisted node_modules
-rg 'nodeLinker hoisted' $HOME/git/nixpkgs/pkgs/by-name
+rg 'nodeLinker hoisted' /data/git/NixOS-nixpkgs/pkgs/by-name
 ```
 
 ## npm Packages

--- a/docs/usage/espanso-usage.md
+++ b/docs/usage/espanso-usage.md
@@ -331,4 +331,4 @@ The espanso module is auto-discovered from:
 - **Matches Guide**: https://espanso.org/docs/matches/basics/
 - **Variables Reference**: https://espanso.org/docs/matches/extensions/
 - **nixpkgs Package**: `pkgs/by-name/es/espanso/package.nix`
-- **Home Manager Module**: `/home/vx/git/home-manager/modules/services/espanso.nix`
+- **Home Manager Module**: `/data/git/nix-community-home-manager/modules/services/espanso.nix`


### PR DESCRIPTION
## Summary
- migrate local mirror path references from `$HOME/git/...` to `/data/git/...` in AGENTS and docs pages
- keep documentation aligned with the active mirror root layout

## Test plan
- `git -C /home/vx/trees/nixos/docs-data-git-path-migration status --short`
- `git -C /home/vx/trees/nixos/docs-data-git-path-migration submodule update --init --recursive`
- `nix develop -c pre-commit run --all-files --hook-stage manual`
