### PR TITLE
chore(flake): update pinned inputs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -261,11 +261,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771830283,
-        "narHash": "sha256-rF1URUo3lDRZUxmGtY5CnJIEtxNLYmZckzXrps5eT2A=",
+        "lastModified": 1771989900,
+        "narHash": "sha256-ncgKvh2F31DB0jFSyWeXrndMKKKowulbLubdpmAI1oo=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "fc10ee91c4ed021b566098e53e3494d098ed4b61",
+        "rev": "1cc8cc397191e8870dd3e400a092b69fdb650a6a",
         "type": "github"
       },
       "original": {
@@ -526,11 +526,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1770726378,
-        "narHash": "sha256-kck+vIbGOaM/dHea7aTBxdFYpeUl/jHOy5W3eyRvVx8=",
+        "lastModified": 1771858127,
+        "narHash": "sha256-Gtre9YoYl3n25tJH2AoSdjuwcqij5CPxL3U3xysYD08=",
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "rev": "5eaaedde414f6eb1aea8b8525c466dc37bba95ae",
+        "rev": "49bbbfc218bf3856dfa631cead3b052d78248b83",
         "type": "github"
       },
       "original": {
@@ -631,11 +631,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771756436,
-        "narHash": "sha256-Tl2I0YXdhSTufGqAaD1ySh8x+cvVsEI1mJyJg12lxhI=",
+        "lastModified": 1771851181,
+        "narHash": "sha256-gFgE6mGUftwseV3DUENMb0k0EiHd739lZexPo5O/sdQ=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "5bd3589390b431a63072868a90c0f24771ff4cbb",
+        "rev": "9a4b494b1aa1b93d8edf167f46dc8e0c0011280c",
         "type": "github"
       },
       "original": {
@@ -691,11 +691,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771816560,
-        "narHash": "sha256-q5Wsb1573qDfIPJctG9CBZP0NMniejoB7SmBLZIVAHg=",
+        "lastModified": 1771988864,
+        "narHash": "sha256-Zc0kPK7nu+bThM5En5ZbLXhROU5DM6sj6rLdJ2wyaRA=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "db94a329058a1a37b49d3209af85708b3338559a",
+        "rev": "378270d796a9380ba72cf4ba0997d2c40a21d42f",
         "type": "github"
       },
       "original": {
@@ -749,11 +749,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771809278,
-        "narHash": "sha256-JCiXUFX5qyw5rqGKeWE5XMXEzbb+tdrCd1Qmb8T+e3Y=",
+        "lastModified": 1771937249,
+        "narHash": "sha256-gw0/Wlg6kWsULPYf60hyFFwJ4+4yOT9dVP2VZSxCiQQ=",
         "owner": "natsukium",
         "repo": "mcp-servers-nix",
-        "rev": "523cf72320cb3e9a39cac1ab522eeda65d2211e1",
+        "rev": "2d95ecb075622a42674a26af2991d4acac01b6db",
         "type": "github"
       },
       "original": {
@@ -814,11 +814,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771815635,
-        "narHash": "sha256-S/yzoTzFeUpvoo45fnrYJOxW1VZMOYnj3MwqwFVpazY=",
+        "lastModified": 1771988398,
+        "narHash": "sha256-iB/wTOyuqyF3XY0K3BL2YPIO7f95/Rt0mMxwpc84IqQ=",
         "owner": "Bad3r",
         "repo": "nix-logseq-git-flake",
-        "rev": "279d933dc20f20b4cf99e6077281f755f892b888",
+        "rev": "a94ca521eff828d6ff6192c89989cca5e6b64913",
         "type": "github"
       },
       "original": {
@@ -829,11 +829,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1771423359,
-        "narHash": "sha256-yRKJ7gpVmXbX2ZcA8nFi6CMPkJXZGjie2unsiMzj3Ig=",
+        "lastModified": 1771969195,
+        "narHash": "sha256-qwcDBtrRvJbrrnv1lf/pREQi8t2hWZxVAyeMo7/E9sw=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "740a22363033e9f1bb6270fbfb5a9574067af15b",
+        "rev": "41c6b421bdc301b2624486e11905c9af7b8ec68e",
         "type": "github"
       },
       "original": {
@@ -891,11 +891,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1771423170,
-        "narHash": "sha256-K7Dg9TQ0mOcAtWTO/FX/FaprtWQ8BmEXTpLIaNRhEwU=",
+        "lastModified": 1771923393,
+        "narHash": "sha256-Fy0+UXELv9hOE8WjYhJt8fMDLYTU2Dqn3cX4BwoGBos=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bcc4a9d9533c033d806a46b37dc444f9b0da49dd",
+        "rev": "ea7f1f06811ce7fcc81d6c6fd4213150c23edcf2",
         "type": "github"
       },
       "original": {
@@ -1107,11 +1107,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1771735105,
-        "narHash": "sha256-MJuVJeszZEziquykEHh/hmgIHYxUcuoG/1aowpLiSeU=",
+        "lastModified": 1771889317,
+        "narHash": "sha256-YV17Q5lEU0S9ppw08Y+cs4eEQJBuc79AzblFoHORLMU=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "d7755d820f5fa8acf7f223309c33e25d4f92e74f",
+        "rev": "b027513c32e5b39b59f64626b87fbe168ae02094",
         "type": "github"
       },
       "original": {
@@ -1326,11 +1326,11 @@
     "workers-rs": {
       "flake": false,
       "locked": {
-        "lastModified": 1771637676,
-        "narHash": "sha256-rzsjHYoEp05/90Jyi/OwmQiUW1YDOEyN0iqnXY+buc8=",
+        "lastModified": 1771986424,
+        "narHash": "sha256-OaOtOE2Mrpe/mzMITaDRGwwCuje/oIE+QjzlXMwkQzw=",
         "owner": "cloudflare",
         "repo": "workers-rs",
-        "rev": "b9e6d423e4d3836a46a3e69a5bcc99758ae6a35d",
+        "rev": "652cd4b5425b55dc0c65f795dd3ad90ce421cf19",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary
- update flake input pins in `flake.lock`
- keep lockfile churn isolated from behavioral and documentation changes

## Test plan
- `git -C /home/vx/trees/nixos/chore-flake-lock-update status --short`
- `git -C /home/vx/trees/nixos/chore-flake-lock-update submodule update --init --recursive`
- `nix flake metadata`
- `nix flake check --accept-flake-config --no-build --offline`
