### PR TITLE
docs(r2-cloud): add atomic integration documentation set

### DIFF
--- a/docs/architecture/05-host-composition.md
+++ b/docs/architecture/05-host-composition.md
@@ -38,17 +38,18 @@ Complete hosts live under `configurations.nixos.<name>.module`. The helper in `m
 
 The System76 host is composed by many files that all extend `configurations.nixos.system76.module`:
 
-| File                                           | Purpose                                             |
-| ---------------------------------------------- | --------------------------------------------------- |
-| `modules/system76/imports.nix`                 | Baseline module imports and hardware profile wiring |
-| `modules/system76/apps-base.nix`               | Imports all discovered NixOS app modules            |
-| `modules/system76/apps-enable.nix`             | Per-app enable/disable defaults                     |
-| `modules/system76/home-manager-apps.nix`       | Extra HM app imports and shared module wiring       |
-| `modules/system76/default-apps.nix`            | XDG default application selection + env vars        |
-| `modules/system76/custom-packages-overlay.nix` | Injects local `packages/*` into host `pkgs` overlay |
-| `modules/system76/hardware-config.nix`         | Filesystems, firmware, low-level hardware settings  |
-| `modules/system76/nvidia-gpu.nix`              | NVIDIA PRIME configuration                          |
-| `modules/system76/services.nix`                | Service-level host behavior                         |
+| File                                           | Purpose                                               |
+| ---------------------------------------------- | ----------------------------------------------------- |
+| `modules/system76/imports.nix`                 | Baseline module imports and hardware profile wiring   |
+| `modules/system76/apps-base.nix`               | Imports all discovered NixOS app modules              |
+| `modules/system76/apps-enable.nix`             | Per-app enable/disable defaults                       |
+| `modules/system76/home-manager-apps.nix`       | Extra HM app imports and shared module wiring         |
+| `modules/system76/default-apps.nix`            | XDG default application selection + env vars          |
+| `modules/system76/custom-packages-overlay.nix` | Injects local `packages/*` into host `pkgs` overlay   |
+| `modules/system76/r2-runtime.nix`              | Host runtime bindings for external `r2-flake` modules |
+| `modules/system76/hardware-config.nix`         | Filesystems, firmware, low-level hardware settings    |
+| `modules/system76/nvidia-gpu.nix`              | NVIDIA PRIME configuration                            |
+| `modules/system76/services.nix`                | Service-level host behavior                           |
 
 ## App and Home Manager Wiring
 
@@ -61,6 +62,10 @@ Home Manager is wired similarly:
 
 - `modules/home-manager/nixos.nix` provides HM base + default app imports
 - `modules/system76/home-manager-apps.nix` appends additional app keys via `home-manager.extraAppImports`
+- `modules/system76/imports.nix` appends external shared modules such as `inputs.r2-flake.homeManagerModules.default`
+
+For integration-specific details of the external R2 module chain, see
+[`../r2-cloud/input-and-module-wiring.md`](../r2-cloud/input-and-module-wiring.md).
 
 ## Single-Host Repository Policy
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -31,6 +31,23 @@
 - [cloudflare/cloudflared-tunnel-sample.md](cloudflare/cloudflared-tunnel-sample.md)
   - Sample NixOS configuration for Cloudflare Tunnel (cloudflared) with ingress rules and credential setup.
 
+## R2 Cloud
+
+- [r2-cloud/README.md](r2-cloud/README.md)
+  - Index for `nix-R2-CloudFlare-Flake` consumer integration docs in this repo.
+- [r2-cloud/input-and-module-wiring.md](r2-cloud/input-and-module-wiring.md)
+  - How `inputs.r2-flake` is wired into System76 NixOS and Home Manager imports.
+- [r2-cloud/secrets-and-rendered-files.md](r2-cloud/secrets-and-rendered-files.md)
+  - Mapping from `secrets/r2.yaml` to `/run/secrets/r2/*` and HM env templates.
+- [r2-cloud/system76-runtime.md](r2-cloud/system76-runtime.md)
+  - Runtime contract for sync/restic/git-annex/r2 wrapper on this host.
+- [r2-cloud/home-manager-r2-cloud.md](r2-cloud/home-manager-r2-cloud.md)
+  - HM-side `programs.r2-cloud` load path and credential-source behavior.
+- [r2-cloud/validation-and-drift-checks.md](r2-cloud/validation-and-drift-checks.md)
+  - Operator checks to prove integration is still intact.
+- [r2-cloud/troubleshooting.md](r2-cloud/troubleshooting.md)
+  - Integration-specific failure diagnosis and repair paths.
+
 ## Drafts
 
 - [drafts/android-emulator-network-plan.md](drafts/android-emulator-network-plan.md)

--- a/docs/r2-cloud/README.md
+++ b/docs/r2-cloud/README.md
@@ -1,0 +1,50 @@
+# R2 Cloud Integration
+
+This directory documents how `/home/vx/nixos` consumes
+`Bad3r/nix-R2-CloudFlare-Flake` for host `system76` and user `vx`.
+
+## Scope
+
+- Consumer-side wiring in this repository:
+  - flake input registration
+  - NixOS/Home Manager module import chain
+  - `secrets/r2.yaml` to runtime file rendering
+  - host runtime configuration (`services.r2-sync`, `services.r2-restic`,
+    `programs.git-annex-r2`, `programs.r2-cloud`)
+- Operator validation and drift checks
+- Failure-mode troubleshooting for this integration
+
+## Source of Truth
+
+- `flake.nix` (`inputs.r2-flake`)
+- `modules/system76/imports.nix` (producer module imports)
+- `modules/security/r2-cloud-secrets.nix` (system secrets/templates)
+- `modules/home/r2-secrets.nix` (HM secrets/template)
+- `modules/system76/r2-runtime.nix` (runtime consumers)
+- `modules/security/sops-policy.nix` (SOPS creation rule for `secrets/r2.yaml`)
+
+## Not Covered
+
+- `services.duplicati-r2` and `secrets/duplicati-r2.yaml`
+- Cloudflare Worker deployment workflows owned by the producer repo
+- General SOPS onboarding (see `../sops/README.md`)
+
+## Reading Order
+
+| Document                         | Purpose                                                          |
+| -------------------------------- | ---------------------------------------------------------------- |
+| `input-and-module-wiring.md`     | Exact integration path from `inputs.r2-flake` to host/HM imports |
+| `secrets-and-rendered-files.md`  | `secrets/r2.yaml` key mapping and rendered file contract         |
+| `system76-runtime.md`            | Runtime service and mount layout currently enabled on this host  |
+| `home-manager-r2-cloud.md`       | HM-side wrapper, secret template, and module loading behavior    |
+| `validation-and-drift-checks.md` | Commands to prove integration is still wired correctly           |
+| `troubleshooting.md`             | Fast diagnosis for common breakages                              |
+
+## Upstream Producer Docs
+
+- Repository:
+  <https://github.com/Bad3r/nix-R2-CloudFlare-Flake>
+- Option reference index:
+  <https://github.com/Bad3r/nix-R2-CloudFlare-Flake/blob/main/docs/reference/index.md>
+- Quickstart:
+  <https://github.com/Bad3r/nix-R2-CloudFlare-Flake/blob/main/docs/quickstart.md>

--- a/docs/r2-cloud/home-manager-r2-cloud.md
+++ b/docs/r2-cloud/home-manager-r2-cloud.md
@@ -1,0 +1,65 @@
+# Home Manager `r2-cloud`
+
+## Scope
+
+Document how Home Manager is wired to provide the `r2` wrapper and credential
+inputs for user `vx`.
+
+## Source of Truth
+
+- `modules/system76/imports.nix`
+- `modules/home-manager/nixos.nix`
+- `modules/home/r2-secrets.nix`
+- `modules/system76/r2-runtime.nix`
+
+## Not Covered
+
+- Producer implementation internals in
+  `nix-R2-CloudFlare-Flake/modules/home-manager/*`
+
+## Module Load Path
+
+1. Host-level HM shared module import:
+   - `inputs.r2-flake.homeManagerModules.default`
+   - file: `modules/system76/imports.nix`
+2. Consumer-local HM secrets module import:
+   - `flake.homeManagerModules.r2Secrets`
+   - loaded from `modules/home/r2-secrets.nix` via
+     `modules/home-manager/nixos.nix`
+3. Host-level option assignment for user `vx`:
+   - `home-manager.users.${username}.programs.r2-cloud = { ... }`
+   - file: `modules/system76/r2-runtime.nix`
+
+## Active `programs.r2-cloud` Contract in This Repo
+
+Configured values:
+
+- `enable = true`
+- `accountIdFile = "/run/secrets/r2/account-id"`
+- `credentialsFile = "/run/secrets/r2/credentials.env"`
+- `explorerEnvFile = "/run/secrets/r2/explorer.env"`
+
+Operational effect:
+
+- `r2` wrapper is in the HM user profile
+- wrapper reads credentials/account ID from rendered runtime secret paths
+- wrapper can source Worker share admin variables from `explorer.env`
+
+## Relationship to HM Env Template
+
+`modules/home/r2-secrets.nix` renders `~/.config/cloudflare/r2/env`, but current
+host runtime explicitly points `programs.r2-cloud.credentialsFile` at
+`/run/secrets/r2/credentials.env`.
+
+Treat these as two valid credential surfaces:
+
+- system path for host-managed runtime usage
+- HM path for user-scoped/manual workflows
+
+## Quick Verification
+
+```bash
+rg -n 'inputs\\.r2-flake\\.homeManagerModules\\.default' modules/system76/imports.nix
+rg -n 'r2Secrets|cloudflare/r2/env' modules/home-manager/nixos.nix modules/home/r2-secrets.nix
+rg -n 'home-manager\\.users\\..*programs\\.r2-cloud' modules/system76/r2-runtime.nix
+```

--- a/docs/r2-cloud/input-and-module-wiring.md
+++ b/docs/r2-cloud/input-and-module-wiring.md
@@ -1,0 +1,56 @@
+# Input and Module Wiring
+
+## Scope
+
+Document the exact code path that wires `nix-R2-CloudFlare-Flake` into this
+repository.
+
+## Source of Truth
+
+- `flake.nix`
+- `modules/system76/imports.nix`
+- `modules/home-manager/nixos.nix`
+
+## Not Covered
+
+- Runtime unit behavior and mount layout (see `system76-runtime.md`)
+- Secret key mapping details (see `secrets-and-rendered-files.md`)
+
+## Wiring Path
+
+1. Producer flake input is registered:
+   - `inputs.r2-flake.url = "github:Bad3r/nix-R2-CloudFlare-Flake?ref=main";`
+   - File: `flake.nix`
+2. NixOS module surface is imported for `system76`:
+   - `inputs.r2-flake.nixosModules.default`
+   - File: `modules/system76/imports.nix`
+3. Home Manager module surface is appended for `system76`:
+   - `inputs.r2-flake.homeManagerModules.default`
+   - File: `modules/system76/imports.nix`
+4. Repo-local HM secrets module is also loaded globally:
+   - `flake.homeManagerModules.r2Secrets` from `modules/home/r2-secrets.nix`
+   - wired by `modules/home-manager/nixos.nix`
+
+## Why Both HM Module Paths Exist
+
+- `inputs.r2-flake.homeManagerModules.default` provides the producer wrapper
+  and option surfaces (`programs.r2-cloud`, credentials behavior, rclone
+  integration).
+- `flake.homeManagerModules.r2Secrets` is consumer-local and only handles this
+  repo's SOPS materialization to `~/.config/cloudflare/r2/env`.
+
+These two paths are complementary: producer logic + consumer secret plumbing.
+
+## Quick Verification
+
+```bash
+rg -n 'r2-flake\\.url' flake.nix
+rg -n 'inputs\\.r2-flake\\.(nixosModules|homeManagerModules)\\.default' modules/system76/imports.nix
+rg -n 'r2Secrets' modules/home-manager/nixos.nix modules/home/r2-secrets.nix
+```
+
+Expected result:
+
+- all three commands return at least one match
+- no local host path override is required for normal operation (use Nix input
+  override only for temporary producer-development testing)

--- a/docs/r2-cloud/secrets-and-rendered-files.md
+++ b/docs/r2-cloud/secrets-and-rendered-files.md
@@ -1,0 +1,72 @@
+# Secrets and Rendered Files
+
+## Scope
+
+Document how `secrets/r2.yaml` is transformed into runtime files used by
+system services and the `r2` CLI wrapper.
+
+## Source of Truth
+
+- `modules/security/sops-policy.nix`
+- `modules/security/r2-cloud-secrets.nix`
+- `modules/home/r2-secrets.nix`
+- `modules/system76/r2-runtime.nix`
+
+## Not Covered
+
+- Generic SOPS workflows and editor usage (see `../sops/README.md`)
+- Non-R2 secret files
+
+## Policy and Source File
+
+- SOPS policy includes explicit creation rule `path_regex: secrets/r2\.yaml`.
+- Source of truth file: `secrets/r2.yaml`.
+- System declarations are guarded by `builtins.pathExists "${secretsRoot}/r2.yaml"`.
+
+## System Secret Mapping (`/run/secrets/r2/*`)
+
+| YAML key in `secrets/r2.yaml` | Declared secret path                    | Primary consumers                                             |
+| ----------------------------- | --------------------------------------- | ------------------------------------------------------------- |
+| `account_id`                  | `/run/secrets/r2/account-id`            | `services.r2-sync`, `services.r2-restic`, `programs.r2-cloud` |
+| `access_key_id`               | `/run/secrets/r2/access-key-id`         | `r2-credentials.env` template                                 |
+| `secret_access_key`           | `/run/secrets/r2/secret-access-key`     | `r2-credentials.env` template                                 |
+| `restic_password`             | `/run/secrets/r2/restic-password`       | `services.r2-restic.passwordFile`                             |
+| `explorer_admin_kid`          | `/run/secrets/r2/explorer-admin-kid`    | `r2-explorer.env` template                                    |
+| `explorer_admin_secret`       | `/run/secrets/r2/explorer-admin-secret` | `r2-explorer.env` template                                    |
+
+Rendered templates:
+
+- `/run/secrets/r2/credentials.env`
+  - `R2_ACCOUNT_ID`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+- `/run/secrets/r2/explorer.env`
+  - `R2_EXPLORER_BASE_URL`, `R2_EXPLORER_ADMIN_KID`, `R2_EXPLORER_ADMIN_SECRET`
+
+Permissions:
+
+- system secret files are mode `0400`
+- owner is `metaOwner.username` (user `vx` in this repo)
+
+## Home Manager R2 Env Template
+
+Consumer-local HM module `flake.homeManagerModules.r2Secrets` also reads
+`secrets/r2.yaml` and renders:
+
+- `~/.config/cloudflare/r2/env` (mode `0400`)
+
+with:
+
+- `R2_ACCOUNT_ID`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+
+This HM env file exists for user-space workflows, while the active host runtime
+in `modules/system76/r2-runtime.nix` explicitly points to
+`/run/secrets/r2/credentials.env`.
+
+## Quick Verification
+
+```bash
+rg -n 'path_regex: secrets/r2\\.yaml' modules/security/sops-policy.nix
+rg -n 'r2/(account-id|access-key-id|secret-access-key|restic-password|explorer-admin-kid|explorer-admin-secret)' modules/security/r2-cloud-secrets.nix
+rg -n 'templates\\.(\"r2-credentials\\.env\"|\"r2-explorer\\.env\"|\"cloudflare/r2/env\")' modules/security/r2-cloud-secrets.nix modules/home/r2-secrets.nix
+```

--- a/docs/r2-cloud/system76-runtime.md
+++ b/docs/r2-cloud/system76-runtime.md
@@ -1,0 +1,67 @@
+# System76 Runtime
+
+## Scope
+
+Document the current `system76` runtime contract that consumes `r2-flake`
+modules.
+
+## Source of Truth
+
+- `modules/system76/r2-runtime.nix`
+
+## Not Covered
+
+- Producer option defaults and full schema table
+  (see upstream `docs/reference/index.md`)
+- Duplicati backup service (`services.duplicati-r2`)
+
+## Enabled Services and Programs
+
+| Surface                                   | Enabled | Key bindings in this repo                                                                     |
+| ----------------------------------------- | ------- | --------------------------------------------------------------------------------------------- |
+| `services.r2-sync`                        | yes     | `credentialsFile=/run/secrets/r2/credentials.env`, `accountIdFile=/run/secrets/r2/account-id` |
+| `services.r2-restic`                      | yes     | same credentials/account ID files + `passwordFile=/run/secrets/r2/restic-password`            |
+| `programs.git-annex-r2`                   | yes     | `credentialsFile=/run/secrets/r2/credentials.env`                                             |
+| `home-manager.users.vx.programs.r2-cloud` | yes     | `accountIdFile`, `credentialsFile`, `explorerEnvFile` all under `/run/secrets/r2`             |
+
+## Sync Mount Profiles
+
+Current configured mounts:
+
+1. `workspace`
+   - bucket: `nix-r2-cf-r2e-files-prod`
+   - remote prefix: `workspace`
+   - mount point: `/data/r2/mount/workspace`
+   - local path: `/data/r2/workspace`
+   - sync interval: `5m`
+2. `fonts`
+   - bucket: `nix-r2-cf-r2e-files-prod`
+   - remote prefix: `fonts`
+   - mount point: `/data/r2/mount/fonts`
+   - local path: `/data/fonts`
+   - sync interval: `30m`
+
+## Restic Profile
+
+- bucket: `nix-r2-cf-backups-prod`
+- paths: `/data/r2/workspace`
+- credentials/account/password paths all sourced from `/run/secrets/r2/*`
+
+## Runtime Ownership and Filesystem Contract
+
+- `programs.fuse.userAllowOther = true` is enabled.
+- Service units run as `vx` user/group for:
+  - `r2-mount-workspace`
+  - `r2-bisync-workspace`
+  - `r2-mount-fonts`
+  - `r2-bisync-fonts`
+  - `r2-restic-backup`
+- `systemd.tmpfiles` ensures `/data/r2` and required mount/workspace
+  directories exist and are user-owned.
+
+## Quick Verification
+
+```bash
+rg -n 'services\\.r2-sync|services\\.r2-restic|programs\\.git-annex-r2|programs\\.fuse\\.userAllowOther' modules/system76/r2-runtime.nix
+rg -n 'r2-(mount|bisync|restic)' modules/system76/r2-runtime.nix
+```

--- a/docs/r2-cloud/troubleshooting.md
+++ b/docs/r2-cloud/troubleshooting.md
@@ -1,0 +1,104 @@
+# Troubleshooting
+
+## Scope
+
+Fast diagnosis for integration-specific failures between this repo and
+`nix-R2-CloudFlare-Flake`.
+
+## Source of Truth
+
+- `flake.nix`
+- `modules/system76/imports.nix`
+- `modules/security/r2-cloud-secrets.nix`
+- `modules/system76/r2-runtime.nix`
+- `modules/home/r2-secrets.nix`
+
+## Not Covered
+
+- Duplicati-specific issues (`docs/usage/duplicati-r2-backups.md`)
+- Producer-repo CI/workflow failures
+
+## Symptom: Missing `r2` options during eval/build
+
+Typical error shape:
+
+- missing option/attribute under `services.r2-*`, `programs.git-annex-r2`, or
+  `programs.r2-cloud`
+
+Checks:
+
+```bash
+rg -n 'inputs\\.r2-flake\\.nixosModules\\.default' modules/system76/imports.nix
+rg -n 'inputs\\.r2-flake\\.homeManagerModules\\.default' modules/system76/imports.nix
+```
+
+Fix:
+
+- restore both import lines in `modules/system76/imports.nix`
+
+## Symptom: `/run/secrets/r2/*` files missing at runtime
+
+Checks:
+
+```bash
+test -f secrets/r2.yaml && echo present || echo missing
+rg -n 'path_regex: secrets/r2\\.yaml' modules/security/sops-policy.nix
+rg -n 'r2SecretExists|builtins\\.pathExists' modules/security/r2-cloud-secrets.nix
+```
+
+Fix:
+
+1. ensure `secrets/r2.yaml` exists and is encrypted with a matching SOPS policy
+2. confirm creation rule still includes `secrets/r2.yaml`
+3. rebuild/activate after secret changes
+
+## Symptom: `r2-mount-*` or `r2-restic-backup` fails to start
+
+Checks:
+
+```bash
+systemctl status r2-mount-workspace --no-pager
+systemctl status r2-restic-backup --no-pager
+journalctl -u r2-mount-workspace -n 100 --no-pager
+journalctl -u r2-restic-backup -n 100 --no-pager
+```
+
+Common causes:
+
+- credentials/account/password file path missing under `/run/secrets/r2`
+- permissions/ownership mismatch on `/data/r2/*` paths
+- missing account ID in rendered credentials env
+
+Fix:
+
+- verify `modules/system76/r2-runtime.nix` paths match
+  `modules/security/r2-cloud-secrets.nix` template outputs exactly
+- verify tmpfiles directories are present and user-owned (`vx`)
+
+## Symptom: `r2 share worker ...` fails due missing admin env vars
+
+Checks:
+
+```bash
+test -s /run/secrets/r2/explorer.env
+rg -n 'explorerEnvFile' modules/system76/r2-runtime.nix modules/security/r2-cloud-secrets.nix
+```
+
+Fix:
+
+- ensure `explorer_admin_kid` and `explorer_admin_secret` are present in
+  `secrets/r2.yaml`
+- ensure `/run/secrets/r2/explorer.env` template is still declared and assigned
+  to `programs.r2-cloud.explorerEnvFile`
+
+## Symptom: HM env path confusion
+
+Facts:
+
+- system runtime uses `/run/secrets/r2/credentials.env`
+- HM template module renders `~/.config/cloudflare/r2/env`
+
+Fix:
+
+- decide which surface should be used by each consumer and keep paths explicit
+- do not rely on defaults when system-level runtime should use `/run/secrets/r2`

--- a/docs/r2-cloud/validation-and-drift-checks.md
+++ b/docs/r2-cloud/validation-and-drift-checks.md
@@ -23,10 +23,15 @@ expected files/options in this repository.
 Run from repo root:
 
 ```bash
+# Verify flake input registration
 rg -n 'r2-flake\\.url' flake.nix
+# Verify module imports from r2-flake
 rg -n 'inputs\\.r2-flake\\.(nixosModules|homeManagerModules)\\.default' modules/system76/imports.nix
+# Verify runtime service and program configurations
 rg -n 'services\\.r2-sync|services\\.r2-restic|programs\\.git-annex-r2|programs\\.r2-cloud' modules/system76/r2-runtime.nix
-rg -n 'path_regex: secrets/r2\\.yaml' modules/security/sops-policy.nix
+# Verify SOPS creation rule for r2 secrets
+rg -n 'path_regex: secrets/r2\\\.yaml' modules/security/sops-policy.nix
+# Verify secret file references
 rg -n 'r2-credentials\\.env|r2-explorer\\.env|cloudflare/r2/env' modules/security/r2-cloud-secrets.nix modules/home/r2-secrets.nix
 ```
 

--- a/docs/r2-cloud/validation-and-drift-checks.md
+++ b/docs/r2-cloud/validation-and-drift-checks.md
@@ -1,0 +1,70 @@
+# Validation and Drift Checks
+
+## Scope
+
+Operator checks to confirm `r2-flake` integration is intact and still mapped to
+expected files/options in this repository.
+
+## Source of Truth
+
+- `flake.nix`
+- `modules/system76/imports.nix`
+- `modules/system76/r2-runtime.nix`
+- `modules/security/r2-cloud-secrets.nix`
+- `modules/home/r2-secrets.nix`
+- `modules/security/sops-policy.nix`
+
+## Not Covered
+
+- Producer CI checks (`nix-R2-CloudFlare-Flake/scripts/ci/validate.sh`)
+
+## Static Wiring Checks
+
+Run from repo root:
+
+```bash
+rg -n 'r2-flake\\.url' flake.nix
+rg -n 'inputs\\.r2-flake\\.(nixosModules|homeManagerModules)\\.default' modules/system76/imports.nix
+rg -n 'services\\.r2-sync|services\\.r2-restic|programs\\.git-annex-r2|programs\\.r2-cloud' modules/system76/r2-runtime.nix
+rg -n 'path_regex: secrets/r2\\.yaml' modules/security/sops-policy.nix
+rg -n 'r2-credentials\\.env|r2-explorer\\.env|cloudflare/r2/env' modules/security/r2-cloud-secrets.nix modules/home/r2-secrets.nix
+```
+
+Expected result:
+
+- each command returns at least one hit
+- no renamed path or option leaves these checks empty
+
+## Evaluation and Build-Level Checks
+
+```bash
+nix flake check --accept-flake-config --no-build --offline
+nix build .#nixosConfigurations.system76.config.system.build.toplevel
+```
+
+Expected result:
+
+- both commands exit `0`
+- no missing-option/module import errors for `r2` surfaces
+
+## Runtime Presence Checks (after switch/boot)
+
+```bash
+test -s /run/secrets/r2/account-id
+test -s /run/secrets/r2/credentials.env
+test -s /run/secrets/r2/restic-password
+systemctl status r2-mount-workspace --no-pager
+systemctl status r2-restic-backup --no-pager
+```
+
+Expected result:
+
+- secret files exist and are non-empty
+- systemd units are present (and active/invokable according to host state)
+
+## Drift Signals to Treat as Breakage
+
+- `inputs.r2-flake.*` import removed from `modules/system76/imports.nix`
+- `programs.r2-cloud` assignment removed from `modules/system76/r2-runtime.nix`
+- `secrets/r2.yaml` creation rule removed from `modules/security/sops-policy.nix`
+- secret template paths changed without consumer path updates

--- a/docs/sops/README.md
+++ b/docs/sops/README.md
@@ -71,6 +71,9 @@ The R2 cutover uses `secrets/r2.yaml` as the source of truth. System secrets are
 extracted to `/run/secrets/r2/*` and Home Manager renders
 `~/.config/cloudflare/r2/env` via `modules/home/r2-secrets.nix`.
 
+For the full integration contract (input wiring, runtime consumers, drift
+checks), see [`docs/r2-cloud/README.md`](../r2-cloud/README.md).
+
 ## Editing Encrypted Files Safely
 
 ### Interactive Editing


### PR DESCRIPTION
## Summary
- add a new atomic docs directory `docs/r2-cloud/` covering consumer integration of `nix-R2-CloudFlare-Flake`
- document exact input/module wiring, secrets rendering contract, system76 runtime bindings, HM wiring, validation checks, and troubleshooting
- update `docs/index.md` and cross-link from `docs/sops/README.md` and `docs/architecture/05-host-composition.md`

## Test plan
- `git submodule update --init --recursive`
- `nix develop -c pre-commit run --all-files --hook-stage manual`
- `nix flake check --accept-flake-config --no-build --offline`
