### PR TITLE
refactor(sops-runtime): split system and home-manager runtime modules

### DIFF
--- a/docs/sops/README.md
+++ b/docs/sops/README.md
@@ -15,7 +15,8 @@ configuration path.
   - `owner_bad3r` (Age public key) – the maintainer who edits secrets.
   - `host_pub_key` (Age public key) – the System76 laptop recipient used for decryption at activation time.
   - Three specific rules in addition to the general catch-all: `secrets/act.yaml`, `secrets/r2.yaml`, and `secrets/fonts/.+`.
-- `modules/security/secrets.nix` imports `inputs.sops-nix.nixosModules.sops`, exposes `age`/`sops` in `environment.systemPackages`, and points `sops.age.keyFile` to `/var/lib/sops-nix/key.txt`.
+- `modules/security/sops-runtime.nix` owns the shared NixOS `sops-nix` runtime import, exposes `age`/`sops` in `environment.systemPackages`, and points `sops.age.keyFile` to `/var/lib/sops-nix/key.txt`.
+- `modules/security/secrets.nix` only declares repository-managed system secrets and templates.
 - Secret declarations are guarded with `builtins.pathExists`. If `secrets/act.yaml` is missing the entire block is skipped, keeping evaluation pure.
 - Secret files are resolved from `${rootPath}/secrets` via shared `secretsRoot`
   module arguments (no dedicated flake input is required).
@@ -35,7 +36,8 @@ configuration path.
 
 ### Home Manager user service
 
-The Home Manager side now runs `sops-nix.service` with an isolated home directory at
+The Home Manager runtime now lives in `modules/home-manager/sops-runtime.nix` and runs
+`sops-nix.service` with an isolated home directory at
 `~/.local/share/sops-nix`. Make sure `~/.config/sops/age/keys.txt` contains the user Age
 identity (matching the `owner_bad3r` recipient). Because the service never sees `~/.ssh/`,
 hardware-backed SSH keys can coexist without breaking SOPS.

--- a/modules/home-manager/base.nix
+++ b/modules/home-manager/base.nix
@@ -1,32 +1,7 @@
 _: {
-  flake.homeManagerModules.base =
-    {
-      lib,
-      metaOwner,
-      ...
-    }:
-    let
-      # Construct homeDirectory from metaOwner directly, don't rely on config.home.homeDirectory
-      homeDirectory = "/home/${metaOwner.username}";
-      sopsServiceHome = "${homeDirectory}/.local/share/sops-nix";
-    in
-    {
-      # Don't set home.username/homeDirectory - they're set explicitly in nixos.nix
-      home.preferXdgDirectories = true;
-
-      programs.home-manager.enable = true;
-      systemd.user.startServices = "sd-switch";
-
-      # Use homeDirectory from metaOwner, not config.home.homeDirectory
-      sops.age.keyFile = lib.mkDefault "${homeDirectory}/.config/sops/age/keys.txt";
-
-      home.activation.ensureSopsServiceHome = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        mkdir -p '${sopsServiceHome}'
-        chmod 700 '${sopsServiceHome}'
-      '';
-
-      systemd.user.services.sops-nix.Service.Environment = lib.mkForce [
-        "HOME=${sopsServiceHome}"
-      ];
-    };
+  flake.homeManagerModules.base = {
+    home.preferXdgDirectories = true;
+    programs.home-manager.enable = true;
+    systemd.user.startServices = "sd-switch";
+  };
 }

--- a/modules/home-manager/nixos.nix
+++ b/modules/home-manager/nixos.nix
@@ -117,7 +117,6 @@ let
               or is exported via flake.homeManagerModules.apps.${name}
       '';
 
-  sopsModule = inputs.sops-nix.homeManagerModules.sops;
   stateVersionModule =
     { osConfig, ... }:
     {
@@ -127,6 +126,11 @@ let
     "flake"
     "homeManagerModules"
     "base"
+  ];
+  sopsRuntimeModule = loadHomeModule ../home-manager/sops-runtime.nix [
+    "flake"
+    "homeManagerModules"
+    "sopsRuntime"
   ];
   context7Module = loadHomeModule ../home/context7-secrets.nix [
     "flake"
@@ -156,9 +160,9 @@ let
   allAppImports = lib.unique (defaultAppImports ++ extraAppImports);
   appModules = map loadAppModule allAppImports;
   coreModules = [
-    sopsModule
     stateVersionModule
     baseModule
+    sopsRuntimeModule
     context7Module
     r2Module
     virustotalModule

--- a/modules/home-manager/sops-runtime.nix
+++ b/modules/home-manager/sops-runtime.nix
@@ -1,0 +1,27 @@
+_: {
+  flake.homeManagerModules.sopsRuntime =
+    {
+      inputs,
+      lib,
+      metaOwner,
+      ...
+    }:
+    let
+      homeDirectory = "/home/${metaOwner.username}";
+      sopsServiceHome = "${homeDirectory}/.local/share/sops-nix";
+    in
+    {
+      imports = [ inputs.sops-nix.homeManagerModules.sops ];
+
+      sops.age.keyFile = lib.mkDefault "${homeDirectory}/.config/sops/age/keys.txt";
+
+      home.activation.ensureSopsServiceHome = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        mkdir -p '${sopsServiceHome}'
+        chmod 700 '${sopsServiceHome}'
+      '';
+
+      systemd.user.services.sops-nix.Service.Environment = lib.mkForce [
+        "HOME=${sopsServiceHome}"
+      ];
+    };
+}

--- a/modules/security/acme-cloudflare-secrets.nix
+++ b/modules/security/acme-cloudflare-secrets.nix
@@ -17,8 +17,8 @@
       cfTokenExists = builtins.pathExists cfTokenFile;
     in
     {
-      # sops-nix is imported centrally in modules/security/secrets.nix (base),
-      # so we only declare the secret here.
+      # Hosts import the shared sops runtime module separately, so this module
+      # only declares the secret here.
       config = lib.mkIf cfTokenExists {
         sops.secrets."cf-api-token" = {
           sopsFile = cfTokenFile;

--- a/modules/security/r2-cloud-secrets.nix
+++ b/modules/security/r2-cloud-secrets.nix
@@ -26,8 +26,8 @@
         '';
       };
 
-      # sops-nix is imported centrally in modules/security/secrets.nix (base),
-      # so this module only declares secrets/templates.
+      # Hosts import the shared sops runtime module separately, so this module
+      # only declares secrets/templates.
       config = lib.mkMerge [
         (lib.mkIf r2SecretsEnabled {
           sops = {

--- a/modules/security/secrets.nix
+++ b/modules/security/secrets.nix
@@ -1,9 +1,8 @@
-{ inputs, secretsRoot, ... }:
+{ secretsRoot, ... }:
 {
   flake.nixosModules.base =
     {
       config,
-      pkgs,
       lib,
       metaOwner,
       ...
@@ -18,8 +17,6 @@
       ownerName = metaOwner.username;
     in
     {
-      imports = [ inputs.sops-nix.nixosModules.sops ];
-
       options.security.repoSecrets.enable = lib.mkOption {
         type = lib.types.bool;
         default = true;
@@ -27,15 +24,6 @@
       };
 
       config = {
-        environment.systemPackages = with pkgs; [
-          age
-          sops
-        ];
-
-        # Configure sops-nix (key file path can be customized per host)
-        sops.age.keyFile = lib.mkForce "/var/lib/sops-nix/key.txt";
-        sops.age.sshKeyPaths = lib.mkForce [ ];
-
         # Only declare secrets if the encrypted file is present in repo
         # (prevents evaluation errors when secrets repo is absent)
         _module.args = { };

--- a/modules/security/sops-runtime.nix
+++ b/modules/security/sops-runtime.nix
@@ -1,0 +1,20 @@
+{ inputs, ... }:
+{
+  flake.nixosModules.sopsRuntime =
+    {
+      lib,
+      pkgs,
+      ...
+    }:
+    {
+      imports = [ inputs.sops-nix.nixosModules.sops ];
+
+      environment.systemPackages = with pkgs; [
+        age
+        sops
+      ];
+
+      sops.age.keyFile = lib.mkForce "/var/lib/sops-nix/key.txt";
+      sops.age.sshKeyPaths = lib.mkForce [ ];
+    };
+}

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -34,6 +34,7 @@ in
       # Required infrastructure (exported NixOS modules)
       # Note: base includes Stylix via modules/style/stylix.nix contribution
       config.flake.nixosModules.base
+      config.flake.nixosModules.sopsRuntime
       config.flake.nixosModules.lang
       config.flake.nixosModules.ssh
       config.flake.nixosModules."duplicati-r2"

--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -35,6 +35,7 @@ in
   configurations.nixos.tpnix.module = {
     imports = [
       config.flake.nixosModules.base
+      config.flake.nixosModules.sopsRuntime
       config.flake.nixosModules.lang
       config.flake.nixosModules.ssh
     ]


### PR DESCRIPTION
## Summary
- move shared Home Manager SOPS runtime wiring out of `homeManagerModules.base` into a dedicated `homeManagerModules.sopsRuntime`
- add a shared `nixosModules.sopsRuntime`, import it explicitly from both hosts, and keep `modules/security/secrets.nix` focused on secret declarations only
- update direct SOPS docs/comments so runtime ownership now points at the dedicated runtime modules

## Test plan
- `statix check modules/home-manager/base.nix`
- `statix check modules/home-manager/nixos.nix`
- `statix check modules/home-manager/sops-runtime.nix`
- `statix check modules/security/sops-runtime.nix`
- `statix check modules/security/secrets.nix`
- `statix check modules/system76/imports.nix`
- `statix check modules/tpnix/imports.nix`
- `deadnix modules/home-manager/base.nix modules/home-manager/nixos.nix modules/home-manager/sops-runtime.nix modules/security/sops-runtime.nix modules/security/secrets.nix modules/system76/imports.nix modules/tpnix/imports.nix`
- `git diff --check`
- `nix-instantiate --parse modules/home-manager/base.nix`
- `nix-instantiate --parse modules/home-manager/nixos.nix`
- `nix-instantiate --parse modules/home-manager/sops-runtime.nix`
- `nix-instantiate --parse modules/security/sops-runtime.nix`
- `nix-instantiate --parse modules/security/secrets.nix`
- `nix-instantiate --parse modules/system76/imports.nix`
- `nix-instantiate --parse modules/tpnix/imports.nix`
- `nix eval --accept-flake-config --impure --json --expr 'let f = builtins.getFlake (toString ./.); in { system76Key = f.nixosConfigurations.system76.config.sops.age.keyFile; tpnixKey = f.nixosConfigurations.tpnix.config.sops.age.keyFile; system76Env = f.nixosConfigurations.system76.config.home-manager.users.vx.systemd.user.services.sops-nix.Service.Environment; tpnixEnv = f.nixosConfigurations.tpnix.config.home-manager.users.vx.systemd.user.services.sops-nix.Service.Environment; system76State = f.nixosConfigurations.system76.config.system.stateVersion; tpnixState = f.nixosConfigurations.tpnix.config.system.stateVersion; }'`
- `nix flake check --accept-flake-config --no-build --offline`
