### PR TITLE
refactor(repo-secrets): split ACT system and repo GPG HM secrets

### DIFF
--- a/docs/drafts/tpnix-cryptographic-identity-bootstrap-plan.md
+++ b/docs/drafts/tpnix-cryptographic-identity-bootstrap-plan.md
@@ -37,7 +37,7 @@ Provide an end-to-end, reproducible, and host-isolated cryptographic setup for `
    - `secrets/gpg/tpnix.asc`
    - `secrets/ssh/tpnix/id_ed25519.asc`
 5. Runtime secret paths:
-   - `/run/secrets/gpg/vx-secret-key` (declared via `sops.secrets."gpg/vx-secret-key"`)
+   - Home Manager `config.sops.secrets."gpg/vx-secret-key".path` (declared via a dedicated Home Manager GPG secret module)
    - `/run/secrets/ssh/vx-auth-key` (declared via `sops.secrets."ssh/vx-auth-key"`)
 6. SSH client identity for `tpnix`: use managed runtime key path, not `~/.ssh/id_ed25519`.
 
@@ -65,30 +65,28 @@ Provide an end-to-end, reproducible, and host-isolated cryptographic setup for `
 
 2. `modules/system76/imports.nix`
    - Add explicit host signing key:
-     - `home-manager.users.${metaOwner.username}.programs.git.signing.key = lib.mkForce "<SYSTEM76_GPG_FPR>";`
+     - `home-manager.users.${metaOwner.username}.programs.git.signing.key = lib.mkForce "<SYSTEM76_GPG_FINGERPRINT>";`
 
 3. `modules/tpnix/imports.nix`
-   - Set `security.repoSecrets.enable = lib.mkForce true;`
+   - Do not rely on `security.repoSecrets` for OpenPGP material; that module is ACT-only.
    - Add explicit host signing key:
-     - `home-manager.users.${metaOwner.username}.programs.git.signing.key = lib.mkForce "<TPNIX_GPG_FPR>";`
+     - `home-manager.users.${metaOwner.username}.programs.git.signing.key = lib.mkForce "<TPNIX_GPG_FINGERPRINT>";`
    - Override SSH identity file for `tpnix`:
      - `home-manager.users.${metaOwner.username}.programs.ssh.matchBlocks."*".identityFile = lib.mkForce [ "/run/secrets/ssh/vx-auth-key" ];`
 
 4. `modules/security/secrets.nix`
    - Resolve host slug from `config.networking.hostName`.
-   - Replace single GPG secret source with host-specific source:
-     - `secrets/gpg/${host}.asc`
    - Add host-scoped SSH secret source:
      - `secrets/ssh/${host}/id_ed25519.asc`
+   - Keep repository ACT secrets separate from host key material.
    - Declare:
-     - `sops.secrets."gpg/vx-secret-key"` (`format = "binary"`, owner `vx`, mode `0400`)
      - `sops.secrets."ssh/vx-auth-key"` (`format = "binary"`, owner `vx`, mode `0400`, path `/run/secrets/ssh/vx-auth-key`)
 
 5. `modules/home/pass-secret-service.nix`
    - Replace static fingerprint with dynamic source:
      - `config.programs.git.signing.key`
-   - Read secret path from OS config:
-     - `osConfig.sops.secrets."gpg/vx-secret-key".path`
+   - Read secret path from Home Manager config:
+     - `config.sops.secrets."gpg/vx-secret-key".path`
    - Keep guarded activation (import only when both fingerprint and secret path exist).
 
 6. `modules/tpnix/ssh.nix`

--- a/modules/home/repo-gpg-secret.nix
+++ b/modules/home/repo-gpg-secret.nix
@@ -3,14 +3,25 @@
   # Keep the repository GPG key separate from the base HM stack so hosts opt in
   # explicitly via home-manager.sharedModules.
   flake.homeManagerModules.repoGpgSecret =
-    { lib, ... }:
+    {
+      config,
+      lib,
+      ...
+    }:
     let
+      cfg = config.home.repoGpgSecret;
       gpgSecretFile = "${secretsRoot}/gpg/vx.asc";
       gpgSecretExists = builtins.pathExists gpgSecretFile;
     in
     {
+      options.home.repoGpgSecret.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "Whether to provision the repository GPG secret.";
+      };
+
       config = lib.mkMerge [
-        (lib.mkIf gpgSecretExists {
+        (lib.mkIf (cfg.enable && gpgSecretExists) {
           sops.secrets."gpg/vx-secret-key" = {
             sopsFile = gpgSecretFile;
             format = "binary";
@@ -18,9 +29,9 @@
           };
         })
 
-        (lib.mkIf (!gpgSecretExists) {
+        (lib.mkIf (cfg.enable && !gpgSecretExists) {
           warnings = [
-            "homeManagerModules.repoGpgSecret is enabled but ${gpgSecretFile} is missing; skipping gpg secret."
+            "home.repoGpgSecret.enable is true but ${gpgSecretFile} is missing; skipping gpg secret."
           ];
         })
       ];

--- a/modules/home/repo-gpg-secret.nix
+++ b/modules/home/repo-gpg-secret.nix
@@ -1,0 +1,28 @@
+{ secretsRoot, ... }:
+{
+  # Keep the repository GPG key separate from the base HM stack so hosts opt in
+  # explicitly via home-manager.sharedModules.
+  flake.homeManagerModules.repoGpgSecret =
+    { lib, ... }:
+    let
+      gpgSecretFile = "${secretsRoot}/gpg/vx.asc";
+      gpgSecretExists = builtins.pathExists gpgSecretFile;
+    in
+    {
+      config = lib.mkMerge [
+        (lib.mkIf gpgSecretExists {
+          sops.secrets."gpg/vx-secret-key" = {
+            sopsFile = gpgSecretFile;
+            format = "binary";
+            mode = "0400";
+          };
+        })
+
+        (lib.mkIf (!gpgSecretExists) {
+          warnings = [
+            "homeManagerModules.repoGpgSecret is enabled but ${gpgSecretFile} is missing; skipping gpg secret."
+          ];
+        })
+      ];
+    };
+}

--- a/modules/security/secrets.nix
+++ b/modules/security/secrets.nix
@@ -1,6 +1,6 @@
 { secretsRoot, ... }:
 {
-  flake.nixosModules.base =
+  flake.nixosModules.repoSecrets =
     {
       config,
       lib,
@@ -9,62 +9,41 @@
     }:
     let
       cfg = config.security.repoSecrets;
-      # Detect if act secret file exists to avoid evaluation failures
       actSecretFile = "${secretsRoot}/act.yaml";
-      gpgSecretFile = "${secretsRoot}/gpg/vx.asc";
       actSecretExists = builtins.pathExists actSecretFile;
-      gpgSecretExists = builtins.pathExists gpgSecretFile;
       ownerName = metaOwner.username;
     in
     {
       options.security.repoSecrets.enable = lib.mkOption {
         type = lib.types.bool;
         default = true;
-        description = "Whether to declare repository-managed SOPS secrets (act/gpg).";
+        description = "Whether to declare repository-managed system SOPS secrets for act.";
       };
 
-      config = {
-        # Only declare secrets if the encrypted file is present in repo
-        # (prevents evaluation errors when secrets repo is absent)
-        _module.args = { };
-      }
-      // lib.mkIf (cfg.enable && actSecretExists) {
-        sops.secrets."act/github_token" = {
-          sopsFile = actSecretFile;
-          mode = "0400";
-          owner = ownerName;
-        };
+      config = lib.mkMerge [
+        (lib.mkIf (cfg.enable && actSecretExists) {
+          sops.secrets."act/github_token" = {
+            sopsFile = actSecretFile;
+            mode = "0400";
+            owner = ownerName;
+          };
 
-        # Template an env file: GITHUB_TOKEN=...
-        sops.templates."act-env" = {
-          content = ''
-            GITHUB_TOKEN={{ .act/github_token }}
-          '';
-          mode = "0400";
-          owner = ownerName;
-        };
+          sops.templates."act-env" = {
+            content = ''
+              GITHUB_TOKEN={{ .act/github_token }}
+            '';
+            mode = "0400";
+            owner = ownerName;
+          };
 
-        # Expose a stable path for act to use
-        environment.etc."act/secrets.env".source = config.sops.templates."act-env".path;
-      }
-      // lib.mkIf (cfg.enable && gpgSecretExists) {
-        sops.secrets."gpg/vx-secret-key" = {
-          sopsFile = gpgSecretFile;
-          format = "binary";
-          mode = "0400";
-          owner = ownerName;
-        };
-      }
-      // lib.mkIf (cfg.enable && !actSecretExists) {
-        warnings = [
-          "security.repoSecrets.enable is true but ${actSecretFile} is missing; skipping act secret."
-        ];
-      }
-      // lib.mkIf (cfg.enable && !gpgSecretExists) {
-        warnings = [
-          "security.repoSecrets.enable is true but ${gpgSecretFile} is missing; skipping gpg secret."
-        ];
-      };
+          environment.etc."act/secrets.env".source = config.sops.templates."act-env".path;
+        })
+
+        (lib.mkIf (cfg.enable && !actSecretExists) {
+          warnings = [
+            "security.repoSecrets.enable is true but ${actSecretFile} is missing; skipping act secret."
+          ];
+        })
+      ];
     };
-
 }

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -80,6 +80,7 @@ in
     };
     home-manager.users.${metaOwner.username}.home = {
       context7Secrets.enable = lib.mkDefault true;
+      repoGpgSecret.enable = lib.mkDefault true;
       r2Secrets.enable = lib.mkDefault true;
       virustotalSecrets.enable = lib.mkDefault true;
     };

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -23,6 +23,11 @@ let
   # Optional flake module checks
   system76SupportExists = lib.hasAttrByPath [ "flake" "nixosModules" "system76-support" ] config;
   lenovyMonitorExists = lib.hasAttrByPath [ "flake" "nixosModules" "hardware-lenovo-y27q-20" ] config;
+  repoGpgSecretModuleExists = lib.hasAttrByPath [
+    "self"
+    "homeManagerModules"
+    "repoGpgSecret"
+  ] inputs;
 in
 {
   configurations.nixos.system76.module = {
@@ -35,6 +40,7 @@ in
       # Note: base includes Stylix via modules/style/stylix.nix contribution
       config.flake.nixosModules.base
       config.flake.nixosModules.sopsRuntime
+      config.flake.nixosModules.repoSecrets
       config.flake.nixosModules.lang
       config.flake.nixosModules.ssh
       config.flake.nixosModules."duplicati-r2"
@@ -93,7 +99,14 @@ in
       go.extended.enable = true;
     };
 
-    home-manager.sharedModules = lib.mkAfter [ inputs.r2-flake.homeManagerModules.default ];
+    home-manager.sharedModules = lib.mkAfter (
+      [
+        inputs.r2-flake.homeManagerModules.default
+      ]
+      ++ lib.optionals repoGpgSecretModuleExists [
+        (lib.getAttrFromPath [ "self" "homeManagerModules" "repoGpgSecret" ] inputs)
+      ]
+    );
   };
 
   # Export the System76 configuration so the flake exposes it under nixosConfigurations

--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -36,6 +36,7 @@ in
     imports = [
       config.flake.nixosModules.base
       config.flake.nixosModules.sopsRuntime
+      config.flake.nixosModules.repoSecrets
       config.flake.nixosModules.lang
       config.flake.nixosModules.ssh
     ]


### PR DESCRIPTION
## Summary
- narrow `repoSecrets` to the ACT system secret/template flow and export it as `flake.nixosModules.repoSecrets`
- export the repository GPG key as a dedicated Home Manager module with an explicit `home.repoGpgSecret.enable` option
- wire `repoSecrets` into both host imports and enable `repoGpgSecret` from the System76 host wiring while keeping `tpnix` off
- refresh the direct stale draft-doc references for the moved repo GPG secret path and ownership

## Test plan
- `statix check modules/security/secrets.nix`
- `statix check modules/home/repo-gpg-secret.nix`
- `statix check modules/system76/imports.nix`
- `statix check modules/tpnix/imports.nix`
- `nix-instantiate --parse modules/security/secrets.nix`
- `nix-instantiate --parse modules/home/repo-gpg-secret.nix`
- `nix-instantiate --parse modules/system76/imports.nix`
- `nix-instantiate --parse modules/tpnix/imports.nix`
- `nix eval --accept-flake-config --json '.#homeManagerModules' --apply 'mods: builtins.hasAttr "repoGpgSecret" mods'`
- `nix eval --accept-flake-config --json '.#nixosConfigurations.system76.config.home-manager.users.vx.home.repoGpgSecret.enable'`
- `nix eval --accept-flake-config --json '.#nixosConfigurations.system76.config.home-manager.users.vx.sops.secrets' --apply 'secrets: builtins.hasAttr "gpg/vx-secret-key" secrets'`
- `nix eval --accept-flake-config --json '.#nixosConfigurations.tpnix.config.home-manager.users.vx.sops.secrets' --apply 'secrets: builtins.hasAttr "gpg/vx-secret-key" secrets'`
- `nix eval --accept-flake-config --json '.#nixosConfigurations.system76.config.sops.secrets' --apply 'secrets: builtins.hasAttr "gpg/vx-secret-key" secrets'`
- `nix eval --accept-flake-config '.#nixosConfigurations.system76.config.security.repoSecrets.enable'`
- `nix eval --accept-flake-config '.#nixosConfigurations.tpnix.config.security.repoSecrets.enable'`
- `nix eval --accept-flake-config '.#nixosConfigurations.system76.config.system.stateVersion'`
- `nix eval --accept-flake-config '.#nixosConfigurations.tpnix.config.system.stateVersion'`
- `nix flake check --accept-flake-config --no-build --offline`
- `git diff --check`
