### PR TITLE
refactor(password-managers): split secret-service backends by host

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "secrets"]
 	path = secrets
-	url = git@github.com:Bad3r/secrets.git
+	url = https://github.com/Bad3r/secrets.git
 	branch = main

--- a/modules/home/pass-secret-service.nix
+++ b/modules/home/pass-secret-service.nix
@@ -1,9 +1,8 @@
 {
-  flake.homeManagerModules.base =
+  flake.homeManagerModules.passGpgBootstrap =
     {
       config,
       lib,
-      pkgs,
       ...
     }:
     let
@@ -15,36 +14,32 @@
       haveKeyPath = keyPath != null;
     in
     {
-      home = {
-        packages = lib.mkBefore [ pkgs.pass ];
-
-        activation.importPassGpgKey = lib.mkIf haveKeyPath (
-          lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-            key_file="${keyPath}"
-            set -euo pipefail
-            if [ -r "$key_file" ]; then
-              if ! gpg --batch --list-secret-keys ${keyFingerprint} >/dev/null 2>&1; then
-                gpg --batch --yes --import "$key_file"
-                if ! echo "5\ny\n" | gpg --batch --yes --command-fd 0 --edit-key ${keyFingerprint} trust quit >/dev/null; then
-                  echo "Failed to record ultimate trust for ${keyFingerprint}" >&2
-                  exit 1
-                fi
-              fi
-            fi
-          ''
-        );
-
-        activation.initPassStore = lib.mkIf haveKeyPath (
-          lib.hm.dag.entryAfter [ "importPassGpgKey" ] ''
-            set -euo pipefail
-            if [ ! -d "$HOME/.password-store" ]; then
-              if ! pass init --quiet ${keyFingerprint}; then
-                echo "Failed to initialize pass store with ${keyFingerprint}" >&2
+      home.activation.importPassGpgKey = lib.mkIf haveKeyPath (
+        lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+          key_file="${keyPath}"
+          set -euo pipefail
+          if [ -r "$key_file" ]; then
+            if ! gpg --batch --list-secret-keys ${keyFingerprint} >/dev/null 2>&1; then
+              gpg --batch --yes --import "$key_file"
+              if ! echo "5\ny\n" | gpg --batch --yes --command-fd 0 --edit-key ${keyFingerprint} trust quit >/dev/null; then
+                echo "Failed to record ultimate trust for ${keyFingerprint}" >&2
                 exit 1
               fi
             fi
-          ''
-        );
-      };
+          fi
+        ''
+      );
+
+      home.activation.initPassStore = lib.mkIf haveKeyPath (
+        lib.hm.dag.entryAfter [ "importPassGpgKey" ] ''
+          set -euo pipefail
+          if [ ! -d "$HOME/.password-store" ]; then
+            if ! pass init --quiet ${keyFingerprint}; then
+              echo "Failed to initialize pass store with ${keyFingerprint}" >&2
+              exit 1
+            fi
+          fi
+        ''
+      );
     };
 }

--- a/modules/password-managers/gnome-keyring.nix
+++ b/modules/password-managers/gnome-keyring.nix
@@ -1,36 +1,5 @@
-_:
-let
-  mkHomeModule =
-    {
-      config,
-      lib,
-      ...
-    }:
-    let
-      cfg = config.services.pass-secret-service;
-    in
-    {
-      services = {
-        pass-secret-service.enable = lib.mkForce true;
-        gnome-keyring.enable = lib.mkForce false;
-      };
-
-      systemd.user.services.pass-secret-service = lib.mkIf cfg.enable {
-        Unit = {
-          After = [ "graphical-session.target" ];
-          PartOf = lib.mkForce [ "graphical-session.target" ];
-        };
-        Service.Environment = [
-          "DISPLAY=:0"
-          "XAUTHORITY=%h/.Xauthority"
-        ];
-        Install = {
-          Alias = [ "dbus-org.freedesktop.secrets.service" ];
-          WantedBy = lib.mkForce [ "graphical-session.target" ];
-        };
-      };
-    };
-in
-{
-  flake.homeManagerModules.base = mkHomeModule;
+_: {
+  flake.homeManagerModules.gnomeKeyringBackend = {
+    services.gnome-keyring.enable = true;
+  };
 }

--- a/modules/password-managers/pass-secret-service.nix
+++ b/modules/password-managers/pass-secret-service.nix
@@ -1,0 +1,35 @@
+_:
+let
+  mkHomeModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.services.pass-secret-service;
+    in
+    {
+      home.packages = lib.mkBefore [ pkgs.pass ];
+      services.pass-secret-service.enable = true;
+
+      systemd.user.services.pass-secret-service = lib.mkIf cfg.enable {
+        Unit = {
+          After = [ "graphical-session.target" ];
+          PartOf = lib.mkForce [ "graphical-session.target" ];
+        };
+        Service.Environment = [
+          "DISPLAY=:0"
+          "XAUTHORITY=%h/.Xauthority"
+        ];
+        Install = {
+          Alias = [ "dbus-org.freedesktop.secrets.service" ];
+          WantedBy = lib.mkForce [ "graphical-session.target" ];
+        };
+      };
+    };
+in
+{
+  flake.homeManagerModules.passSecretServiceBackend = mkHomeModule;
+}

--- a/modules/system76/gnome-keyring.nix
+++ b/modules/system76/gnome-keyring.nix
@@ -1,7 +1,11 @@
-{ lib, ... }:
+{ config, lib, ... }:
 {
   configurations.nixos.system76.module = {
     services.gnome.gnome-keyring.enable = lib.mkForce false;
     security.pam.services.login.enableGnomeKeyring = lib.mkForce false;
+    home-manager.sharedModules = lib.mkAfter [
+      config.flake.homeManagerModules.passSecretServiceBackend
+      config.flake.homeManagerModules.passGpgBootstrap
+    ];
   };
 }

--- a/modules/tpnix/gnome-keyring.nix
+++ b/modules/tpnix/gnome-keyring.nix
@@ -1,4 +1,5 @@
-_: {
+{ config, lib, ... }:
+{
   configurations.nixos.tpnix.module = {
     services.gnome.gnome-keyring.enable = true;
     security.pam.services = {
@@ -6,5 +7,6 @@ _: {
       lightdm.enableGnomeKeyring = true;
       lightdm-autologin.enableGnomeKeyring = true;
     };
+    home-manager.sharedModules = lib.mkAfter [ config.flake.homeManagerModules.gnomeKeyringBackend ];
   };
 }


### PR DESCRIPTION
## Summary
- split pass bootstrap from secret-service backend selection so backend choice no longer comes from the global Home Manager `base` stack
- keep `system76` on the pass-backed secret service and preserve the `dbus-org.freedesktop.secrets.service` alias plus graphical-session unit wiring in the new pass backend module
- enable GNOME Keyring explicitly on `tpnix` via a dedicated Home Manager backend module
- switch the `secrets` submodule URL to HTTPS so fresh worktrees can initialize without SSH hardware-key auth

## Test plan
- `git submodule sync --recursive`
- `git submodule update --init --recursive`
- `statix check modules/home/pass-secret-service.nix`
- `statix check modules/password-managers/pass-secret-service.nix`
- `statix check modules/password-managers/gnome-keyring.nix`
- `statix check modules/system76/gnome-keyring.nix`
- `statix check modules/tpnix/gnome-keyring.nix`
- `nix eval --accept-flake-config '.#nixosConfigurations.system76.config.home-manager.users.vx.services.pass-secret-service.enable'`
- `nix eval --accept-flake-config '.#nixosConfigurations.system76.config.home-manager.users.vx.services.gnome-keyring.enable'`
- `nix eval --accept-flake-config '.#nixosConfigurations.tpnix.config.home-manager.users.vx.services.pass-secret-service.enable'`
- `nix eval --accept-flake-config '.#nixosConfigurations.tpnix.config.home-manager.users.vx.services.gnome-keyring.enable'`
- `nix eval --impure --json --expr 'let flake = builtins.getFlake \"path:/home/vx/trees/nixos/refactor-password-manager-host-backends-r2\"; lib = flake.inputs.nixpkgs.lib; in lib.attrByPath [\"nixosConfigurations\" \"system76\" \"config\" \"home-manager\" \"users\" \"vx\" \"systemd\" \"user\" \"services\" \"pass-secret-service\" \"Install\" \"Alias\"] [] flake'`
- `rg -n 'dbus-org\\.freedesktop\\.secrets\\.service|systemd\\.user\\.services\\.pass-secret-service' modules`
- `git diff --check`
- `nix flake check --accept-flake-config --no-build --offline`