### PR TITLE
refactor(agents): extract commit skill API

### DIFF
--- a/modules/agents/skills.nix
+++ b/modules/agents/skills.nix
@@ -74,7 +74,16 @@ let
         field: value: validateNonEmptyString skillName "codex.openaiYaml.interface.${field}" value
       ) validatedInterface
     else
-      throw "Agent skill '${skillName}' missing Codex interface fields: ${lib.concatStringsSep ", " missingFields}";
+      throw ''
+        Agent skill '${skillName}' missing Codex interface fields: ${lib.concatStringsSep ", " missingFields}
+
+        Example:
+          codex.openaiYaml.interface = {
+            display_name = "My Skill";
+            short_description = "Does something useful";
+            default_prompt = "Use this skill to...";
+          };
+      '';
 
   validateClientSpec =
     skillName: client: clientSpec:

--- a/modules/agents/skills.nix
+++ b/modules/agents/skills.nix
@@ -1,0 +1,284 @@
+{ config, lib, ... }:
+let
+  reservedPublicSkillNames = [ "list" ];
+
+  validClients = [
+    "claude"
+    "codex"
+  ];
+
+  rawSkills = config.flake.lib.agents._internal.skills.raw;
+
+  renderFrontmatter =
+    fields: fieldOrder:
+    let
+      orderedKeys = lib.filter (key: fields ? ${key}) fieldOrder;
+      extraKeys = lib.sort builtins.lessThan (
+        lib.filter (key: !(lib.elem key fieldOrder)) (lib.attrNames fields)
+      );
+      keys = orderedKeys ++ extraKeys;
+      lines = map (key: "${key}: ${builtins.toJSON fields.${key}}") keys;
+    in
+    ''
+      ---
+      ${lib.concatStringsSep "\n" lines}
+      ---
+    '';
+
+  renderSkillDocument =
+    {
+      title,
+      prelude ? "",
+      body,
+    }:
+    lib.concatStringsSep "\n\n" (
+      lib.filter (part: part != "") [
+        "# ${title}"
+        prelude
+        body
+      ]
+    );
+
+  validateNonEmptyString =
+    skillName: field: value:
+    if builtins.isString value && value != "" then
+      value
+    else
+      throw "Agent skill '${skillName}' requires non-empty string field '${field}'";
+
+  validateAllowedFields =
+    context: allowedFields: attrs:
+    let
+      extraFields = lib.filter (field: !(lib.elem field allowedFields)) (lib.attrNames attrs);
+    in
+    if extraFields == [ ] then
+      attrs
+    else
+      throw "Agent skill ${context} has unknown fields: ${lib.concatStringsSep ", " extraFields}";
+
+  validateOpenaiInterface =
+    skillName: interface:
+    let
+      validatedInterface =
+        validateAllowedFields "'${skillName}'.codex.openaiYaml.interface'" requiredFields
+          interface;
+      requiredFields = [
+        "display_name"
+        "short_description"
+        "default_prompt"
+      ];
+      missingFields = lib.filter (field: !(validatedInterface ? ${field})) requiredFields;
+    in
+    if missingFields == [ ] then
+      lib.mapAttrs (
+        field: value: validateNonEmptyString skillName "codex.openaiYaml.interface.${field}" value
+      ) validatedInterface
+    else
+      throw "Agent skill '${skillName}' missing Codex interface fields: ${lib.concatStringsSep ", " missingFields}";
+
+  validateClientSpec =
+    skillName: client: clientSpec:
+    let
+      allowedFields =
+        {
+          claude = [
+            "frontmatter"
+            "prelude"
+          ];
+          codex = [
+            "frontmatter"
+            "prelude"
+            "openaiYaml"
+          ];
+        }
+        .${client};
+      validatedClientSpec = validateAllowedFields "'${skillName}'.${client}'" allowedFields clientSpec;
+    in
+    if client == "codex" then
+      let
+        openaiYaml = validatedClientSpec.openaiYaml or { };
+        validatedOpenaiYaml = validateAllowedFields "'${skillName}'.codex.openaiYaml'" [
+          "interface"
+        ] openaiYaml;
+        interface = validateOpenaiInterface skillName (validatedOpenaiYaml.interface or { });
+      in
+      validatedClientSpec
+      // {
+        openaiYaml = validatedOpenaiYaml // {
+          inherit interface;
+        };
+      }
+    else
+      validatedClientSpec;
+
+  validateSkillSpec =
+    registryKey: spec:
+    let
+      allowedFields = [
+        "name"
+        "title"
+        "description"
+        "body"
+      ]
+      ++ validClients;
+      validatedSpec = validateAllowedFields "'${registryKey}'" allowedFields spec;
+      name = validateNonEmptyString registryKey "name" validatedSpec.name;
+      title = validateNonEmptyString registryKey "title" validatedSpec.title;
+      description = validateNonEmptyString registryKey "description" validatedSpec.description;
+      body = validateNonEmptyString registryKey "body" validatedSpec.body;
+      presentClients = lib.filter (client: validatedSpec ? ${client}) validClients;
+      validatedClients = lib.genAttrs presentClients (
+        client: validateClientSpec name client validatedSpec.${client}
+      );
+    in
+    if name != registryKey then
+      throw "Agent skill registry key '${registryKey}' must match skill name '${name}'"
+    else if lib.elem name reservedPublicSkillNames then
+      throw "Agent skill '${name}' uses reserved public name '${name}'"
+    else
+      {
+        inherit
+          name
+          title
+          description
+          body
+          ;
+      }
+      // validatedClients;
+
+  renderCodexMarkdown =
+    spec:
+    let
+      frontmatter =
+        renderFrontmatter
+          (
+            {
+              inherit (spec)
+                name
+                description
+                ;
+            }
+            // (spec.codex.frontmatter or { })
+          )
+          [
+            "name"
+            "description"
+          ];
+      body = renderSkillDocument {
+        inherit (spec)
+          title
+          body
+          ;
+        prelude = spec.codex.prelude or "";
+      };
+    in
+    ''
+      ${frontmatter}
+
+      ${body}
+    '';
+
+  renderCodexOpenaiYaml =
+    spec:
+    let
+      inherit (spec.codex.openaiYaml) interface;
+    in
+    ''
+      interface:
+        display_name: ${builtins.toJSON interface.display_name}
+        short_description: ${builtins.toJSON interface.short_description}
+        default_prompt: ${builtins.toJSON interface.default_prompt}
+    '';
+
+  renderClaudeMarkdown =
+    spec:
+    let
+      frontmatter =
+        renderFrontmatter
+          (
+            {
+              inherit (spec)
+                name
+                description
+                ;
+            }
+            // (spec.claude.frontmatter or { })
+          )
+          [
+            "name"
+            "description"
+            "disable-model-invocation"
+            "allowed-tools"
+            "argument-hint"
+          ];
+      body = renderSkillDocument {
+        inherit (spec)
+          title
+          body
+          ;
+        prelude = spec.claude.prelude or "";
+      };
+    in
+    ''
+      ${frontmatter}
+
+      ${body}
+    '';
+
+  compileSkill =
+    registryKey: rawSpec:
+    let
+      spec = validateSkillSpec registryKey rawSpec;
+      codexMarkdown = if spec ? codex then renderCodexMarkdown spec else null;
+      codexOpenaiYaml = if spec ? codex then renderCodexOpenaiYaml spec else null;
+      claudeMarkdown = if spec ? claude then renderClaudeMarkdown spec else null;
+    in
+    {
+      inherit (spec)
+        name
+        title
+        description
+        ;
+    }
+    // lib.optionalAttrs (spec ? claude) {
+      claude = claudeMarkdown;
+    }
+    // lib.optionalAttrs (spec ? codex) {
+      codex =
+        pkgs:
+        let
+          skillMdFile = pkgs.writeText "codex-skill-${spec.name}-SKILL.md" codexMarkdown;
+          openaiYamlFile = pkgs.writeText "codex-skill-${spec.name}-openai.yaml" codexOpenaiYaml;
+        in
+        {
+          dir = pkgs.runCommand "codex-skill-${spec.name}" { } ''
+            mkdir -p "$out/agents"
+            cp ${skillMdFile} "$out/SKILL.md"
+            cp ${openaiYamlFile} "$out/agents/openai.yaml"
+          '';
+          markdown = codexMarkdown;
+          openaiYaml = codexOpenaiYaml;
+        };
+    };
+
+  compiledSkills = lib.mapAttrs compileSkill rawSkills;
+in
+{
+  options.flake.lib.agents = {
+    _internal.skills.raw = lib.mkOption {
+      type = lib.types.attrsOf lib.types.anything;
+      default = { };
+      description = "Canonical raw skill specifications compiled into public client outputs.";
+    };
+
+    skills = lib.mkOption {
+      type = lib.types.attrsOf lib.types.anything;
+      default = { };
+      description = "Public compiled agent skills keyed by skill name plus discovery attrs.";
+    };
+  };
+
+  config.flake.lib.agents.skills = compiledSkills // {
+    list = compiledSkills;
+  };
+}

--- a/modules/agents/skills/commit.nix
+++ b/modules/agents/skills/commit.nix
@@ -1,53 +1,5 @@
-/*
-  Shared Skill Library
-
-  This module provides flake.lib.skills with:
-    - skillDefs: Canonical, agent-agnostic skill definitions
-    - renderCodexSkillMd: Render SKILL.md for Codex
-    - mkCodexSkillDir: Build a full Codex skill directory (SKILL.md + agents/openai.yaml)
-    - renderClaudeSkillMd: Render SKILL.md for Claude Code
-
-  Consumers:
-    - modules/hm-apps/codex.nix
-    - modules/hm-apps/claude-code.nix
-*/
-{ lib, ... }:
+_:
 let
-  renderFrontmatter =
-    fields: fieldOrder:
-    let
-      orderedKeys = lib.filter (key: fields ? ${key}) fieldOrder;
-      extraKeys = lib.sort builtins.lessThan (
-        lib.filter (key: !(lib.elem key fieldOrder)) (lib.attrNames fields)
-      );
-      keys = orderedKeys ++ extraKeys;
-      lines = map (key: "${key}: ${builtins.toJSON fields.${key}}") keys;
-    in
-    ''
-      ---
-      ${lib.concatStringsSep "\n" lines}
-      ---
-    '';
-
-  renderSkillBody =
-    {
-      title,
-      intro ? "",
-      sections ? [ ],
-      body,
-    }:
-    let
-      sectionBlocks = lib.filter (section: section != "") sections;
-      sectionText = lib.concatStringsSep "\n\n" sectionBlocks;
-      introText = lib.optionalString (intro != "") "${intro}\n\n";
-      sectionsText = lib.optionalString (sectionText != "") "${sectionText}\n\n";
-    in
-    ''
-      # ${title}
-
-      ${introText}${sectionsText}${body}
-    '';
-
   commitSelectModeSection = command: ''
     ## Select Mode
 
@@ -272,162 +224,54 @@ let
     2. Explain whether commit/push/PR happened or not.
     3. Provide the smallest safe recovery step and continue only after confirmation when state is ambiguous.
   '';
-
-  skillDefs = {
-    commit = {
-      id = "commit";
-      title = "Git Commit Skill";
-      body = commitSkillBody;
-      targets = {
-        codex = true;
-        claude = true;
-      };
-
-      codex = {
-        frontmatter = {
-          name = "commit";
-          description = "Safe commit workflow: default to a fresh ~/trees worktree + branch; allow current-branch commit/push only when explicitly requested, including main/master.";
-        };
-        intro = "Create a well-formatted git commit following all project safety rules and Conventional Commits format.";
-        sections = [ (commitSelectModeSection "$commit") ];
-        interface = {
-          display_name = "Commit Workflow";
-          short_description = "Safe commit, push, branch, and PR workflow";
-          default_prompt = "Use $commit with default worktree + new-branch flow. Commit/push on the current branch only when the user explicitly requests it, including main/master.";
-        };
-      };
-
-      claude = {
-        frontmatter = {
-          name = "commit";
-          description = "Safe commit workflow: default to a fresh ~/trees worktree + branch; allow current-branch commit/push only when explicitly requested, including main/master.";
-          "disable-model-invocation" = true;
-          "allowed-tools" =
-            "Bash(git status*), Bash(git diff*), Bash(git log*), Bash(git add *), Bash(git commit *), Bash(git worktree *), Bash(git stash *), Bash(git restore *), Bash(git ls-files *), Bash(git for-each-ref *), Bash(git rev-parse *), Bash(git branch *), Bash(git push *), Bash(mkdir *), Bash(rip *), Bash(gh repo view *), Bash(gh pr *), Bash(gh label *), Read, Grep, Glob";
-          "argument-hint" = "[optional commit message]";
-        };
-        intro = "Create a well-formatted git commit following all project safety rules and Conventional Commits format.";
-        dynamicSections = [
-          (commitSelectModeSection "/commit")
-          ''
-            ## Current Git State
-
-            Working tree status:
-            !`git status --short`
-
-            Already staged changes:
-            !`git diff --staged --stat`
-
-            Recent commits (for style reference):
-            !`git log --oneline -5`
-          ''
-          ''
-            ### If `$ARGUMENTS` is provided
-
-            Use the provided text as the commit message directly. Still run through safety checks before committing.
-          ''
-        ];
-      };
-    };
-  };
-
-  renderCodexSkillMd =
-    skillDef:
-    if !(skillDef.targets.codex or false) then
-      throw "Skill '${skillDef.id}' does not target Codex"
-    else
-      let
-        frontmatter = renderFrontmatter skillDef.codex.frontmatter [
-          "name"
-          "description"
-        ];
-        body = renderSkillBody {
-          inherit (skillDef) title;
-          intro = skillDef.codex.intro or "";
-          sections = skillDef.codex.sections or [ ];
-          inherit (skillDef) body;
-        };
-      in
-      ''
-        ${frontmatter}
-
-        ${body}
-      '';
-
-  renderCodexOpenaiYaml =
-    skillDef:
-    if !(skillDef.targets.codex or false) then
-      throw "Skill '${skillDef.id}' does not target Codex"
-    else
-      let
-        interface = skillDef.codex.interface or { };
-        requiredFields = [
-          "display_name"
-          "short_description"
-          "default_prompt"
-        ];
-        missingFields = lib.filter (field: !(interface ? ${field})) requiredFields;
-      in
-      if missingFields != [ ] then
-        throw "Skill '${skillDef.id}' missing Codex interface fields: ${lib.concatStringsSep ", " missingFields}"
-      else
-        ''
-          interface:
-            display_name: ${builtins.toJSON interface.display_name}
-            short_description: ${builtins.toJSON interface.short_description}
-            default_prompt: ${builtins.toJSON interface.default_prompt}
-        '';
-
-  mkCodexSkillDir =
-    pkgs: skillDef:
-    if !(skillDef.targets.codex or false) then
-      throw "Skill '${skillDef.id}' does not target Codex"
-    else
-      let
-        skillMdFile = pkgs.writeText "codex-skill-${skillDef.id}-SKILL.md" (renderCodexSkillMd skillDef);
-        openaiYamlFile = pkgs.writeText "codex-skill-${skillDef.id}-openai.yaml" (
-          renderCodexOpenaiYaml skillDef
-        );
-      in
-      pkgs.runCommand "codex-skill-${skillDef.id}" { } ''
-        mkdir -p "$out/agents"
-        cp ${skillMdFile} "$out/SKILL.md"
-        cp ${openaiYamlFile} "$out/agents/openai.yaml"
-      '';
-
-  renderClaudeSkillMd =
-    skillDef:
-    if !(skillDef.targets.claude or false) then
-      throw "Skill '${skillDef.id}' does not target Claude Code"
-    else
-      let
-        frontmatter = renderFrontmatter skillDef.claude.frontmatter [
-          "name"
-          "description"
-          "disable-model-invocation"
-          "allowed-tools"
-          "argument-hint"
-        ];
-        body = renderSkillBody {
-          inherit (skillDef) title;
-          intro = skillDef.claude.intro or "";
-          sections = skillDef.claude.dynamicSections or [ ];
-          inherit (skillDef) body;
-        };
-      in
-      ''
-        ${frontmatter}
-
-        ${body}
-      '';
 in
 {
-  flake.lib.skills = {
-    inherit
-      skillDefs
-      renderCodexSkillMd
-      mkCodexSkillDir
-      renderClaudeSkillMd
-      ;
+  flake.lib.agents._internal.skills.raw.commit = {
+    name = "commit";
+    title = "Git Commit Skill";
+    description = "Safe commit workflow: default to a fresh ~/trees worktree + branch; allow current-branch commit/push only when explicitly requested, including main/master.";
+    body = commitSkillBody;
+
+    codex = {
+      prelude = ''
+        Create a well-formatted git commit following all project safety rules and Conventional Commits format.
+
+        ${commitSelectModeSection "$commit"}
+      '';
+      openaiYaml.interface = {
+        display_name = "Commit Workflow";
+        short_description = "Safe commit, push, branch, and PR workflow";
+        default_prompt = "Use $commit with default worktree + new-branch flow. Commit/push on the current branch only when the user explicitly requests it, including main/master.";
+      };
+    };
+
+    claude = {
+      frontmatter = {
+        "disable-model-invocation" = true;
+        "allowed-tools" =
+          "Bash(git status*), Bash(git diff*), Bash(git log*), Bash(git add *), Bash(git commit *), Bash(git worktree *), Bash(git stash *), Bash(git restore *), Bash(git ls-files *), Bash(git for-each-ref *), Bash(git rev-parse *), Bash(git branch *), Bash(git push *), Bash(mkdir *), Bash(rip *), Bash(gh repo view *), Bash(gh pr *), Bash(gh label *), Read, Grep, Glob";
+        "argument-hint" = "[optional commit message]";
+      };
+      prelude = ''
+        Create a well-formatted git commit following all project safety rules and Conventional Commits format.
+
+        ${commitSelectModeSection "/commit"}
+
+        ## Current Git State
+
+        Working tree status:
+        !`git status --short`
+
+        Already staged changes:
+        !`git diff --staged --stat`
+
+        Recent commits (for style reference):
+        !`git log --oneline -5`
+
+        ### If `$ARGUMENTS` is provided
+
+        Use the provided text as the commit message directly. Still run through safety checks before committing.
+      '';
+    };
   };
 }

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -7,7 +7,7 @@
 
   Notes:
     * MCP servers configured via flake.lib.mcp (modules/integrations/mcp-servers.nix)
-    * Commit skill rules from flake.lib.skills (modules/integrations/skills.nix)
+    * Agent skills configured via flake.lib.agents.skills (modules/agents/skills.nix)
     * Context7 API key provisioned via SOPS at `sops.secrets."context7/api-key"`
 */
 
@@ -18,7 +18,7 @@ _: {
       lib,
       pkgs,
       mcpLib,
-      skillsLib,
+      agents,
       ...
     }:
     let
@@ -142,8 +142,7 @@ _: {
       claudeJsonConfigFile = pkgs.writeText "claude-json-config.json" (builtins.toJSON claudeJsonConfig);
 
       # ── Commit Skill ──────────────────────────────────────────────────────
-      commitSkill = skillsLib.skillDefs.commit;
-      commitSkillMd = skillsLib.renderClaudeSkillMd commitSkill;
+      commitSkillMd = agents.skills.commit.claude;
 
     in
     {

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -35,7 +35,7 @@ _: {
       config,
       lib,
       mcpLib,
-      skillsLib,
+      agents,
       ...
     }:
     let
@@ -323,8 +323,7 @@ _: {
       };
 
       # ── Commit Skill ──────────────────────────────────────────────────────
-      commitSkill = skillsLib.skillDefs.commit;
-      commitSkillDir = skillsLib.mkCodexSkillDir pkgs commitSkill;
+      commitSkillDir = (agents.skills.commit.codex pkgs).dir;
 
       baseConfigFile = tomlFormat.generate "codex-config-base" baseSettings;
       nixProjectsFile = tomlFormat.generate "codex-nix-projects" nixProjectSettings;

--- a/modules/home-manager/nixos.nix
+++ b/modules/home-manager/nixos.nix
@@ -186,8 +186,8 @@ in
             metaOwner
             secretsRoot
             ;
+          inherit (config.flake.lib) agents;
           mcpLib = config.flake.lib.mcp;
-          skillsLib = config.flake.lib.skills;
         };
         backupFileExtension = "hm.bk";
 

--- a/modules/meta/flake-output.nix
+++ b/modules/meta/flake-output.nix
@@ -46,6 +46,13 @@
           default = { };
           description = "MCP (Model Context Protocol) server catalog and builder functions.";
         };
+        agents = lib.mkOption {
+          type = lib.types.submodule {
+            freeformType = lib.types.attrsOf lib.types.anything;
+          };
+          default = { };
+          description = "Agent helper libraries, registries, and client-specific compiled outputs.";
+        };
       };
 
       homeManagerModules = lib.mkOption {


### PR DESCRIPTION
## Summary
- move the shared commit skill definition into `modules/agents/skills/commit.nix`
- compile client-specific outputs under `flake.lib.agents.skills.commit` via `modules/agents/skills.nix`
- rewire the Codex and Claude Home Manager modules to consume `agents.skills` and remove the legacy `modules/integrations/skills.nix`

## Test plan
- `nix eval --raw .#lib.agents.skills.commit.name`
- `nix eval .#lib.agents.skills.commit.claude --apply builtins.typeOf --raw`
- `nix eval --json --impure --expr 'let f = builtins.getFlake (toString ./.); pkgs = import f.inputs.nixpkgs { system = builtins.currentSystem; }; c = f.lib.agents.skills.commit.codex pkgs; in { hasDir = c ? dir; hasMarkdown = c ? markdown; hasOpenaiYaml = c ? openaiYaml; markdownType = builtins.typeOf c.markdown; openaiYamlType = builtins.typeOf c.openaiYaml; }'`
- `nix eval --json '.#nixosConfigurations.system76.config.home-manager.extraSpecialArgs' --apply builtins.attrNames`
- `nix flake check --accept-flake-config --no-build --offline`
