### PR TITLE
feat(codex): harden execpolicy defaults and workspace access

### DIFF
--- a/modules/apps/codex.nix
+++ b/modules/apps/codex.nix
@@ -29,6 +29,19 @@
     }:
     let
       cfg = config.programs.codex.extended;
+      defaultPackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.codex;
+      # Uncomment to locally patch the upstream default exec timeout. This requires
+      # building a custom Codex derivation instead of using the cached upstream one.
+      # defaultExecTimeoutMs = 60000;
+      # defaultPackage =
+      #   inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.codex.overrideAttrs
+      #     (old: {
+      #       postPatch = (old.postPatch or "") + ''
+      #         substituteInPlace core/src/exec.rs \
+      #           --replace-fail 'pub const DEFAULT_EXEC_COMMAND_TIMEOUT_MS: u64 = 10_000;' \
+      #           'pub const DEFAULT_EXEC_COMMAND_TIMEOUT_MS: u64 = ${toString defaultExecTimeoutMs};'
+      #       '';
+      #     });
     in
     {
       options.programs.codex.extended = {
@@ -40,8 +53,8 @@
 
         package = lib.mkOption {
           type = lib.types.package;
-          default = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.codex;
-          defaultText = lib.literalExpression "inputs.llm-agents.packages.\${system}.codex";
+          default = defaultPackage;
+          defaultText = lib.literalExpression "defaultPackage";
           description = "The codex package to use.";
         };
       };

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -44,6 +44,442 @@ _: {
       configDir = "${config.xdg.configHome}/codex";
       agentsDir = "${config.xdg.configHome}/agents";
       tomlFormat = pkgs.formats.toml { };
+      execPolicyRule =
+        {
+          pattern,
+          decision ? "allow",
+          justification ? null,
+        }:
+        let
+          justificationPart = lib.optionalString (
+            justification != null
+          ) ", justification=${builtins.toJSON justification}";
+        in
+        "prefix_rule(pattern=${builtins.toJSON pattern}, decision=${builtins.toJSON decision}${justificationPart})";
+
+      execPolicyHostExecutable =
+        {
+          name,
+          paths,
+        }:
+        "host_executable(name=${builtins.toJSON name}, paths=${builtins.toJSON paths})";
+
+      # Translate common rm flags into rip so Codex defaults to recoverable deletions.
+      rmShim = pkgs.writeShellScriptBin "rm" ''
+        set -euo pipefail
+
+        force=0
+        operands=()
+
+        while [ "$#" -gt 0 ]; do
+          case "$1" in
+            --)
+              shift
+              while [ "$#" -gt 0 ]; do
+                operands+=("$1")
+                shift
+              done
+              break
+              ;;
+            -f|--force)
+              force=1
+              shift
+              ;;
+            -r|-R|--recursive)
+              shift
+              ;;
+            -[!-]*)
+              bundle="''${1#-}"
+              unsupported="''${bundle//[fRr]/}"
+              if [ -n "$unsupported" ]; then
+                echo "rm shim: unsupported rm option '$1'; use rip directly for nonstandard flags" >&2
+                exit 2
+              fi
+              case "$bundle" in
+                *f*)
+                  force=1
+                  ;;
+              esac
+              shift
+              ;;
+            --*)
+              echo "rm shim: unsupported rm option '$1'; use rip directly for nonstandard flags" >&2
+              exit 2
+              ;;
+            *)
+              operands+=("$1")
+              shift
+              ;;
+          esac
+        done
+
+        cmd=(${lib.getExe pkgs.rip2})
+        if [ "$force" -eq 1 ]; then
+          cmd+=(--force)
+        fi
+
+        if [ "''${#operands[@]}" -eq 0 ]; then
+          exec "''${cmd[@]}"
+        fi
+
+        exec "''${cmd[@]}" -- "''${operands[@]}"
+      '';
+
+      execPolicyManagedRules =
+        let
+          allowAllCommands = [
+            "rip"
+            "sed"
+            "head"
+            "tail"
+            "awk"
+            "nl"
+            "rg"
+            "grep"
+            "jq"
+            "yq"
+            "htmlq"
+            "sqlite"
+            "sqlite3"
+            "cat"
+            "uv"
+            "bun"
+            "npm"
+            "npx"
+            "bunx"
+            "deno"
+            "devenv"
+            "direnv"
+            "treefmt"
+            "touch"
+            "ls"
+            "exa"
+            "eza"
+            "du"
+            "lsblk"
+            "playwright"
+            "chromium"
+          ];
+          allowedNixPatterns = [
+            [
+              "nix"
+              "develop"
+            ]
+            [
+              "nix"
+              "run"
+            ]
+            [
+              "nix"
+              "shell"
+            ]
+            [
+              "nix"
+              "fmt"
+            ]
+            [
+              "nix"
+              "eval"
+            ]
+            [
+              "nix"
+              "build"
+            ]
+            [
+              "nix"
+              "flake"
+              "check"
+            ]
+            [
+              "nix"
+              "store"
+              "diff-closure"
+            ]
+            [
+              "nix"
+              "store"
+              "repair"
+            ]
+            [ "nix-instantiate" ]
+          ];
+          promptedGitRules = [
+            {
+              pattern = [
+                "git"
+                "clean"
+              ];
+              decision = "prompt";
+              justification = "Potentially destructive git command; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "reset"
+              ];
+              decision = "prompt";
+              justification = "Potentially destructive git command; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "rebase"
+              ];
+              decision = "prompt";
+              justification = "History-rewriting git command; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "restore"
+              ];
+              decision = "prompt";
+              justification = "This can discard tracked changes; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "stash"
+                "drop"
+              ];
+              decision = "prompt";
+              justification = "Dropping a stash is destructive; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "stash"
+                "clear"
+              ];
+              decision = "prompt";
+              justification = "Clearing stashes is destructive; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "stash"
+                "pop"
+              ];
+              decision = "prompt";
+              justification = "Popping a stash mutates the worktree; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "branch"
+                "-d"
+              ];
+              decision = "prompt";
+              justification = "Branch deletion should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "branch"
+                "-D"
+              ];
+              decision = "prompt";
+              justification = "Force branch deletion should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "branch"
+                "--delete"
+              ];
+              decision = "prompt";
+              justification = "Branch deletion should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "tag"
+                "-d"
+              ];
+              decision = "prompt";
+              justification = "Tag deletion should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "tag"
+                "--delete"
+              ];
+              decision = "prompt";
+              justification = "Tag deletion should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "worktree"
+                "remove"
+              ];
+              decision = "prompt";
+              justification = "Removing a worktree can delete files; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "remote"
+                "prune"
+              ];
+              decision = "prompt";
+              justification = "Remote prune deletes remote-tracking refs; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "filter-branch"
+              ];
+              decision = "prompt";
+              justification = "History-rewriting git command; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "filter-repo"
+              ];
+              decision = "prompt";
+              justification = "History-rewriting git command; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "gc"
+              ];
+              decision = "prompt";
+              justification = "Garbage collection can make history harder to recover; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "prune"
+              ];
+              decision = "prompt";
+              justification = "Pruning unreachable objects should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "reflog"
+                "expire"
+              ];
+              decision = "prompt";
+              justification = "Expiring reflog entries reduces recovery options; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "push"
+                "-f"
+              ];
+              decision = "prompt";
+              justification = "Force push should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "push"
+                "--force"
+              ];
+              decision = "prompt";
+              justification = "Force push should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "push"
+                "--force-with-lease"
+              ];
+              decision = "prompt";
+              justification = "Force push should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "push"
+                "--mirror"
+              ];
+              decision = "prompt";
+              justification = "Mirroring a push can rewrite or delete many remote refs; ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "push"
+                "--delete"
+              ];
+              decision = "prompt";
+              justification = "Deleting remote refs should ask before running.";
+            }
+            {
+              pattern = [
+                "git"
+                "push"
+                "--prune"
+              ];
+              decision = "prompt";
+              justification = "Pruning remote refs should ask before running.";
+            }
+          ];
+          forbiddenRmRules = [
+            {
+              pattern = [ "/bin/rm" ];
+              decision = "forbidden";
+              justification = "Use `rm` (shimmed to `rip`) or `rip` directly.";
+            }
+            {
+              pattern = [ "/usr/bin/rm" ];
+              decision = "forbidden";
+              justification = "Use `rm` (shimmed to `rip`) or `rip` directly.";
+            }
+            {
+              pattern = [ "/run/current-system/sw/bin/rm" ];
+              decision = "forbidden";
+              justification = "Use `rm` (shimmed to `rip`) or `rip` directly.";
+            }
+          ];
+        in
+        lib.concatStringsSep "\n" (
+          [
+            "# Managed by Home Manager. Edit modules/hm-apps/codex.nix."
+            "# Allowlisted nix commands bypass sandbox because Linux Codex currently cannot use"
+            "# network.allow_unix_sockets to reach /nix/var/nix/daemon-socket/socket."
+            "# Git destructive coverage is best-effort: execpolicy only matches argv prefixes,"
+            "# so forms like `git -C repo reset --hard`, `git checkout -- path`, or"
+            "# `git push origin main --force` do not hit these prompt rules."
+            ""
+            "# Bare rm resolves to a local shim that runs rip. Common absolute rm paths are forbidden."
+            (execPolicyHostExecutable {
+              name = "rm";
+              paths = [ "${rmShim}/bin/rm" ];
+            })
+            (execPolicyRule {
+              pattern = [ "rm" ];
+              decision = "allow";
+              justification = "Bare `rm` is rewritten to the local rip-backed shim.";
+            })
+            ""
+            "# Auto-allowed command prefixes"
+          ]
+          ++ map (cmd: execPolicyRule { pattern = [ cmd ]; }) allowAllCommands
+          ++ [
+            ""
+            "# Auto-allowed nix prefixes"
+          ]
+          ++ map (pattern: execPolicyRule { inherit pattern; }) allowedNixPatterns
+          ++ [
+            ""
+            "# Destructive git prefixes that must ask first"
+          ]
+          ++ map execPolicyRule promptedGitRules
+          ++ [
+            ""
+            "# Common rm bypass paths are forbidden"
+          ]
+          ++ map execPolicyRule forbiddenRmRules
+        )
+        + "\n";
+      execPolicyManagedRulesFile = pkgs.writeText "codex-managed.rules" execPolicyManagedRules;
 
       # MCP servers via compiled agents.mcp client profile
       codexMcpServers = agents.mcp.clients.codex.servers pkgs;
@@ -56,8 +492,7 @@ _: {
         analytics = {
           enabled = true;
         };
-        #approval_policy = "on-request";
-        approval_policy = "never";
+        approval_policy = "on-request";
         apps = { };
         background_terminal_max_timeout = 300000;
         # chatgpt_base_url = null;
@@ -145,6 +580,7 @@ _: {
           log_user_prompt = false;
           trace_exporter = "none";
         };
+        # default_permissions = null;
         # permissions = null;
         # personality = null;
         # plan_mode_reasoning_effort = null;
@@ -155,8 +591,8 @@ _: {
         project_root_markers = [ ".git" ];
         projects = { };
         # review_model = null;
-        sandbox_mode = "workspace-write";
-        # sandbox_workspace_write = {
+        # sandbox_mode = "workspace-write"; # Legacy syntax; prefer default_permissions.
+        # sandbox_workspace_write = { # Legacy syntax; prefer default_permissions.
         #   exclude_slash_tmp = null;
         #   exclude_tmpdir_env_var = null;
         #   network_access = null;
@@ -195,9 +631,8 @@ _: {
         review_model = "gpt-5.4";
         profile = "default";
         commit_attribution = "";
-        #approval_policy = "on-request";
-        approval_policy = "never";
-        sandbox_mode = "workspace-write";
+        approval_policy = "on-request";
+        default_permissions = "workspace";
         personality = "pragmatic";
         web_search = "live";
         zsh_path = lib.getExe pkgs.zsh;
@@ -276,6 +711,23 @@ _: {
           max_unused_days = 24; # Default: 30
         };
 
+        permissions = {
+          workspace = {
+            filesystem = {
+              ":minimal" = "read";
+              ":tmpdir" = "write";
+              ":project_roots" = {
+                "." = "write";
+              };
+              "/data/git" = "read";
+              "~/trees" = "write";
+              "~/git" = "write";
+              "~/igit" = "write";
+              "~/nixos" = "write";
+            };
+          };
+        };
+
         # Shell environment
         shell_environment_policy = {
           "inherit" = "all";
@@ -318,7 +770,6 @@ _: {
           default = {
             model = "gpt-5.4";
             approval_policy = "on-request";
-            sandbox_mode = "workspace-write";
             # model_supports_reasoning_summaries = true; # Avoid sending reasoning.summary.
             model_reasoning_effort = "xhigh";
             model_verbosity = "medium";
@@ -358,6 +809,11 @@ _: {
                 userProjects="$cfgDir/trusted-projects.toml"
                 out="$cfgDir/config.toml"
                 tmpOut="''${out}.tmp"
+                tmpDir="/tmp/agents"
+
+                mkdir -p "$tmpDir"
+                export TMPDIR="$tmpDir"
+                export PATH="${rmShim}/bin:$PATH"
 
                 if [ -f "$base" ]; then
                   if ${tomlMergePython}/bin/python - "$base" "$nixProjects" "$userProjects" "$tmpOut" <<'PY'
@@ -425,50 +881,65 @@ _: {
           packages = [ codexWrapped ];
 
           # Seed user-managed trusted projects file on first activation
-          activation.codexTrustedProjectsSeed = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-                        userProjects="${configDir}/trusted-projects.toml"
-                        if [ ! -f "$userProjects" ]; then
-                          cat > "$userProjects" << 'EOF'
-            # User-managed trusted project paths for Codex.
-            # Merged with nix-managed config on each codex launch.
-            # Changes take effect immediately — no rebuild required.
-            #
-            # Format:
-            # [projects."/path/to/project"]
-            # trust_level = "trusted"
-            EOF
-                        fi
-          '';
+          activation = {
+            codexTrustedProjectsSeed = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+                          userProjects="${configDir}/trusted-projects.toml"
+                          if [ ! -f "$userProjects" ]; then
+                            cat > "$userProjects" << 'EOF'
+              # User-managed trusted project paths for Codex.
+              # Merged with nix-managed config on each codex launch.
+              # Changes take effect immediately — no rebuild required.
+              #
+              # Format:
+              # [projects."/path/to/project"]
+              # trust_level = "trusted"
+              EOF
+                          fi
+            '';
 
-          # Codex discovers user skills in ~/.agents/skills
-          activation.codexAgentsHomeLink = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-            agentsHome="${homeDir}/.agents"
-            legacyBackupBase="${homeDir}/.agents.pre-xdg-migration"
+            codexExecPolicySeed = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+                          rulesDir="${configDir}/rules"
+                          defaultRules="$rulesDir/default.rules"
 
-            # If ~/.agents is a real directory, migrate its contents into
-            # ~/.config/agents and archive the legacy directory before linking.
-            if [ -d "$agentsHome" ] && [ ! -L "$agentsHome" ]; then
-              run mkdir -p "${agentsDir}"
-              run cp -a "$agentsHome/." "${agentsDir}/"
+                          run mkdir -p "$rulesDir"
+                          if [ ! -f "$defaultRules" ]; then
+                            cat > "$defaultRules" << 'EOF'
+              # User-managed execpolicy amendments for Codex.
+              # Runtime-approved command prefixes are appended here.
+              EOF
+                          fi
+            '';
 
-              backupPath="$legacyBackupBase"
-              if [ -e "$backupPath" ]; then
-                i=0
-                while :; do
-                  candidate="''${legacyBackupBase}-$$-$i"
-                  if [ ! -e "$candidate" ]; then
-                    backupPath="$candidate"
-                    break
-                  fi
-                  i=$((i + 1))
-                done
+            # Codex discovers user skills in ~/.agents/skills
+            codexAgentsHomeLink = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+              agentsHome="${homeDir}/.agents"
+              legacyBackupBase="${homeDir}/.agents.pre-xdg-migration"
+
+              # If ~/.agents is a real directory, migrate its contents into
+              # ~/.config/agents and archive the legacy directory before linking.
+              if [ -d "$agentsHome" ] && [ ! -L "$agentsHome" ]; then
+                run mkdir -p "${agentsDir}"
+                run cp -a "$agentsHome/." "${agentsDir}/"
+
+                backupPath="$legacyBackupBase"
+                if [ -e "$backupPath" ]; then
+                  i=0
+                  while :; do
+                    candidate="''${legacyBackupBase}-$$-$i"
+                    if [ ! -e "$candidate" ]; then
+                      backupPath="$candidate"
+                      break
+                    fi
+                    i=$((i + 1))
+                  done
+                fi
+                run mv "$agentsHome" "$backupPath"
               fi
-              run mv "$agentsHome" "$backupPath"
-            fi
 
-            run mkdir -p "${agentsDir}/skills"
-            run ln -sfnT "${agentsDir}" "$agentsHome"
-          '';
+              run mkdir -p "${agentsDir}/skills"
+              run ln -sfnT "${agentsDir}" "$agentsHome"
+            '';
+          };
 
           sessionVariables = {
             CODEX_HOME = lib.mkDefault configDir;
@@ -483,9 +954,14 @@ _: {
           # Nix-managed trusted projects (read-only symlink to store)
           "codex/projects.nix.toml".source = nixProjectsFile;
 
+          # Nix-managed execpolicy rules (read-only symlink to store)
+          "codex/rules/20-managed.rules".source = execPolicyManagedRulesFile;
+
           # User-level Codex instructions under XDG config home
           "codex/AGENTS.md".text = ''
             If you are unsure how to do something, use `gh_grep` to search code examples from GitHub.
+            Always set `timeout_ms` explicitly for shell commands because sandboxed commands can hit a short default timeout.
+            Use `60000` ms when no command-specific timeout is obvious, and increase it further for builds, installs, tests, or other long-running commands.
           '';
 
           # Commit skill (user-scoped, discovered by SkillsManager at ~/.agents/skills/)

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -44,6 +44,9 @@ _: {
       configDir = "${config.xdg.configHome}/codex";
       agentsDir = "${config.xdg.configHome}/agents";
       tomlFormat = pkgs.formats.toml { };
+      coreutilsMktemp = lib.getExe' pkgs.coreutils "mktemp";
+      coreutilsRm = lib.getExe' pkgs.coreutils "rm";
+      coreutilsSha256sum = lib.getExe' pkgs.coreutils "sha256sum";
       execPolicyRule =
         {
           pattern,
@@ -802,35 +805,81 @@ _: {
       # Wrapper that assembles config.toml before launching codex.
       # Uses parser-based TOML merge with precedence:
       # base settings < nix-managed projects < user-managed projects.
+      # Re-merges only when the input file hashes change.
       codexWrapped = pkgs.writeShellScriptBin "codex" ''
                 cfgDir="''${CODEX_HOME:-${configDir}}"
                 base="$cfgDir/config.base.toml"
                 nixProjects="$cfgDir/projects.nix.toml"
                 userProjects="$cfgDir/trusted-projects.toml"
                 out="$cfgDir/config.toml"
-                tmpOut="''${out}.tmp"
+                mergeStamp="$cfgDir/config.merge.sha256"
                 tmpDir="/tmp/agents"
+                tmpOut=""
+                tmpStamp=""
 
                 mkdir -p "$tmpDir"
                 export TMPDIR="$tmpDir"
                 export PATH="${rmShim}/bin:$PATH"
 
+                cleanupMergeArtifacts() {
+                  if [ -n "$tmpOut" ] && [ -e "$tmpOut" ]; then
+                    ${coreutilsRm} -f -- "$tmpOut"
+                  fi
+                  if [ -n "$tmpStamp" ] && [ -e "$tmpStamp" ]; then
+                    ${coreutilsRm} -f -- "$tmpStamp"
+                  fi
+                }
+
+                hashInputs() {
+                  for path in "$base" "$nixProjects" "$userProjects"; do
+                    if [ -f "$path" ]; then
+                      printf 'file\t%s\t' "$path"
+                      ${coreutilsSha256sum} "$path"
+                    else
+                      printf 'missing\t%s\n' "$path"
+                    fi
+                  done | ${coreutilsSha256sum} | awk '{print $1}'
+                }
+
                 if [ -f "$base" ]; then
-                  if ${tomlMergePython}/bin/python - "$base" "$nixProjects" "$userProjects" "$tmpOut" <<'PY'
+                  inputHash="$(hashInputs)"
+                  cachedHash=""
+                  if [ -f "$mergeStamp" ]; then
+                    read -r cachedHash < "$mergeStamp" || cachedHash=""
+                  fi
+
+                  if [ ! -s "$out" ] || [ "$cachedHash" != "$inputHash" ]; then
+                    tmpOut="$(${coreutilsMktemp} "$tmpDir/codex-config.XXXXXXXX.toml")" || {
+                      echo "codex-wrapper: ERROR: failed to create temporary config file in $tmpDir" >&2
+                      exit 1
+                    }
+                    tmpStamp="$(${coreutilsMktemp} "$tmpDir/codex-config-stamp.XXXXXXXX")" || {
+                      echo "codex-wrapper: ERROR: failed to create temporary stamp file in $tmpDir" >&2
+                      exit 1
+                    }
+                    trap cleanupMergeArtifacts EXIT INT TERM
+
+                    if ${tomlMergePython}/bin/python - "$base" "$nixProjects" "$userProjects" "$tmpOut" <<'PY'
         from pathlib import Path
         import sys
         import tomllib
         import tomlkit
 
 
-        def load_toml(path_str: str) -> dict:
+        def load_toml(label: str, path_str: str) -> dict:
             path = Path(path_str)
             if not path.exists():
                 return {}
-            raw = path.read_text(encoding="utf-8")
+            try:
+                raw = path.read_text(encoding="utf-8")
+            except OSError as exc:
+                raise SystemExit(f"{label}: failed to read {path}: {exc}") from exc
             if not raw.strip():
                 return {}
-            return tomllib.loads(raw)
+            try:
+                return tomllib.loads(raw)
+            except tomllib.TOMLDecodeError as exc:
+                raise SystemExit(f"{label}: invalid TOML in {path}: {exc}") from exc
 
 
         def deep_merge(base: dict, override: dict) -> dict:
@@ -845,23 +894,40 @@ _: {
 
         base_path, nix_projects_path, user_projects_path, out_path = sys.argv[1:5]
         merged = {}
-        for path in (base_path, nix_projects_path, user_projects_path):
-            deep_merge(merged, load_toml(path))
+        for label, path in (
+            ("base config", base_path),
+            ("nix-managed projects", nix_projects_path),
+            ("user-managed projects", user_projects_path),
+        ):
+            deep_merge(merged, load_toml(label, path))
 
-        Path(out_path).write_text(tomlkit.dumps(merged), encoding="utf-8")
+        out_file = Path(out_path)
+        try:
+            out_file.write_text(tomlkit.dumps(merged), encoding="utf-8")
+        except OSError as exc:
+            raise SystemExit(f"failed to write merged config to {out_file}: {exc}") from exc
         PY
-                  then
-                    if [ -s "$tmpOut" ]; then
-                      mv "$tmpOut" "$out"
+                    then
+                      if [ -s "$tmpOut" ]; then
+                        if ! printf '%s\n' "$inputHash" > "$tmpStamp"; then
+                          echo "codex-wrapper: ERROR: failed to write merge stamp to $tmpStamp" >&2
+                          exit 1
+                        fi
+                        mv "$tmpOut" "$out"
+                        tmpOut=""
+                        mv "$tmpStamp" "$mergeStamp"
+                        tmpStamp=""
+                        trap - EXIT INT TERM
+                      else
+                        echo "codex-wrapper: ERROR: merged config is empty or missing at $tmpOut" >&2
+                        exit 1
+                      fi
                     else
-                      echo "codex-wrapper: ERROR: merged config is empty or missing at $tmpOut" >&2
-                      exit 1
+                      mergeStatus=$?
+                      echo "codex-wrapper: ERROR: failed to merge config (exit $mergeStatus)" >&2
+                      echo "codex-wrapper: ERROR: base=$base nixProjects=$nixProjects userProjects=$userProjects out=$out" >&2
+                      exit "$mergeStatus"
                     fi
-                  else
-                    mergeStatus=$?
-                    echo "codex-wrapper: ERROR: failed to merge config (exit $mergeStatus)" >&2
-                    echo "codex-wrapper: ERROR: base=$base nixProjects=$nixProjects userProjects=$userProjects" >&2
-                    exit "$mergeStatus"
                   fi
                 fi
 
@@ -914,6 +980,8 @@ _: {
             codexAgentsHomeLink = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
               agentsHome="${homeDir}/.agents"
               legacyBackupBase="${homeDir}/.agents.pre-xdg-migration"
+              maxLegacyBackups=8
+              maxBackupAttempts=32
 
               # If ~/.agents is a real directory, migrate its contents into
               # ~/.config/agents and archive the legacy directory before linking.
@@ -921,10 +989,21 @@ _: {
                 run mkdir -p "${agentsDir}"
                 run cp -a "$agentsHome/." "${agentsDir}/"
 
+                existingLegacyBackups=0
+                for candidate in "$legacyBackupBase" "$legacyBackupBase"-*; do
+                  if [ -e "$candidate" ]; then
+                    existingLegacyBackups=$((existingLegacyBackups + 1))
+                  fi
+                done
+                if [ "$existingLegacyBackups" -ge "$maxLegacyBackups" ]; then
+                  echo "codex-activation: ERROR: refusing to create more than $maxLegacyBackups legacy backups matching $legacyBackupBase*" >&2
+                  exit 1
+                fi
+
                 backupPath="$legacyBackupBase"
                 if [ -e "$backupPath" ]; then
                   i=0
-                  while :; do
+                  while [ "$i" -lt "$maxBackupAttempts" ]; do
                     candidate="''${legacyBackupBase}-$$-$i"
                     if [ ! -e "$candidate" ]; then
                       backupPath="$candidate"
@@ -932,6 +1011,10 @@ _: {
                     fi
                     i=$((i + 1))
                   done
+                  if [ "$i" -ge "$maxBackupAttempts" ]; then
+                    echo "codex-activation: ERROR: exhausted $maxBackupAttempts backup name attempts for $legacyBackupBase" >&2
+                    exit 1
+                  fi
                 fi
                 run mv "$agentsHome" "$backupPath"
               fi

--- a/modules/hm-apps/codex.nix
+++ b/modules/hm-apps/codex.nix
@@ -128,6 +128,31 @@ _: {
         exec "''${cmd[@]}" -- "''${operands[@]}"
       '';
 
+      # Scope recoverable bare `rm` rewrites to the top-level Codex shell command
+      # instead of mutating PATH for every subprocess those commands spawn.
+      codexZshWrapper = pkgs.writeShellScriptBin "codex-zsh" ''
+        set -euo pipefail
+
+        realZsh=${lib.getExe pkgs.zsh}
+        rmShimPath=${rmShim}/bin/rm
+
+        if [ "$#" -ge 2 ] && { [ "$1" = "-c" ] || [ "$1" = "-lc" ]; }; then
+          shellFlag="$1"
+          wrappedCommand="$2"
+          shift 2
+
+          export CODEX_WRAPPED_COMMAND="$wrappedCommand"
+          exec "$realZsh" "$shellFlag" '
+            rm() {
+              "'"$rmShimPath"'" "$@"
+            }
+            eval "$CODEX_WRAPPED_COMMAND"
+          ' "$@"
+        fi
+
+        exec "$realZsh" "$@"
+      '';
+
       execPolicyManagedRules =
         let
           allowAllCommands = [
@@ -638,7 +663,7 @@ _: {
         default_permissions = "workspace";
         personality = "pragmatic";
         web_search = "live";
-        zsh_path = lib.getExe pkgs.zsh;
+        zsh_path = lib.getExe codexZshWrapper;
 
         # Developer instructions for security research context
         developer_instructions = ''
@@ -819,7 +844,6 @@ _: {
 
                 mkdir -p "$tmpDir"
                 export TMPDIR="$tmpDir"
-                export PATH="${rmShim}/bin:$PATH"
 
                 cleanupMergeArtifacts() {
                   if [ -n "$tmpOut" ] && [ -e "$tmpOut" ]; then


### PR DESCRIPTION
## Summary

This tightens the Codex integration in both the NixOS app module and the Home Manager module.

In `modules/apps/codex.nix`, the default Codex package is factored into a named binding so local timeout patching can be enabled without changing the option shape.

In `modules/hm-apps/codex.nix`, the Codex configuration moves from the legacy sandbox setting to a named `default_permissions = \"workspace\"` profile, seeds a managed execpolicy rules file, places a `rip`-backed `rm` shim on `PATH`, and expands writable home-relative roots to `~/nixos`, `~/trees`, `~/git`, and `~/igit` alongside the existing `/data/git` read root.

The review also keeps `approval_policy = \"on-request\"` instead of the granular object form because the current Codex shell permission path still needs `OnRequest` for working additional-permission escalation.

## Review Notes

- `~/...` is used intentionally instead of `$HOME/...`; the current Codex path normalization accepts `~/...` and expands it to the active user home directory.
- The activation hooks were grouped under a single `home.activation = { ... };` attrset so `statix` stays clean.
- The managed execpolicy comments explicitly note the current argv-prefix matching limitations for destructive git coverage.

## Test Plan

- `nix-instantiate --parse modules/apps/codex.nix`
- `nix-instantiate --parse modules/hm-apps/codex.nix`
- `git diff --check -- modules/apps/codex.nix modules/hm-apps/codex.nix`
- `git commit` pre-commit hooks: `deadnix`, `nix-parse`, `statix`, `treefmt`, `typos`
- `git push -u origin feat/codex-execpolicy-hardening` pre-push hooks: `apps-catalog-sync`, `gitleaks`, `managed-files-drift`, `vulnix`