### PR TITLE
fix(codex): allow Codex writes under ~/.config and ~/dotfiles

### DIFF
--- a/modules/agents/codex/_settings.nix
+++ b/modules/agents/codex/_settings.nix
@@ -113,6 +113,8 @@ let
           "~/git" = "write";
           "~/igit" = "write";
           "~/nixos" = "write";
+          "~/dotfiles" = "write";
+          "~/.config" = "write";
         };
       };
     };


### PR DESCRIPTION
## Summary
- add `~/dotfiles` to Codex read-write project paths
- add `~/.config` to Codex read-write project paths

## Test plan
- `git diff --staged --check`
- `nix-instantiate --parse modules/agents/codex/_settings.nix`
- `rg -n -C 2 '\"~/dotfiles\"|\"~/.config\"|\"~/nixos\"' modules/agents/codex/_settings.nix`
- `git push -u origin fix/codex-write-paths` (post-push hooks passed: `apps-catalog-sync`, `gitleaks`, `managed-files-drift`, `vulnix`)
- attempted `nix build --offline --accept-flake-config .#nixosConfigurations.system76.config.system.build.toplevel --no-link`; blocked by upstream GitHub tarball fetch timeout for `NixOS/nixpkgs`