### PR TITLE
fix(nixvim): add plenary for hmts injections

### DIFF
--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -284,8 +284,14 @@ _: {
           '';
 
           # hmts.nvim - enhanced treesitter injections for Home Manager/Nix files
+          # plenary.nvim is added explicitly because the pinned nixvim/nixpkgs
+          # combination does not currently pull telescope's runtime dependency
+          # onto the packpath.
           # Detects embedded languages via /* lang */ comments, shebangs, and filename inference
-          extraPlugins = [ pkgs.vimPlugins.hmts-nvim ];
+          extraPlugins = [
+            pkgs.vimPlugins.plenary-nvim
+            pkgs.vimPlugins.hmts-nvim
+          ];
 
           # Plugins configuration
           plugins = {


### PR DESCRIPTION
## Summary
- add `plenary-nvim` alongside `hmts-nvim` in the `extraPlugins` set
- document why the dependency needs to be explicit with the current pinned nixvim/nixpkgs combination

## Test plan
- `git diff --staged --check`
- `nix-instantiate --parse modules/hm-apps/nixvim.nix`
- `nix eval --offline --accept-flake-config --impure --json --expr 'let flake = builtins.getFlake (toString /home/vx/trees/nixos/fix-nixvim-hmts-plenary); xs = flake.nixosConfigurations.system76.config.home-manager.users.vx.programs.nixvim.extraPlugins; nameOf = p: if p ? pname then p.pname else if p ? name then p.name else ""; in { hasPlenary = builtins.any (p: builtins.match "plenary.*" (nameOf p) != null) xs; hasHmts = builtins.any (p: builtins.match "hmts.*" (nameOf p) != null) xs; }'`
- `git push -u origin fix/nixvim-hmts-plenary` (post-push hooks passed: `apps-catalog-sync`, `gitleaks`, `managed-files-drift`, `vulnix`)
- attempted `nix build --offline --accept-flake-config .#nixosConfigurations.system76.config.system.build.toplevel --no-link`; blocked by upstream GitHub tarball fetch timeout for `NixOS/nixpkgs`