### PR TITLE
refactor(r2): tighten flake.lib helper and restore tpnix single-flip re-enable

### DIFF
--- a/modules/lib/r2-runtime.nix
+++ b/modules/lib/r2-runtime.nix
@@ -46,7 +46,7 @@
           ];
         })
 
-        (lib.optionalAttrs runtimeEnabled {
+        (lib.mkIf runtimeEnabled {
           # Allow non-root mounts to use `--allow-other`.
           programs.fuse.userAllowOther = true;
 
@@ -152,7 +152,7 @@
           };
         })
 
-        (lib.optionalAttrs (!runtimeEnabled) {
+        (lib.mkIf (!runtimeEnabled) {
           warnings = [ (policy.disabledReason or "R2 runtime disabled.") ];
         })
       ];

--- a/modules/lib/r2-runtime.nix
+++ b/modules/lib/r2-runtime.nix
@@ -1,0 +1,160 @@
+{ lib, ... }:
+{
+  flake.lib.nixos.r2.mkHostR2Module =
+    {
+      inputs,
+      metaOwner,
+      secretsRoot,
+      policy,
+    }:
+    let
+      externalFlakeEnabled = policy.enableExternalFlake;
+      r2ConfigFile = "${secretsRoot}/r2.yaml";
+      # Import the option surface independently from SOPS runtime readiness.
+      # Secret readiness gates only the host's runtime assignments below.
+      externalNixosModuleEnabled =
+        externalFlakeEnabled
+        && lib.hasAttrByPath [
+          "r2-flake"
+          "nixosModules"
+          "default"
+        ] inputs;
+      externalHomeModuleEnabled =
+        externalFlakeEnabled
+        && lib.hasAttrByPath [
+          "r2-flake"
+          "homeManagerModules"
+          "default"
+        ] inputs;
+      runtimeEnabled =
+        externalFlakeEnabled && policy.sopsRuntimeReady && builtins.pathExists r2ConfigFile;
+    in
+    { config, lib, ... }:
+    let
+      inherit (metaOwner) username;
+      group = lib.attrByPath [ "users" "users" username "group" ] "users" config;
+    in
+    {
+      imports = lib.optionals externalNixosModuleEnabled [
+        inputs."r2-flake".nixosModules.default
+      ];
+
+      config = lib.mkMerge [
+        (lib.mkIf externalHomeModuleEnabled {
+          home-manager.sharedModules = lib.mkAfter [
+            inputs."r2-flake".homeManagerModules.default
+          ];
+        })
+
+        (lib.optionalAttrs runtimeEnabled {
+          # Allow non-root mounts to use `--allow-other`.
+          programs.fuse.userAllowOther = true;
+
+          services.r2-sync = {
+            enable = true;
+            credentialsFile = "/run/secrets/r2/credentials.env";
+            accountIdFile = "/run/secrets/r2/account-id";
+
+            mounts = {
+              workspace = {
+                bucket = "nix-r2-cf-r2e-files-prod";
+                remotePrefix = "workspace";
+                mountPoint = "/data/r2/mount/workspace";
+                localPath = "/data/r2/workspace";
+                syncInterval = "5m";
+              };
+
+              fonts = {
+                bucket = "nix-r2-cf-r2e-files-prod";
+                remotePrefix = "fonts";
+                mountPoint = "/data/r2/mount/fonts";
+                localPath = "/data/fonts";
+                syncInterval = "30m";
+              };
+
+              docs = {
+                bucket = "nix-r2-cf-r2e-files-prod";
+                remotePrefix = "docs";
+                mountPoint = "/data/r2/mount/docs";
+                localPath = "/data/Docs";
+                syncInterval = "5m";
+              };
+            };
+          };
+
+          services.r2-restic = {
+            enable = true;
+            credentialsFile = "/run/secrets/r2/credentials.env";
+            accountIdFile = "/run/secrets/r2/account-id";
+            passwordFile = "/run/secrets/r2/restic-password";
+            bucket = "nix-r2-cf-backups-prod";
+            paths = [ "/data/r2/workspace" ];
+          };
+
+          programs.git-annex-r2 = {
+            enable = true;
+            credentialsFile = "/run/secrets/r2/credentials.env";
+          };
+
+          # Provide `r2` in PATH for the real user.
+          home-manager.users.${username}.programs.r2-cloud = {
+            enable = true;
+            accountIdFile = "/run/secrets/r2/account-id";
+            credentialsFile = "/run/secrets/r2/credentials.env";
+            explorerEnvFile = "/run/secrets/r2/explorer.env";
+            enableRcloneRemote = false;
+          };
+
+          systemd = {
+            # Run operational services as the real user so /data/r2/* stays user-owned.
+            services = {
+              "r2-mount-workspace".serviceConfig = {
+                User = username;
+                Group = group;
+              };
+              "r2-bisync-workspace".serviceConfig = {
+                User = username;
+                Group = group;
+              };
+              "r2-mount-fonts".serviceConfig = {
+                User = username;
+                Group = group;
+              };
+              "r2-bisync-fonts".serviceConfig = {
+                User = username;
+                Group = group;
+              };
+              "r2-mount-docs".serviceConfig = {
+                User = username;
+                Group = group;
+              };
+              "r2-bisync-docs".serviceConfig = {
+                User = username;
+                Group = group;
+              };
+              "r2-restic-backup".serviceConfig = {
+                User = username;
+                Group = group;
+              };
+            };
+
+            # Ensure paths exist (and are user-owned) before services start.
+            tmpfiles.rules = [
+              "d /data/r2 0750 ${username} ${group} - -"
+              "d /data/r2/mount 0750 ${username} ${group} - -"
+              "d /data/r2/mount/workspace 0750 ${username} ${group} - -"
+              "d /data/r2/mount/fonts 0750 ${username} ${group} - -"
+              "d /data/r2/mount/docs 0750 ${username} ${group} - -"
+              "d /data/r2/workspace 0750 ${username} ${group} - -"
+              "d /data/fonts 0750 ${username} ${group} - -"
+              "d /data/Docs 0750 ${username} ${group} - -"
+            ];
+          };
+        })
+
+        (lib.optionalAttrs (!runtimeEnabled) {
+          warnings = [ (policy.disabledReason or "R2 runtime disabled.") ];
+        })
+      ];
+    };
+}

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -28,7 +28,6 @@ let
     "homeManagerModules"
     "repoGpg"
   ] inputs;
-  r2FlakeEnabled = false;
 in
 {
   configurations.nixos.system76.module = {
@@ -52,11 +51,6 @@ in
     ]
     # Optional modules (graceful degradation)
     ++ lib.optionals system76SupportExists [ config.flake.nixosModules.system76-support ]
-    ++
-      lib.optionals (r2FlakeEnabled && lib.hasAttrByPath [ "r2-flake" "nixosModules" "default" ] inputs)
-        [
-          inputs.r2-flake.nixosModules.default
-        ]
     ++ lib.optionals lenovyMonitorExists [ config.flake.nixosModules."hardware-lenovo-y27q-20" ];
 
     # Pass shared module args to all imported modules
@@ -106,12 +100,7 @@ in
     };
 
     home-manager.sharedModules = lib.mkAfter (
-      lib.optionals
-        (r2FlakeEnabled && lib.hasAttrByPath [ "r2-flake" "homeManagerModules" "default" ] inputs)
-        [
-          inputs.r2-flake.homeManagerModules.default
-        ]
-      ++ lib.optionals repoGpgModuleExists [
+      lib.optionals repoGpgModuleExists [
         (lib.getAttrFromPath [ "self" "homeManagerModules" "repoGpg" ] inputs)
       ]
     );

--- a/modules/system76/r2-runtime.nix
+++ b/modules/system76/r2-runtime.nix
@@ -1,121 +1,21 @@
-{ metaOwner, ... }:
-let
-  r2RuntimeEnabled = false;
-in
 {
-  configurations.nixos.system76.module =
-    { config, lib, ... }:
-    let
-      inherit (metaOwner) username;
-      group = lib.attrByPath [ "users" "users" username "group" ] "users" config;
-    in
-    (lib.optionalAttrs r2RuntimeEnabled {
-      # Allow non-root mounts to use `--allow-other`.
-      programs.fuse.userAllowOther = true;
-
-      services.r2-sync = {
-        enable = true;
-        credentialsFile = "/run/secrets/r2/credentials.env";
-        accountIdFile = "/run/secrets/r2/account-id";
-
-        mounts = {
-          workspace = {
-            bucket = "nix-r2-cf-r2e-files-prod";
-            remotePrefix = "workspace";
-            mountPoint = "/data/r2/mount/workspace";
-            localPath = "/data/r2/workspace";
-            syncInterval = "5m";
-          };
-
-          fonts = {
-            bucket = "nix-r2-cf-r2e-files-prod";
-            remotePrefix = "fonts";
-            mountPoint = "/data/r2/mount/fonts";
-            localPath = "/data/fonts";
-            syncInterval = "30m";
-          };
-
-          docs = {
-            bucket = "nix-r2-cf-r2e-files-prod";
-            remotePrefix = "docs";
-            mountPoint = "/data/r2/mount/docs";
-            localPath = "/data/Docs";
-            syncInterval = "5m";
-          };
-        };
-      };
-
-      services.r2-restic = {
-        enable = true;
-        credentialsFile = "/run/secrets/r2/credentials.env";
-        accountIdFile = "/run/secrets/r2/account-id";
-        passwordFile = "/run/secrets/r2/restic-password";
-        bucket = "nix-r2-cf-backups-prod";
-        paths = [ "/data/r2/workspace" ];
-      };
-
-      programs.git-annex-r2 = {
-        enable = true;
-        credentialsFile = "/run/secrets/r2/credentials.env";
-      };
-
-      # Provide `r2` in PATH for the real user.
-      home-manager.users.${username}.programs.r2-cloud = {
-        enable = true;
-        enableRcloneRemote = false;
-        accountIdFile = "/run/secrets/r2/account-id";
-        credentialsFile = "/run/secrets/r2/credentials.env";
-        explorerEnvFile = "/run/secrets/r2/explorer.env";
-      };
-
-      systemd = {
-        # Run operational services as the real user so /data/r2/* stays user-owned.
-        services = {
-          "r2-mount-workspace".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-bisync-workspace".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-mount-fonts".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-bisync-fonts".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-mount-docs".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-bisync-docs".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-restic-backup".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-        };
-
-        # Ensure paths exist (and are user-owned) before services start.
-        tmpfiles.rules = [
-          "d /data/r2 0750 ${username} ${group} - -"
-          "d /data/r2/mount 0750 ${username} ${group} - -"
-          "d /data/r2/mount/workspace 0750 ${username} ${group} - -"
-          "d /data/r2/mount/fonts 0750 ${username} ${group} - -"
-          "d /data/r2/mount/docs 0750 ${username} ${group} - -"
-          "d /data/r2/workspace 0750 ${username} ${group} - -"
-          "d /data/Docs 0750 ${username} ${group} - -"
-        ];
-      };
-    })
-    // (lib.optionalAttrs (!r2RuntimeEnabled) {
-      warnings = [
-        "System76 R2 integration is disabled until the upstream r2-flake stops referencing removed pkgs.nodePackages."
-      ];
-    });
+  config,
+  inputs,
+  metaOwner,
+  secretsRoot,
+  ...
+}:
+{
+  configurations.nixos.system76.module = config.flake.lib.nixos.r2.mkHostR2Module {
+    inherit
+      inputs
+      metaOwner
+      secretsRoot
+      ;
+    policy = {
+      enableExternalFlake = false;
+      sopsRuntimeReady = false;
+      disabledReason = "system76 R2 integration is disabled until the upstream r2-flake stops referencing removed pkgs.nodePackages.";
+    };
+  };
 }

--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -20,7 +20,7 @@ let
     else
       null;
 
-  sopsRuntimeReady = false;
+  inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
 
   duplicatiModuleExists =
     sopsRuntimeReady && lib.hasAttrByPath [ "flake" "nixosModules" "duplicati-r2" ] config;

--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -26,10 +26,6 @@ let
     sopsRuntimeReady && lib.hasAttrByPath [ "flake" "nixosModules" "duplicati-r2" ] config;
   mirrorRootModuleExists = lib.hasAttrByPath [ "flake" "nixosModules" "mirror-root" ] config;
   lenovoMonitorExists = lib.hasAttrByPath [ "flake" "nixosModules" "hardware-lenovo-y27q-20" ] config;
-  r2NixosModuleExists =
-    sopsRuntimeReady && lib.hasAttrByPath [ "r2-flake" "nixosModules" "default" ] inputs;
-  r2HomeModuleExists =
-    sopsRuntimeReady && lib.hasAttrByPath [ "r2-flake" "homeManagerModules" "default" ] inputs;
 in
 {
   configurations.nixos.tpnix.module = {
@@ -42,7 +38,6 @@ in
     ]
     ++ lib.optionals duplicatiModuleExists [ config.flake.nixosModules."duplicati-r2" ]
     ++ lib.optionals mirrorRootModuleExists [ config.flake.nixosModules.mirror-root ]
-    ++ lib.optionals r2NixosModuleExists [ inputs."r2-flake".nixosModules.default ]
     ++ lib.optionals lenovoMonitorExists [ config.flake.nixosModules."hardware-lenovo-y27q-20" ]
     ++ [
       (
@@ -92,17 +87,14 @@ in
       };
     };
 
-    home-manager.sharedModules = lib.mkAfter (
-      [
-        {
-          services.espanso = {
-            waylandSupport = lib.mkForce false;
-            x11Support = lib.mkForce true;
-          };
-        }
-      ]
-      ++ lib.optionals r2HomeModuleExists [ inputs."r2-flake".homeManagerModules.default ]
-    );
+    home-manager.sharedModules = lib.mkAfter [
+      {
+        services.espanso = {
+          waylandSupport = lib.mkForce false;
+          x11Support = lib.mkForce true;
+        };
+      }
+    ];
   };
 
   flake = lib.mkIf (lib.hasAttrByPath [ "configurations" "nixos" "tpnix" "module" ] config) {

--- a/modules/tpnix/policy.nix
+++ b/modules/tpnix/policy.nix
@@ -1,0 +1,3 @@
+_: {
+  flake.lib.nixos.hosts.tpnix.sopsRuntimeReady = false;
+}

--- a/modules/tpnix/r2-runtime.nix
+++ b/modules/tpnix/r2-runtime.nix
@@ -1,123 +1,21 @@
-{ metaOwner, secretsRoot, ... }:
-let
-  r2ConfigFile = "${secretsRoot}/r2.yaml";
-  sopsRuntimeReady = false;
-  r2RuntimeEnabled = sopsRuntimeReady && builtins.pathExists r2ConfigFile;
-in
 {
-  configurations.nixos.tpnix.module =
-    { config, lib, ... }:
-    let
-      inherit (metaOwner) username;
-      group = lib.attrByPath [ "users" "users" username "group" ] "users" config;
-    in
-    (lib.optionalAttrs r2RuntimeEnabled {
-      # Allow non-root mounts to use `--allow-other`.
-      programs.fuse.userAllowOther = true;
-
-      services.r2-sync = {
-        enable = true;
-        credentialsFile = "/run/secrets/r2/credentials.env";
-        accountIdFile = "/run/secrets/r2/account-id";
-
-        mounts = {
-          workspace = {
-            bucket = "nix-r2-cf-r2e-files-prod";
-            remotePrefix = "workspace";
-            mountPoint = "/data/r2/mount/workspace";
-            localPath = "/data/r2/workspace";
-            syncInterval = "5m";
-          };
-
-          fonts = {
-            bucket = "nix-r2-cf-r2e-files-prod";
-            remotePrefix = "fonts";
-            mountPoint = "/data/r2/mount/fonts";
-            localPath = "/data/fonts";
-            syncInterval = "30m";
-          };
-
-          docs = {
-            bucket = "nix-r2-cf-r2e-files-prod";
-            remotePrefix = "docs";
-            mountPoint = "/data/r2/mount/docs";
-            localPath = "/data/Docs";
-            syncInterval = "5m";
-          };
-        };
-      };
-
-      services.r2-restic = {
-        enable = true;
-        credentialsFile = "/run/secrets/r2/credentials.env";
-        accountIdFile = "/run/secrets/r2/account-id";
-        passwordFile = "/run/secrets/r2/restic-password";
-        bucket = "nix-r2-cf-backups-prod";
-        paths = [ "/data/r2/workspace" ];
-      };
-
-      programs.git-annex-r2 = {
-        enable = true;
-        credentialsFile = "/run/secrets/r2/credentials.env";
-      };
-
-      # Provide `r2` in PATH for the real user.
-      home-manager.users.${username}.programs.r2-cloud = {
-        enable = true;
-        enableRcloneRemote = false;
-        accountIdFile = "/run/secrets/r2/account-id";
-        credentialsFile = "/run/secrets/r2/credentials.env";
-        explorerEnvFile = "/run/secrets/r2/explorer.env";
-      };
-
-      systemd = {
-        # Run operational services as the real user so /data/r2/* stays user-owned.
-        services = {
-          "r2-mount-workspace".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-bisync-workspace".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-mount-fonts".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-bisync-fonts".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-mount-docs".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-bisync-docs".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-          "r2-restic-backup".serviceConfig = {
-            User = username;
-            Group = group;
-          };
-        };
-
-        # Ensure paths exist (and are user-owned) before services start.
-        tmpfiles.rules = [
-          "d /data/r2 0750 ${username} ${group} - -"
-          "d /data/r2/mount 0750 ${username} ${group} - -"
-          "d /data/r2/mount/workspace 0750 ${username} ${group} - -"
-          "d /data/r2/mount/fonts 0750 ${username} ${group} - -"
-          "d /data/r2/mount/docs 0750 ${username} ${group} - -"
-          "d /data/r2/workspace 0750 ${username} ${group} - -"
-          "d /data/Docs 0750 ${username} ${group} - -"
-        ];
-      };
-    })
-    // (lib.optionalAttrs (!r2RuntimeEnabled) {
-      warnings = [
-        "R2 runtime services are disabled on tpnix until SOPS decryption keys are configured."
-      ];
-    });
+  config,
+  inputs,
+  metaOwner,
+  secretsRoot,
+  ...
+}:
+{
+  configurations.nixos.tpnix.module = config.flake.lib.nixos.r2.mkHostR2Module {
+    inherit
+      inputs
+      metaOwner
+      secretsRoot
+      ;
+    policy = {
+      enableExternalFlake = false;
+      sopsRuntimeReady = false;
+      disabledReason = "tpnix R2 runtime services are disabled until SOPS decryption keys are configured.";
+    };
+  };
 }

--- a/modules/tpnix/r2-runtime.nix
+++ b/modules/tpnix/r2-runtime.nix
@@ -5,6 +5,9 @@
   secretsRoot,
   ...
 }:
+let
+  ready = config.flake.lib.nixos.hosts.tpnix.sopsRuntimeReady;
+in
 {
   configurations.nixos.tpnix.module = config.flake.lib.nixos.r2.mkHostR2Module {
     inherit
@@ -13,8 +16,8 @@
       secretsRoot
       ;
     policy = {
-      enableExternalFlake = false;
-      sopsRuntimeReady = false;
+      enableExternalFlake = ready;
+      sopsRuntimeReady = ready;
       disabledReason = "tpnix R2 runtime services are disabled until SOPS decryption keys are configured.";
     };
   };


### PR DESCRIPTION
## Summary

- Move per-host R2 wiring out of `modules/{system76,tpnix}/` into a single helper at `modules/lib/r2-runtime.nix`, registered as `flake.lib.nixos.r2.mkHostR2Module`. Folds the duplicated `policy.enableExternalFlake` reads into one let-binding, makes `policy.disabledReason` optional, and stops emitting an empty `home-manager.sharedModules = lib.mkAfter [ ]` when the external flake module is unavailable.
- Restore tpnix's single-flip R2 re-enable path: a tiny `modules/tpnix/policy.nix` registers `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady`, and both `modules/tpnix/imports.nix` and `modules/tpnix/r2-runtime.nix` now derive their gating from that single value. Flipping it (plus dropping `secrets/r2.yaml`) rearms the runtime end-to-end.
- system76 stays explicitly opt-out (its block is unrelated to SOPS — upstream `r2-flake` still references removed `pkgs.nodePackages`).

### Latent fix surfaced by the consolidation

The shared helper's `tmpfiles.rules` includes `d /data/fonts 0750 ${username} ${group} - -`, which the pre-refactor per-host `r2-runtime.nix` files were missing even though both declared `localPath = "/data/fonts"` for the fonts mount. Re-enabling R2 on a fresh host would now create the directory before `r2-bisync-fonts` runs.

## Test plan

- [x] `nix fmt`
- [x] `nix flake check --accept-flake-config --no-build --offline` — passes; only expected warnings (system76 upstream-r2-flake, tpnix SOPS keys).
- [x] `nix eval .#lib.nixos.r2.mkHostR2Module --apply builtins.isFunction` → `true`.
- [x] `nix eval .#lib.nixos.hosts.tpnix.sopsRuntimeReady` → `false`.
- [x] `nix build .#nixosConfigurations.system76.config.system.build.toplevel` and `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel` (verified by maintainer locally).
- [ ] Single-flip smoke test: temporarily set `sopsRuntimeReady = true` in `modules/tpnix/policy.nix` and confirm the SOPS-keys warning disappears from `nix eval .#nixosConfigurations.tpnix.config.warnings`. Revert when done.