### PR TITLE
refactor(tpnix): unify sopsRuntimeReady reads under shared flake.lib source

### DIFF
--- a/modules/tpnix/duplicati.nix
+++ b/modules/tpnix/duplicati.nix
@@ -1,8 +1,13 @@
-{ lib, secretsRoot, ... }:
+{
+  config,
+  lib,
+  secretsRoot,
+  ...
+}:
 let
   manifestFile = "${secretsRoot}/duplicati-config.json";
   credentialsFile = "${secretsRoot}/duplicati-r2.yaml";
-  sopsRuntimeReady = false;
+  inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
   duplicatiSecretsReady =
     sopsRuntimeReady && (builtins.pathExists manifestFile) && (builtins.pathExists credentialsFile);
 in

--- a/modules/tpnix/fonts.nix
+++ b/modules/tpnix/fonts.nix
@@ -1,11 +1,12 @@
 {
+  config,
   lib,
   secretsRoot,
   ...
 }:
 let
   fontArchive = "${secretsRoot}/fonts/monolisa.tar.zst";
-  sopsRuntimeReady = false;
+  inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
   secretExists = builtins.pathExists fontArchive;
   secretName = "fonts/monolisa.archive";
   secretRuntimePath = "/run/secrets/fonts/monolisa.archive";


### PR DESCRIPTION
## Summary

Follow-up to #128: that PR established `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady` (set in `modules/tpnix/policy.nix`) as the single source of truth for tpnix's SOPS readiness, and rewired `modules/tpnix/imports.nix` and `modules/tpnix/r2-runtime.nix` to derive from it. `modules/tpnix/fonts.nix` and `modules/tpnix/duplicati.nix` were left out of that PR's scope — they each kept their own local `sopsRuntimeReady = false;` let-binding.

This PR closes that gap: both modules now `inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;` so flipping the one line in `policy.nix` re-enables the MonoLisa font installer and `services.duplicati-r2` alongside the R2 runtime, instead of requiring three separate edits across three files.

No behavior change: `sopsRuntimeReady` remains `false` until the SOPS keys are configured.

## Test plan

- [x] `nix flake check --accept-flake-config --no-build --offline` — passes; warnings unchanged (system76 upstream-r2-flake, tpnix SOPS keys, MonoLisa secret install, duplicati-r2).
- [ ] Single-flip smoke test: temporarily set `sopsRuntimeReady = true` in `modules/tpnix/policy.nix` and confirm `nix eval .#nixosConfigurations.tpnix.config.warnings` no longer contains the MonoLisa or duplicati-r2 warnings (subject to whether the corresponding `secrets/*.yaml` are present). Revert when done.