### PR TITLE
feat(git-hooks): auto-init submodules after worktree add via post-checkout

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Managed by Nix. Edit modules/development/git-hooks-post-checkout.nix
+# then run `nix develop -c write-files` to refresh.
+#
+# post-checkout args: $1=prev_head $2=new_head $3=flag (1=branch, 0=file)
+# Fires on `git checkout <branch>` and on `git worktree add`.
+[ "${3:-0}" = "1" ] || exit 0
+
+if ! git submodule update --init --recursive --quiet; then
+  printf 'post-checkout: submodule update failed (continuing)\n' >&2
+fi
+exit 0

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Inputs prefixed with `dedupe_` exist solely for deduplication via `.follows` dec
 The following files are defined in Nix and generated via [mightyiam/files](https://github.com/mightyiam/files) using `nix develop -c write-files`:
 
 - `.actrc`
+- `.githooks/post-checkout`
 - `.gitignore`
 - `.gitleaks.toml`
 - `.sops.yaml`

--- a/modules/development/git-hooks-post-checkout.nix
+++ b/modules/development/git-hooks-post-checkout.nix
@@ -1,0 +1,25 @@
+_: {
+  perSystem =
+    { pkgs, ... }:
+    {
+      files.files = [
+        {
+          path_ = ".githooks/post-checkout";
+          drv = pkgs.writeText "post-checkout" ''
+            #!/usr/bin/env bash
+            # Managed by Nix. Edit modules/development/git-hooks-post-checkout.nix
+            # then run `nix develop -c write-files` to refresh.
+            #
+            # post-checkout args: $1=prev_head $2=new_head $3=flag (1=branch, 0=file)
+            # Fires on `git checkout <branch>` and on `git worktree add`.
+            [ "''${3:-0}" = "1" ] || exit 0
+
+            if ! git submodule update --init --recursive --quiet; then
+              printf 'post-checkout: submodule update failed (continuing)\n' >&2
+            fi
+            exit 0
+          '';
+        }
+      ];
+    };
+}

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -137,6 +137,9 @@
           if [ -n "''${repo_root}" ] && [ -x "''${repo_root}/scripts/hooks/sync-pre-commit-hooks.sh" ]; then
             "''${repo_root}/scripts/hooks/sync-pre-commit-hooks.sh"
           fi
+          if [ -n "''${repo_root}" ] && [ -x "''${repo_root}/scripts/hooks/install-git-hooks.sh" ]; then
+            "''${repo_root}/scripts/hooks/install-git-hooks.sh"
+          fi
         '';
       };
 

--- a/scripts/hooks/install-git-hooks.sh
+++ b/scripts/hooks/install-git-hooks.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -Eeu -o pipefail
+
+error_msg() {
+  printf 'install-git-hooks: %s\n' "$1" >&2
+}
+
+main() {
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    error_msg "must be run from within a git worktree"
+    exit 1
+  fi
+
+  local repo_root git_common_dir hooks_dir src name dest
+  repo_root="$(git rev-parse --show-toplevel)"
+  git_common_dir="$(readlink -f "$(git rev-parse --git-common-dir)")"
+  hooks_dir="${git_common_dir}/hooks"
+
+  cd "${repo_root}"
+
+  if [[ ! -d .githooks ]]; then
+    return 0
+  fi
+
+  mkdir -p "${hooks_dir}"
+
+  shopt -s nullglob
+  for src in .githooks/*; do
+    [[ -f ${src} ]] || continue
+    name="$(basename "${src}")"
+    dest="${hooks_dir}/${name}"
+    install -m 0755 "${src}" "${dest}"
+  done
+}
+
+main "$@"

--- a/scripts/hooks/install-git-hooks.sh
+++ b/scripts/hooks/install-git-hooks.sh
@@ -28,6 +28,12 @@ main() {
   for src in .githooks/*; do
     [[ -f ${src} ]] || continue
     name="$(basename "${src}")"
+    case "${name}" in
+    pre-commit | pre-push)
+      error_msg "refusing to overwrite pre-commit-managed hook: ${name} (owned by scripts/hooks/sync-pre-commit-hooks.sh)"
+      exit 1
+      ;;
+    esac
     dest="${hooks_dir}/${name}"
     install -m 0755 "${src}" "${dest}"
   done


### PR DESCRIPTION
## Summary

- Add a tracked `.githooks/post-checkout` (materialized via the `mightyiam/files` writer) that runs `git submodule update --init --recursive` on branch checkouts, so `git worktree add` no longer leaves the `secrets` submodule uninitialized.
- Add `scripts/hooks/install-git-hooks.sh` and wire it into the devshell `shellHook` so the tracked hook is materialized into `$GIT_COMMON_DIR/hooks/post-checkout` (with exec bit) on every `nix develop` entry.
- The hook is gated on `$3 = 1` (branch checkout), so plain file checkouts do not trigger it. On submodule failure (offline, missing creds), it warns and exits 0 so `git worktree add` is never blocked.
- `managed-files-drift` automatically covers `.githooks/post-checkout` because it iterates every `cat … > path` line emitted by the files writer — no changes to that hook required.

## Test plan

- [x] `nix fmt`
- [x] `nix develop -c pre-commit run --all-files --hook-stage manual`
- [x] `nix flake check --accept-flake-config --no-build`
- [x] `nix develop -c write-files` is idempotent (`git diff --exit-code .githooks/`)
- [x] `nix develop -c hook-managed-files-drift` passes
- [x] After re-entering `nix develop`, `.git/hooks/post-checkout` exists with mode `0755`
- [x] `git worktree add --detach /tmp/test-wt main` leaves `secrets/` initialized in the new worktree (verified `submodule status` shows the SHA at `heads/main`, no leading `-`)
- [x] `git worktree remove` cleanup