### PR TITLE
feat(nixvim): integrate diffview.nvim with neogit, octo, git-conflict

### DIFF
--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -746,11 +746,8 @@ _: {
                       ];
                     };
 
-                    signs = {
-                      fold_closed = "";
-                      fold_open = "";
-                      done = "";
-                    };
+                    # Suppress the default "✓" done glyph for an icon-free panel.
+                    signs.done = "";
 
                     view = {
                       default.winbar_info = true;
@@ -905,7 +902,6 @@ _: {
                   settings = {
                     picker = "telescope";
                     enable_builtin = true;
-                    use_local_fs = false;
                     default_remote = [
                       "upstream"
                       "origin"

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -351,6 +351,14 @@ _: {
                     end, 150)
                   end,
                 })
+
+                -- diffview: diagonal slashes for diff filler lines (lower visual noise than '-')
+                vim.opt.fillchars:append({ diff = "╱" })
+
+                -- :DvStash → quick stash inspector (per USAGE.md recipe)
+                vim.api.nvim_create_user_command("DvStash", function()
+                  vim.cmd("DiffviewFileHistory -g --range=stash")
+                end, { desc = "Inspect git stash via diffview" })
               '';
 
               # hmts.nvim - enhanced treesitter injections for Home Manager/Nix files
@@ -710,6 +718,123 @@ _: {
                   };
                 };
 
+                # Diff/PR review surface with diffview.nvim
+                diffview = {
+                  enable = true;
+
+                  lazyLoad = {
+                    enable = true;
+                    settings.cmd = [
+                      "DiffviewOpen"
+                      "DiffviewClose"
+                      "DiffviewFocusFiles"
+                      "DiffviewToggleFiles"
+                      "DiffviewRefresh"
+                      "DiffviewLog"
+                      "DiffviewFileHistory"
+                    ];
+                  };
+
+                  settings = {
+                    enhanced_diff_hl = true;
+                    show_help_hints = false;
+
+                    default_args = {
+                      DiffviewOpen = [
+                        "--imply-local"
+                        "-uno"
+                      ];
+                    };
+
+                    signs = {
+                      fold_closed = "";
+                      fold_open = "";
+                      done = "";
+                    };
+
+                    view = {
+                      default.winbar_info = true;
+                      merge_tool = {
+                        layout = "diff3_mixed";
+                        winbar_info = true;
+                      };
+                      file_history.winbar_info = true;
+                    };
+
+                    file_panel.tree_options.folder_statuses = "always";
+
+                    commit_log_panel.win_config = {
+                      type = "float";
+                      relative = "editor";
+                      border = "rounded";
+                      width.__raw = "math.floor(vim.o.columns * 0.8)";
+                      height.__raw = "math.floor(vim.o.lines * 0.8)";
+                      row.__raw = "math.floor(vim.o.lines * 0.1)";
+                      col.__raw = "math.floor(vim.o.columns * 0.1)";
+                    };
+
+                    hooks = {
+                      diff_buf_read.__raw = ''
+                        function(_)
+                          vim.opt_local.wrap = false
+                          vim.opt_local.list = false
+                          vim.opt_local.colorcolumn = "80"
+                          vim.opt_local.cursorline = false
+                          vim.opt_local.signcolumn = "no"
+                        end
+                      '';
+                    };
+
+                    keymaps = {
+                      file_panel = [
+                        {
+                          mode = "n";
+                          key = "cc";
+                          action.__raw = ''
+                            function()
+                              vim.ui.input({ prompt = "Commit message: " }, function(msg)
+                                if not msg or msg == "" then return end
+                                vim.cmd(("!git commit -m %s"):format(vim.fn.shellescape(msg)))
+                              end)
+                            end
+                          '';
+                          description = "Commit staged changes";
+                        }
+                        {
+                          mode = "n";
+                          key = "ca";
+                          action.__raw = ''
+                            function()
+                              vim.ui.input({ prompt = "Amend commit (empty=no-edit): " }, function(msg)
+                                if not msg or msg == "" then
+                                  vim.cmd("!git commit --amend --no-edit")
+                                else
+                                  vim.cmd(("!git commit --amend -m %s"):format(vim.fn.shellescape(msg)))
+                                end
+                              end)
+                            end
+                          '';
+                          description = "Amend last commit";
+                        }
+                        {
+                          mode = "n";
+                          key = "<esc>";
+                          action.__raw = "require('diffview.actions').close";
+                          description = "Close diffview";
+                        }
+                      ];
+                      file_history_panel = [
+                        {
+                          mode = "n";
+                          key = "<esc>";
+                          action.__raw = "require('diffview.actions').close";
+                          description = "Close diffview";
+                        }
+                      ];
+                    };
+                  };
+                };
+
                 # Comment plugin
                 comment = {
                   enable = true;
@@ -966,6 +1091,56 @@ _: {
                   key = "K";
                   action = ":m '<-2<CR>gv=gv";
                   options.desc = "Move line up";
+                }
+
+                # Diffview
+                {
+                  mode = "n";
+                  key = "<leader>gd";
+                  action = "<cmd>DiffviewOpen<CR>";
+                  options.desc = "Diffview: open";
+                }
+                {
+                  mode = "n";
+                  key = "<leader>gD";
+                  action = "<cmd>DiffviewClose<CR>";
+                  options.desc = "Diffview: close";
+                }
+                {
+                  mode = "n";
+                  key = "<leader>gh";
+                  action = "<cmd>DiffviewFileHistory %<CR>";
+                  options.desc = "Diffview: file history (current)";
+                }
+                {
+                  mode = "n";
+                  key = "<leader>gH";
+                  action = "<cmd>DiffviewFileHistory<CR>";
+                  options.desc = "Diffview: file history (all)";
+                }
+                {
+                  mode = "n";
+                  key = "<leader>gp";
+                  action = "<cmd>DiffviewOpen origin/HEAD...HEAD --imply-local<CR>";
+                  options.desc = "Diffview: PR diff";
+                }
+                {
+                  mode = "n";
+                  key = "<leader>gP";
+                  action = "<cmd>DiffviewFileHistory --range=origin/HEAD...HEAD --right-only --no-merges<CR>";
+                  options.desc = "Diffview: per-commit PR review";
+                }
+                {
+                  mode = "n";
+                  key = "<leader>gs";
+                  action = "<cmd>DiffviewOpen --staged<CR>";
+                  options.desc = "Diffview: staged";
+                }
+                {
+                  mode = "n";
+                  key = "<leader>gS";
+                  action = "<cmd>DvStash<CR>";
+                  options.desc = "Diffview: stash";
                 }
               ];
 

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -479,9 +479,9 @@ _: {
                       "gi" = "implementation";
                       "gr" = "references";
                       "K" = "hover";
-                      "<leader>rn" = "rename";
                       "<leader>la" = "code_action";
-                      "<leader>f" = "format";
+                      "<leader>lf" = "format";
+                      "<leader>lr" = "rename";
                     };
                   };
                 };

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -479,9 +479,9 @@ _: {
                       "gi" = "implementation";
                       "gr" = "references";
                       "K" = "hover";
-                      "<leader>la" = "code_action";
-                      "<leader>lf" = "format";
-                      "<leader>lr" = "rename";
+                      "<leader>rn" = "rename";
+                      "<leader>ca" = "code_action";
+                      "<leader>f" = "format";
                     };
                   };
                 };

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -861,6 +861,24 @@ _: {
                   };
                 };
 
+                # Inline GitHub PR/issue review via `gh` CLI
+                octo = {
+                  enable = true;
+                  lazyLoad = {
+                    enable = true;
+                    settings.cmd = [ "Octo" ];
+                  };
+                  settings = {
+                    picker = "telescope";
+                    enable_builtin = true;
+                    use_local_fs = false;
+                    default_remote = [
+                      "upstream"
+                      "origin"
+                    ];
+                  };
+                };
+
                 # Comment plugin
                 comment = {
                   enable = true;
@@ -1175,6 +1193,14 @@ _: {
                   key = "<leader>gn";
                   action = "<cmd>Neogit<CR>";
                   options.desc = "Neogit: open";
+                }
+
+                # Octo
+                {
+                  mode = "n";
+                  key = "<leader>go";
+                  action = "<cmd>Octo<CR>";
+                  options.desc = "Octo: PR review";
                 }
               ];
 

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -472,7 +472,7 @@ _: {
                       "gr" = "references";
                       "K" = "hover";
                       "<leader>rn" = "rename";
-                      "<leader>ca" = "code_action";
+                      "<leader>la" = "code_action";
                       "<leader>f" = "format";
                     };
                   };

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -802,7 +802,21 @@ _: {
                             function()
                               vim.ui.input({ prompt = "Commit message: " }, function(msg)
                                 if not msg or msg == "" then return end
-                                vim.cmd(("!git commit -m %s"):format(vim.fn.shellescape(msg)))
+                                vim.system(
+                                  { "git", "commit", "-m", msg },
+                                  { text = true },
+                                  vim.schedule_wrap(function(out)
+                                    if out.code == 0 then
+                                      vim.notify("Committed", vim.log.levels.INFO)
+                                      vim.cmd("DiffviewRefresh")
+                                    else
+                                      vim.notify(
+                                        "git commit failed: " .. (out.stderr or ""),
+                                        vim.log.levels.ERROR
+                                      )
+                                    end
+                                  end)
+                                )
                               end)
                             end
                           '';
@@ -814,11 +828,24 @@ _: {
                           action.__raw = ''
                             function()
                               vim.ui.input({ prompt = "Amend commit (empty=no-edit): " }, function(msg)
+                                local args = { "git", "commit", "--amend" }
                                 if not msg or msg == "" then
-                                  vim.cmd("!git commit --amend --no-edit")
+                                  table.insert(args, "--no-edit")
                                 else
-                                  vim.cmd(("!git commit --amend -m %s"):format(vim.fn.shellescape(msg)))
+                                  table.insert(args, "-m")
+                                  table.insert(args, msg)
                                 end
+                                vim.system(args, { text = true }, vim.schedule_wrap(function(out)
+                                  if out.code == 0 then
+                                    vim.notify("Amended", vim.log.levels.INFO)
+                                    vim.cmd("DiffviewRefresh")
+                                  else
+                                    vim.notify(
+                                      "git commit --amend failed: " .. (out.stderr or ""),
+                                      vim.log.levels.ERROR
+                                    )
+                                  end
+                                end))
                               end)
                             end
                           '';

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -763,15 +763,23 @@ _: {
 
                     file_panel.tree_options.folder_statuses = "always";
 
-                    commit_log_panel.win_config = {
-                      type = "float";
-                      relative = "editor";
-                      border = "rounded";
-                      width.__raw = "math.floor(vim.o.columns * 0.8)";
-                      height.__raw = "math.floor(vim.o.lines * 0.8)";
-                      row.__raw = "math.floor(vim.o.lines * 0.1)";
-                      col.__raw = "math.floor(vim.o.columns * 0.1)";
-                    };
+                    # Function form: re-evaluated each open so the float tracks
+                    # terminal resizes instead of locking to startup dimensions.
+                    commit_log_panel.win_config.__raw = ''
+                      function()
+                        local width = math.floor(vim.o.columns * 0.8)
+                        local height = math.floor(vim.o.lines * 0.8)
+                        return {
+                          type = "float",
+                          relative = "editor",
+                          border = "rounded",
+                          width = width,
+                          height = height,
+                          row = math.floor((vim.o.lines - height) / 2),
+                          col = math.floor((vim.o.columns - width) / 2),
+                        }
+                      end
+                    '';
 
                     hooks = {
                       diff_buf_read.__raw = ''

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -1200,7 +1200,7 @@ _: {
                 {
                   mode = "n";
                   key = "<leader>gp";
-                  action = "<cmd>DiffviewOpen origin/HEAD...HEAD --imply-local<CR>";
+                  action = "<cmd>DiffviewOpen origin/HEAD...HEAD<CR>";
                   options.desc = "Diffview: PR diff";
                 }
                 {

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -835,6 +835,21 @@ _: {
                   };
                 };
 
+                # Magit-style git interface, backed by diffview for inline diffs
+                neogit = {
+                  enable = true;
+                  lazyLoad = {
+                    enable = true;
+                    settings.cmd = [ "Neogit" ];
+                  };
+                  settings = {
+                    integrations.diffview = true;
+                    graph_style = "unicode";
+                    disable_commit_confirmation = false;
+                    kind = "tab";
+                  };
+                };
+
                 # Comment plugin
                 comment = {
                   enable = true;
@@ -1141,6 +1156,14 @@ _: {
                   key = "<leader>gS";
                   action = "<cmd>DvStash<CR>";
                   options.desc = "Diffview: stash";
+                }
+
+                # Neogit
+                {
+                  mode = "n";
+                  key = "<leader>gn";
+                  action = "<cmd>Neogit<CR>";
+                  options.desc = "Neogit: open";
                 }
               ];
 

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -850,6 +850,17 @@ _: {
                   };
                 };
 
+                # Three-way merge conflict navigator (co/ct/cb/c0, ]x/[x defaults)
+                git-conflict = {
+                  enable = true;
+                  settings = {
+                    default_mappings = true;
+                    default_commands = true;
+                    disable_diagnostics = false;
+                    list_opener = "copen";
+                  };
+                };
+
                 # Comment plugin
                 comment = {
                   enable = true;

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -880,18 +880,17 @@ _: {
                   settings = {
                     integrations.diffview = true;
                     graph_style = "unicode";
-                    disable_commit_confirmation = false;
-                    kind = "tab";
                   };
                 };
 
-                # Three-way merge conflict navigator (co/ct/cb/c0, ]x/[x defaults)
+                # Three-way merge conflict navigator. Default mappings rebind
+                # `co`/`ct`/`cb`/`c0` (and `]x`/`[x`) inside conflict buffers,
+                # so vim's `ct{char}` motion is shadowed while markers remain.
                 git-conflict = {
                   enable = true;
                   settings = {
                     default_mappings = true;
                     default_commands = true;
-                    disable_diagnostics = false;
                     list_opener = "copen";
                   };
                 };


### PR DESCRIPTION
## Summary

- Wire `diffview.nvim` into the nixvim module with Tier 1+Tier 2 defaults: `--imply-local -uno` PR-review args, `diff3_mixed` merge layout, diagonal-slash diff fill, winbar labels, floating commit log, ESC-to-close, `vim.ui.input` commit recipe, and `:DvStash` user command.
- Add a `<leader>g*` keymap namespace (gd/gD/gh/gH/gp/gP/gs/gS for diffview; gn for neogit; go for octo). Move LSP `code_action` from `<leader>ca` to `<leader>la` so diffview's `diff3` `conflict_choose("all")` default stays free.
- Add `neogit` with `integrations.diffview = true`, `git-conflict.nvim` for in-buffer conflict navigation, and `octo.nvim` for inline GitHub PR/issue review (telescope picker, already enabled).
- Lazy-load command-driven plugins via `lz-n` (`DiffviewOpen`, `Neogit`, `Octo`); `git-conflict` stays eager and auto-detects conflicts on BufRead.

## Test plan

- [x] `nix flake check --accept-flake-config --no-build --offline`
- [x] `nix build .#nixosConfigurations.system76.config.system.build.toplevel`
- [ ] In Neovim: `:DiffviewOpen origin/HEAD...HEAD --imply-local -uno` (or `<leader>gp`) opens panel; LSP active in right pane
- [ ] `:DiffviewFileHistory %` (or `<leader>gh`) opens file history; `<esc>` closes
- [ ] `:Neogit` (or `<leader>gn`) opens; `dd` invokes diffview-backed diff
- [ ] In a file with conflict markers, `]x` jumps to next conflict; `co`/`ct`/`cb` resolve
- [ ] `<leader>la` invokes LSP code action; `<leader>ca` no longer triggers code action
- [ ] `:DvStash` opens stash file history