### PR TITLE
refactor(proton-vpn): retire local overlay workaround

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -966,11 +966,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1776949667,
-        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
+        "lastModified": 1777395829,
+        "narHash": "sha256-HposVFZcsBCevgqLR73w/BpSe8J1lMgw5kASnnxO3A4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
+        "rev": "e75f25705c2934955ee5075e62530d74aca973c6",
         "type": "github"
       },
       "original": {

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -17,6 +17,9 @@
 */
 
 _: {
+  # Upstream akinsho/git-conflict.nvim ships no LICENSE file, so nixpkgs flags
+  # the plugin as unfree. The allowlist entry is required for evaluation until
+  # upstream publishes a license.
   nixpkgs.allowedUnfreePackages = [ "git-conflict.nvim" ];
 
   flake.homeManagerModules.apps.nixvim =

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -17,6 +17,8 @@
 */
 
 _: {
+  nixpkgs.allowedUnfreePackages = [ "git-conflict.nvim" ];
+
   flake.homeManagerModules.apps.nixvim =
     {
       inputs,
@@ -889,6 +891,7 @@ _: {
                 # so vim's `ct{char}` motion is shadowed while markers remain.
                 git-conflict = {
                   enable = true;
+                  package = pkgs.vimPlugins.git-conflict-nvim;
                   settings = {
                     default_mappings = true;
                     default_commands = true;

--- a/modules/system76/custom-packages-overlay.nix
+++ b/modules/system76/custom-packages-overlay.nix
@@ -45,36 +45,6 @@ _: {
           NODE_GYP = "${prev."node-gyp"}/bin/node-gyp";
         });
 
-        # Track the latest upstream ProtonVPN release line (api-core 5.x)
-        # ahead of the nixpkgs channel pin. The GTK app pins
-        # proton-vpn-api-core (>= 5.0.0) in debian/control, so both move
-        # together.
-        pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
-          (_: python-prev: {
-            proton-vpn-api-core = python-prev.proton-vpn-api-core.overridePythonAttrs (_: rec {
-              version = "5.0.1";
-              src = prev.fetchFromGitHub {
-                owner = "ProtonVPN";
-                repo = "python-proton-vpn-api-core";
-                rev = "v${version}";
-                hash = "sha256-XdQLgHKNqBNwY51niSiE1HHxLJ3efipS03IUiyHQCiY=";
-              };
-            });
-          })
-        ];
-
-        proton-vpn =
-          (final.callPackage (prev.path + "/pkgs/by-name/pr/proton-vpn/package.nix") { }).overrideAttrs
-            (_: rec {
-              version = "4.15.3";
-              src = prev.fetchFromGitHub {
-                owner = "ProtonVPN";
-                repo = "proton-vpn-gtk-app";
-                tag = "v${version}";
-                hash = "sha256-2v8BckNmm7Ecw+uAgOyfofHDPWgXkJJ8DmhMszb0tg0=";
-              };
-            });
-
         # i3 window manager utilities
         i3-focus-or-launch = final.callPackage ../../packages/i3-focus-or-launch { };
         i3-scratchpad-show-or-create = final.callPackage ../../packages/i3-scratchpad-show-or-create { };

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -8,6 +8,14 @@ _: {
     }:
     let
       cfg = config.system76.gpu;
+      # nix-cachyos-kernel exposes the closed driver as the package itself;
+      # current nixpkgs' NVIDIA module expects the closed module at `.mod`.
+      closedNvidiaPackage =
+        package:
+        package
+        // {
+          mod = package;
+        };
     in
     {
       options.system76.gpu = {
@@ -60,7 +68,7 @@ _: {
 
             nvidia = {
               # GTX 1070 Max-Q is supported by the 580.xx legacy branch; newer production drivers ignore it.
-              package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
+              package = closedNvidiaPackage config.boot.kernelPackages.nvidiaPackages.legacy_580;
               modesetting.enable = true;
               powerManagement.enable = true;
               # Fine-grained power management (D3 power gating) is incompatible with PRIME sync.

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -10,6 +10,7 @@ _: {
       cfg = config.system76.gpu;
       # nix-cachyos-kernel exposes the closed driver as the package itself;
       # current nixpkgs' NVIDIA module expects the closed module at `.mod`.
+      # Mirror any change in modules/tpnix/power.nix.
       closedNvidiaPackage =
         package:
         package

--- a/modules/tpnix/custom-packages-overlay.nix
+++ b/modules/tpnix/custom-packages-overlay.nix
@@ -34,36 +34,6 @@ _: {
           NODE_GYP = "${prev."node-gyp"}/bin/node-gyp";
         });
 
-        # Track the latest upstream ProtonVPN release line (api-core 5.x)
-        # ahead of the nixpkgs channel pin. The GTK app pins
-        # proton-vpn-api-core (>= 5.0.0) in debian/control, so both move
-        # together.
-        pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
-          (_: python-prev: {
-            proton-vpn-api-core = python-prev.proton-vpn-api-core.overridePythonAttrs (_: rec {
-              version = "5.0.1";
-              src = prev.fetchFromGitHub {
-                owner = "ProtonVPN";
-                repo = "python-proton-vpn-api-core";
-                rev = "v${version}";
-                hash = "sha256-XdQLgHKNqBNwY51niSiE1HHxLJ3efipS03IUiyHQCiY=";
-              };
-            });
-          })
-        ];
-
-        proton-vpn =
-          (final.callPackage (prev.path + "/pkgs/by-name/pr/proton-vpn/package.nix") { }).overrideAttrs
-            (_: rec {
-              version = "4.15.3";
-              src = prev.fetchFromGitHub {
-                owner = "ProtonVPN";
-                repo = "proton-vpn-gtk-app";
-                tag = "v${version}";
-                hash = "sha256-2v8BckNmm7Ecw+uAgOyfofHDPWgXkJJ8DmhMszb0tg0=";
-              };
-            });
-
         # i3 window manager utilities
         i3-focus-or-launch = final.callPackage ../../packages/i3-focus-or-launch { };
         i3-scratchpad-show-or-create = final.callPackage ../../packages/i3-scratchpad-show-or-create { };

--- a/modules/tpnix/power.nix
+++ b/modules/tpnix/power.nix
@@ -6,6 +6,16 @@
       pkgs,
       ...
     }:
+    let
+      # nix-cachyos-kernel exposes the closed driver as the package itself;
+      # current nixpkgs' NVIDIA module expects the closed module at `.mod`.
+      closedNvidiaPackage =
+        package:
+        package
+        // {
+          mod = package;
+        };
+    in
     {
       boot.blacklistedKernelModules = [ "nouveau" ];
 
@@ -21,7 +31,7 @@
         ];
 
         nvidia = {
-          package = config.boot.kernelPackages.nvidiaPackages.production;
+          package = closedNvidiaPackage config.boot.kernelPackages.nvidiaPackages.production;
           modesetting.enable = true;
           open = false;
           gsp.enable = true;

--- a/modules/tpnix/power.nix
+++ b/modules/tpnix/power.nix
@@ -9,6 +9,7 @@
     let
       # nix-cachyos-kernel exposes the closed driver as the package itself;
       # current nixpkgs' NVIDIA module expects the closed module at `.mod`.
+      # Mirror any change in modules/system76/nvidia-gpu.nix.
       closedNvidiaPackage =
         package:
         package


### PR DESCRIPTION
## Summary

- Advance the root nixpkgs input to the revision containing upstream `proton-vpn 4.15.3` and `proton-vpn-api-core 5.0.1`.
- Remove the now-redundant ProtonVPN overrides from both `system76` and `tpnix` host overlays.
- Add the two small compatibility fixes required by that nixpkgs bump: NixVim `git-conflict.nvim` unfree/package wiring and CachyOS closed NVIDIA `.mod` package shape.

Closes #116.

## Commit Structure

- `fix(nixvim): use host git-conflict package`
- `fix(nvidia): adapt CachyOS closed driver package`
- `refactor(proton-vpn): retire local overlay workaround`

## Test Plan

- `git diff --check`
- `rg -n 'proton-vpn-api-core|proton-vpn\\s*=' modules/system76/custom-packages-overlay.nix modules/tpnix/custom-packages-overlay.nix || true`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.system76.pkgs.proton-vpn.version`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.system76.pkgs.python3Packages.proton-vpn-api-core.version`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.tpnix.pkgs.proton-vpn.version`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.tpnix.pkgs.python3Packages.proton-vpn-api-core.version`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.tpnix.config.system.build.toplevel.drvPath`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.system76.config.system.build.toplevel.drvPath`
- Not run: `nix flake check` per maintainer instruction in this session.
