### PR TITLE
feat(protonmail-bridge): add headless bridge daemon

### DIFF
--- a/modules/apps/protonmail-bridge.nix
+++ b/modules/apps/protonmail-bridge.nix
@@ -9,6 +9,7 @@
     * Runs the upstream Bridge binary as a systemd user service in `--noninteractive` mode.
     * Translates Proton Mail's encrypted API into local IMAP on `127.0.0.1:1143` (STARTTLS) and SMTP on `127.0.0.1:1025` (STARTTLS).
     * Talks to the host's Secret Service implementation over D-Bus (libsecret), so any GNOME Keyring, KWallet, or `pass-secret-service` backend works without further configuration.
+    * Upstream's user unit is gated on `graphical-session.target`, so the daemon only starts once a desktop session is active; on a headless host the unit will sit idle.
 
   Initial sign-in:
     The daemon runs with `--noninteractive` and cannot perform the first login. After enabling the
@@ -64,7 +65,7 @@ let
             ]
           );
           default = null;
-          description = "Log level forwarded to services.protonmail-bridge.logLevel; null leaves the upstream default in place.";
+          description = "Log level forwarded to services.protonmail-bridge.logLevel; null preserves upstream's `mkOptionDefault`.";
         };
       };
 

--- a/modules/apps/protonmail-bridge.nix
+++ b/modules/apps/protonmail-bridge.nix
@@ -1,0 +1,81 @@
+/*
+  Package: protonmail-bridge
+  Description: Headless Proton Mail Bridge daemon that exposes Proton Mail to local IMAP/SMTP clients.
+  Homepage: https://proton.me/mail/bridge
+  Documentation: https://proton.me/support/protonmail-bridge-install
+  Repository: https://github.com/ProtonMail/proton-bridge
+
+  Summary:
+    * Runs the upstream Bridge binary as a systemd user service in `--noninteractive` mode.
+    * Translates Proton Mail's encrypted API into local IMAP on `127.0.0.1:1143` (STARTTLS) and SMTP on `127.0.0.1:1025` (STARTTLS).
+    * Talks to the host's Secret Service implementation over D-Bus (libsecret), so any GNOME Keyring, KWallet, or `pass-secret-service` backend works without further configuration.
+
+  Initial sign-in:
+    The daemon runs with `--noninteractive` and cannot perform the first login. After enabling the
+    module, run `protonmail-bridge --cli` interactively once, type `login` to complete the Proton
+    flow, then `info` to print the per-account Bridge password. Paste that password into the mail
+    client; the daemon picks up the stored credentials from the keyring on the next start.
+
+  Example Usage:
+    * Point Thunderbird (or any IMAP client) at `127.0.0.1`, IMAP `1143`, SMTP `1025`, both with STARTTLS, using the Bridge-generated password.
+*/
+_:
+let
+  ProtonmailBridgeModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.services."protonmail-bridge".extended;
+    in
+    {
+      options.services."protonmail-bridge".extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable protonmail-bridge.";
+        };
+
+        package = lib.mkPackageOption pkgs "protonmail-bridge" { };
+
+        path = lib.mkOption {
+          type = lib.types.listOf lib.types.path;
+          default = [ ];
+          example = lib.literalExpression "with pkgs; [ pass gnome-keyring ]";
+          description = ''
+            Extra derivations placed on the daemon's PATH. Defaults to an empty list because Bridge
+            talks to the system Secret Service over D-Bus (libsecret) and needs no extra binaries;
+            override when selecting a non-Secret-Service credential backend.
+          '';
+        };
+
+        logLevel = lib.mkOption {
+          type = lib.types.nullOr (
+            lib.types.enum [
+              "panic"
+              "fatal"
+              "error"
+              "warn"
+              "info"
+              "debug"
+            ]
+          );
+          default = null;
+          description = "Log level forwarded to services.protonmail-bridge.logLevel; null leaves the upstream default in place.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        services.protonmail-bridge = {
+          enable = true;
+          inherit (cfg) package path logLevel;
+        };
+      };
+    };
+in
+{
+  flake.nixosModules.apps."protonmail-bridge" = ProtonmailBridgeModule;
+}

--- a/modules/apps/protonmail-bridge.nix
+++ b/modules/apps/protonmail-bridge.nix
@@ -69,10 +69,15 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        services.protonmail-bridge = {
-          enable = true;
-          inherit (cfg) package path logLevel;
-        };
+        services.protonmail-bridge = lib.mkMerge [
+          {
+            enable = true;
+            inherit (cfg) package path;
+          }
+          (lib.mkIf (cfg.logLevel != null) {
+            inherit (cfg) logLevel;
+          })
+        ];
       };
     };
 in

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -287,6 +287,7 @@
       "prefetch-yarn-deps".extended.enable = lib.mkOverride 1100 true;
       procps.extended.enable = lib.mkOverride 1100 true;
       "proton-vpn".extended.enable = lib.mkOverride 1100 true;
+      "protonmail-bridge".extended.enable = lib.mkOverride 1100 true;
       psmisc.extended.enable = lib.mkOverride 1100 true;
       pwgen.extended.enable = lib.mkOverride 1100 true;
       pymupdf.extended.enable = lib.mkOverride 1100 true;

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -287,7 +287,6 @@
       "prefetch-yarn-deps".extended.enable = lib.mkOverride 1100 true;
       procps.extended.enable = lib.mkOverride 1100 true;
       "proton-vpn".extended.enable = lib.mkOverride 1100 true;
-      "protonmail-bridge".extended.enable = lib.mkOverride 1100 true;
       psmisc.extended.enable = lib.mkOverride 1100 true;
       pwgen.extended.enable = lib.mkOverride 1100 true;
       pymupdf.extended.enable = lib.mkOverride 1100 true;
@@ -430,6 +429,7 @@
       espanso.extended.enable = lib.mkOverride 1100 true;
       flameshot.extended.enable = lib.mkOverride 1100 true;
       pcscd.extended.enable = lib.mkOverride 1100 true;
+      "protonmail-bridge".extended.enable = lib.mkOverride 1100 true;
     };
   };
 }

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -271,7 +271,6 @@
       "prefetch-yarn-deps".extended.enable = lib.mkOverride 1100 false;
       procps.extended.enable = lib.mkOverride 1100 false;
       "proton-vpn".extended.enable = lib.mkOverride 1100 true;
-      "protonmail-bridge".extended.enable = lib.mkOverride 1100 true;
       psmisc.extended.enable = lib.mkOverride 1100 true; # Provides killall
       pwgen.extended.enable = lib.mkOverride 1100 true;
       pymupdf.extended.enable = lib.mkOverride 1100 true;
@@ -414,6 +413,7 @@
       espanso.extended.enable = lib.mkOverride 1100 true;
       flameshot.extended.enable = lib.mkOverride 1100 true;
       pcscd.extended.enable = lib.mkOverride 1100 true;
+      "protonmail-bridge".extended.enable = lib.mkOverride 1100 true;
     };
   };
 }

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -271,6 +271,7 @@
       "prefetch-yarn-deps".extended.enable = lib.mkOverride 1100 false;
       procps.extended.enable = lib.mkOverride 1100 false;
       "proton-vpn".extended.enable = lib.mkOverride 1100 true;
+      "protonmail-bridge".extended.enable = lib.mkOverride 1100 true;
       psmisc.extended.enable = lib.mkOverride 1100 true; # Provides killall
       pwgen.extended.enable = lib.mkOverride 1100 true;
       pymupdf.extended.enable = lib.mkOverride 1100 true;


### PR DESCRIPTION
## Summary
- Add `modules/apps/protonmail-bridge.nix` wrapping `services.protonmail-bridge` under `services."protonmail-bridge".extended` (enable / package / path / logLevel forwarded verbatim).
- Enable the daemon on `system76` and `tpnix` via the `services` block of each host's `apps-enable.nix` catalog.
- The daemon runs as a systemd user service with `--noninteractive` and exposes IMAP on `127.0.0.1:1143` (STARTTLS) and SMTP on `127.0.0.1:1025` (STARTTLS); both ports stay on the loopback interface and need no firewall changes.
- Bridge talks to the host's Secret Service over D-Bus (libsecret), so it picks up whichever keyring backend each host already runs (`gnome-keyring` on tpnix, `pass-secret-service` on system76).

## Test plan
- [x] `nix develop -c pre-commit run --all-files --hook-stage manual`
- [x] `nix flake check --accept-flake-config --no-build --offline`
- [x] `nix eval .#nixosConfigurations.system76.config.services.protonmail-bridge.enable` -> `true`
- [x] `nix eval .#nixosConfigurations.tpnix.config.services.protonmail-bridge.enable` -> `true`
- [x] `nix eval .#nixosConfigurations.system76.options.services."protonmail-bridge".extended.enable.default --apply 'x: x'` -> `false`
- [x] `nix build .#nixosConfigurations.system76.config.system.build.toplevel`
- [x] `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel`
- One-time interactive login (`protonmail-bridge --cli`, then `login`, then `info`) is a per-host manual step after deploy; the noninteractive daemon cannot perform the first sign-in.