### PR TITLE
feat(gecko): whitelist codeassist.google and aistudio.google.com in uBlock Origin

### DIFF
--- a/modules/hm-apps/_gecko-browser-common.nix
+++ b/modules/hm-apps/_gecko-browser-common.nix
@@ -125,6 +125,8 @@ let
     "gemini.google.com * 3p-frame noop"
     "notebooklm.google * 3p-script noop"
     "notebooklm.google * 3p-frame noop"
+    "codeassist.google * 3p-script noop"
+    "codeassist.google * 3p-frame noop"
 
     # Proton web properties
     "proton.me * 3p-script noop"

--- a/modules/hm-apps/_gecko-browser-common.nix
+++ b/modules/hm-apps/_gecko-browser-common.nix
@@ -127,6 +127,8 @@ let
     "notebooklm.google * 3p-frame noop"
     "codeassist.google * 3p-script noop"
     "codeassist.google * 3p-frame noop"
+    "aistudio.google.com * 3p-script noop"
+    "aistudio.google.com * 3p-frame noop"
 
     # Proton web properties
     "proton.me * 3p-script noop"


### PR DESCRIPTION
## Summary

- Adds `codeassist.google` and `aistudio.google.com` to the AI tools section of the shared Gecko browser uBlock Origin medium-mode allowlist.
- Permits third-party scripts and frames on the Gemini Code Assist and Google AI Studio web apps for Firefox, Floorp, and LibreWolf profiles using the shared policy.

## Test plan

- [x] Inspect the generated diff to confirm the new rule lines were added inside the AI tools group.
- [ ] Reload the browser profile (Firefox, Floorp, or LibreWolf) and visit `https://codeassist.google` to confirm the page loads without uBO blocking third-party scripts or frames.
- [ ] Reload the browser profile and visit `https://aistudio.google.com` to confirm the page loads without uBO blocking third-party scripts or frames.