### PR TITLE
fix(nixvim): drop broken hmts.nvim plugin

### DIFF
--- a/docs/guides/custom-packages-style-guide.md
+++ b/docs/guides/custom-packages-style-guide.md
@@ -222,7 +222,7 @@ writeShellApplication {
   ];
 
   # NOTE: The /* bash */ annotation enables treesitter language injection
-  # for proper syntax highlighting and LSP support (via otter.nvim/hmts.nvim)
+  # for proper syntax highlighting and LSP support (via otter.nvim)
   text = /* bash */ ''
     echo "Example script"
     curl -s https://api.example.com | jq .

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -370,14 +370,11 @@ _: {
                 end, { desc = "Inspect git stash via diffview" })
               '';
 
-              # hmts.nvim - enhanced treesitter injections for Home Manager/Nix files
               # plenary.nvim is added explicitly because the pinned nixvim/nixpkgs
               # combination does not currently pull telescope's runtime dependency
               # onto the packpath.
-              # Detects embedded languages via /* lang */ comments, shebangs, and filename inference
               extraPlugins = [
                 pkgs.vimPlugins.plenary-nvim
-                pkgs.vimPlugins.hmts-nvim
               ];
 
               # Plugins configuration
@@ -945,7 +942,6 @@ _: {
                 };
 
                 # Otter - LSP features for embedded languages (e.g., bash in writeShellApplication)
-                # Works with hmts.nvim: hmts detects languages via injection queries, otter provides LSP
                 # Activation deferred in extraConfigLua to prevent blocking UI on file open
                 # Diagnostics filtered in extraConfigLua to suppress shellcheck ''${ false positives for nix
                 otter = {


### PR DESCRIPTION
## Summary
- Removes `pkgs.vimPlugins.hmts-nvim` from the nixvim Home Manager module (`modules/hm-apps/nixvim.nix`).
- Neovim 0.12 dropped the `all = false` compat shim on `vim.treesitter.query.add_predicate`. `hmts.nvim`'s `plugin/hmts.lua:127` still indexes the predicate match by capture name (`match[predicate[2]]:parent()`), which is `nil` under the new capture-id-keyed shape. Result: `attempt to call method 'parent' (a nil value)` raised through the treesitter highlighter every time a `.nix` buffer is opened.
- Both `vimPlugins.hmts-nvim` (1.3.0) and the `unstable-2025-06-11` variant in nixpkgs ship the broken line; upstream `calops/hmts.nvim` has not published a fix.
- Updates the `writeShellApplication` example in `docs/guides/custom-packages-style-guide.md` to reference only `otter.nvim`. The bundled nix-grammar injections plus otter still cover `/* lang */ "..."` highlighting and embedded-language LSP. The HM-specific path inference (e.g. `home.file."foo.py".text`) is the only thing lost; not currently relied on in this repo.

## Test plan
- [ ] `./build.sh --host system76`
- [ ] `nvim modules/hm-apps/nixvim.nix` and confirm no decoration provider crash on entry
- [ ] Open a `writeShellApplication` `text = /* bash */ ''...''` block; verify treesitter injection still highlights and otter attaches a bash LSP