### PR TITLE
refactor(nixvim): use onedark.nvim instead of stylix base16 mapping

### DIFF
--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -47,12 +47,17 @@ _: {
       config =
         if nvimEnabled then
           {
+            # Use navarasu/onedark.nvim directly instead of stylix's base16 mapping
+            stylix.targets.nixvim.enable = false;
+
             programs.nixvim = {
               enable = true;
               package = nvimPkg;
               viAlias = true;
               vimAlias = true;
               defaultEditor = true;
+
+              colorschemes.onedark.enable = true;
 
               # Leader key
               globals.mapleader = mkDefault " ";
@@ -1012,6 +1017,7 @@ _: {
                       separator = true;
                     }
                   ];
+                  settings.options.style_preset.__raw = "require('bufferline').style_preset.minimal";
                 };
 
                 # Web devicons (required by nvim-tree, telescope, bufferline, lualine)

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -1001,7 +1001,6 @@ _: {
                 # Lazy loading
                 lz-n.enable = true;
 
-                # Status line (uses Stylix theme)
                 lualine = {
                   enable = true;
                 };


### PR DESCRIPTION
## Summary
- Disables `stylix.targets.nixvim` so stylix no longer injects a colorscheme into nvim. Stylix kept theming everything else (kitty/alacritty, GTK/Qt, Firefox/Floorp/LibreWolf, Chromium, Zathura, dunst).
- Enables nixvim's first-class `colorschemes.onedark` module (`navarasu/onedark.nvim`), which is the hand-tuned port that ships richer chrome shades (`bg0`/`bg1`/`bg2`/`bg3`/`bg_d`) and per-treesitter-scope highlight assignments matching the original Atom theme.
- Sets `plugins.bufferline.settings.options.style_preset = minimal` (passed via `__raw` so the value resolves to the upstream `bufferline.style_preset.minimal` enum). Bufferline derives its `BufferLine*` highlights at runtime from `Normal.bg`; with the dark scheme it produced `tint(Normal.bg, -45) = #16181c` for the tabline strip, which clashed with the new palette. The minimal preset collapses those auto-shaded chrome colors back to `Normal.bg`.

## Why
The previous setup fed the base16-onedark palette through `mini.base16`'s mechanical mapping. That mapping is template-driven (types→base0A, functions→base0D, strings→base0B, …), which loses the hand-curated tweaks that make a "real" OneDark recognisable. Background tones in particular drift: base16 has only `base00`/`base01` for chrome, while `onedark.nvim` has `bg0` (`#282c34`), `bg1` (`#31353f`), `bg2` (`#393f4a`), `bg3` (`#3b3f4c`), and `bg_d` (`#21252b`). The result felt flat and the bufferline strip stuck out as too dark.

## Test plan
- [ ] `./build.sh --host system76`
- [ ] Open `nvim modules/hm-apps/nixvim.nix`; verify the OneDark palette is applied (treesitter token colors should match Atom's OneDark, not the base16 approximation)
- [ ] Confirm bufferline tabline strip is flat against `Normal.bg` (`#282c34`) instead of `#16181c`
- [ ] Confirm stylix-themed surfaces outside nvim (terminal, GTK, Firefox/Floorp/LibreWolf, dunst) are unchanged