### PR TITLE
feat(apps): add Doom Emacs via nix-doom-emacs-unstraightened

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,12 @@ Canonical documentation lives under `docs/architecture/`.
 
 ## Nix Configuration
 
-| Setting                        | Value                  | Purpose                                                    |
-| ------------------------------ | ---------------------- | ---------------------------------------------------------- |
-| `abort-on-warn`                | `false`                | Disabled due to upstream nixpkgs warning (issue `#485682`) |
-| `extra-experimental-features`  | `[ "pipe-operators" ]` | Enable pipe operator syntax in Nix expressions             |
-| `allow-import-from-derivation` | `false`                | Prevent IFD for purity and reproducibility                 |
-| `experimental-features`        | `nix-command flakes`   | Enable flakes and new Nix CLI                              |
+| Setting                        | Value                  | Purpose                                                                     |
+| ------------------------------ | ---------------------- | --------------------------------------------------------------------------- |
+| `abort-on-warn`                | `false`                | Disabled due to upstream nixpkgs warning (issue `#485682`)                  |
+| `extra-experimental-features`  | `[ "pipe-operators" ]` | Enable pipe operator syntax in Nix expressions                              |
+| `allow-import-from-derivation` | `true`                 | Required by `nix-doom-emacs-unstraightened` (no other module relies on IFD) |
+| `experimental-features`        | `nix-command flakes`   | Enable flakes and new Nix CLI                                               |
 
 These settings are mirrored in `build.sh` via `NIX_CONFIGURATION`.
 

--- a/build.sh
+++ b/build.sh
@@ -208,6 +208,8 @@ BOOTSTRAP_SUBSTITUTERS=(
   "https://cache.numtide.com"
   "https://nixpkgs-unfree.cachix.org"
   "https://nix-logseq-git-flake.cachix.org"
+  "https://nix-community.cachix.org"
+  "https://doom-emacs-unstraightened.cachix.org"
   "https://attic.xuyh0120.win/lantian"
 )
 BOOTSTRAP_TRUSTED_KEYS=(
@@ -216,6 +218,8 @@ BOOTSTRAP_TRUSTED_KEYS=(
   "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
   "nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs="
   "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo="
+  "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
+  "doom-emacs-unstraightened.cachix.org-1:O5oOlRPnmQEvVaFyuMTmthCEooHbrg54WgSLR07tmg4="
   "lantian:EeAUQ+W+6r7EtwnmYjeVwx5kOGEBpjlBfPlzGlTNvHc="
 )
 
@@ -261,7 +265,8 @@ configure_nix_config() {
   NIX_CONFIG=""
   append_nix_config_line "experimental-features = nix-command flakes pipe-operators"
   append_nix_config_line "accept-flake-config = true"
-  append_nix_config_line "allow-import-from-derivation = false"
+  # IFD required by `nix-doom-emacs-unstraightened` (see flake.nix#nixConfig).
+  append_nix_config_line "allow-import-from-derivation = true"
   append_nix_config_line "abort-on-warn = false"
 
   append_nix_config_line "access-tokens = github.com=$(gh auth token)"

--- a/flake.lock
+++ b/flake.lock
@@ -327,6 +327,66 @@
         "type": "github"
       }
     },
+    "doomemacs": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1777326848,
+        "narHash": "sha256-7ErKUgw6Ch7hP1oBjMSos8xXRD+rxxjaOldRn+TcClo=",
+        "owner": "doomemacs",
+        "repo": "doomemacs",
+        "rev": "6be3337b49867bd86f90fe5ca4beeb6b38afaddb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "doomemacs",
+        "repo": "doomemacs",
+        "type": "github"
+      }
+    },
+    "emacs-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1777631609,
+        "narHash": "sha256-mVuwqfmX3ev8eRgzRBYkN3UZ9rn1Uo5MRAoX6pCN6q0=",
+        "owner": "nix-community",
+        "repo": "emacs-overlay",
+        "rev": "00b5f387f4f557a0f5a3902023b62aa15d020683",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "emacs-overlay",
+        "type": "github"
+      }
+    },
+    "emacs-overlay_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-doom-emacs-unstraightened"
+        ],
+        "nixpkgs-stable": [
+          "nix-doom-emacs-unstraightened"
+        ]
+      },
+      "locked": {
+        "lastModified": 1777628916,
+        "narHash": "sha256-HeafeyKK6IxdSmdS/lFRkkOkgNZYQ2WsWx9tBVv785c=",
+        "owner": "nix-community",
+        "repo": "emacs-overlay",
+        "rev": "00b089698f39f7c41eabe8a8d9869ebbc1759a7e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "emacs-overlay",
+        "type": "github"
+      }
+    },
     "files": {
       "locked": {
         "lastModified": 1776952985,
@@ -544,7 +604,7 @@
     },
     "flake-utils": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1731533236,
@@ -860,6 +920,29 @@
         "type": "github"
       }
     },
+    "nix-doom-emacs-unstraightened": {
+      "inputs": {
+        "doomemacs": "doomemacs",
+        "emacs-overlay": "emacs-overlay_2",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1777629537,
+        "narHash": "sha256-fBpoc/+nYcE2TCyNPzfy5OPZCyvp5GARc6r4R0EYXUs=",
+        "owner": "marienz",
+        "repo": "nix-doom-emacs-unstraightened",
+        "rev": "ff8ef70369fcfb398577cd866b415f649fc68022",
+        "type": "github"
+      },
+      "original": {
+        "owner": "marienz",
+        "repo": "nix-doom-emacs-unstraightened",
+        "type": "github"
+      }
+    },
     "nix-index-database": {
       "inputs": {
         "nixpkgs": [
@@ -964,6 +1047,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1777428379,
+        "narHash": "sha256-ypxFOeDz+CqADEQNL72haqGjvZQdBR5Vc7pyx2JDttI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "755f5aa91337890c432639c60b6064bb7fe67769",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1777395829,
@@ -1020,7 +1119,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_3"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1777236345,
@@ -1101,6 +1200,7 @@
         "dedupe_flake-utils": "dedupe_flake-utils",
         "dedupe_nur": "dedupe_nur",
         "dedupe_systems": "dedupe_systems",
+        "emacs-overlay": "emacs-overlay",
         "files": "files",
         "flake-parts": "flake-parts",
         "git-hooks": "git-hooks",
@@ -1110,6 +1210,7 @@
         "make-shell": "make-shell",
         "mcp-servers-nix": "mcp-servers-nix",
         "nix-cachyos-kernel": "nix-cachyos-kernel",
+        "nix-doom-emacs-unstraightened": "nix-doom-emacs-unstraightened",
         "nix-index-database": "nix-index-database",
         "nix-logseq-git-flake": "nix-logseq-git-flake",
         "nixos-hardware": "nixos-hardware",
@@ -1262,6 +1363,21 @@
       }
     },
     "systems_3": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_4": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,10 @@
   nixConfig = {
     abort-on-warn = false;
     extra-experimental-features = [ "pipe-operators" ];
-    allow-import-from-derivation = false;
+    # IFD is required by `nix-doom-emacs-unstraightened` (lib.importJSON of
+    # `doom-intermediates/packages.json`). No other module in this repo relies
+    # on IFD; flake evaluation otherwise stays pure.
+    allow-import-from-derivation = true;
   };
 
   inputs = {
@@ -71,6 +74,16 @@
       url = "github:xddxdd/nix-cachyos-kernel/release";
     };
 
+    emacs-overlay = {
+      url = "github:nix-community/emacs-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
+    nix-doom-emacs-unstraightened = {
+      url = "github:marienz/nix-doom-emacs-unstraightened";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
     nixos-hardware.url = "github:NixOS/nixos-hardware/master";
@@ -134,6 +147,7 @@
       flake = false;
       url = "github:cloudflare/cloudflare-go";
     };
+
     cloudflare-python = {
       flake = false;
       url = "github:cloudflare/cloudflare-python";

--- a/modules/apps/doom-emacs-doomdir/config.el
+++ b/modules/apps/doom-emacs-doomdir/config.el
@@ -1,0 +1,3 @@
+;;; config.el -*- lexical-binding: t; -*-
+
+;; Personal Doom configuration goes here. Empty by default.

--- a/modules/apps/doom-emacs-doomdir/init.el
+++ b/modules/apps/doom-emacs-doomdir/init.el
@@ -1,0 +1,11 @@
+;;; init.el -*- lexical-binding: t; -*-
+
+;; Minimal placeholder Doom Emacs configuration.
+;; Override `programs.doom-emacs.extended.doomDir' to point at a real
+;; doomdir checkout for a meaningful setup.
+;;
+;; `doom!' must declare at least one module group; calling it without
+;; arguments errors out with "Wrong number of arguments" in
+;; `doom-module-mplist-map'. Enabling the `:ui doom' module gives the
+;; default Doom theme/UI without pulling in heavier feature modules.
+(doom! :ui doom)

--- a/modules/apps/doom-emacs-doomdir/packages.el
+++ b/modules/apps/doom-emacs-doomdir/packages.el
@@ -1,0 +1,4 @@
+;; -*- no-byte-compile: t; -*-
+;;; packages.el
+
+;; Declare extra Emacs packages here with `package!'. Empty by default.

--- a/modules/apps/doom-emacs.nix
+++ b/modules/apps/doom-emacs.nix
@@ -1,0 +1,107 @@
+/*
+  Package: doom-emacs
+  Description: Doom Emacs framework built reproducibly with Nix via marienz/nix-doom-emacs-unstraightened.
+  Homepage: https://github.com/doomemacs/doomemacs
+  Documentation: https://docs.doomemacs.org/
+  Repository: https://github.com/marienz/nix-doom-emacs-unstraightened
+
+  Summary:
+    * Builds Doom Emacs with a sealed package set (no straight.el) by snapshotting modules and dependencies through Nix.
+    * Bundles a user doomdir (init.el / packages.el / config.el) into the produced Emacs derivation so activation is fully declarative.
+
+  Options:
+    enable: Toggle the doom-emacs integration; the actual package is installed by the Home Manager module.
+    package: Emacs derivation passed to Unstraightened (defaults to pkgs.emacs from the emacs-overlay).
+    doomDir: Path to the doomdir bundled into the build (defaults to a minimal in-tree placeholder).
+    enableService: Enable the Home Manager `services.emacs` user daemon backed by Doom.
+
+  Notes:
+    * Package sourced from nix-doom-emacs-unstraightened (github:marienz/nix-doom-emacs-unstraightened).
+    * Adds inputs.emacs-overlay.overlays.default to nixpkgs.overlays for the host whenever `enable = true`.
+      That registration is global: it changes pkgs.emacs and every package that builds against the Emacs
+      tree (notmuch, mu, mu4e, pdf-tools, anything using emacsPackages / emacsWithPackages). Account for
+      that side-effect when debugging unrelated Emacs regressions.
+    * Wires `nix-community.cachix.org` (emacs-overlay artefacts) and
+      `doom-emacs-unstraightened.cachix.org` (Doom build artefacts) into
+      `nix.settings.extra-substituters` so substitution covers both layers. Trust
+      keys are mirrored in `extra-trusted-public-keys`.
+    * Configuration and install delegated to Home Manager (modules/hm-apps/doom-emacs.nix).
+    * Override doomDir to point at a real Doom configuration for a personalised setup.
+*/
+{ inputs, ... }:
+{
+  flake.nixosModules.apps.doom-emacs =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.doom-emacs.extended;
+      cacheSubstituter = "https://nix-community.cachix.org";
+      cachePublicKey = "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs=";
+      doomCacheSubstituter = "https://doom-emacs-unstraightened.cachix.org";
+      doomCachePublicKey = "doom-emacs-unstraightened.cachix.org-1:O5oOlRPnmQEvVaFyuMTmthCEooHbrg54WgSLR07tmg4=";
+    in
+    {
+      options.programs.doom-emacs.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether this host uses Doom Emacs built via nix-doom-emacs-unstraightened.
+            Activation happens through the matching Home Manager module
+            (modules/hm-apps/doom-emacs.nix), which imports the upstream homeModule.
+          '';
+        };
+
+        package = lib.mkOption {
+          type = lib.types.package;
+          default = pkgs.emacs;
+          defaultText = lib.literalExpression "pkgs.emacs";
+          description = ''
+            Emacs derivation passed to Unstraightened. The default tracks
+            `pkgs.emacs` from the emacs-overlay registered by this module.
+            Set this to e.g. `pkgs.emacs-pgtk` to switch variants.
+          '';
+        };
+
+        doomDir = lib.mkOption {
+          type = lib.types.path;
+          default = ./doom-emacs-doomdir;
+          defaultText = lib.literalExpression "./doom-emacs-doomdir";
+          description = ''
+            Path to the Doom configuration directory (init.el / packages.el / config.el)
+            bundled into the build. The default is a placeholder; point this at a real
+            doomdir to install a meaningful configuration.
+          '';
+        };
+
+        enableService = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to enable the Home Manager `services.emacs` user daemon. The
+            upstream homeModule wires `services.emacs.package` to the Doom build
+            automatically, so the daemon launches the Unstraightened binary.
+            Defaults to `false` because `systemctl --user` keeps the daemon
+            restarting if Doom errors out on a placeholder configuration; opt in
+            per host once a real doomdir is wired up.
+          '';
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        nixpkgs.overlays = [ inputs.emacs-overlay.overlays.default ];
+        nix.settings.extra-substituters = lib.mkAfter [
+          cacheSubstituter
+          doomCacheSubstituter
+        ];
+        nix.settings.extra-trusted-public-keys = lib.mkAfter [
+          cachePublicKey
+          doomCachePublicKey
+        ];
+      };
+    };
+}

--- a/modules/base/nix-settings.nix
+++ b/modules/base/nix-settings.nix
@@ -10,8 +10,9 @@
       # Disabled due to upstream nixpkgs warning in make-options-doc
       # See: https://github.com/NixOS/nixpkgs/issues/485682
       abort-on-warn = false;
-      # Prevent IFD to ensure evaluation purity and build reproducibility
-      allow-import-from-derivation = false;
+      # Required by `nix-doom-emacs-unstraightened`, which evaluates a JSON
+      # manifest produced by a build derivation. Mirrors flake.nix#nixConfig.
+      allow-import-from-derivation = true;
       keep-outputs = false;
       experimental-features = [
         "nix-command"

--- a/modules/hm-apps/doom-emacs.nix
+++ b/modules/hm-apps/doom-emacs.nix
@@ -1,0 +1,67 @@
+/*
+  Package: doom-emacs
+  Description: Home Manager activation for Doom Emacs built via marienz/nix-doom-emacs-unstraightened.
+  Homepage: https://github.com/doomemacs/doomemacs
+  Documentation: https://docs.doomemacs.org/
+  Repository: https://github.com/marienz/nix-doom-emacs-unstraightened
+
+  Summary:
+    * Imports the upstream Home Manager `homeModule` so `programs.doom-emacs.enable = true` builds Doom with the user's doomdir.
+    * Optionally enables the user-level `services.emacs` daemon so the Doom-flavoured Emacs starts on login.
+
+  Notes:
+    * Activated only when `programs.doom-emacs.extended.enable = true` in the host NixOS config.
+    * Reads doomDir / doomLocalDir / package / enableService from the matching NixOS module so configuration stays in one place.
+    * Upstream sets `services.emacs.package` to the Doom build automatically when `programs.doom-emacs.provideEmacs = true` (the default).
+*/
+_: {
+  flake.homeManagerModules.apps.doom-emacs =
+    {
+      config,
+      inputs,
+      lib,
+      pkgs,
+      osConfig,
+      ...
+    }:
+    let
+      doomEnabled = lib.attrByPath [
+        "programs"
+        "doom-emacs"
+        "extended"
+        "enable"
+      ] false osConfig;
+
+      doomCfg = lib.attrByPath [
+        "programs"
+        "doom-emacs"
+        "extended"
+      ] { } osConfig;
+
+      doomPackage = doomCfg.package;
+      inherit (doomCfg) doomDir enableService;
+    in
+    {
+      imports = [ inputs.nix-doom-emacs-unstraightened.homeModule ];
+
+      config = lib.mkIf doomEnabled {
+        programs.doom-emacs = {
+          enable = true;
+          inherit doomDir;
+          doomLocalDir = "${config.xdg.dataHome}/nix-doom";
+          emacs = doomPackage;
+          # Upstream's default reads `config.programs.{ripgrep,git,fd}.package`;
+          # this repo opts those Home Manager wrappers out (`package = null`),
+          # so the upstream default would inject null entries that fail
+          # `types.listOf types.package`. Source the binaries directly from pkgs.
+          extraBinPackages = with pkgs; [
+            git
+            ripgrep
+            fd
+          ];
+        };
+
+        services.emacs.enable = lib.mkDefault enableService;
+      };
+    };
+}

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -99,6 +99,7 @@
       dnsleak.extended.enable = lib.mkOverride 1100 true;
       docker.extended.enable = lib.mkOverride 1100 true;
       dolphin.extended.enable = lib.mkOverride 1100 false;
+      "doom-emacs".extended.enable = lib.mkOverride 1100 true;
       "dragon-drop".extended.enable = lib.mkOverride 1100 true;
       dropbox.extended.enable = lib.mkOverride 1100 true;
       dua.extended.enable = lib.mkOverride 1100 true;

--- a/modules/system76/home-manager-apps.nix
+++ b/modules/system76/home-manager-apps.nix
@@ -11,6 +11,7 @@ let
     # "copyq"
     "dive"
     "docker-compose"
+    "doom-emacs"
     "element-desktop"
     "espanso"
     # "evince"

--- a/modules/system76/nix-substituters.nix
+++ b/modules/system76/nix-substituters.nix
@@ -10,6 +10,8 @@ let
     "https://cache.garnix.io"
     "https://cache.numtide.com"
     "https://nixpkgs-unfree.cachix.org" # unfree packages (unrar, etc.)
+    # nix-community.cachix.org / doom-emacs-unstraightened.cachix.org are
+    # appended by modules/apps/doom-emacs.nix when the module is enabled.
   ];
   trustedKeys = [
     "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -85,6 +85,7 @@
       dnsleak.extended.enable = lib.mkOverride 1100 true;
       docker.extended.enable = lib.mkOverride 1100 false;
       dolphin.extended.enable = lib.mkOverride 1100 false;
+      "doom-emacs".extended.enable = lib.mkOverride 1100 true;
       "dragon-drop".extended.enable = lib.mkOverride 1100 true;
       dropbox.extended.enable = lib.mkOverride 1100 false;
       dua.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/home-manager-apps.nix
+++ b/modules/tpnix/home-manager-apps.nix
@@ -11,6 +11,7 @@ let
     # "copyq"
     "dive"
     "docker-compose"
+    "doom-emacs"
     "element-desktop"
     "espanso"
     # "evince"

--- a/modules/tpnix/nix-substituters.nix
+++ b/modules/tpnix/nix-substituters.nix
@@ -10,6 +10,8 @@ let
     "https://cache.garnix.io"
     "https://cache.numtide.com"
     "https://nixpkgs-unfree.cachix.org" # unfree packages (unrar, etc.)
+    # nix-community.cachix.org / doom-emacs-unstraightened.cachix.org are
+    # appended by modules/apps/doom-emacs.nix when the module is enabled.
   ];
   trustedKeys = [
     "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="


### PR DESCRIPTION
## Summary

- Wires `nix-doom-emacs-unstraightened` and `emacs-overlay` as flake inputs and exposes Doom Emacs through `programs.doom-emacs.extended.{enable,package,doomDir,enableService}`.
- Splits responsibilities mirror-style with the existing neovim/nixvim pattern: `modules/apps/doom-emacs.nix` declares options, registers the emacs-overlay, and owns the Doom-specific cachix wiring; `modules/hm-apps/doom-emacs.nix` imports the upstream `homeModule` and resolves `doomLocalDir` via `config.xdg.dataHome`.
- A placeholder `modules/apps/doom-emacs-doomdir/` ships so `enable = true` evaluates without an external doom config; override `programs.doom-emacs.extended.doomDir` to point at a real doomdir.
- Enables Doom on both `system76` and `tpnix`, flips `allow-import-from-derivation = true` consistently across `flake.nix#nixConfig`, `build.sh`, `modules/base/nix-settings.nix`, and the `AGENTS.md` configuration table, and wires `nix-community.cachix.org` (emacs-overlay) plus `doom-emacs-unstraightened.cachix.org` (Doom builds) via the module's `nix.settings.extra-substituters` and the `build.sh` bootstrap arrays.

## IFD policy

`nix-doom-emacs-unstraightened` uses `lib.importJSON` against a build artifact (`doom-intermediates/packages.json`) and therefore requires `allow-import-from-derivation = true`. This PR adopts option 1 from the original heads-up: flip the policy in every mirrored location with a comment at each toggle pinning the change to this module. No other module in the repo relies on IFD; flake evaluation otherwise stays pure.

## Test plan

- [x] `nix flake check --accept-flake-config --no-build` -> `all checks passed!`
- [x] `nix eval .#nixosConfigurations.system76.config.system.build.toplevel.outPath` returns a store path.
- [x] `nix eval .#nixosConfigurations.tpnix.config.system.build.toplevel.outPath` returns a store path.
- [x] Pre-commit hooks (deadnix, nix-parse, statix, treefmt, typos) pass on every commit.
- [ ] `./build.sh --host system76` post-deploy verification on the real host.
- [ ] `systemctl --user status emacs.service` shows the Doom-flavoured Emacs daemon running.
- [ ] `emacsclient -c` opens a Doom Emacs frame using the bundled placeholder doomdir (or a personalised override).
- [ ] `doom-emacs-unstraightened.cachix.org` substitution is exercised on the next Doom build.
