### PR TITLE
feat(apps): add jupyter-all, marp-cli, quarto + tpnix catalog tweaks

### DIFF
--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -1,0 +1,54 @@
+/*
+  Package: jupyter-all
+  Description: Jupyter wrapper bundling JupyterLab, the classic notebook server, and a curated set of language kernels.
+  Homepage: https://jupyter.org/
+  Documentation: https://docs.jupyter.org/
+  Repository: https://github.com/jupyter/notebook
+
+  Summary:
+    * Provides a single environment with `jupyter`, `jupyter-lab`, `jupyter-notebook`, `jupyter-console`, `jupyter-nbconvert`, and `ipython` entry points.
+    * Ships additional Clojure (Clojupyter) and Octave kernels in addition to the default Python kernel via the nixpkgs override.
+
+  Options:
+    notebook: Launch the classic web-based Jupyter Notebook server.
+    lab: Start the JupyterLab next-generation notebook IDE.
+    console: Open a terminal-based interactive kernel session.
+    nbconvert <input>: Convert notebooks to HTML, PDF, slides, Markdown, scripts, or other formats.
+    kernelspec <subcommand>: Manage installed Jupyter kernels (list, install, remove, provision).
+    server: Run only the headless Jupyter server backend without a UI.
+
+  Notes:
+    * `jupyter-all` is `jupyter.override` from nixpkgs that registers Clojure (clojupyter) and Octave kernels alongside the Python kernel.
+    * The Wolfram kernel is intentionally excluded upstream because it is unfree.
+*/
+_:
+let
+  JupyterAllModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs."jupyter-all".extended;
+    in
+    {
+      options.programs."jupyter-all".extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable jupyter-all.";
+        };
+
+        package = lib.mkPackageOption pkgs "jupyter-all" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.jupyter-all = JupyterAllModule;
+}

--- a/modules/apps/marp-cli.nix
+++ b/modules/apps/marp-cli.nix
@@ -6,12 +6,14 @@
   Repository: https://github.com/marp-team/marp-cli
 
   Summary:
-    * Renders Marp Markdown decks to HTML, PDF, PPTX, or PNG/JPEG image files.
+    * Renders Marp Markdown decks to HTML (default), PDF, PPTX, or PNG/JPEG image files.
     * Provides a watcher and a presentation server for previewing slide decks during authoring.
 
   Options:
     -o <file>: Write output to the given path; the extension selects the converter.
-    --pdf, --html, --pptx, --image: Force a specific output format regardless of the output filename.
+    --pdf, --pptx: Force PDF or PowerPoint output regardless of the output filename.
+    --image <png|jpeg>: Convert only the first slide page into a single image file.
+    --images <png|jpeg>: Convert every slide page into separate image files.
     -w, --watch: Re-render automatically when input Markdown or theme files change.
     -s, --server: Serve the input directory as a slide deck index over HTTP.
     -p, --preview: Open a preview window after conversion (requires a desktop environment).

--- a/modules/apps/marp-cli.nix
+++ b/modules/apps/marp-cli.nix
@@ -1,0 +1,51 @@
+/*
+  Package: marp-cli
+  Description: A CLI interface for Marp and Marpit based converters.
+  Homepage: https://marp.app/
+  Documentation: https://github.com/marp-team/marp-cli#readme
+  Repository: https://github.com/marp-team/marp-cli
+
+  Summary:
+    * Renders Marp Markdown decks to HTML, PDF, PPTX, or PNG/JPEG image files.
+    * Provides a watcher and a presentation server for previewing slide decks during authoring.
+
+  Options:
+    -o <file>: Write output to the given path; the extension selects the converter.
+    --pdf, --html, --pptx, --image: Force a specific output format regardless of the output filename.
+    -w, --watch: Re-render automatically when input Markdown or theme files change.
+    -s, --server: Serve the input directory as a slide deck index over HTTP.
+    -p, --preview: Open a preview window after conversion (requires a desktop environment).
+    --theme <name|path>: Apply a built-in theme name or a custom CSS file to the deck.
+    --engine <module>: Replace the default Marpit engine with a custom JavaScript module.
+*/
+_:
+let
+  MarpCliModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs."marp-cli".extended;
+    in
+    {
+      options.programs."marp-cli".extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable marp-cli.";
+        };
+
+        package = lib.mkPackageOption pkgs "marp-cli" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.marp-cli = MarpCliModule;
+}

--- a/modules/apps/quarto.nix
+++ b/modules/apps/quarto.nix
@@ -1,0 +1,51 @@
+/*
+  Package: quarto
+  Description: Open-source scientific and technical publishing system built on Pandoc.
+  Homepage: https://quarto.org/
+  Documentation: https://quarto.org/docs/guide/
+  Repository: https://github.com/quarto-dev/quarto-cli
+
+  Summary:
+    * Renders computational documents authored in Markdown, Jupyter, or RMarkdown into HTML, PDF, DOCX, ePub, or revealjs presentations.
+    * Provides project, preview, and publishing workflows for books, websites, manuscripts, and dashboards backed by Pandoc and Knitr/Jupyter engines.
+
+  Options:
+    render <input>: Render a single document or project to its configured output formats.
+    preview <input>: Render and serve a document with live reload while editing.
+    create <type> <name>: Scaffold a new project, document, or extension from a template.
+    publish <provider>: Publish rendered output to providers such as Quarto Pub, GitHub Pages, Netlify, or Connect.
+    check: Verify the local installation, including Pandoc, LaTeX, and Jupyter dependencies.
+    install <type> <target>: Install extensions, formats, or TinyTeX into the current project or user scope.
+    convert <input>: Convert between Quarto, Jupyter, and RMarkdown source representations.
+*/
+_:
+let
+  QuartoModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.quarto.extended;
+    in
+    {
+      options.programs.quarto.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable quarto.";
+        };
+
+        package = lib.mkPackageOption pkgs "quarto" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.quarto = QuartoModule;
+}

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -178,6 +178,7 @@
       jnv.extended.enable = lib.mkOverride 1100 true;
       john.extended.enable = lib.mkOverride 1100 true;
       jq.extended.enable = lib.mkOverride 1100 true;
+      "jupyter-all".extended.enable = lib.mkOverride 1100 true;
       just.extended.enable = lib.mkOverride 1100 true;
       karere.extended.enable = lib.mkOverride 1100 true;
       kcolorchooser.extended.enable = lib.mkOverride 1100 true;
@@ -213,6 +214,7 @@
       "maestral-gui".extended.enable = lib.mkOverride 1100 true;
       maim.extended.enable = lib.mkOverride 1100 true;
       malimite.extended.enable = lib.mkOverride 1100 false;
+      "marp-cli".extended.enable = lib.mkOverride 1100 true;
       marktext.extended.enable = lib.mkOverride 1100 true;
       mattermost.extended.enable = lib.mkOverride 1100 false;
       "media-toolchain".extended.enable = lib.mkOverride 1100 true;
@@ -297,6 +299,7 @@
       qbittorrent.extended.enable = lib.mkOverride 1100 true;
       qpdf.extended.enable = lib.mkOverride 1100 true;
       qrencode.extended.enable = lib.mkOverride 1100 true;
+      quarto.extended.enable = lib.mkOverride 1100 true;
       radare2.extended.enable = lib.mkOverride 1100 false;
       raindrop.extended.enable = lib.mkOverride 1100 true;
       rar.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -164,6 +164,7 @@
       jnv.extended.enable = lib.mkOverride 1100 false;
       john.extended.enable = lib.mkOverride 1100 true;
       jq.extended.enable = lib.mkOverride 1100 true;
+      "jupyter-all".extended.enable = lib.mkOverride 1100 true;
       just.extended.enable = lib.mkOverride 1100 false;
       karere.extended.enable = lib.mkOverride 1100 false;
       kcolorchooser.extended.enable = lib.mkOverride 1100 false;
@@ -197,6 +198,7 @@
       "maestral-gui".extended.enable = lib.mkOverride 1100 false;
       maim.extended.enable = lib.mkOverride 1100 true;
       malimite.extended.enable = lib.mkOverride 1100 false;
+      "marp-cli".extended.enable = lib.mkOverride 1100 true;
       marktext.extended.enable = lib.mkOverride 1100 true;
       mattermost.extended.enable = lib.mkOverride 1100 false;
       "media-toolchain".extended.enable = lib.mkOverride 1100 true;
@@ -281,6 +283,7 @@
       qbittorrent.extended.enable = lib.mkOverride 1100 true;
       qpdf.extended.enable = lib.mkOverride 1100 true;
       qrencode.extended.enable = lib.mkOverride 1100 true;
+      quarto.extended.enable = lib.mkOverride 1100 true;
       radare2.extended.enable = lib.mkOverride 1100 false;
       raindrop.extended.enable = lib.mkOverride 1100 false;
       rar.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -186,7 +186,7 @@
       localsend.extended.enable = lib.mkOverride 1100 true;
       logseq.extended.enable = lib.mkOverride 1100 true;
       logseq.extended.disableGpuCompositing = lib.mkOverride 1100 true;
-      "logseq-cli".extended.enable = lib.mkOverride 1100 true;
+      "logseq-cli".extended.enable = lib.mkOverride 1100 false;
       lshw.extended.enable = lib.mkOverride 1100 true;
       lsof.extended.enable = lib.mkOverride 1100 true;
       ltrace.extended.enable = lib.mkOverride 1100 true;


### PR DESCRIPTION
## Summary

Add three publishing/data-science modules and wire them into both host catalogs. Each module follows the standard `programs.<pkg>.extended` opt-in pattern (`mkOption`, `mkPackageOption`, `mkIf cfg.enable`, exported via `flake.nixosModules.apps.<name>`):

- **jupyter-all**: `pkgs.jupyter-all` from nixpkgs (`jupyter.override` registering Clojupyter and Octave kernels alongside the default Python kernel) bundling JupyterLab, classic notebook, console, nbconvert, and ipython.
- **marp-cli**: render Marp Markdown decks to HTML (default), PDF, PPTX, or PNG/JPEG image files; watch mode and presentation server included.
- **quarto**: Pandoc-backed scientific publishing system (HTML, PDF, DOCX, ePub, revealjs) with project / preview / publish workflows.

Also disables `logseq-cli` in the tpnix catalog (separate atomic commit), since the host's Logseq usage no longer needs the CLI variant.

## Test plan

- [x] `nix-instantiate --parse` on all five touched files
- [x] pre-commit hooks (deadnix, statix, treefmt, typos, gitleaks, managed-files-drift): green at push
- [x] `nix flake check --accept-flake-config --no-build --offline`: all checks passed
- [x] `nix build .#nixosConfigurations.system76.config.system.build.toplevel`: store path `/nix/store/2j4r2wadmvz3lhzzcpci6kzk7rlhpydn-nixos-system-system76-26.05.20260428.e75f257`
- [x] `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel`: store path `/nix/store/xgr2sr2z8yk20ms3y3ryjzxxv105q4h3-nixos-system-tpnix-26.05.20260428.e75f257`
