### PR TITLE
feat(tpnix): source kitty shell integration in zsh

### DIFF
--- a/modules/tpnix/zsh.nix
+++ b/modules/tpnix/zsh.nix
@@ -43,6 +43,16 @@ in
         # Mirror bash behavior: expose hostname through HOSTNAME in zsh.
         export HOSTNAME="$HOST"
 
+        # Source kitty's shell integration when running inside kitty.
+        # Why: HM's programs.kitty sets shell_integration=no-rc, but it only
+        # auto-sources from HM-managed zsh; this zsh is NixOS-managed.
+        if [[ -n "$KITTY_INSTALLATION_DIR" ]]; then
+          export KITTY_SHELL_INTEGRATION="enabled"
+          autoload -Uz -- "$KITTY_INSTALLATION_DIR"/shell-integration/zsh/kitty-integration
+          kitty-integration
+          unfunction kitty-integration
+        fi
+
         # Register custom build.sh completions from zsh site-functions.
         if (( $+functions[compdef] )); then
           autoload -Uz _build_sh

--- a/modules/tpnix/zsh.nix
+++ b/modules/tpnix/zsh.nix
@@ -47,7 +47,7 @@ in
         # Why: HM's programs.kitty sets shell_integration=no-rc, but it only
         # auto-sources from HM-managed zsh; this zsh is NixOS-managed.
         if [[ -n "$KITTY_INSTALLATION_DIR" && -f "$KITTY_INSTALLATION_DIR"/shell-integration/zsh/kitty-integration ]]; then
-          export KITTY_SHELL_INTEGRATION="enabled"
+          export KITTY_SHELL_INTEGRATION="''${KITTY_SHELL_INTEGRATION:-enabled}"
           autoload -Uz -- "$KITTY_INSTALLATION_DIR"/shell-integration/zsh/kitty-integration
           kitty-integration
           unfunction kitty-integration

--- a/modules/tpnix/zsh.nix
+++ b/modules/tpnix/zsh.nix
@@ -46,7 +46,7 @@ in
         # Source kitty's shell integration when running inside kitty.
         # Why: HM's programs.kitty sets shell_integration=no-rc, but it only
         # auto-sources from HM-managed zsh; this zsh is NixOS-managed.
-        if [[ -n "$KITTY_INSTALLATION_DIR" ]]; then
+        if [[ -n "$KITTY_INSTALLATION_DIR" && -f "$KITTY_INSTALLATION_DIR"/shell-integration/zsh/kitty-integration ]]; then
           export KITTY_SHELL_INTEGRATION="enabled"
           autoload -Uz -- "$KITTY_INSTALLATION_DIR"/shell-integration/zsh/kitty-integration
           kitty-integration


### PR DESCRIPTION
## Summary

HM's `programs.kitty` sets `shell_integration = "no-rc"` and only auto-sources kitty's zsh integration for HM-managed zsh. The system zsh on tpnix is NixOS-managed, so prompt marks, scrollback hints, and remote command tracking weren't applied while running inside kitty.

When `KITTY_INSTALLATION_DIR` is set (running inside kitty), the snippet:
- exports `KITTY_SHELL_INTEGRATION` (defaulting to `enabled`, but preserving any value kitty propagated from `kitty.conf`)
- guards on the integration script's existence so a stale or externally-injected `KITTY_INSTALLATION_DIR` doesn't error every shell
- autoloads and calls the bundled `kitty-integration` function from `$KITTY_INSTALLATION_DIR/shell-integration/zsh/`
- unsets the function after use to keep the namespace tidy

## Test plan

- [x] `nix-instantiate --parse modules/tpnix/zsh.nix`
- [x] `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel`
- [x] `zsh -n` on the rendered `/etc/zshrc` (sanity-checks the interpolated init string)
- [x] pre-commit hooks (`deadnix`, `nix-parse`, `statix`, `treefmt`, `typos`) — green on each commit
- [ ] On tpnix in kitty, confirm `$KITTY_SHELL_INTEGRATION` is set and `ksi` features (Cmd+click, jump-to-prompt) work in zsh (manual on-host check)

`nix flake check` is intentionally not listed: this is a value-level edit inside an existing module string, with no structural change.