### PR TITLE
fix(nixvim): forward allowUnfreePredicate to nixvim's pkgs instance

### DIFF
--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -59,6 +59,11 @@ _: {
 
               colorschemes.onedark.enable = true;
 
+              # Nixvim builds its own pkgs instance, so the system-level
+              # allowUnfreePredicate doesn't apply. Forward it so unfree
+              # plugins listed in `nixpkgs.allowedUnfreePackages` are honored.
+              nixpkgs.config.allowUnfreePredicate = pkgs.config.allowUnfreePredicate;
+
               # Leader key
               globals.mapleader = mkDefault " ";
               globals.maplocalleader = mkDefault " ";


### PR DESCRIPTION
## Summary

Nixvim builds its own pkgs instance, so the system-level `allowUnfreePredicate` does not apply automatically when nixvim resolves its plugin set. As a result, plugins explicitly listed in `nixpkgs.allowedUnfreePackages` (the file already lists `git-conflict.nvim`, which upstream ships without a LICENSE) are rejected as unfree by nixvim's internal evaluator.

This PR forwards only the `allowUnfreePredicate` from the host pkgs into nixvim's wrapper-internal nixpkgs config:

```nix
nixpkgs.config.allowUnfreePredicate = pkgs.config.allowUnfreePredicate;
```

The host pkgs is configured by `modules/meta/nixpkgs-allowed-unfree.nix`, which composes the `nixpkgs.allowedUnfreePackages` allowlists declared by app modules (including the `git-conflict.nvim` entry at the top of `modules/hm-apps/nixvim.nix`). Forwarding the resulting predicate is sufficient to honor that allowlist inside nixvim's plugin evaluator, without replacing nixvim's own pkgs instance.

### Scope and intent

Nixvim must keep its own `pkgs` instance. Earlier iterations that swapped to `nixpkgs.useGlobalPackages = true;` (or `nixpkgs.pkgs = pkgs;`) were reverted at maintainer request and are explicitly out of scope. Only the targeted predicate forward is intended.

## Test plan

- [x] `nix build .#nixosConfigurations.system76.config.system.build.toplevel` succeeds
- [x] `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel` succeeds
- [x] `nix eval` of `programs.nixvim.nixpkgs.config.allowUnfreePredicate` against a synthetic `git-conflict.nvim` returns `true`; against an unlisted unfree package returns `false`
- [ ] After switch: open Neovim and confirm `git-conflict.nvim` loads without an unfree-rejection error