### PR TITLE
feat(claude-code): enable frontend-design plugin

### DIFF
--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -136,8 +136,11 @@ in
           };
           example = lib.literalExpression ''
             {
-              "frontend-design@claude-plugins-official" = true;
-              "some-other-plugin@some-marketplace" = false;
+              # Enable an extra plugin from a registered marketplace:
+              "design-system@some-marketplace" = true;
+              # Keep an entry registered in settings.json but disabled
+              # (per-key override; differs from omitting the entry entirely):
+              "frontend-design@claude-plugins-official" = false;
             }
           '';
           description = ''
@@ -148,7 +151,9 @@ in
             whole attrset to drop defaults entirely. The marketplace named in
             the suffix must already be registered in
             `~/.claude/plugins/known_marketplaces.json` for the entry to take
-            effect.
+            effect. LSP plugin keys (those that would collide with
+            `lspPlugins.<key>@claude-plugins-official`) are rejected by
+            assertion to avoid silently masking the LSP-managed enable state.
           '';
         };
       };
@@ -163,28 +168,59 @@ in
               # The bun HM module owns BUN_INSTALL/PATH setup and the createBunDir DAG node.
               home-manager.extraAppImports = lib.mkAfter (lib.optional cfg.installMethods.bun.enable "bun");
 
-              assertions = [
-                {
-                  assertion = cfg.anyInstallEnabled;
-                  message = ''
-                    programs.claude-code.extended.enable = true, but no install method
-                    is enabled. Set one of:
-                      programs.claude-code.extended.installMethods.nix.enable = true;
-                      programs.claude-code.extended.installMethods.bun.enable = true;
-                    (typically in modules/<host>/apps-enable.nix)
-                  '';
-                }
-                {
-                  assertion = (!cfg.installMethods.bun.enable) || config.programs.bun.extended.enable;
-                  message = ''
-                    programs.claude-code.extended.installMethods.bun.enable requires
-                    programs.bun.extended.enable = true. Enable bun in your host's
-                    apps-enable.nix (e.g. modules/tpnix/apps-enable.nix:32 or
-                    modules/system76/apps-enable.nix:47) before enabling the bun
-                    install method for claude-code.
-                  '';
-                }
-              ];
+              assertions =
+                let
+                  extraKeys = lib.attrNames cfg.extraPlugins;
+                  malformedKeys = lib.filter (k: builtins.match ".+@.+" k == null) extraKeys;
+                  lspKeysWithMarket = map (k: "${k}@claude-plugins-official") (lib.attrNames cfg.lspPlugins);
+                  lspCollisions = lib.intersectLists extraKeys lspKeysWithMarket;
+                in
+                [
+                  {
+                    assertion = cfg.anyInstallEnabled;
+                    message = ''
+                      programs.claude-code.extended.enable = true, but no install method
+                      is enabled. Set one of:
+                        programs.claude-code.extended.installMethods.nix.enable = true;
+                        programs.claude-code.extended.installMethods.bun.enable = true;
+                      (typically in modules/<host>/apps-enable.nix)
+                    '';
+                  }
+                  {
+                    assertion = (!cfg.installMethods.bun.enable) || config.programs.bun.extended.enable;
+                    message = ''
+                      programs.claude-code.extended.installMethods.bun.enable requires
+                      programs.bun.extended.enable = true. Enable bun in your host's
+                      apps-enable.nix (e.g. modules/tpnix/apps-enable.nix:32 or
+                      modules/system76/apps-enable.nix:47) before enabling the bun
+                      install method for claude-code.
+                    '';
+                  }
+                  {
+                    assertion = malformedKeys == [ ];
+                    message = ''
+                      programs.claude-code.extended.extraPlugins keys must follow the
+                      "<plugin>@<marketplace>" form (matching the suffix used in
+                      ~/.claude/settings.json's enabledPlugins and the marketplace name
+                      in ~/.claude/plugins/known_marketplaces.json). A key without an
+                      "@" suffix is silently ignored by Claude Code at runtime.
+                      Invalid keys: ${toString malformedKeys}
+                    '';
+                  }
+                  {
+                    assertion = lspCollisions == [ ];
+                    message = ''
+                      programs.claude-code.extended.extraPlugins must not include LSP
+                      plugin keys. LSP plugins are managed by
+                      programs.claude-code.extended.lspPlugins.<key> and are merged
+                      into ~/.claude/settings.json with the @claude-plugins-official
+                      marketplace suffix; placing them under extraPlugins would
+                      disable them in settings.json without removing the installed
+                      binary, producing a confusing inconsistency.
+                      Conflicting keys: ${toString lspCollisions}
+                    '';
+                  }
+                ];
             }
           ]
           ++ lib.mapAttrsToList (

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -128,6 +128,29 @@ in
             '';
           }
         ) lspPluginProgramMap;
+
+        extraPlugins = lib.mkOption {
+          type = lib.types.attrsOf lib.types.bool;
+          default = {
+            "frontend-design@claude-plugins-official" = true;
+          };
+          example = lib.literalExpression ''
+            {
+              "frontend-design@claude-plugins-official" = true;
+              "some-other-plugin@some-marketplace" = false;
+            }
+          '';
+          description = ''
+            Additional non-LSP Claude Code plugins to enable, keyed by the
+            `"<plugin>@<marketplace>"` identifier used in
+            `~/.claude/settings.json`'s `enabledPlugins`. Set an entry to
+            `false` to keep the key registered but disabled, or override the
+            whole attrset to drop defaults entirely. The marketplace named in
+            the suffix must already be registered in
+            `~/.claude/plugins/known_marketplaces.json` for the entry to take
+            effect.
+          '';
+        };
       };
 
       config = lib.mkIf cfg.enable (

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -42,9 +42,13 @@ _: {
 
       # Derive enabledPlugins from the NixOS-level lspPlugins option so that the
       # single source of truth lives in programs.claude-code.extended.lspPlugins.
-      enabledPlugins = lib.mapAttrs' (
-        pluginKey: enabled: lib.nameValuePair "${pluginKey}@claude-plugins-official" enabled
-      ) (lib.attrByPath [ "programs" "claude-code" "extended" "lspPlugins" ] { } osConfig);
+      enabledPlugins =
+        (lib.mapAttrs' (
+          pluginKey: enabled: lib.nameValuePair "${pluginKey}@claude-plugins-official" enabled
+        ) (lib.attrByPath [ "programs" "claude-code" "extended" "lspPlugins" ] { } osConfig))
+        // {
+          "frontend-design@claude-code-plugins" = true;
+        };
 
       # Claude Code settings.json configuration
       claudeSettings = {

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -40,15 +40,17 @@ _: {
       # MCP servers via compiled agents.mcp client profile
       mcpServers = agents.mcp.clients.claude.servers pkgs;
 
-      # Derive enabledPlugins from the NixOS-level lspPlugins option so that the
-      # single source of truth lives in programs.claude-code.extended.lspPlugins.
+      # enabledPlugins is composed of:
+      #   1. LSP plugins derived from programs.claude-code.extended.lspPlugins
+      #      (single source of truth for LSP-style plugins).
+      #   2. Additional plugins from programs.claude-code.extended.extraPlugins,
+      #      keyed by the "<plugin>@<marketplace>" identifier used by
+      #      Claude Code's settings.json.
       enabledPlugins =
         (lib.mapAttrs' (
           pluginKey: enabled: lib.nameValuePair "${pluginKey}@claude-plugins-official" enabled
         ) (lib.attrByPath [ "programs" "claude-code" "extended" "lspPlugins" ] { } osConfig))
-        // {
-          "frontend-design@claude-code-plugins" = true;
-        };
+        // (lib.attrByPath [ "programs" "claude-code" "extended" "extraPlugins" ] { } osConfig);
 
       # Claude Code settings.json configuration
       claudeSettings = {

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -11,6 +11,13 @@
     * Optional Context7 API key can be provisioned via SOPS at `sops.secrets."context7/api-key"`
     * LSP plugin enablement and binary installation are governed by
       programs.claude-code.extended.lspPlugins in modules/apps/claude-code.nix.
+    * Additional non-LSP plugins are governed by
+      programs.claude-code.extended.extraPlugins in modules/apps/claude-code.nix.
+    * `enabledPlugins` keys end with `@<marketplace>` (see
+      ~/.claude/plugins/known_marketplaces.json). Default plugins assume the
+      `claude-plugins-official` marketplace is registered (install once with
+      `claude-plugins install anthropics/claude-plugins-official`); entries
+      that reference an unregistered marketplace are silently ignored.
 */
 
 _: {


### PR DESCRIPTION
## Summary

Exposes `programs.claude-code.extended.extraPlugins` (`attrsOf bool`) in `modules/apps/claude-code.nix` so non-LSP Claude Code plugins can be toggled per-host without editing the Home Manager module. The Home Manager side derives `enabledPlugins` as the merge of the existing `lspPlugins`-derived map and the new `extraPlugins` attrset.

The default for `extraPlugins` enables `frontend-design@claude-plugins-official`, replacing the original `frontend-design@claude-code-plugins` entry. Upstream verification (`anthropics/claude-plugins-official` `marketplace.json` via `gh api`) confirmed that `frontend-design` lives in the same marketplace as the existing LSP plugins; `anthropics/claude-code-plugins` does not exist.

The module Notes block now lists both option entry points and calls out that `enabledPlugins` keys silently no-op when their marketplace is not registered in `~/.claude/plugins/known_marketplaces.json`.

## Test plan

- [x] `nix fmt`
- [x] `nix develop -c pre-commit run --hook-stage manual --files modules/apps/claude-code.nix modules/hm-apps/claude-code.nix`
- [x] `nix flake check --accept-flake-config --no-build --offline`
- [x] `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel --no-link`
- [x] `nix eval` of resolved `home.file.".claude/settings.json".text` confirms `"frontend-design@claude-plugins-official": true` lands in `enabledPlugins` alongside the LSP entries.
- [ ] After switch: open Claude Code and confirm the frontend-design plugin shows up enabled in `~/.claude/settings.json`.