### PR TITLE
fix(sops): gate install-secrets service dependencies

### DIFF
--- a/docs/usage/duplicati-r2-backups.md
+++ b/docs/usage/duplicati-r2-backups.md
@@ -246,8 +246,7 @@ Tidy the scratch directory when finished and scrub sensitive artifacts.
      sudo systemctl start duplicati-r2-generate-units.service
      ```
 
-   - Activation-script hosts (the current `system76`/`tpnix` default — only
-     the encrypted manifest changed):
+   - Activation-script hosts (only the encrypted manifest changed):
 
      ```bash
      sudo /run/current-system/activate

--- a/docs/usage/duplicati-r2-backups.md
+++ b/docs/usage/duplicati-r2-backups.md
@@ -229,12 +229,30 @@ Tidy the scratch directory when finished and scrub sensitive artifacts.
    rm /tmp/duplicati-config.json.tmp /tmp/duplicati-config.json.wrapped
    ```
 
-4. **Refresh secrets and regenerate unit files.**
+4. **Refresh secrets and regenerate unit files.** Pick the path that matches
+   your sops backend:
+   - Always-correct (rebuilds the closure):
 
-   ```bash
-   sudo nixos-rebuild switch --flake .#<host>
-   sudo systemctl start duplicati-r2-generate-units.service
-   ```
+     ```bash
+     sudo nixos-rebuild switch --flake .#<host>
+     sudo systemctl start duplicati-r2-generate-units.service
+     ```
+
+   - `sops.useSystemdActivation = true` hosts (only the encrypted manifest
+     changed):
+
+     ```bash
+     sudo systemctl restart sops-install-secrets.service
+     sudo systemctl start duplicati-r2-generate-units.service
+     ```
+
+   - Activation-script hosts (the current `system76`/`tpnix` default — only
+     the encrypted manifest changed):
+
+     ```bash
+     sudo /run/current-system/activate
+     sudo systemctl start duplicati-r2-generate-units.service
+     ```
 
 5. **Run the new backup manually** (optional, but recommended) and inspect logs:
 

--- a/docs/usage/duplicati-r2-backups.md
+++ b/docs/usage/duplicati-r2-backups.md
@@ -122,10 +122,11 @@ and enable the service:
 }
 ```
 
-During activation `sops-install-secrets` decrypts the manifest and rewrites
-runtime unit files via the `duplicati-r2-generate-units.service`. The rendered
-manifest lives at `/run/duplicati-r2/config.json` and every timer/service points
-to it through `DUPLICATI_R2_CONFIG`.
+During activation `sops-nix` decrypts the manifest, either through activation
+scripts or `sops-install-secrets.service` depending on the host backend. The
+`duplicati-r2-generate-units.service` then rewrites runtime unit files. The
+rendered manifest lives at `/run/duplicati-r2/config.json` and every
+timer/service points to it through `DUPLICATI_R2_CONFIG`.
 
 > Prefer encrypted manifests for hosts deployed from this repo--paths and
 > schedules stay out of Git and only materialize on the target system. Inline
@@ -231,7 +232,7 @@ Tidy the scratch directory when finished and scrub sensitive artifacts.
 4. **Refresh secrets and regenerate unit files.**
 
    ```bash
-   sudo systemctl restart sops-install-secrets.service
+   sudo nixos-rebuild switch --flake .#<host>
    sudo systemctl start duplicati-r2-generate-units.service
    ```
 

--- a/modules/security/sops-helpers.nix
+++ b/modules/security/sops-helpers.nix
@@ -1,5 +1,15 @@
+# Shared gating helper for `sops-install-secrets.service` ordering. The
+# unit only exists when `sops.useSystemdActivation = true`; activation-script
+# hosts decrypt secrets before any unit ordering. See issue #37.
 { lib, ... }:
+let
+  sopsInstallSecretsService = "sops-install-secrets.service";
+in
 {
-  flake.lib.security.sopsInstallSecretsDeps =
-    nixosConfig: lib.optional nixosConfig.sops.useSystemdActivation "sops-install-secrets.service";
+  flake.lib.security = {
+    inherit sopsInstallSecretsService;
+
+    sopsInstallSecretsDeps =
+      nixosConfig: lib.optional nixosConfig.sops.useSystemdActivation sopsInstallSecretsService;
+  };
 }

--- a/modules/security/sops-helpers.nix
+++ b/modules/security/sops-helpers.nix
@@ -1,0 +1,5 @@
+{ lib, ... }:
+{
+  flake.lib.security.sopsInstallSecretsDeps =
+    nixosConfig: lib.optional nixosConfig.sops.useSystemdActivation "sops-install-secrets.service";
+}

--- a/modules/services/duplicati-r2.nix
+++ b/modules/services/duplicati-r2.nix
@@ -123,6 +123,9 @@ let
       manifestTemplateName = "duplicati-r2-manifest.json";
       generatorServiceName = "duplicati-r2-generate-units";
       sopsInstallSecretsService = "sops-install-secrets.service";
+      # Gate the dependency on `sops.useSystemdActivation`: sops-nix only
+      # creates `sops-install-secrets.service` under that mode (issue #37);
+      # activation-script hosts decrypt secrets before any unit ordering.
       installSecretsDeps = sopsInstallSecretsDeps config;
       generatedUnitAfter = concatStringsSep " " ([ "network-online.target" ] ++ installSecretsDeps);
       generatedUnitRequiresLine = lib.optionalString (

--- a/modules/services/duplicati-r2.nix
+++ b/modules/services/duplicati-r2.nix
@@ -1,6 +1,6 @@
 { config, secretsRoot, ... }:
 let
-  inherit (config.flake.lib.security) sopsInstallSecretsDeps;
+  inherit (config.flake.lib.security) sopsInstallSecretsDeps sopsInstallSecretsService;
   module =
     {
       config,
@@ -122,7 +122,6 @@ let
       manifestDest = "/run/duplicati-r2/config.json";
       manifestTemplateName = "duplicati-r2-manifest.json";
       generatorServiceName = "duplicati-r2-generate-units";
-      sopsInstallSecretsService = "sops-install-secrets.service";
       # Gate the dependency on `sops.useSystemdActivation`: sops-nix only
       # creates `sops-install-secrets.service` under that mode (issue #37);
       # activation-script hosts decrypt secrets before any unit ordering.

--- a/modules/services/duplicati-r2.nix
+++ b/modules/services/duplicati-r2.nix
@@ -121,6 +121,15 @@ let
       manifestDest = "/run/duplicati-r2/config.json";
       manifestTemplateName = "duplicati-r2-manifest.json";
       generatorServiceName = "duplicati-r2-generate-units";
+      sopsInstallSecretsService = "sops-install-secrets.service";
+      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
+        "sops"
+        "useSystemdActivation"
+      ] false config) sopsInstallSecretsService;
+      generatedUnitAfter = concatStringsSep " " ([ "network-online.target" ] ++ sopsInstallSecretsDeps);
+      generatedUnitRequires = lib.optionalString (
+        sopsInstallSecretsDeps != [ ]
+      ) "Requires=${sopsInstallSecretsService}";
 
       usingSecret = cfg.configFile != null;
 
@@ -547,8 +556,8 @@ let
                       cat > "$unit_dir/$service" <<EOF
           [Unit]
           Description=Duplicati R2 backup ($slug)
-          After=network-online.target sops-install-secrets.service
-          Requires=sops-install-secrets.service
+          After=${generatedUnitAfter}
+          ${generatedUnitRequires}
           Wants=network-online.target
 
           [Service]
@@ -584,8 +593,8 @@ let
                         cat > "$unit_dir/$verify_service" <<EOF
           [Unit]
           Description=Duplicati R2 verification ($slug)
-          After=network-online.target sops-install-secrets.service
-          Requires=sops-install-secrets.service
+          After=${generatedUnitAfter}
+          ${generatedUnitRequires}
           Wants=network-online.target
 
           [Service]
@@ -810,11 +819,8 @@ let
 
           systemd.services.${generatorServiceName} = {
             description = "Generate Duplicati R2 systemd units";
-            after = [
-              "sops-install-secrets.service"
-              "network-online.target"
-            ];
-            requires = [ "sops-install-secrets.service" ];
+            after = sopsInstallSecretsDeps ++ [ "network-online.target" ];
+            requires = sopsInstallSecretsDeps;
             wants = [ "network-online.target" ];
             wantedBy = [ "multi-user.target" ];
             restartTriggers = [

--- a/modules/services/duplicati-r2.nix
+++ b/modules/services/duplicati-r2.nix
@@ -125,9 +125,9 @@ let
       sopsInstallSecretsService = "sops-install-secrets.service";
       installSecretsDeps = sopsInstallSecretsDeps config;
       generatedUnitAfter = concatStringsSep " " ([ "network-online.target" ] ++ installSecretsDeps);
-      generatedUnitRequires = lib.optionalString (
+      generatedUnitRequiresLine = lib.optionalString (
         installSecretsDeps != [ ]
-      ) "Requires=${sopsInstallSecretsService}";
+      ) "\nRequires=${sopsInstallSecretsService}";
 
       usingSecret = cfg.configFile != null;
 
@@ -554,8 +554,7 @@ let
                       cat > "$unit_dir/$service" <<EOF
           [Unit]
           Description=Duplicati R2 backup ($slug)
-          After=${generatedUnitAfter}
-          ${generatedUnitRequires}
+          After=${generatedUnitAfter}${generatedUnitRequiresLine}
           Wants=network-online.target
 
           [Service]
@@ -591,8 +590,7 @@ let
                         cat > "$unit_dir/$verify_service" <<EOF
           [Unit]
           Description=Duplicati R2 verification ($slug)
-          After=${generatedUnitAfter}
-          ${generatedUnitRequires}
+          After=${generatedUnitAfter}${generatedUnitRequiresLine}
           Wants=network-online.target
 
           [Service]

--- a/modules/services/duplicati-r2.nix
+++ b/modules/services/duplicati-r2.nix
@@ -1,5 +1,6 @@
-{ secretsRoot, ... }:
+{ config, secretsRoot, ... }:
 let
+  inherit (config.flake.lib.security) sopsInstallSecretsDeps;
   module =
     {
       config,
@@ -122,13 +123,10 @@ let
       manifestTemplateName = "duplicati-r2-manifest.json";
       generatorServiceName = "duplicati-r2-generate-units";
       sopsInstallSecretsService = "sops-install-secrets.service";
-      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
-        "sops"
-        "useSystemdActivation"
-      ] false config) sopsInstallSecretsService;
-      generatedUnitAfter = concatStringsSep " " ([ "network-online.target" ] ++ sopsInstallSecretsDeps);
+      installSecretsDeps = sopsInstallSecretsDeps config;
+      generatedUnitAfter = concatStringsSep " " ([ "network-online.target" ] ++ installSecretsDeps);
       generatedUnitRequires = lib.optionalString (
-        sopsInstallSecretsDeps != [ ]
+        installSecretsDeps != [ ]
       ) "Requires=${sopsInstallSecretsService}";
 
       usingSecret = cfg.configFile != null;
@@ -819,8 +817,8 @@ let
 
           systemd.services.${generatorServiceName} = {
             description = "Generate Duplicati R2 systemd units";
-            after = sopsInstallSecretsDeps ++ [ "network-online.target" ];
-            requires = sopsInstallSecretsDeps;
+            after = installSecretsDeps ++ [ "network-online.target" ];
+            requires = installSecretsDeps;
             wants = [ "network-online.target" ];
             wantedBy = [ "multi-user.target" ];
             restartTriggers = [

--- a/modules/system76/fonts.nix
+++ b/modules/system76/fonts.nix
@@ -12,7 +12,13 @@ let
 in
 {
   configurations.nixos.system76.module =
-    { pkgs, ... }:
+    { config, pkgs, ... }:
+    let
+      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
+        "sops"
+        "useSystemdActivation"
+      ] false config) "sops-install-secrets.service";
+    in
     {
       config = lib.mkMerge [
         {
@@ -79,8 +85,8 @@ in
           systemd.services.monolisa-fonts = {
             description = "Install MonoLisa fonts from encrypted archive";
             wantedBy = [ "multi-user.target" ];
-            after = [ "sops-install-secrets.service" ];
-            requires = [ "sops-install-secrets.service" ];
+            after = sopsInstallSecretsDeps;
+            requires = sopsInstallSecretsDeps;
             path = [
               pkgs.coreutils
               pkgs.findutils

--- a/modules/system76/fonts.nix
+++ b/modules/system76/fonts.nix
@@ -1,10 +1,12 @@
 {
+  config,
   lib,
   secretsRoot,
   ...
 }:
 let
   fontArchive = "${secretsRoot}/fonts/monolisa.tar.zst";
+  inherit (config.flake.lib.security) sopsInstallSecretsDeps;
   secretExists = builtins.pathExists fontArchive;
   secretName = "fonts/monolisa.archive";
   secretRuntimePath = "/run/secrets/fonts/monolisa.archive";
@@ -14,10 +16,7 @@ in
   configurations.nixos.system76.module =
     { config, pkgs, ... }:
     let
-      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
-        "sops"
-        "useSystemdActivation"
-      ] false config) "sops-install-secrets.service";
+      installSecretsDeps = sopsInstallSecretsDeps config;
     in
     {
       config = lib.mkMerge [
@@ -85,8 +84,8 @@ in
           systemd.services.monolisa-fonts = {
             description = "Install MonoLisa fonts from encrypted archive";
             wantedBy = [ "multi-user.target" ];
-            after = sopsInstallSecretsDeps;
-            requires = sopsInstallSecretsDeps;
+            after = installSecretsDeps;
+            requires = installSecretsDeps;
             path = [
               pkgs.coreutils
               pkgs.findutils

--- a/modules/system76/usbguard.nix
+++ b/modules/system76/usbguard.nix
@@ -61,7 +61,7 @@ in
           };
 
           systemd.services.usbguard = {
-            after = lib.mkAfter installSecretsDeps;
+            after = lib.mkIf (installSecretsDeps != [ ]) (lib.mkAfter installSecretsDeps);
             preStart = lib.mkAfter ''
               install -D -m 0600 /dev/null ${runtimeRuleFile}
               cat ${baseRulesFile} > ${runtimeRuleFile}

--- a/modules/system76/usbguard.nix
+++ b/modules/system76/usbguard.nix
@@ -33,7 +33,13 @@ let
 in
 {
   configurations.nixos.system76.module =
-    { lib, ... }:
+    { config, lib, ... }:
+    let
+      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
+        "sops"
+        "useSystemdActivation"
+      ] false config) "sops-install-secrets.service";
+    in
     {
       imports = moduleImports;
 
@@ -56,7 +62,7 @@ in
           };
 
           systemd.services.usbguard = {
-            after = lib.mkAfter [ "sops-install-secrets.service" ];
+            after = lib.mkAfter sopsInstallSecretsDeps;
             preStart = lib.mkAfter ''
               install -D -m 0600 /dev/null ${runtimeRuleFile}
               cat ${baseRulesFile} > ${runtimeRuleFile}

--- a/modules/system76/usbguard.nix
+++ b/modules/system76/usbguard.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   metaOwner,
@@ -6,6 +7,7 @@
   ...
 }:
 let
+  inherit (config.flake.lib.security) sopsInstallSecretsDeps;
   usbguardLib =
     let
       libAttrs = import ../security/usbguard-lib.nix { inherit lib; };
@@ -35,10 +37,7 @@ in
   configurations.nixos.system76.module =
     { config, lib, ... }:
     let
-      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
-        "sops"
-        "useSystemdActivation"
-      ] false config) "sops-install-secrets.service";
+      installSecretsDeps = sopsInstallSecretsDeps config;
     in
     {
       imports = moduleImports;
@@ -62,7 +61,7 @@ in
           };
 
           systemd.services.usbguard = {
-            after = lib.mkAfter sopsInstallSecretsDeps;
+            after = lib.mkAfter installSecretsDeps;
             preStart = lib.mkAfter ''
               install -D -m 0600 /dev/null ${runtimeRuleFile}
               cat ${baseRulesFile} > ${runtimeRuleFile}

--- a/modules/tpnix/fonts.nix
+++ b/modules/tpnix/fonts.nix
@@ -7,6 +7,7 @@
 let
   fontArchive = "${secretsRoot}/fonts/monolisa.tar.zst";
   inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
+  inherit (config.flake.lib.security) sopsInstallSecretsDeps;
   secretExists = builtins.pathExists fontArchive;
   secretName = "fonts/monolisa.archive";
   secretRuntimePath = "/run/secrets/fonts/monolisa.archive";
@@ -16,10 +17,7 @@ in
   configurations.nixos.tpnix.module =
     { config, pkgs, ... }:
     let
-      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
-        "sops"
-        "useSystemdActivation"
-      ] false config) "sops-install-secrets.service";
+      installSecretsDeps = sopsInstallSecretsDeps config;
     in
     {
       config = lib.mkMerge [
@@ -105,8 +103,8 @@ in
           systemd.services.monolisa-fonts = {
             description = "Install MonoLisa fonts from encrypted archive";
             wantedBy = [ "multi-user.target" ];
-            after = sopsInstallSecretsDeps;
-            requires = sopsInstallSecretsDeps;
+            after = installSecretsDeps;
+            requires = installSecretsDeps;
             path = [
               pkgs.coreutils
               pkgs.findutils

--- a/modules/tpnix/fonts.nix
+++ b/modules/tpnix/fonts.nix
@@ -14,7 +14,13 @@ let
 in
 {
   configurations.nixos.tpnix.module =
-    { pkgs, ... }:
+    { config, pkgs, ... }:
+    let
+      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
+        "sops"
+        "useSystemdActivation"
+      ] false config) "sops-install-secrets.service";
+    in
     {
       config = lib.mkMerge [
         {
@@ -99,8 +105,8 @@ in
           systemd.services.monolisa-fonts = {
             description = "Install MonoLisa fonts from encrypted archive";
             wantedBy = [ "multi-user.target" ];
-            after = [ "sops-install-secrets.service" ];
-            requires = [ "sops-install-secrets.service" ];
+            after = sopsInstallSecretsDeps;
+            requires = sopsInstallSecretsDeps;
             path = [
               pkgs.coreutils
               pkgs.findutils

--- a/modules/tpnix/usbguard.nix
+++ b/modules/tpnix/usbguard.nix
@@ -61,7 +61,7 @@ in
           };
 
           systemd.services.usbguard = {
-            after = lib.mkAfter installSecretsDeps;
+            after = lib.mkIf (installSecretsDeps != [ ]) (lib.mkAfter installSecretsDeps);
             preStart = lib.mkAfter ''
               install -D -m 0600 /dev/null ${runtimeRuleFile}
               cat ${baseRulesFile} > ${runtimeRuleFile}

--- a/modules/tpnix/usbguard.nix
+++ b/modules/tpnix/usbguard.nix
@@ -1,4 +1,5 @@
 {
+  config,
   lib,
   pkgs,
   metaOwner,
@@ -6,6 +7,7 @@
   ...
 }:
 let
+  inherit (config.flake.lib.security) sopsInstallSecretsDeps;
   usbguardLib =
     let
       libAttrs = import ../security/usbguard-lib.nix { inherit lib; };
@@ -35,10 +37,7 @@ in
   configurations.nixos.tpnix.module =
     { config, lib, ... }:
     let
-      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
-        "sops"
-        "useSystemdActivation"
-      ] false config) "sops-install-secrets.service";
+      installSecretsDeps = sopsInstallSecretsDeps config;
     in
     {
       imports = moduleImports;
@@ -62,7 +61,7 @@ in
           };
 
           systemd.services.usbguard = {
-            after = lib.mkAfter sopsInstallSecretsDeps;
+            after = lib.mkAfter installSecretsDeps;
             preStart = lib.mkAfter ''
               install -D -m 0600 /dev/null ${runtimeRuleFile}
               cat ${baseRulesFile} > ${runtimeRuleFile}

--- a/modules/tpnix/usbguard.nix
+++ b/modules/tpnix/usbguard.nix
@@ -33,7 +33,13 @@ let
 in
 {
   configurations.nixos.tpnix.module =
-    { lib, ... }:
+    { config, lib, ... }:
+    let
+      sopsInstallSecretsDeps = lib.optional (lib.attrByPath [
+        "sops"
+        "useSystemdActivation"
+      ] false config) "sops-install-secrets.service";
+    in
     {
       imports = moduleImports;
 
@@ -56,7 +62,7 @@ in
           };
 
           systemd.services.usbguard = {
-            after = lib.mkAfter [ "sops-install-secrets.service" ];
+            after = lib.mkAfter sopsInstallSecretsDeps;
             preStart = lib.mkAfter ''
               install -D -m 0600 /dev/null ${runtimeRuleFile}
               cat ${baseRulesFile} > ${runtimeRuleFile}


### PR DESCRIPTION
## Summary

- Gate local `sops-install-secrets.service` dependencies on `sops.useSystemdActivation` so hosts using activation-script mode do not reference a missing unit.
- Apply the same backend-aware dependency handling to Duplicati R2 generated units, MonoLisa font install units, and USBGuard ordering.
- Update the Duplicati R2 usage docs so operators rebuild/switch instead of restarting `sops-install-secrets.service` unconditionally.

Fixes #37.

## Test plan

- `nix fmt`
- `git diff --check`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config.systemd.services --apply '<affected service deps>'`
- `nix eval --accept-flake-config --json .#nixosConfigurations.tpnix.config.systemd.services --apply '<affected service deps>'`
- `nix eval --accept-flake-config --raw '.#nixosConfigurations.system76.config.systemd.units."duplicati-r2-generate-units.service".text' | rg -n 'After=|Requires=|sops-install-secrets|network-online'`
- `nix eval --accept-flake-config --raw '.#nixosConfigurations.system76.config.systemd.units."monolisa-fonts.service".text' | rg -n 'After=|Requires=|sops-install-secrets|WantedBy'`
- `nix flake check --accept-flake-config --no-build --offline`

Note: a full `nix flake check --accept-flake-config` was attempted first, but it builds unrelated package checks and currently fails in `checks.x86_64-linux.packages/pentest-cutter` with `SBK_CUTTERPLUGIN_IDX`/`SBK_CutterPlugin_IDX` compile errors. A full `system76` toplevel build was also stopped because it was pulling/building the whole unrelated host closure; the targeted evaluation above validates this fix without that broad build cost.
