### PR TITLE
chore(cutter): disable pentest-cutter pending nixpkgs shiboken6 fix

### DIFF
--- a/modules/devshell/pentesting.nix
+++ b/modules/devshell/pentesting.nix
@@ -88,18 +88,20 @@ let
     }
     { name = "wappalyzer"; }
     # ghidra: installed system-wide via programs.ghidra.extended
-    {
-      name = "cutter";
-      desktop = {
-        desktopName = "Cutter (Pentesting Shell)";
-        comment = "Reverse engineering platform powered by rizin";
-        categories = [
-          "Development"
-          "Security"
-        ];
-        icon = "cutter";
-      };
-    }
+    # cutter: disabled — upstream cutter 2.4.1 fails to build against Qt/PySide6 6.11.
+    # Tracking: https://github.com/Bad3r/nixos/issues/156
+    # {
+    #   name = "cutter";
+    #   desktop = {
+    #     desktopName = "Cutter (Pentesting Shell)";
+    #     comment = "Reverse engineering platform powered by rizin";
+    #     categories = [
+    #       "Development"
+    #       "Security"
+    #     ];
+    #     icon = "cutter";
+    #   };
+    # }
     {
       name = "iaito";
       desktop = {
@@ -182,7 +184,7 @@ in
           john
           sqlmap
           hashcat
-          cutter
+          # cutter # disabled — see https://github.com/Bad3r/nixos/issues/156
           iaito
           radare2
           rizin

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -82,7 +82,7 @@
       "csharp-ls".extended.enable = lib.mkOverride 1100 false;
       curl.extended.enable = lib.mkOverride 1100 true;
       curlie.extended.enable = lib.mkOverride 1100 true;
-      cutter.extended.enable = lib.mkOverride 1100 false;
+      cutter.extended.enable = lib.mkOverride 1100 false; # Disabled — see https://github.com/Bad3r/nixos/issues/156
       "czkawka-cli".extended.enable = lib.mkOverride 1100 true;
       "czkawka-gui".extended.enable = lib.mkOverride 1100 true;
       ddrescue.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -68,7 +68,7 @@
       "csharp-ls".extended.enable = lib.mkOverride 1100 false;
       curl.extended.enable = lib.mkOverride 1100 true;
       curlie.extended.enable = lib.mkOverride 1100 true;
-      cutter.extended.enable = lib.mkOverride 1100 false;
+      cutter.extended.enable = lib.mkOverride 1100 false; # Disabled — see https://github.com/Bad3r/nixos/issues/156
       "czkawka-cli".extended.enable = lib.mkOverride 1100 false;
       "czkawka-gui".extended.enable = lib.mkOverride 1100 false;
       ddrescue.extended.enable = lib.mkOverride 1100 false;


### PR DESCRIPTION
## Summary

- Comment out the `cutter` entry in `modules/devshell/pentesting.nix` (`toolDefs` and `toolPackageMap`) so `flake.packages.x86_64-linux.pentest-cutter` is no longer exposed and the auto-derived `checks.x86_64-linux.packages/pentest-cutter` no longer fires `nixpkgs.cutter`'s broken build.
- Annotate the existing `cutter.extended.enable = lib.mkOverride 1100 false` lines on `system76` and `tpnix` with a pointer to the tracking issue.
- Code is commented out (not removed) so reverting once the upstream fix lands is a one-shot uncomment plus host flip.

Tracking: https://github.com/Bad3r/nixos/issues/156

## Test plan

- [x] `nix develop -c nix flake check --accept-flake-config --no-build --offline` → `all checks passed!`; `pentest-cutter` no longer in derivation list.
- [x] `nix eval .#nixosConfigurations.system76.config.system.build.toplevel.drvPath` succeeds.
- [x] `nix eval .#nixosConfigurations.tpnix.config.system.build.toplevel.drvPath` succeeds.
- [x] `nix develop -c pre-commit run --all-files --hook-stage manual` → all hooks pass.