### PR TITLE
feat(apps): package codeburn and enable on system76 and tpnix

### DIFF
--- a/modules/apps/codeburn.nix
+++ b/modules/apps/codeburn.nix
@@ -39,7 +39,7 @@ let
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Whether to enable codeburn.";
+          description = "Whether to enable Codeburn, an interactive TUI dashboard for AI coding token cost observability.";
         };
 
         package = lib.mkPackageOption pkgs "codeburn" { };

--- a/modules/apps/codeburn.nix
+++ b/modules/apps/codeburn.nix
@@ -1,0 +1,55 @@
+/*
+  Package: codeburn
+  Description: Interactive TUI dashboard for AI coding token cost observability across Claude Code, Codex, Cursor, OpenCode, Pi, and Copilot.
+  Homepage: https://github.com/getagentseal/codeburn
+  Documentation: https://github.com/getagentseal/codeburn#readme
+  Repository: https://github.com/getagentseal/codeburn
+
+  Summary:
+    * Local-first dashboard that reads provider session transcripts and prices each turn against a bundled LiteLLM snapshot (no proxy, no API keys).
+    * Classifies every turn into 13 task categories and tracks one-shot edit success rate, plan overage, and outcome (shipped vs reverted vs abandoned).
+
+  Options:
+    report: Interactive usage dashboard with provider, period, and currency toggles.
+    today: Single-day usage breakdown.
+    month: Current-month usage breakdown.
+    status: Compact today plus week plus month line for status bars.
+    export: Emit usage data as CSV or JSON for downstream tooling.
+    optimize: Scan sessions and Claude Code config for waste patterns and fixes.
+    yield: Correlate AI spend with git history to label outcomes (experimental).
+
+  Notes:
+    * Custom package built from getagentseal/codeburn via packages/codeburn (buildNpmPackage on Node 22).
+    * Upstream build script downloads LiteLLM prices over the network; the derivation patches package.json to skip that step and uses the snapshot already committed at src/data/litellm-snapshot.json.
+*/
+_:
+let
+  CodeburnModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.codeburn.extended;
+    in
+    {
+      options.programs.codeburn.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable codeburn.";
+        };
+
+        package = lib.mkPackageOption pkgs "codeburn" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.codeburn = CodeburnModule;
+}

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -74,6 +74,7 @@
       "cloudflare-warp".extended.enable = lib.mkOverride 1100 true;
       cloudflared.extended.enable = lib.mkOverride 1100 true;
       cmake.extended.enable = lib.mkOverride 1100 true;
+      codeburn.extended.enable = lib.mkOverride 1100 true;
       "coderabbit-cli".extended.enable = lib.mkOverride 1100 true;
       codex.extended.enable = lib.mkOverride 1100 true;
       coreutils.extended.enable = lib.mkOverride 1100 true;

--- a/modules/system76/custom-packages-overlay.nix
+++ b/modules/system76/custom-packages-overlay.nix
@@ -15,6 +15,7 @@ _: {
         opendirectorydownloader = final.callPackage ../../packages/opendirectorydownloader { };
         malimite = final.callPackage ../../packages/malimite { };
         claude-wpa = final.callPackage ../../packages/claude-wpa { };
+        codeburn = final.callPackage ../../packages/codeburn { };
         rg-fzf = final.callPackage ../../packages/rg-fzf { };
         sss-nix-repair = final.callPackage ../../packages/sss-nix-repair { };
         source-map-explorer = final.callPackage ../../packages/source-map-explorer { };

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -60,6 +60,7 @@
       "cloudflare-warp".extended.enable = lib.mkOverride 1100 false;
       cloudflared.extended.enable = lib.mkOverride 1100 false;
       cmake.extended.enable = lib.mkOverride 1100 true;
+      codeburn.extended.enable = lib.mkOverride 1100 true;
       "coderabbit-cli".extended.enable = lib.mkOverride 1100 false;
       codex.extended.enable = lib.mkOverride 1100 true;
       coreutils.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/custom-packages-overlay.nix
+++ b/modules/tpnix/custom-packages-overlay.nix
@@ -15,6 +15,7 @@ _: {
         opendirectorydownloader = final.callPackage ../../packages/opendirectorydownloader { };
         malimite = final.callPackage ../../packages/malimite { };
         claude-wpa = final.callPackage ../../packages/claude-wpa { };
+        codeburn = final.callPackage ../../packages/codeburn { };
         rg-fzf = final.callPackage ../../packages/rg-fzf { };
         sss-nix-repair = final.callPackage ../../packages/sss-nix-repair { };
         source-map-explorer = final.callPackage ../../packages/source-map-explorer { };

--- a/packages/codeburn/default.nix
+++ b/packages/codeburn/default.nix
@@ -22,12 +22,14 @@ buildNpmPackage rec {
 
   # The upstream `build` script invokes scripts/bundle-litellm.mjs, which
   # downloads the LiteLLM price table from the network. The snapshot it would
-  # produce is already committed to src/data/litellm-snapshot.json, so skip
-  # the network step and run tsup directly.
+  # produce is already committed to src/data/litellm-snapshot.json, so drop
+  # the script and run tsup directly. Re-verify the substituted text on the
+  # next version bump.
   postPatch = ''
     substituteInPlace package.json \
       --replace-fail '"build": "node scripts/bundle-litellm.mjs && tsup"' \
                      '"build": "tsup"'
+    rm scripts/bundle-litellm.mjs
   '';
 
   meta = {

--- a/packages/codeburn/default.nix
+++ b/packages/codeburn/default.nix
@@ -1,0 +1,40 @@
+{
+  lib,
+  buildNpmPackage,
+  fetchFromGitHub,
+  nodejs_22,
+}:
+
+buildNpmPackage rec {
+  pname = "codeburn";
+  version = "0.9.5";
+
+  src = fetchFromGitHub {
+    owner = "getagentseal";
+    repo = "codeburn";
+    rev = "v${version}";
+    hash = "sha256-54NWcnVXQIDz2JzzFW8SJ+I2Ff6KyumrO3DdrvzuHUE=";
+  };
+
+  nodejs = nodejs_22;
+
+  npmDepsHash = "sha256-vcChnFLiuiymqZb4ojvv7a7Cdg4BYYT+ZraTVELEsQ0=";
+
+  # The upstream `build` script invokes scripts/bundle-litellm.mjs, which
+  # downloads the LiteLLM price table from the network. The snapshot it would
+  # produce is already committed to src/data/litellm-snapshot.json, so skip
+  # the network step and run tsup directly.
+  postPatch = ''
+    substituteInPlace package.json \
+      --replace-fail '"build": "node scripts/bundle-litellm.mjs && tsup"' \
+                     '"build": "tsup"'
+  '';
+
+  meta = {
+    description = "Interactive TUI dashboard for AI coding token cost observability";
+    homepage = "https://github.com/getagentseal/codeburn";
+    license = lib.licenses.mit;
+    mainProgram = "codeburn";
+    platforms = lib.platforms.linux;
+  };
+}


### PR DESCRIPTION
## Summary

- Adds `packages/codeburn/default.nix`, a `buildNpmPackage` derivation for `getagentseal/codeburn@v0.9.5` on Node 22 (MIT). The upstream `build` script invokes `scripts/bundle-litellm.mjs`, which fetches the LiteLLM price table from the network; `postPatch` rewrites the script to run only `tsup`, since the snapshot is already committed at `src/data/litellm-snapshot.json`.
- Registers `codeburn` in both `modules/system76/custom-packages-overlay.nix` and `modules/tpnix/custom-packages-overlay.nix`.
- Adds `modules/apps/codeburn.nix` exposing `programs.codeburn.extended.{enable,package}` per the apps style guide.
- Enables `codeburn.extended` in both `modules/system76/apps-enable.nix` and `modules/tpnix/apps-enable.nix` (alphabetically ordered before `coderabbit-cli`).

CodeBurn is an interactive TUI dashboard for AI coding token cost observability across Claude Code, Codex, Cursor, OpenCode, Pi, and Copilot. It is not available in nixpkgs or the `llm-agents.nix` flake.

## Test plan

- [x] `nix build .#nixosConfigurations.system76.pkgs.codeburn` succeeds; resulting binary reports `0.9.5`
- [x] `nix flake check --accept-flake-config --no-build` passes
- [x] `nix build .#nixosConfigurations.system76.config.system.build.toplevel` succeeds
- [x] `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel` succeeds
- [x] `codeburn` present in `environment.systemPackages` for both `system76` and `tpnix`