### PR TITLE
feat(csec): add wordlists module and flake.csec namespace

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,12 @@ Canonical documentation lives under `docs/architecture/`.
 
 ## Nix Configuration
 
-| Setting                        | Value                  | Purpose                                                                     |
-| ------------------------------ | ---------------------- | --------------------------------------------------------------------------- |
-| `abort-on-warn`                | `false`                | Disabled due to upstream nixpkgs warning (issue `#485682`)                  |
-| `extra-experimental-features`  | `[ "pipe-operators" ]` | Enable pipe operator syntax in Nix expressions                              |
-| `allow-import-from-derivation` | `true`                 | Required by `nix-doom-emacs-unstraightened` (no other module relies on IFD) |
-| `experimental-features`        | `nix-command flakes`   | Enable flakes and new Nix CLI                                               |
+| Setting                        | Value                  | Purpose                                                                                     |
+| ------------------------------ | ---------------------- | ------------------------------------------------------------------------------------------- |
+| `abort-on-warn`                | `false`                | Disabled due to upstream nixpkgs warning (issue `#485682`)                                  |
+| `extra-experimental-features`  | `[ "pipe-operators" ]` | Enable pipe operator syntax in Nix expressions                                              |
+| `allow-import-from-derivation` | `true`                 | Required by IFD consumers: `nix-doom-emacs-unstraightened` and `modules/csec/wordlists.nix` |
+| `experimental-features`        | `nix-command flakes`   | Enable flakes and new Nix CLI                                                               |
 
 These settings are mirrored in `build.sh` via `NIX_CONFIGURATION`.
 

--- a/docs/architecture/03-nixos-modules.md
+++ b/docs/architecture/03-nixos-modules.md
@@ -84,6 +84,34 @@ This means many host-only packages are **not** available under `.#packages.<syst
 | `modules/hardware/monitors/lenovo-y27q-20.nix` | `flake.nixosModules."hardware-lenovo-y27q-20"` | Monitor profile                   |
 | `modules/system76/virtualization.nix`          | host options under `system76.virtualization.*` | Virtualization app toggles        |
 
+## The `flake.csec` Namespace
+
+Cybersecurity-tooling NixOS modules register under `flake.csec.<feature>`, declared in `modules/meta/flake-output.nix` as `attrsOf deferredModule`. Each feature is a first-class entry rather than collapsing into a parent module like sub-keys under `flake.nixosModules.*` would (`lazyAttrsOf raw` does not give per-feature merge semantics without flat name mangling).
+
+```nix
+flake.csec = {
+  wordlists = { ... };  # Kali-style symlinks under /usr/share/wordlists/
+  # Future feature modules register here.
+};
+```
+
+Hosts opt in explicitly by importing the module and toggling its enable flag:
+
+```nix
+# modules/system76/imports.nix
+configurations.nixos.system76.module = {
+  imports = [
+    config.flake.csec.wordlists
+    # ...
+  ];
+  csec.wordlists.enable = true;
+};
+```
+
+| Module                       | Export                 | Purpose                                                                                |
+| ---------------------------- | ---------------------- | -------------------------------------------------------------------------------------- |
+| `modules/csec/wordlists.nix` | `flake.csec.wordlists` | Kali-style wordlist symlinks (auto-discovered via IFD, see `flake.nix#nixConfig` note) |
+
 ## System-Level Utilities
 
 | Module                                    | Purpose                                        |

--- a/flake.nix
+++ b/flake.nix
@@ -2,9 +2,13 @@
   nixConfig = {
     abort-on-warn = false;
     extra-experimental-features = [ "pipe-operators" ];
-    # IFD is required by `nix-doom-emacs-unstraightened` (lib.importJSON of
-    # `doom-intermediates/packages.json`). No other module in this repo relies
-    # on IFD; flake evaluation otherwise stays pure.
+    # IFD consumers in this repo:
+    #   * nix-doom-emacs-unstraightened: lib.importJSON of
+    #     `doom-intermediates/packages.json`.
+    #   * modules/csec/wordlists.nix: builtins.readDir on
+    #     `${pkgs.wordlists}/share/wordlists` to auto-discover symlink names.
+    # Update both this comment and modules/base/nix-settings.nix when adding
+    # or removing IFD consumers.
     allow-import-from-derivation = true;
   };
 

--- a/modules/base/nix-settings.nix
+++ b/modules/base/nix-settings.nix
@@ -10,8 +10,13 @@
       # Disabled due to upstream nixpkgs warning in make-options-doc
       # See: https://github.com/NixOS/nixpkgs/issues/485682
       abort-on-warn = false;
-      # Required by `nix-doom-emacs-unstraightened`, which evaluates a JSON
-      # manifest produced by a build derivation. Mirrors flake.nix#nixConfig.
+      # IFD consumers in this repo (mirrors flake.nix#nixConfig):
+      #   * nix-doom-emacs-unstraightened: evaluates a JSON manifest produced
+      #     by a build derivation.
+      #   * modules/csec/wordlists.nix: reads the wordlists store path with
+      #     builtins.readDir to auto-discover top-level entries.
+      # Update both this comment and flake.nix when adding or removing IFD
+      # consumers.
       allow-import-from-derivation = true;
       keep-outputs = false;
       experimental-features = [

--- a/modules/csec/wordlists.nix
+++ b/modules/csec/wordlists.nix
@@ -28,8 +28,8 @@
   Note: this module relies on import-from-derivation to read the wordlists
   store path at evaluation time.
 */
-let
-  module =
+{
+  flake.csec.wordlists =
     {
       config,
       lib,
@@ -103,7 +103,4 @@ let
         ) links;
       };
     };
-in
-{
-  flake.csec.wordlists = module;
 }

--- a/modules/csec/wordlists.nix
+++ b/modules/csec/wordlists.nix
@@ -57,9 +57,9 @@
         user = "root";
         group = "root";
       };
-      missingManualTargets = lib.filter (name: !builtins.pathExists (toString cfg.manualLinks.${name})) (
-        lib.attrNames cfg.manualLinks
-      );
+      missingManualEntries = lib.filterAttrs (
+        _name: target: !builtins.pathExists (toString target)
+      ) cfg.manualLinks;
     in
     {
       options.csec.wordlists = {
@@ -137,13 +137,13 @@
       config = lib.mkIf cfg.enable {
         assertions = [
           {
-            assertion = missingManualTargets == [ ];
+            assertion = missingManualEntries == { };
             message = ''
               csec.wordlists.manualLinks references targets that do not
               exist in the Nix store:
-              ${lib.concatMapStringsSep "\n" (
-                name: "  - ${name} -> ${toString cfg.manualLinks.${name}}"
-              ) missingManualTargets}
+              ${lib.concatStringsSep "\n" (
+                lib.mapAttrsToList (name: target: "  - ${name} -> ${toString target}") missingManualEntries
+              )}
               An upstream package layout likely changed; update the
               affected entries (or remove them) in
               `csec.wordlists.manualLinks`.

--- a/modules/csec/wordlists.nix
+++ b/modules/csec/wordlists.nix
@@ -1,0 +1,108 @@
+/*
+  csec.wordlists
+
+  Materializes Kali-style wordlist symlinks under /usr/share/wordlists/ for
+  packages that ship wordlists in their own share/ subtree, so tutorials,
+  scripts, and tools that hardcode the canonical paths "just work" on this
+  host.
+
+  Built-in links (matching Kali Linux paths under /usr/share/wordlists/):
+
+  - Every top-level entry under ${pkgs.wordlists}/share/wordlists/ is
+    discovered at evaluation time via builtins.readDir, so anything the
+    upstream nixpkgs `wordlists` meta-package adds (currently seclists,
+    wfuzz, nmap.lst, rockyou.txt) is exposed automatically.
+  - Plus three manual entries pointing at packages outside the meta-package:
+      * dirbuster   -> ${pkgs.dirbuster}/share/dirbuster
+      * metasploit  -> ${pkgs.metasploit}/share/msf/data/wordlists
+      * john.lst    -> ${pkgs.john}/share/john/password.lst
+
+  Add more via csec.wordlists.extraLinks; explicit entries override the
+  auto-discovered ones if names collide. Hosts opt in by importing
+  flake.csec.wordlists and setting csec.wordlists.enable = true.
+
+  Future csec feature modules should export their own
+  flake.csec.<name> entry (declared in modules/meta/flake-output.nix as
+  attrsOf deferredModule) so each is opt-in independently.
+
+  Note: this module relies on import-from-derivation to read the wordlists
+  store path at evaluation time.
+*/
+let
+  module =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.csec.wordlists;
+      parent = dirOf cfg.path;
+      wordlistsRoot = "${pkgs.wordlists}/share/wordlists";
+      wordlistsAutoLinks = lib.mapAttrs (name: _type: "${wordlistsRoot}/${name}") (
+        builtins.readDir wordlistsRoot
+      );
+      manualLinks = {
+        dirbuster = "${pkgs.dirbuster}/share/dirbuster";
+        metasploit = "${pkgs.metasploit}/share/msf/data/wordlists";
+        "john.lst" = "${pkgs.john}/share/john/password.lst";
+      };
+      builtinLinks = wordlistsAutoLinks // manualLinks;
+      links = builtinLinks // cfg.extraLinks;
+      dirEntry = {
+        mode = "0755";
+        user = "root";
+        group = "root";
+      };
+    in
+    {
+      options.csec.wordlists = {
+        enable = lib.mkEnableOption "Kali-style wordlist symlinks under /usr/share/wordlists/";
+
+        path = lib.mkOption {
+          type = lib.types.path;
+          default = "/usr/share/wordlists";
+          description = ''
+            Filesystem path under which wordlist symlinks are created.
+            The parent directory is also created if missing.
+          '';
+        };
+
+        extraLinks = lib.mkOption {
+          type = lib.types.attrsOf lib.types.path;
+          default = { };
+          example = lib.literalExpression ''
+            {
+              rockyou = "''${pkgs.rockyou}/share/wordlists/rockyou.txt";
+            }
+          '';
+          description = ''
+            Extra name -> source mappings. Each entry creates
+            <path>/<name> as a symlink to the given target. Built-in
+            links may be overridden by setting the same attribute name.
+          '';
+        };
+      };
+
+      # Use systemd.tmpfiles.settings (structured interface) so paths and
+      # symlink targets containing spaces or special characters are quoted
+      # and C-escaped by NixOS rather than interpolated into a space-delimited
+      # rule string.
+      config = lib.mkIf cfg.enable {
+        systemd.tmpfiles.settings."10-csec-wordlists" = {
+          "${parent}".d = dirEntry;
+          "${cfg.path}".d = dirEntry;
+        }
+        // lib.mapAttrs' (
+          name: target:
+          lib.nameValuePair "${cfg.path}/${name}" {
+            "L+".argument = toString target;
+          }
+        ) links;
+      };
+    };
+in
+{
+  flake.csec.wordlists = module;
+}

--- a/modules/csec/wordlists.nix
+++ b/modules/csec/wordlists.nix
@@ -12,21 +12,29 @@
     discovered at evaluation time via builtins.readDir, so anything the
     upstream nixpkgs `wordlists` meta-package adds (currently seclists,
     wfuzz, nmap.lst, rockyou.txt) is exposed automatically.
-  - Plus three manual entries pointing at packages outside the meta-package:
+  - Plus the entries declared in `csec.wordlists.manualLinks`, defaulting
+    to packages that ship their wordlists outside the meta-package:
       * dirbuster   -> ${pkgs.dirbuster}/share/dirbuster
       * metasploit  -> ${pkgs.metasploit}/share/msf/data/wordlists
-      * john.lst    -> ${pkgs.john}/share/john/password.lst
+      * john.lst    -> ${pkgs.john}/share/john/password.lst (single file
+                       rather than a directory, intentional Kali parity)
 
-  Add more via csec.wordlists.extraLinks; explicit entries override the
-  auto-discovered ones if names collide. Hosts opt in by importing
-  flake.csec.wordlists and setting csec.wordlists.enable = true.
+  Hosts that do not need the heavier defaults (metasploit alone is
+  ~800 MB) can drop them with `csec.wordlists.manualLinks = { }` or
+  override individual entries by name. Add unrelated symlinks via
+  `csec.wordlists.extraLinks`; entries in `extraLinks` win over both
+  auto-discovered and manual links when names collide. Hosts opt in by
+  importing flake.csec.wordlists and setting csec.wordlists.enable = true.
 
   Future csec feature modules should export their own
   flake.csec.<name> entry (declared in modules/meta/flake-output.nix as
   attrsOf deferredModule) so each is opt-in independently.
 
-  Note: this module relies on import-from-derivation to read the wordlists
-  store path at evaluation time.
+  Note: this module relies on import-from-derivation. `builtins.readDir`
+  realises the `pkgs.wordlists` store path during evaluation, and each
+  declared `manualLinks` target is checked with `builtins.pathExists` so
+  upstream layout drift surfaces as an assertion failure rather than a
+  silent dangling symlink.
 */
 {
   flake.csec.wordlists =
@@ -42,18 +50,15 @@
       wordlistsAutoLinks = lib.mapAttrs (name: _type: "${wordlistsRoot}/${name}") (
         builtins.readDir wordlistsRoot
       );
-      manualLinks = {
-        dirbuster = "${pkgs.dirbuster}/share/dirbuster";
-        metasploit = "${pkgs.metasploit}/share/msf/data/wordlists";
-        "john.lst" = "${pkgs.john}/share/john/password.lst";
-      };
-      builtinLinks = wordlistsAutoLinks // manualLinks;
-      links = builtinLinks // cfg.extraLinks;
+      links = wordlistsAutoLinks // cfg.manualLinks // cfg.extraLinks;
       dirEntry = {
         mode = "0755";
         user = "root";
         group = "root";
       };
+      missingManualTargets = lib.filter (name: !builtins.pathExists (toString cfg.manualLinks.${name})) (
+        lib.attrNames cfg.manualLinks
+      );
     in
     {
       options.csec.wordlists = {
@@ -71,8 +76,32 @@
           '';
         };
 
+        manualLinks = lib.mkOption {
+          type = lib.types.attrsOf (lib.types.either lib.types.path lib.types.str);
+          default = {
+            dirbuster = "${pkgs.dirbuster}/share/dirbuster";
+            metasploit = "${pkgs.metasploit}/share/msf/data/wordlists";
+            "john.lst" = "${pkgs.john}/share/john/password.lst";
+          };
+          defaultText = lib.literalExpression ''
+            {
+              dirbuster = "''${pkgs.dirbuster}/share/dirbuster";
+              metasploit = "''${pkgs.metasploit}/share/msf/data/wordlists";
+              "john.lst" = "''${pkgs.john}/share/john/password.lst";
+            }
+          '';
+          description = ''
+            Manual name -> store-path mappings for tools whose wordlists
+            live outside the `pkgs.wordlists` meta-package. Each target
+            is checked with `builtins.pathExists` at evaluation time, so
+            upstream layout changes fail loudly. Set to `{ }` to opt
+            out of the default heavyweight packages (notably
+            `metasploit`, ~800 MB).
+          '';
+        };
+
         extraLinks = lib.mkOption {
-          type = lib.types.attrsOf lib.types.path;
+          type = lib.types.attrsOf (lib.types.either lib.types.path lib.types.str);
           default = { };
           example = lib.literalExpression ''
             {
@@ -80,9 +109,11 @@
             }
           '';
           description = ''
-            Extra name -> source mappings. Each entry creates
-            <path>/<name> as a symlink to the given target. Built-in
-            links may be overridden by setting the same attribute name.
+            Extra name -> source mappings layered on top of the
+            auto-discovered and manual links. Each entry creates
+            `<path>/<name>` as a symlink to the given target. Names
+            already provided by `manualLinks` or auto-discovery are
+            overridden by entries here.
           '';
         };
       };
@@ -92,6 +123,19 @@
       # and C-escaped by NixOS rather than interpolated into a space-delimited
       # rule string.
       config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = missingManualTargets == [ ];
+            message = ''
+              csec.wordlists.manualLinks references targets that do not
+              exist in the Nix store: ${lib.concatStringsSep ", " missingManualTargets}.
+              An upstream package layout likely changed; update the
+              affected entries (or remove them) in
+              `csec.wordlists.manualLinks`.
+            '';
+          }
+        ];
+
         systemd.tmpfiles.settings."10-csec-wordlists" = {
           "${cfg.path}".d = dirEntry;
         }

--- a/modules/csec/wordlists.nix
+++ b/modules/csec/wordlists.nix
@@ -10,8 +10,9 @@
 
   - Every top-level entry under ${pkgs.wordlists}/share/wordlists/ is
     discovered at evaluation time via builtins.readDir, so anything the
-    upstream nixpkgs `wordlists` meta-package adds (currently seclists,
-    wfuzz, nmap.lst, rockyou.txt) is exposed automatically.
+    upstream nixpkgs `wordlists` meta-package adds (e.g. seclists, wfuzz,
+    nmap.lst, rockyou.txt at the time of writing) is exposed
+    automatically.
   - Plus the entries declared in `csec.wordlists.manualLinks`, defaulting
     to packages that ship their wordlists outside the meta-package:
       * dirbuster   -> ${pkgs.dirbuster}/share/dirbuster

--- a/modules/csec/wordlists.nix
+++ b/modules/csec/wordlists.nix
@@ -69,10 +69,21 @@
           default = "/usr/share/wordlists";
           description = ''
             Filesystem path under which wordlist symlinks are created.
-            The parent directory must already exist (it does for the
-            default `/usr/share`); this module never adjusts permissions
-            of any directory outside `cfg.path` itself, so configuring a
-            user-owned location such as `/home/<user>/wordlists` is safe.
+
+            Two contracts apply:
+
+            - The parent directory of `cfg.path` must already exist
+              (always true for the default `/usr/share`); this module
+              never adjusts permissions of anything outside `cfg.path`
+              itself.
+            - The directory at `cfg.path` is enforced as
+              `0755 root:root` on every boot via the systemd-tmpfiles
+              `d` rule, so pointing this option at a user-owned path
+              such as `/home/<user>/wordlists` will have ownership
+              reclaimed by root on each activation. Use a
+              system-managed location (the default
+              `/usr/share/wordlists`, `/var/lib/wordlists`, etc.)
+              unless that behaviour is acceptable.
           '';
         };
 

--- a/modules/csec/wordlists.nix
+++ b/modules/csec/wordlists.nix
@@ -38,7 +38,6 @@ let
     }:
     let
       cfg = config.csec.wordlists;
-      parent = dirOf cfg.path;
       wordlistsRoot = "${pkgs.wordlists}/share/wordlists";
       wordlistsAutoLinks = lib.mapAttrs (name: _type: "${wordlistsRoot}/${name}") (
         builtins.readDir wordlistsRoot
@@ -65,7 +64,10 @@ let
           default = "/usr/share/wordlists";
           description = ''
             Filesystem path under which wordlist symlinks are created.
-            The parent directory is also created if missing.
+            The parent directory must already exist (it does for the
+            default `/usr/share`); this module never adjusts permissions
+            of any directory outside `cfg.path` itself, so configuring a
+            user-owned location such as `/home/<user>/wordlists` is safe.
           '';
         };
 
@@ -91,7 +93,6 @@ let
       # rule string.
       config = lib.mkIf cfg.enable {
         systemd.tmpfiles.settings."10-csec-wordlists" = {
-          "${parent}".d = dirEntry;
           "${cfg.path}".d = dirEntry;
         }
         // lib.mapAttrs' (

--- a/modules/csec/wordlists.nix
+++ b/modules/csec/wordlists.nix
@@ -139,7 +139,10 @@
             assertion = missingManualTargets == [ ];
             message = ''
               csec.wordlists.manualLinks references targets that do not
-              exist in the Nix store: ${lib.concatStringsSep ", " missingManualTargets}.
+              exist in the Nix store:
+              ${lib.concatMapStringsSep "\n" (
+                name: "  - ${name} -> ${toString cfg.manualLinks.${name}}"
+              ) missingManualTargets}
               An upstream package layout likely changed; update the
               affected entries (or remove them) in
               `csec.wordlists.manualLinks`.

--- a/modules/meta/flake-output.nix
+++ b/modules/meta/flake-output.nix
@@ -75,6 +75,16 @@
         description = "Aggregated Home Manager modules for the single System76 host";
       };
 
+      # Cybersecurity-tooling NixOS modules. Declared with attrsOf
+      # deferredModule so each feature (`flake.csec.<feature>`) is a
+      # first-class entry rather than collapsing into the parent module
+      # like sub-keys under `flake.nixosModules.*` would.
+      csec = lib.mkOption {
+        type = lib.types.attrsOf lib.types.deferredModule;
+        default = { };
+        description = "Per-feature csec NixOS modules (merged by name).";
+      };
+
     };
   };
 }

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -39,6 +39,7 @@ in
       # Required infrastructure (exported NixOS modules)
       # Note: base includes Stylix via modules/style/stylix.nix contribution
       config.flake.nixosModules.base
+      config.flake.csec.wordlists
       config.flake.nixosModules.sopsRuntime
       config.flake.nixosModules.repoSecrets
       config.flake.nixosModules.lang
@@ -69,6 +70,9 @@ in
 
     # Hardware support
     hardware.system76.extended.enable = true;
+
+    # Cybersecurity wordlist symlinks under /usr/share/wordlists/
+    csec.wordlists.enable = true;
 
     # Security & authentication
     security = {

--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -31,6 +31,7 @@ in
   configurations.nixos.tpnix.module = {
     imports = [
       config.flake.nixosModules.base
+      config.flake.csec.wordlists
       config.flake.nixosModules.sopsRuntime
       config.flake.nixosModules.repoSecrets
       config.flake.nixosModules.lang
@@ -79,6 +80,9 @@ in
       repoSecrets.enable = lib.mkForce false;
       r2CloudSecrets.enable = lib.mkForce false;
     };
+
+    # Cybersecurity wordlist symlinks under /usr/share/wordlists/
+    csec.wordlists.enable = true;
     home-manager.users.${metaOwner.username} = {
       home = {
         context7Secrets.enable = lib.mkForce false;


### PR DESCRIPTION
## Summary

- Adds the new `flake.csec` flake-output (`attrsOf deferredModule`) so cybersecurity feature modules can register independently from `flake.nixosModules.*`.
- First feature: `csec.wordlists` materializes Kali-style symlinks under `/usr/share/wordlists/` from `pkgs.wordlists`, plus the entries declared in `csec.wordlists.manualLinks` (default: `dirbuster`, `metasploit`, `john.lst`). Auto-discovers entries via `builtins.readDir` (the second IFD consumer in the repo); each `manualLinks` target is checked with `builtins.pathExists` at evaluation time so upstream layout drift surfaces as an actionable assertion failure rather than a dangling symlink.
- Hosts that do not need the heavyweight defaults can drop them with `csec.wordlists.manualLinks = { }` or override individual entries by name; `csec.wordlists.extraLinks` layers further mappings on top of both the auto-discovered and manual sets.
- Both system76 and tpnix opt in via `config.flake.csec.wordlists` and `csec.wordlists.enable = true`.
- Documents the namespace under `docs/architecture/03-nixos-modules.md` and updates the IFD comments in `flake.nix`, `modules/base/nix-settings.nix`, and `AGENTS.md` to keep all IFD-consumer references in lockstep.

## Test plan

- [x] `nix flake check --accept-flake-config --no-build --offline` (requires `pkgs.wordlists` already realised in the local store; the `builtins.readDir` IFD evaluates that derivation up-front, so a fresh evaluator without the cached path will fail before any build runs)
- [x] `nix eval .#nixosConfigurations.system76.config.systemd.tmpfiles.settings."10-csec-wordlists"` confirms the expected `L+` and `d` entries materialise.
- [x] Ad-hoc eval confirms `csec.wordlists.manualLinks = { }` drops the heavy defaults and that a deliberately-bogus target triggers the existence assertion as expected.
- [ ] On system76 / tpnix after merge: `ls -l /usr/share/wordlists/` shows the auto-discovered links plus the manual entries.
