### PR TITLE
feat(csec): add recon and web-testing tool modules

### DIFF
--- a/modules/apps/dnsenum.nix
+++ b/modules/apps/dnsenum.nix
@@ -1,0 +1,52 @@
+/*
+  Package: dnsenum
+  Description: Multi-purpose DNS enumeration toolkit for reconnaissance.
+  Homepage: nil
+  Documentation: nil
+  Repository: https://github.com/fwaeytens/dnsenum
+
+  Summary:
+    * Gathers DNS host records (A, NS, MX), attempts AXFR transfers, performs Google subdomain scraping, and brute-forces names from a wordlist.
+    * Resolves discovered hosts in parallel, walks PTR records via netranges, and emits XML reports for downstream tooling.
+
+  Options:
+    --enum: Convenience switch equivalent to `--threads 5 -s 15 -w` for combined enumeration.
+    --dnsserver <server>: Force queries against a specific resolver instead of system DNS.
+    -f <file>: Subdomain wordlist used for brute-force name generation.
+    -r: Recurse into NS records returned during the scan.
+    --noreverse: Skip reverse-lookup expansion of discovered network ranges.
+    -o <file>: Write the run as an XML report.
+    -t <seconds>: TCP/UDP DNS query timeout per request.
+    -p <pages> / -s <results>: Limit Google scraping to the given page count and result cap.
+*/
+_:
+let
+  DnsenumModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.dnsenum.extended;
+    in
+    {
+      options.programs.dnsenum.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable dnsenum.";
+        };
+
+        package = lib.mkPackageOption pkgs "dnsenum" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.dnsenum = DnsenumModule;
+}

--- a/modules/apps/ffuf.nix
+++ b/modules/apps/ffuf.nix
@@ -1,7 +1,7 @@
 /*
   Package: ffuf
   Description: Fast Go-based web fuzzer for content discovery, virtual host enumeration, and parameter brute-forcing.
-  Homepage: nil
+  Homepage: https://ffuf.io
   Documentation: https://github.com/ffuf/ffuf/wiki
   Repository: https://github.com/ffuf/ffuf
 

--- a/modules/apps/ffuf.nix
+++ b/modules/apps/ffuf.nix
@@ -1,0 +1,55 @@
+/*
+  Package: ffuf
+  Description: Fast Go-based web fuzzer for content discovery, virtual host enumeration, and parameter brute-forcing.
+  Homepage: nil
+  Documentation: https://github.com/ffuf/ffuf/wiki
+  Repository: https://github.com/ffuf/ffuf
+
+  Summary:
+    * Replaces `FUZZ` keywords in URLs, headers, and request bodies with high concurrency and minimal overhead.
+    * Supports recursive discovery, multi-wordlist modes (clusterbomb, pitchfork, sniper), autocalibration, and replay through intercepting proxies.
+
+  Options:
+    -u <url>: Target URL containing one or more `FUZZ` keywords.
+    -w <wordlist[:KEY]>: Wordlist payload, optionally bound to a custom keyword for multi-list runs.
+    -mc <codes>: Match HTTP status codes (default 200-299,301,302,307,401,403,405,500).
+    -fc <codes>: Filter HTTP status codes from results.
+    -t <n>: Number of concurrent threads (default 40).
+    -recursion: Recurse into matched paths; combine with `-recursion-depth`.
+    -mode <strategy>: Multi-wordlist mode (clusterbomb, pitchfork, sniper).
+    -e <ext1,ext2>: Extend the FUZZ keyword with the listed file extensions.
+    -request <file>: Load a raw HTTP request file with FUZZ keywords; pair with `-request-proto`.
+    -json: Emit newline-delimited JSON for downstream tooling.
+    -x <proxy>: Send traffic through an HTTP or SOCKS5 proxy (e.g. `http://127.0.0.1:8080`).
+*/
+_:
+let
+  FfufModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.ffuf.extended;
+    in
+    {
+      options.programs.ffuf.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable ffuf.";
+        };
+
+        package = lib.mkPackageOption pkgs "ffuf" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.ffuf = FfufModule;
+}

--- a/modules/apps/nuclei-templates.nix
+++ b/modules/apps/nuclei-templates.nix
@@ -1,0 +1,51 @@
+/*
+  Package: nuclei-templates
+  Description: Curated detection templates that drive the nuclei vulnerability scanner.
+  Homepage: https://github.com/projectdiscovery/nuclei-templates
+  Documentation: https://docs.projectdiscovery.io/templates
+  Repository: https://github.com/projectdiscovery/nuclei-templates
+
+  Summary:
+    * Installs the upstream template corpus covering CVEs, misconfigurations, default credentials, exposed panels, and DAST checks.
+    * Provides templates for the http, dns, network, file, ssl, headless, code, javascript, and dast protocols, plus reusable workflow profiles.
+
+  Options:
+    /run/current-system/sw/share/nuclei-templates: Active system reference for the installed template tree.
+    -t <category>/: Pass a category (e.g. `http/cves`, `network/`, `dns/`) to nuclei via `-t`.
+    -w profiles/<file>.yml: Run a curated workflow profile bundled under `share/nuclei-templates/profiles`.
+
+  Notes:
+    * Data-only package; tools should reference files under `share/nuclei-templates` rather than expecting a CLI binary.
+    * Pair with `programs.nuclei.extended.enable` and point `-ud` or `nuclei -update-template-dir` at this path to keep scans pinned to the system closure.
+*/
+_:
+let
+  NucleiTemplatesModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.nuclei-templates.extended;
+    in
+    {
+      options.programs.nuclei-templates.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable nuclei-templates.";
+        };
+
+        package = lib.mkPackageOption pkgs "nuclei-templates" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.nuclei-templates = NucleiTemplatesModule;
+}

--- a/modules/apps/nuclei.nix
+++ b/modules/apps/nuclei.nix
@@ -1,0 +1,53 @@
+/*
+  Package: nuclei
+  Description: Template-based vulnerability scanner focusing on configurability, extensibility, and ease of use.
+  Homepage: https://github.com/projectdiscovery/nuclei
+  Documentation: https://docs.projectdiscovery.io/tools/nuclei
+  Repository: https://github.com/projectdiscovery/nuclei
+
+  Summary:
+    * Executes YAML-based detection templates against URLs, hosts, or file lists with high concurrency and structured output.
+    * Slots into the ProjectDiscovery pipeline downstream of subfinder, dnsx, and httpx for end-to-end recon and exploitation triage.
+
+  Options:
+    -u <target>: Target URL or host to scan (repeatable).
+    -l <file>: Read targets from a file, one per line.
+    -t <path>: Run only templates matching the given path or directory.
+    -tags <list>: Filter templates by comma-separated tags (e.g. `cve,oast`).
+    -severity <list>: Limit execution to templates of the listed severities (info, low, medium, high, critical).
+    -as / -automatic-scan: Use wappalyzer-style technology detection to pick relevant templates automatically.
+    -o <file>: Write findings to the specified output file.
+    -j / -jsonl: Emit JSON-line output suitable for downstream tooling.
+    -ud <dir>: Override the templates directory (defaults to `$HOME/.local/nuclei-templates`).
+*/
+_:
+let
+  NucleiModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.nuclei.extended;
+    in
+    {
+      options.programs.nuclei.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable nuclei.";
+        };
+
+        package = lib.mkPackageOption pkgs "nuclei" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.nuclei = NucleiModule;
+}

--- a/modules/apps/wfuzz.nix
+++ b/modules/apps/wfuzz.nix
@@ -1,0 +1,52 @@
+/*
+  Package: wfuzz
+  Description: Web application fuzzer for content discovery, parameter testing, and brute force.
+  Homepage: nil
+  Documentation: https://wfuzz.readthedocs.io
+  Repository: https://github.com/xmendez/wfuzz
+
+  Summary:
+    * Replaces FUZZ keywords in URLs, headers, and bodies using configurable payloads, encoders, and iterators.
+    * Filters and matches by HTTP status, response size, and word/line counts to surface anomalies during web assessments.
+
+  Options:
+    -u <url>: Target URL containing one or more `FUZZ` keywords.
+    -z <payload>: Payload definition (e.g. `file,wordlist.txt`, `range,1-100`, `list,a-b-c`).
+    -w <file>: Wordlist payload shortcut (alias for `-z file,<file>`).
+    -t <n>: Number of concurrent connections (default 10).
+    -X <method>: HTTP method to use, including `FUZZ` for method fuzzing.
+    --hc / --hl / --hh / --hs: Hide responses by status code, line count, word count, or size respectively.
+    --sc / --sl / --sh / --ss: Show only responses matching the given status, line, word, or size criteria.
+    -p <ip:port[:type]>: Route requests through one or more proxies (HTTP, SOCKS4, SOCKS5).
+*/
+_:
+let
+  WfuzzModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.wfuzz.extended;
+    in
+    {
+      options.programs.wfuzz.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable wfuzz.";
+        };
+
+        package = lib.mkPackageOption pkgs "wfuzz" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.wfuzz = WfuzzModule;
+}

--- a/modules/apps/wpscan.nix
+++ b/modules/apps/wpscan.nix
@@ -1,0 +1,56 @@
+/*
+  Package: wpscan
+  Description: Black box WordPress security scanner for identifying vulnerabilities, misconfigurations, and weak credentials.
+  Homepage: https://wpscan.com/wordpress-cli-scanner/
+  Documentation: https://github.com/wpscanteam/wpscan/wiki
+  Repository: https://github.com/wpscanteam/wpscan
+
+  Summary:
+    * Enumerates WordPress core, themes, plugins, users, and exposed backups, correlating findings against the WPScan vulnerability database.
+    * Performs authenticated scans, password brute-forcing against `xmlrpc.php` and `wp-login.php`, and HTTP fingerprinting through a configurable detection engine.
+
+  Options:
+    --url <url>: Target blog URL (HTTP or HTTPS); mandatory for scans.
+    -e [opts]: Enumerate components (e.g. `vp,vt,u`: vulnerable plugins/themes and users).
+    --plugins-detection <mode>: Plugin detection aggressiveness (`passive`, `mixed`, `aggressive`).
+    --api-token <token>: Authenticate to the WPScan API for richer vulnerability metadata.
+    -P <wordlist>: Password list for `--passwords` brute force; pair with `-U` for usernames.
+    -U <users>: User list or comma-separated names to attempt during password attacks.
+    -o <file> / -f <format>: Persist results to a file in `cli`, `cli-no-colour`, or `json` format.
+    --random-user-agent: Randomize the User-Agent for each request to evade simple WAFs.
+
+  Notes:
+    * `pkgs.wpscan` ships under an unfree-redistributable license; entry below opts the package into `nixpkgs.allowedUnfreePackages`.
+*/
+_:
+let
+  WpscanModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.wpscan.extended;
+    in
+    {
+      options.programs.wpscan.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable wpscan.";
+        };
+
+        package = lib.mkPackageOption pkgs "wpscan" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  nixpkgs.allowedUnfreePackages = [ "wpscan" ];
+  flake.nixosModules.apps.wpscan = WpscanModule;
+}

--- a/modules/apps/xnlinkfinder.nix
+++ b/modules/apps/xnlinkfinder.nix
@@ -1,0 +1,54 @@
+/*
+  Package: xnlinkfinder
+  Description: Endpoint, parameter, and target-specific wordlist discovery tool for web reconnaissance.
+  Homepage: nil
+  Documentation: nil
+  Repository: https://github.com/xnl-h4ck3r/xnLinkFinder
+
+  Summary:
+    * Crawls URLs, raw files, archived Burp/ZAP/Caido exports, and HAR captures to extract links, JS-defined endpoints, and potential parameters.
+    * Outputs deduplicated link, parameter, wordlist, and out-of-scope files alongside detected secrets (AWS keys, JWTs, GitHub tokens, private keys).
+
+  Options:
+    -i <input>: URL, URL list, directory, or Burp/ZAP/Caido/HAR file to inspect.
+    -o <file>: Output path for discovered links (default `output.txt`; `cli` for stdout-only).
+    -op <file>: Output path for potential parameters (default `parameters.txt`).
+    -owl <file>: Output path for the target-specific wordlist (no wordlist by default).
+    -os <file>: Output path for detected secrets (AWS, GitHub tokens, JWTs, private keys, etc.).
+    -sp <domain|file>: Scope prefix used to expand relative `/` links to absolute URLs.
+    -sf <domain|file>: Scope filter restricting accepted hosts during crawling.
+    -d <depth>: Crawl depth when `-i` is a URL (paired with `-p` for concurrency).
+    -H <"name: value">: Add custom request headers; repeat the flag to attach multiple.
+    -inc: Include link source/context in the output for triage.
+*/
+_:
+let
+  XnlinkfinderModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.xnlinkfinder.extended;
+    in
+    {
+      options.programs.xnlinkfinder.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable xnlinkfinder.";
+        };
+
+        package = lib.mkPackageOption pkgs "xnlinkfinder" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.xnlinkfinder = XnlinkfinderModule;
+}

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -97,6 +97,7 @@
       discord.extended.enable = lib.mkOverride 1100 true;
       dmenu.extended.enable = lib.mkOverride 1100 true;
       dmidecode.extended.enable = lib.mkOverride 1100 true;
+      dnsenum.extended.enable = lib.mkOverride 1100 true;
       dnsleak.extended.enable = lib.mkOverride 1100 true;
       dnsx.extended.enable = lib.mkOverride 1100 true;
       docker.extended.enable = lib.mkOverride 1100 true;
@@ -115,6 +116,7 @@
       exiftool.extended.enable = lib.mkOverride 1100 true;
       f3.extended.enable = lib.mkOverride 1100 true;
       feroxbuster.extended.enable = lib.mkOverride 1100 true;
+      ffuf.extended.enable = lib.mkOverride 1100 true;
       file.extended.enable = lib.mkOverride 1100 true;
       "filen-desktop".extended.enable = lib.mkOverride 1100 true;
       filezilla.extended.enable = lib.mkOverride 1100 true;
@@ -261,6 +263,8 @@
       nrm.extended.enable = lib.mkOverride 1100 true;
       nsxiv.extended.enable = lib.mkOverride 1100 true;
       ntfs3g.extended.enable = lib.mkOverride 1100 true;
+      nuclei.extended.enable = lib.mkOverride 1100 true;
+      "nuclei-templates".extended.enable = lib.mkOverride 1100 true;
       nvd.extended.enable = lib.mkOverride 1100 true;
       "nvme-cli".extended.enable = lib.mkOverride 1100 true;
       obsidian.extended.enable = lib.mkOverride 1100 true;
@@ -395,6 +399,7 @@
       webcrack.extended.enable = lib.mkOverride 1100 true;
       webex.extended.enable = lib.mkOverride 1100 true;
       wezterm.extended.enable = lib.mkOverride 1100 false;
+      wfuzz.extended.enable = lib.mkOverride 1100 true;
       wgcf.extended.enable = lib.mkOverride 1100 true;
       wget.extended.enable = lib.mkOverride 1100 true;
       whatweb.extended.enable = lib.mkOverride 1100 true;
@@ -405,6 +410,7 @@
       wireshark.extended.enable = lib.mkOverride 1100 true;
       "worker-build".extended.enable = lib.mkOverride 1100 true;
       "workers-rs-sdk".extended.enable = lib.mkOverride 1100 false;
+      wpscan.extended.enable = lib.mkOverride 1100 true;
       wpsoffice.extended.enable = lib.mkOverride 1100 true;
       wrangler.extended.enable = lib.mkOverride 1100 true;
       xbacklight.extended.enable = lib.mkOverride 1100 true;
@@ -414,6 +420,7 @@
       xh.extended.enable = lib.mkOverride 1100 true;
       xkcdpass.extended.enable = lib.mkOverride 1100 true;
       xkill.extended.enable = lib.mkOverride 1100 true;
+      xnlinkfinder.extended.enable = lib.mkOverride 1100 true;
       xsel.extended.enable = lib.mkOverride 1100 true;
       xxd.extended.enable = lib.mkOverride 1100 true;
       xz.extended.enable = lib.mkOverride 1100 true;

--- a/modules/system76/custom-packages-overlay.nix
+++ b/modules/system76/custom-packages-overlay.nix
@@ -25,6 +25,15 @@ _: {
         tweakcc = final.callPackage ../../packages/tweakcc { };
         video-cache = final.callPackage ../../packages/video-cache { };
 
+        # nixpkgs wfuzz silently drops the `screenshot` plugin on Python 3.13
+        # (removed `pipes` stdlib module) and ships netaddr as a test-only dep,
+        # leaving iprange/ipnet payloads broken with a misleading "pip install"
+        # message. Patches are pending upstream review at xmendez/wfuzz#380 and
+        # nixpkgs PR; remove this override once they land.
+        wfuzz = final.python3Packages.toPythonApplication (
+          final.python3Packages.callPackage ../../packages/wfuzz { }
+        );
+
         # system76-power 1.2.8 aborts profile application when any SCSI host
         # lacks link_power_management_policy (USB-attached SCSI, virtio-scsi,
         # card readers). The daemon then keeps reporting the previous profile

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -83,6 +83,7 @@
       discord.extended.enable = lib.mkOverride 1100 false;
       dmenu.extended.enable = lib.mkOverride 1100 true;
       dmidecode.extended.enable = lib.mkOverride 1100 false;
+      dnsenum.extended.enable = lib.mkOverride 1100 true;
       dnsleak.extended.enable = lib.mkOverride 1100 true;
       dnsx.extended.enable = lib.mkOverride 1100 true;
       docker.extended.enable = lib.mkOverride 1100 false;
@@ -101,6 +102,7 @@
       exiftool.extended.enable = lib.mkOverride 1100 true;
       f3.extended.enable = lib.mkOverride 1100 false;
       feroxbuster.extended.enable = lib.mkOverride 1100 true;
+      ffuf.extended.enable = lib.mkOverride 1100 true;
       file.extended.enable = lib.mkOverride 1100 true;
       "filen-desktop".extended.enable = lib.mkOverride 1100 true;
       filezilla.extended.enable = lib.mkOverride 1100 false;
@@ -245,6 +247,8 @@
       nrm.extended.enable = lib.mkOverride 1100 false;
       nsxiv.extended.enable = lib.mkOverride 1100 true;
       ntfs3g.extended.enable = lib.mkOverride 1100 true;
+      nuclei.extended.enable = lib.mkOverride 1100 true;
+      "nuclei-templates".extended.enable = lib.mkOverride 1100 true;
       nvd.extended.enable = lib.mkOverride 1100 false;
       "nvme-cli".extended.enable = lib.mkOverride 1100 true;
       obsidian.extended.enable = lib.mkOverride 1100 true;
@@ -379,6 +383,7 @@
       webcrack.extended.enable = lib.mkOverride 1100 true;
       webex.extended.enable = lib.mkOverride 1100 true;
       wezterm.extended.enable = lib.mkOverride 1100 false;
+      wfuzz.extended.enable = lib.mkOverride 1100 true;
       wgcf.extended.enable = lib.mkOverride 1100 false;
       wget.extended.enable = lib.mkOverride 1100 true;
       whatweb.extended.enable = lib.mkOverride 1100 true;
@@ -389,6 +394,7 @@
       wireshark.extended.enable = lib.mkOverride 1100 true;
       "worker-build".extended.enable = lib.mkOverride 1100 false;
       "workers-rs-sdk".extended.enable = lib.mkOverride 1100 false;
+      wpscan.extended.enable = lib.mkOverride 1100 true;
       wpsoffice.extended.enable = lib.mkOverride 1100 false;
       wrangler.extended.enable = lib.mkOverride 1100 false;
       xbacklight.extended.enable = lib.mkOverride 1100 true;
@@ -398,6 +404,7 @@
       xh.extended.enable = lib.mkOverride 1100 true;
       xkcdpass.extended.enable = lib.mkOverride 1100 true;
       xkill.extended.enable = lib.mkOverride 1100 true;
+      xnlinkfinder.extended.enable = lib.mkOverride 1100 true;
       xsel.extended.enable = lib.mkOverride 1100 true;
       xxd.extended.enable = lib.mkOverride 1100 true;
       xz.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/custom-packages-overlay.nix
+++ b/modules/tpnix/custom-packages-overlay.nix
@@ -25,6 +25,15 @@ _: {
         tweakcc = final.callPackage ../../packages/tweakcc { };
         video-cache = final.callPackage ../../packages/video-cache { };
 
+        # nixpkgs wfuzz silently drops the `screenshot` plugin on Python 3.13
+        # (removed `pipes` stdlib module) and ships netaddr as a test-only dep,
+        # leaving iprange/ipnet payloads broken with a misleading "pip install"
+        # message. Patches are pending upstream review at xmendez/wfuzz#380 and
+        # nixpkgs PR; remove this override once they land.
+        wfuzz = final.python3Packages.toPythonApplication (
+          final.python3Packages.callPackage ../../packages/wfuzz { }
+        );
+
         # Workaround: marktext 0.17.0's native module rebuild can fail with
         # `node-gyp: not found` under the current Node 24 toolchain.
         marktext = prev.marktext.overrideAttrs (old: {

--- a/packages/wfuzz/default.nix
+++ b/packages/wfuzz/default.nix
@@ -1,0 +1,95 @@
+{
+  lib,
+  stdenv,
+  buildPythonPackage,
+  chardet,
+  colorama,
+  distutils,
+  fetchFromGitHub,
+  netaddr,
+  pycurl,
+  pyparsing,
+  pytestCheckHook,
+  setuptools,
+  six,
+  fetchpatch2,
+  legacy-cgi,
+}:
+
+buildPythonPackage (finalAttrs: {
+  pname = "wfuzz";
+  version = "3.1.1";
+  pyproject = true;
+
+  src = fetchFromGitHub {
+    owner = "xmendez";
+    repo = "wfuzz";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-OYMZHo0ujRzwOcE+EKRNPxffxVbbiMHe+AqBz7q/u2A=";
+  };
+
+  patches = [
+    # replace use of imp module for Python >= 3.12
+    # https://github.com/xmendez/wfuzz/pull/365
+    (fetchpatch2 {
+      url = "https://github.com/xmendez/wfuzz/commit/f4c028b9ada4c36dabf3bc752f69f6ddc110920f.patch?full_index=1";
+      hash = "sha256-t7pUMcdFmwAsGUNBRdZr+Jje/yR0yzeGIgeYNEq4hFE=";
+    })
+    # replace removed `pipes` stdlib module with `shlex` for Python >= 3.13
+    # https://github.com/xmendez/wfuzz/issues/380
+    ./python-313-shlex.patch
+  ];
+
+  build-system = [ setuptools ];
+
+  dependencies = [
+    chardet
+    distutils # src/wfuzz/plugin_api/base.py
+    legacy-cgi
+    netaddr # src/wfuzz/plugins/payloads/{iprange,ipnet}.py
+    pycurl
+    pyparsing
+    setuptools
+    six
+  ]
+  ++ lib.optionals stdenv.hostPlatform.isWindows [ colorama ];
+
+  nativeCheckInputs = [
+    netaddr
+    pytestCheckHook
+  ];
+
+  preCheck = ''
+    export HOME=$(mktemp -d)
+  '';
+
+  disabledTestPaths = [
+    # The tests are requiring a local web server
+    "tests/test_acceptance.py"
+    "tests/acceptance/test_saved_filter.py"
+    # depends on imp module removed from Python 3.12
+    "tests/test_moduleman.py"
+  ];
+
+  pythonImportsCheck = [ "wfuzz" ];
+
+  postInstall = ''
+    mkdir -p $out/share/wordlists/wfuzz
+    cp -R -T "wordlist" "$out/share/wordlists/wfuzz"
+  '';
+
+  meta = {
+    changelog = "https://github.com/xmendez/wfuzz/releases/tag/v${finalAttrs.version}";
+    description = "Web content fuzzer to facilitate web applications assessments";
+    longDescription = ''
+      Wfuzz provides a framework to automate web applications security assessments
+      and could help you to secure your web applications by finding and exploiting
+      web application vulnerabilities.
+    '';
+    homepage = "https://wfuzz.readthedocs.io";
+    license = with lib.licenses; [ gpl2Only ];
+    maintainers = with lib.maintainers; [ pamplemousse ];
+    mainProgram = "wfuzz";
+    platforms = lib.platforms.unix;
+  };
+})

--- a/packages/wfuzz/default.nix
+++ b/packages/wfuzz/default.nix
@@ -90,6 +90,6 @@ buildPythonPackage (finalAttrs: {
     license = with lib.licenses; [ gpl2Only ];
     maintainers = with lib.maintainers; [ pamplemousse ];
     mainProgram = "wfuzz";
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
   };
 })

--- a/packages/wfuzz/default.nix
+++ b/packages/wfuzz/default.nix
@@ -37,6 +37,7 @@ buildPythonPackage (finalAttrs: {
     })
     # replace removed `pipes` stdlib module with `shlex` for Python >= 3.13
     # https://github.com/xmendez/wfuzz/issues/380
+    # Drop once xmendez/wfuzz#380 is merged and a release is cut.
     ./python-313-shlex.patch
   ];
 

--- a/packages/wfuzz/default.nix
+++ b/packages/wfuzz/default.nix
@@ -54,10 +54,7 @@ buildPythonPackage (finalAttrs: {
   ]
   ++ lib.optionals stdenv.hostPlatform.isWindows [ colorama ];
 
-  nativeCheckInputs = [
-    netaddr
-    pytestCheckHook
-  ];
+  nativeCheckInputs = [ pytestCheckHook ];
 
   preCheck = ''
     export HOME=$(mktemp -d)

--- a/packages/wfuzz/python-313-shlex.patch
+++ b/packages/wfuzz/python-313-shlex.patch
@@ -1,0 +1,29 @@
+Replace removed `pipes` stdlib module with `shlex` in screenshot plugin.
+
+`pipes` was deprecated in Python 3.11 (PEP 594) and removed in 3.13;
+`shlex.quote` is the documented stdlib replacement and behaves identically
+for the single argument used here.
+
+Reported upstream: https://github.com/xmendez/wfuzz/issues/380
+
+diff --git a/src/wfuzz/plugins/scripts/screenshot.py b/src/wfuzz/plugins/scripts/screenshot.py
+--- a/src/wfuzz/plugins/scripts/screenshot.py
++++ b/src/wfuzz/plugins/scripts/screenshot.py
+@@ -3,7 +3,7 @@ from wfuzz.externals.moduleman.plugin import moduleman_plugin
+
+ import subprocess
+ import tempfile
+-import pipes
++import shlex
+ import os
+ import re
+
+@@ -42,7 +42,7 @@ class screenshot(BasePlugin):
+         subprocess.call(
+             [
+                 "cutycapt",
+-                "--url=%s" % pipes.quote(fuzzresult.url),
++                "--url=%s" % shlex.quote(fuzzresult.url),
+                 "--out=%s" % filename,
+                 "--insecure",
+                 "--print-backgrounds=on",


### PR DESCRIPTION
## Summary

- Adds NixOS app modules for seven cybersecurity tools and enables them on both system76 and tpnix:
  - `dnsenum` — multi-purpose DNS enumeration toolkit
  - `ffuf` — fast Go web fuzzer
  - `nuclei` — template-based vulnerability scanner
  - `nuclei-templates` — curated detection corpus consumed by nuclei
  - `wfuzz` — web application fuzzer
  - `wpscan` — WordPress black-box scanner (unfree-redistributable, opted in via `nixpkgs.allowedUnfreePackages`)
  - `xnlinkfinder` — endpoint and parameter discovery for web recon
- Bundles a custom `wfuzz` package under `packages/wfuzz/` because nixpkgs' wfuzz silently drops the screenshot plugin on Python 3.13 (removed `pipes` stdlib module) and ships netaddr as test-only, breaking iprange/ipnet payloads. The `python-313-shlex.patch` swaps `pipes.quote` for `shlex.quote` (tracked at xmendez/wfuzz#380); the override pulls netaddr in as a runtime dependency.
- Both host `custom-packages-overlay.nix` modules splice the patched wfuzz into `pkgs`.

## Test plan

- [x] `nix flake check --accept-flake-config --no-build --offline`
- [ ] After merge: `nix run .#nixosConfigurations.<host>.config.system.build.toplevel` succeeds for both hosts.
- [ ] `wfuzz -h` prints help and `wfuzz --plugins` lists the screenshot plugin without import errors.
- [ ] `python3 -c "import wfuzz.plugins.payloads.iprange"` succeeds, confirming `netaddr` is reachable as a runtime dependency.
- [ ] `nuclei -version` and `ls /run/current-system/sw/share/nuclei-templates/` succeed.
