### PR TITLE
refactor(nvidia): drop closedNvidiaPackage wrapper

### DIFF
--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -8,15 +8,6 @@ _: {
     }:
     let
       cfg = config.system76.gpu;
-      # nix-cachyos-kernel exposes the closed driver as the package itself;
-      # current nixpkgs' NVIDIA module expects the closed module at `.mod`.
-      # Mirror any change in modules/tpnix/power.nix.
-      closedNvidiaPackage =
-        package:
-        package
-        // {
-          mod = package;
-        };
     in
     {
       options.system76.gpu = {
@@ -69,7 +60,7 @@ _: {
 
             nvidia = {
               # GTX 1070 Max-Q is supported by the 580.xx legacy branch; newer production drivers ignore it.
-              package = closedNvidiaPackage config.boot.kernelPackages.nvidiaPackages.legacy_580;
+              package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
               modesetting.enable = true;
               powerManagement.enable = true;
               # Fine-grained power management (D3 power gating) is incompatible with PRIME sync.

--- a/modules/tpnix/power.nix
+++ b/modules/tpnix/power.nix
@@ -6,17 +6,6 @@
       pkgs,
       ...
     }:
-    let
-      # nix-cachyos-kernel exposes the closed driver as the package itself;
-      # current nixpkgs' NVIDIA module expects the closed module at `.mod`.
-      # Mirror any change in modules/system76/nvidia-gpu.nix.
-      closedNvidiaPackage =
-        package:
-        package
-        // {
-          mod = package;
-        };
-    in
     {
       boot.blacklistedKernelModules = [ "nouveau" ];
 
@@ -32,7 +21,7 @@
         ];
 
         nvidia = {
-          package = closedNvidiaPackage config.boot.kernelPackages.nvidiaPackages.production;
+          package = config.boot.kernelPackages.nvidiaPackages.production;
           modesetting.enable = true;
           open = false;
           gsp.enable = true;


### PR DESCRIPTION
## Summary

- Removes the `closedNvidiaPackage` helper from both `modules/system76/nvidia-gpu.nix` and `modules/tpnix/power.nix`. The helper attached `mod = package` because older nixpkgs NVIDIA modules expected the closed driver at `.mod`, but both host kernels (nix-cachyos-kernel-derived) now provide `nvidiaPackages` attributes that are already shaped correctly.
- Drops the cross-host "mirror any change here" coupling along with the wrapper.

## Test plan

- [ ] After merge: `./build.sh --host system76 --boot` and `./build.sh --host tpnix --boot` rebuild without NVIDIA driver evaluation errors.
- [ ] Post-reboot: `nvidia-smi` lists the GPU and `glxinfo | rg renderer` shows the NVIDIA driver active.