### PR TITLE
feat(claude-code): allow disabling all install methods

### DIFF
--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -70,8 +70,8 @@ in
           default = false;
           description = ''
             Whether this host uses claude-code. Configures Home Manager side
-            (settings, skills, MCP merge). Requires at least one entry in
-            `installMethods.*.enable` to also be true.
+            (settings, skills, MCP merge) regardless of whether any install
+            method is enabled, so the binary may be managed outside Nix.
           '';
         };
 
@@ -103,17 +103,6 @@ in
               method is enabled. Binary lands at `$XDG_DATA_HOME/bun/bin/claude`.
             '';
           };
-        };
-
-        anyInstallEnabled = lib.mkOption {
-          type = lib.types.bool;
-          readOnly = true;
-          default = cfg.enable && (cfg.installMethods.nix.enable || cfg.installMethods.bun.enable);
-          description = ''
-            Read-only. True if claude-code is enabled with at least one install
-            method. Consumers can use this to check availability without
-            enumerating individual install methods.
-          '';
         };
 
         lspPlugins = lib.mapAttrs (
@@ -176,16 +165,6 @@ in
                   lspCollisions = lib.intersectLists extraKeys lspKeysWithMarket;
                 in
                 [
-                  {
-                    assertion = cfg.anyInstallEnabled;
-                    message = ''
-                      programs.claude-code.extended.enable = true, but no install method
-                      is enabled. Set one of:
-                        programs.claude-code.extended.installMethods.nix.enable = true;
-                        programs.claude-code.extended.installMethods.bun.enable = true;
-                      (typically in modules/<host>/apps-enable.nix)
-                    '';
-                  }
                   {
                     assertion = (!cfg.installMethods.bun.enable) || config.programs.bun.extended.enable;
                     message = ''

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -97,8 +97,10 @@ in
             default = false;
             description = ''
               Install claude-code via `bun install -g @anthropic-ai/claude-code`
-              on every Home Manager activation when `registry.npmjs.org` is
-              reachable. If the reachability probe fails, the install step is
+              on every Home Manager activation when the npm registry probe
+              succeeds (curl against the latest-version endpoint with
+              `--fail --max-time 5`). If the probe fails for any reason
+              (DNS, TLS, HTTP 4xx/5xx, timeout), the install step is
               skipped, a warning is logged, and the existing binary (if any)
               at `$XDG_DATA_HOME/bun/bin/claude` is preserved. Requires
               `programs.bun.extended.enable = true`; this module automatically

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -97,10 +97,13 @@ in
             default = false;
             description = ''
               Install claude-code via `bun install -g @anthropic-ai/claude-code`
-              during every Home Manager activation. Requires
+              on every Home Manager activation when `registry.npmjs.org` is
+              reachable. If the reachability probe fails, the install step is
+              skipped, a warning is logged, and the existing binary (if any)
+              at `$XDG_DATA_HOME/bun/bin/claude` is preserved. Requires
               `programs.bun.extended.enable = true`; this module automatically
               imports the `bun` Home Manager app module when the bun install
-              method is enabled. Binary lands at `$XDG_DATA_HOME/bun/bin/claude`.
+              method is enabled.
             '';
           };
         };

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -236,8 +236,10 @@ _: {
                   --output /dev/null \
                   https://registry.npmjs.org/@anthropic-ai/claude-code/latest; then
                 run ${bunBin} install -g @anthropic-ai/claude-code
+              elif [ -x "$BUN_INSTALL/bin/claude" ]; then
+                echo "warning: installClaudeCodeViaBun: npm registry unreachable, keeping existing install at $BUN_INSTALL/bin/claude" >&2
               else
-                echo "warning: installClaudeCodeViaBun: npm registry unreachable, keeping existing install" >&2
+                echo "warning: installClaudeCodeViaBun: npm registry unreachable and no existing claude-code binary at $BUN_INSTALL/bin/claude; rerun home-manager switch when the network recovers" >&2
               fi
             '';
           };

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -225,7 +225,7 @@ _: {
           // lib.optionalAttrs bunInstallEnabled {
             installClaudeCodeViaBun = lib.hm.dag.entryAfter [ "writeBoundary" "createBunDir" ] ''
               export BUN_INSTALL="${bunInstallDir}"
-              if ${pkgs.curl}/bin/curl --silent --fail --max-time 5 \
+              if ${pkgs.curl}/bin/curl --silent --show-error --fail --max-time 5 \
                   --output /dev/null \
                   https://registry.npmjs.org/@anthropic-ai/claude-code/latest; then
                 run ${bunBin} install -g @anthropic-ai/claude-code

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -225,7 +225,13 @@ _: {
           // lib.optionalAttrs bunInstallEnabled {
             installClaudeCodeViaBun = lib.hm.dag.entryAfter [ "writeBoundary" "createBunDir" ] ''
               export BUN_INSTALL="${bunInstallDir}"
-              run ${bunBin} install -g @anthropic-ai/claude-code
+              if ${pkgs.curl}/bin/curl --silent --fail --max-time 5 \
+                  --output /dev/null \
+                  https://registry.npmjs.org/@anthropic-ai/claude-code/latest; then
+                run ${bunBin} install -g @anthropic-ai/claude-code
+              else
+                echo "warning: installClaudeCodeViaBun: npm registry unreachable, keeping existing install" >&2
+              fi
             '';
           };
 

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -237,9 +237,9 @@ _: {
                   https://registry.npmjs.org/@anthropic-ai/claude-code/latest; then
                 run ${bunBin} install -g @anthropic-ai/claude-code
               elif [ -x "$BUN_INSTALL/bin/claude" ]; then
-                echo "warning: installClaudeCodeViaBun: npm registry unreachable, keeping existing install at $BUN_INSTALL/bin/claude" >&2
+                echo "warning: installClaudeCodeViaBun: npm registry probe failed (see curl error above), keeping existing install at $BUN_INSTALL/bin/claude" >&2
               else
-                echo "warning: installClaudeCodeViaBun: npm registry unreachable and no existing claude-code binary at $BUN_INSTALL/bin/claude; rerun home-manager switch when the network recovers" >&2
+                echo "warning: installClaudeCodeViaBun: npm registry probe failed (see curl error above) and no existing claude-code binary at $BUN_INSTALL/bin/claude; rerun home-manager switch once the registry is reachable" >&2
               fi
             '';
           };

--- a/modules/hm-apps/claude-code.nix
+++ b/modules/hm-apps/claude-code.nix
@@ -223,6 +223,13 @@ _: {
             '';
           }
           // lib.optionalAttrs bunInstallEnabled {
+            # The probe URL is pinned to the public npm registry because every
+            # host in this repo runs bun against the default registry. If a
+            # future host points bun at a private mirror via `~/.bunfig.toml`
+            # or `BUN_CONFIG_REGISTRY`, this probe will check the wrong
+            # endpoint and either skip a working install or run an install
+            # that fails immediately. Update the URL alongside the bun config
+            # if that ever happens.
             installClaudeCodeViaBun = lib.hm.dag.entryAfter [ "writeBoundary" "createBunDir" ] ''
               export BUN_INSTALL="${bunInstallDir}"
               if ${pkgs.curl}/bin/curl --silent --show-error --fail --max-time 5 \

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -61,7 +61,7 @@
       clangd.extended.enable = lib.mkOverride 1100 false;
       "claude-code".extended.enable = lib.mkOverride 1100 true;
       "claude-code".extended.installMethods.nix.enable = lib.mkOverride 1100 false;
-      "claude-code".extended.installMethods.bun.enable = lib.mkOverride 1100 true;
+      "claude-code".extended.installMethods.bun.enable = lib.mkOverride 1100 false;
       "claude-desktop".extended.enable = lib.mkOverride 1100 true;
       "claude-plugins".extended.enable = lib.mkOverride 1100 true;
       "claude-wpa".extended.enable = lib.mkOverride 1100 false; # Deprecated: use claude-desktop

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -59,6 +59,11 @@
       charles.extended.enable = lib.mkOverride 1100 true;
       circumflex.extended.enable = lib.mkOverride 1100 true;
       clangd.extended.enable = lib.mkOverride 1100 false;
+      # Both install methods disabled: the claude-code binary is managed
+      # outside Nix on this host. Home Manager still applies settings,
+      # skills, and MCP merge. To switch back to a Nix-managed binary, set
+      # installMethods.nix.enable = true; for bun-managed, set
+      # installMethods.bun.enable = true and programs.bun.extended.enable = true.
       "claude-code".extended.enable = lib.mkOverride 1100 true;
       "claude-code".extended.installMethods.nix.enable = lib.mkOverride 1100 false;
       "claude-code".extended.installMethods.bun.enable = lib.mkOverride 1100 false;

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -46,8 +46,7 @@
       clangd.extended.enable = lib.mkOverride 1100 false;
       "claude-code".extended.enable = lib.mkOverride 1100 true;
       "claude-code".extended.installMethods.nix.enable = lib.mkOverride 1100 false;
-      # To switch to nix: set nix.enable = true and bun.enable = false
-      "claude-code".extended.installMethods.bun.enable = lib.mkOverride 1100 true;
+      "claude-code".extended.installMethods.bun.enable = lib.mkOverride 1100 false;
       "claude-desktop".extended.enable = lib.mkOverride 1100 true; # Upstream flake still references removed pkgs.nodePackages
       "claude-plugins".extended.enable = lib.mkOverride 1100 false;
       "claude-wpa".extended.enable = lib.mkOverride 1100 false; # Deprecated: use claude-desktop

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -44,6 +44,11 @@
       charles.extended.enable = lib.mkOverride 1100 true;
       circumflex.extended.enable = lib.mkOverride 1100 false;
       clangd.extended.enable = lib.mkOverride 1100 false;
+      # Both install methods disabled: the claude-code binary is managed
+      # outside Nix on this host. Home Manager still applies settings,
+      # skills, and MCP merge. To switch back to a Nix-managed binary, set
+      # installMethods.nix.enable = true; for bun-managed, set
+      # installMethods.bun.enable = true and programs.bun.extended.enable = true.
       "claude-code".extended.enable = lib.mkOverride 1100 true;
       "claude-code".extended.installMethods.nix.enable = lib.mkOverride 1100 false;
       "claude-code".extended.installMethods.bun.enable = lib.mkOverride 1100 false;


### PR DESCRIPTION
## Summary

- Removes the requirement that `programs.claude-code.extended.enable` be paired with at least one install method. Hosts can now opt into the Home Manager surface (settings, skills, MCP merge) while managing the binary outside Nix.
- `modules/apps/claude-code.nix` drops the read-only `anyInstallEnabled` option and the assertion that depended on it; updates the `enable` description so the new contract is explicit.
- `modules/hm-apps/claude-code.nix` wraps the `installClaudeCodeViaBun` activation in a fast curl reachability probe against `registry.npmjs.org`, so a flaky network does not break `home-manager switch`.
- `modules/system76/apps-enable.nix` and `modules/tpnix/apps-enable.nix` flip `installMethods.bun.enable` to false now that both hosts run the binary outside Nix.

## Test plan

- [x] `nix flake check --accept-flake-config --no-build --offline`
- [ ] After merge: `home-manager switch` succeeds on both hosts with no new install method enabled; `claude-code --version` continues to work via the externally-managed binary.
- [ ] Disconnect from network, run activation: warning logged, switch succeeds.