### PR TITLE
fix(pass-secret-service): guard activation when GPG key missing

### DIFF
--- a/modules/home/pass-secret-service.nix
+++ b/modules/home/pass-secret-service.nix
@@ -33,7 +33,7 @@
           if [ -r ${lib.escapeShellArg keyPath} ]; then
             ${lib.getExe passGpgBootstrap} import-key ${lib.escapeShellArg keyPath} ${lib.escapeShellArg keyFingerprint}
           else
-            echo "Skipping GPG key import: secret not yet available at ${keyPath}" >&2
+            echo "Skipping GPG key import: secret not yet available at" ${lib.escapeShellArg keyPath} >&2
           fi
         ''
       );

--- a/modules/home/pass-secret-service.nix
+++ b/modules/home/pass-secret-service.nix
@@ -30,13 +30,19 @@
     {
       home.activation.importPassGpgKey = lib.mkIf haveKeyPath (
         lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-          ${lib.getExe passGpgBootstrap} import-key ${lib.escapeShellArg keyPath} ${lib.escapeShellArg keyFingerprint}
+          if [ -r ${lib.escapeShellArg keyPath} ]; then
+            ${lib.getExe passGpgBootstrap} import-key ${lib.escapeShellArg keyPath} ${lib.escapeShellArg keyFingerprint}
+          else
+            echo "Skipping GPG key import: secret not yet available at ${keyPath}" >&2
+          fi
         ''
       );
 
       home.activation.initPassStore = lib.mkIf haveKeyPath (
         lib.hm.dag.entryAfter [ "importPassGpgKey" ] ''
-          ${lib.getExe passGpgBootstrap} init-store ${lib.escapeShellArg keyFingerprint}
+          if [ -r ${lib.escapeShellArg keyPath} ]; then
+            ${lib.getExe passGpgBootstrap} init-store ${lib.escapeShellArg keyFingerprint}
+          fi
         ''
       );
     };

--- a/modules/home/pass-secret-service.nix
+++ b/modules/home/pass-secret-service.nix
@@ -42,6 +42,8 @@
         lib.hm.dag.entryAfter [ "importPassGpgKey" ] ''
           if [ -r ${lib.escapeShellArg keyPath} ]; then
             ${lib.getExe passGpgBootstrap} init-store ${lib.escapeShellArg keyFingerprint}
+          else
+            echo "Skipping pass store init: secret not yet available at" ${lib.escapeShellArg keyPath} >&2
           fi
         ''
       );


### PR DESCRIPTION
## Summary

- The Home Manager activation that bootstraps `pass-secret-service` via `passGpgBootstrap` unconditionally invoked `import-key` and `init-store` against the configured key path, so `home-manager switch` aborted whenever the secret had not yet been materialized (fresh installs, sops decryption pending, branch switch before rebuild, etc.).
- Wraps both DAG entries in `[ -r "${keyPath}" ]` checks so the missing key is logged as a warning and the activation proceeds.

## Test plan

- [ ] On a host where the GPG key secret is not yet decrypted, `home-manager switch` completes with a warning rather than aborting.
- [ ] Once the secret materializes, the next switch imports the key and initialises the store as before.