### PR TITLE
fix(tpnix): resolve unresolved merge conflict markers in overlay

### DIFF
--- a/modules/tpnix/custom-packages-overlay.nix
+++ b/modules/tpnix/custom-packages-overlay.nix
@@ -25,7 +25,6 @@ _: {
         tweakcc = final.callPackage ../../packages/tweakcc { };
         video-cache = final.callPackage ../../packages/video-cache { };
 
-<<<<<<< feat/csec-tools
         # nixpkgs wfuzz silently drops the `screenshot` plugin on Python 3.13
         # (removed `pipes` stdlib module) and ships netaddr as a test-only dep,
         # leaving iprange/ipnet payloads broken with a misleading "pip install"
@@ -34,7 +33,7 @@ _: {
         wfuzz = final.python3Packages.toPythonApplication (
           final.python3Packages.callPackage ../../packages/wfuzz { }
         );
-=======
+
         # Bump librepods to v0.2.5 (nixpkgs pins v0.2.0). v0.2.5 swaps
         # qtquick3d for qtdeclarative + qttools and adds Widgets/DBus.
         librepods = prev.librepods.overrideAttrs (_old: rec {
@@ -54,7 +53,6 @@ _: {
             prev.qt6.qttools
           ];
         });
->>>>>>> main
 
         # Workaround: marktext 0.17.0's native module rebuild can fail with
         # `node-gyp: not found` under the current Node 24 toolchain.


### PR DESCRIPTION
## Summary

- Resolves the unresolved Git conflict markers left in `modules/tpnix/custom-packages-overlay.nix` lines 28, 37, 57 by the `Merge branch 'main' into feat/csec-tools` commit (`22973ff`) that was carried into `main` by PR #160's squash merge.
- Mirrors the structure of the already-correct sibling `modules/system76/custom-packages-overlay.nix:28-66`, keeping both the `wfuzz` override (originally on `feat/csec-tools`) and the `librepods` v0.2.5 override (originally on `main`). The two overrides are independent and must coexist.
- Restores `nix-instantiate --parse` parity for the file and unblocks `nix flake check` and the `tpnix` host build.

This blocker was reported by the `claude-review` workflow on PR #160 (run [`25340703466`](https://github.com/Bad3r/nixos/actions/runs/25340703466)) at the same instant as the PR merge, so the fix never landed.

## Test plan

- [x] `nix-instantiate --parse modules/tpnix/custom-packages-overlay.nix` exits 0
- [x] `rg '^<<<<<<<|^=======$|^>>>>>>>'` reports no matches in the tree
- [x] `nix flake check --accept-flake-config --no-build` reports `all checks passed!`
- [x] `pre-commit run --all-files` (executed automatically via the commit hook chain) all passing