### PR TITLE
refactor(modules): extract shared customPackages overlay into flake.lib

### DIFF
--- a/modules/base/custom-packages-overlay.nix
+++ b/modules/base/custom-packages-overlay.nix
@@ -1,13 +1,15 @@
-# Shared nixpkgs overlay used by every host. Hosts compose this with any
-# host-specific overlay extras (see `modules/system76/custom-packages-overlay.nix`
-# for an example that adds a hardware-specific patch on top).
+# Shared nixpkgs overlay surfaced as `config.flake.lib.overlays.customPackages`.
+# This module only *defines* the overlay; hosts opt in by composing it into
+# `nixpkgs.overlays` (see `modules/system76/custom-packages-overlay.nix` for an
+# example that prepends this overlay and then layers a hardware-specific patch
+# on top).
 #
 # Resolution rules:
 # - `final.callPackage` for in-tree derivations under `packages/`.
 # - `prev.<pkg>.overrideAttrs` for upstream packages that need patching, version
 #   bumps, or dependency tweaks until the upstream issue is resolved.
 _: {
-  flake.lib.customPackagesOverlay = final: prev: {
+  flake.lib.overlays.customPackages = final: prev: {
     # In-tree custom packages from `packages/`.
     brave-origin = final.callPackage ../../packages/brave-origin { };
     raindrop = final.callPackage ../../packages/raindrop { };

--- a/modules/base/custom-packages-overlay.nix
+++ b/modules/base/custom-packages-overlay.nix
@@ -44,32 +44,35 @@ _: {
 
     # Bump librepods to v0.2.5 (nixpkgs pins v0.2.0). v0.2.5 swaps
     # qtquick3d for qtdeclarative + qttools and adds Widgets/DBus.
+    # Dep lookups go through `final` so any later overlay (e.g. an `openssl`
+    # CVE patch) feeds into this build instead of being silently bypassed.
     librepods = prev.librepods.overrideAttrs (_old: rec {
       version = "0.2.5";
-      src = prev.fetchFromGitHub {
+      src = final.fetchFromGitHub {
         owner = "kavishdevar";
         repo = "librepods";
         tag = "v${version}";
         hash = "sha256-6l1WjwjDbv5e3tDaWo9+XSEjr9ge/hKysIkeUqyiO4U=";
       };
       buildInputs = [
-        prev.libpulseaudio
-        prev.openssl
-        prev.qt6.qtbase
-        prev.qt6.qtconnectivity
-        prev.qt6.qtdeclarative
-        prev.qt6.qttools
+        final.libpulseaudio
+        final.openssl
+        final.qt6.qtbase
+        final.qt6.qtconnectivity
+        final.qt6.qtdeclarative
+        final.qt6.qttools
       ];
     });
 
     # Workaround: marktext 0.17.0's native module rebuild can fail with
-    # `node-gyp: not found` under the current Node 24 toolchain.
+    # `node-gyp: not found` under the current Node 24 toolchain. Pull
+    # `node-gyp` from `final` for the same fixpoint reason as `librepods`.
     marktext = prev.marktext.overrideAttrs (old: {
       nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
-        prev."node-gyp"
+        final."node-gyp"
       ];
-      npm_config_node_gyp = "${prev."node-gyp"}/bin/node-gyp";
-      NODE_GYP = "${prev."node-gyp"}/bin/node-gyp";
+      npm_config_node_gyp = "${final."node-gyp"}/bin/node-gyp";
+      NODE_GYP = "${final."node-gyp"}/bin/node-gyp";
     });
 
     # i3 window manager utilities

--- a/modules/base/custom-packages.nix
+++ b/modules/base/custom-packages.nix
@@ -1,0 +1,79 @@
+# Shared nixpkgs overlay used by every host. Hosts compose this with any
+# host-specific overlay extras (see `modules/system76/custom-packages-overlay.nix`
+# for an example that adds a hardware-specific patch on top).
+#
+# Resolution rules:
+# - `final.callPackage` for in-tree derivations under `packages/`.
+# - `prev.<pkg>.overrideAttrs` for upstream packages that need patching, version
+#   bumps, or dependency tweaks until the upstream issue is resolved.
+_: {
+  flake.lib.customPackagesOverlay = final: prev: {
+    # In-tree custom packages from `packages/`.
+    brave-origin = final.callPackage ../../packages/brave-origin { };
+    raindrop = final.callPackage ../../packages/raindrop { };
+    electron-mail = final.callPackage ../../packages/electron-mail { };
+    wappalyzer-next = final.callPackage ../../packages/wappalyzer-next { };
+    age-plugin-fido2prf = final.callPackage ../../packages/age-plugin-fido2prf { };
+    azd = final.callPackage ../../packages/azd { };
+    charles = final.callPackage ../../packages/charles { };
+    dnsleak = final.callPackage ../../packages/dnsleak { };
+    gitlawb = final.callPackage ../../packages/gitlawb { };
+    opendirectorydownloader = final.callPackage ../../packages/opendirectorydownloader { };
+    malimite = final.callPackage ../../packages/malimite { };
+    claude-wpa = final.callPackage ../../packages/claude-wpa { };
+    codeburn = final.callPackage ../../packages/codeburn { };
+    rg-fzf = final.callPackage ../../packages/rg-fzf { };
+    sss-nix-repair = final.callPackage ../../packages/sss-nix-repair { };
+    source-map-explorer = final.callPackage ../../packages/source-map-explorer { };
+    webcrack = final.callPackage ../../packages/webcrack { };
+    wakaru = final.callPackage ../../packages/wakaru { };
+    restringer = final.callPackage ../../packages/restringer { };
+    tweakcc = final.callPackage ../../packages/tweakcc { };
+    video-cache = final.callPackage ../../packages/video-cache { };
+
+    # nixpkgs wfuzz silently drops the `screenshot` plugin on Python 3.13
+    # (removed `pipes` stdlib module) and ships netaddr as a test-only dep,
+    # leaving iprange/ipnet payloads broken with a misleading "pip install"
+    # message. Patches are pending upstream review at xmendez/wfuzz#380 and
+    # nixpkgs PR; remove this override once they land.
+    wfuzz = final.python3Packages.toPythonApplication (
+      final.python3Packages.callPackage ../../packages/wfuzz { }
+    );
+
+    # Bump librepods to v0.2.5 (nixpkgs pins v0.2.0). v0.2.5 swaps
+    # qtquick3d for qtdeclarative + qttools and adds Widgets/DBus.
+    librepods = prev.librepods.overrideAttrs (_old: rec {
+      version = "0.2.5";
+      src = prev.fetchFromGitHub {
+        owner = "kavishdevar";
+        repo = "librepods";
+        tag = "v${version}";
+        hash = "sha256-6l1WjwjDbv5e3tDaWo9+XSEjr9ge/hKysIkeUqyiO4U=";
+      };
+      buildInputs = [
+        prev.libpulseaudio
+        prev.openssl
+        prev.qt6.qtbase
+        prev.qt6.qtconnectivity
+        prev.qt6.qtdeclarative
+        prev.qt6.qttools
+      ];
+    });
+
+    # Workaround: marktext 0.17.0's native module rebuild can fail with
+    # `node-gyp: not found` under the current Node 24 toolchain.
+    marktext = prev.marktext.overrideAttrs (old: {
+      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+        prev."node-gyp"
+      ];
+      npm_config_node_gyp = "${prev."node-gyp"}/bin/node-gyp";
+      NODE_GYP = "${prev."node-gyp"}/bin/node-gyp";
+    });
+
+    # i3 window manager utilities
+    i3-focus-or-launch = final.callPackage ../../packages/i3-focus-or-launch { };
+    i3-scratchpad-show-or-create = final.callPackage ../../packages/i3-scratchpad-show-or-create { };
+    monitor-query = import ../../lib/shell/monitor-query.nix { inherit (final) writeText; };
+    # toggle-logseq is created in modules/apps/i3wm/config.nix (needs config.gui.scratchpad)
+  };
+}

--- a/modules/system76/custom-packages-overlay.nix
+++ b/modules/system76/custom-packages-overlay.nix
@@ -1,11 +1,8 @@
 { config, ... }:
-let
-  inherit (config.flake.lib) customPackagesOverlay;
-in
 {
   configurations.nixos.system76.module = {
     nixpkgs.overlays = [
-      customPackagesOverlay
+      config.flake.lib.overlays.customPackages
       (_final: prev: {
         # system76-power 1.2.8 aborts profile application when any SCSI host
         # lacks link_power_management_policy (USB-attached SCSI, virtio-scsi,

--- a/modules/system76/custom-packages-overlay.nix
+++ b/modules/system76/custom-packages-overlay.nix
@@ -1,39 +1,12 @@
-_: {
+{ config, ... }:
+let
+  inherit (config.flake.lib) customPackagesOverlay;
+in
+{
   configurations.nixos.system76.module = {
     nixpkgs.overlays = [
-      (final: prev: {
-        # Add custom packages to nixpkgs
-        brave-origin = final.callPackage ../../packages/brave-origin { };
-        raindrop = final.callPackage ../../packages/raindrop { };
-        electron-mail = final.callPackage ../../packages/electron-mail { };
-        wappalyzer-next = final.callPackage ../../packages/wappalyzer-next { };
-        age-plugin-fido2prf = final.callPackage ../../packages/age-plugin-fido2prf { };
-        azd = final.callPackage ../../packages/azd { };
-        charles = final.callPackage ../../packages/charles { };
-        dnsleak = final.callPackage ../../packages/dnsleak { };
-        gitlawb = final.callPackage ../../packages/gitlawb { };
-        opendirectorydownloader = final.callPackage ../../packages/opendirectorydownloader { };
-        malimite = final.callPackage ../../packages/malimite { };
-        claude-wpa = final.callPackage ../../packages/claude-wpa { };
-        codeburn = final.callPackage ../../packages/codeburn { };
-        rg-fzf = final.callPackage ../../packages/rg-fzf { };
-        sss-nix-repair = final.callPackage ../../packages/sss-nix-repair { };
-        source-map-explorer = final.callPackage ../../packages/source-map-explorer { };
-        webcrack = final.callPackage ../../packages/webcrack { };
-        wakaru = final.callPackage ../../packages/wakaru { };
-        restringer = final.callPackage ../../packages/restringer { };
-        tweakcc = final.callPackage ../../packages/tweakcc { };
-        video-cache = final.callPackage ../../packages/video-cache { };
-
-        # nixpkgs wfuzz silently drops the `screenshot` plugin on Python 3.13
-        # (removed `pipes` stdlib module) and ships netaddr as a test-only dep,
-        # leaving iprange/ipnet payloads broken with a misleading "pip install"
-        # message. Patches are pending upstream review at xmendez/wfuzz#380 and
-        # nixpkgs PR; remove this override once they land.
-        wfuzz = final.python3Packages.toPythonApplication (
-          final.python3Packages.callPackage ../../packages/wfuzz { }
-        );
-
+      customPackagesOverlay
+      (_final: prev: {
         # system76-power 1.2.8 aborts profile application when any SCSI host
         # lacks link_power_management_policy (USB-attached SCSI, virtio-scsi,
         # card readers). The daemon then keeps reporting the previous profile
@@ -44,42 +17,6 @@ _: {
             ../../packages/system76-power/skip-non-alpm-scsi-hosts.patch
           ];
         });
-
-        # Bump librepods to v0.2.5 (nixpkgs pins v0.2.0). v0.2.5 swaps
-        # qtquick3d for qtdeclarative + qttools and adds Widgets/DBus.
-        librepods = prev.librepods.overrideAttrs (_old: rec {
-          version = "0.2.5";
-          src = prev.fetchFromGitHub {
-            owner = "kavishdevar";
-            repo = "librepods";
-            tag = "v${version}";
-            hash = "sha256-6l1WjwjDbv5e3tDaWo9+XSEjr9ge/hKysIkeUqyiO4U=";
-          };
-          buildInputs = [
-            prev.libpulseaudio
-            prev.openssl
-            prev.qt6.qtbase
-            prev.qt6.qtconnectivity
-            prev.qt6.qtdeclarative
-            prev.qt6.qttools
-          ];
-        });
-
-        # Workaround: marktext 0.17.0's native module rebuild can fail with
-        # `node-gyp: not found` under the current Node 24 toolchain.
-        marktext = prev.marktext.overrideAttrs (old: {
-          nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
-            prev."node-gyp"
-          ];
-          npm_config_node_gyp = "${prev."node-gyp"}/bin/node-gyp";
-          NODE_GYP = "${prev."node-gyp"}/bin/node-gyp";
-        });
-
-        # i3 window manager utilities
-        i3-focus-or-launch = final.callPackage ../../packages/i3-focus-or-launch { };
-        i3-scratchpad-show-or-create = final.callPackage ../../packages/i3-scratchpad-show-or-create { };
-        monitor-query = import ../../lib/shell/monitor-query.nix { inherit (final) writeText; };
-        # toggle-logseq is created in modules/apps/i3wm/config.nix (needs config.gui.scratchpad)
       })
     ];
   };

--- a/modules/tpnix/custom-packages-overlay.nix
+++ b/modules/tpnix/custom-packages-overlay.nix
@@ -1,75 +1,8 @@
-_: {
+{ config, ... }:
+{
   configurations.nixos.tpnix.module = {
     nixpkgs.overlays = [
-      (final: prev: {
-        # Add custom packages to nixpkgs
-        brave-origin = final.callPackage ../../packages/brave-origin { };
-        raindrop = final.callPackage ../../packages/raindrop { };
-        electron-mail = final.callPackage ../../packages/electron-mail { };
-        wappalyzer-next = final.callPackage ../../packages/wappalyzer-next { };
-        age-plugin-fido2prf = final.callPackage ../../packages/age-plugin-fido2prf { };
-        azd = final.callPackage ../../packages/azd { };
-        charles = final.callPackage ../../packages/charles { };
-        dnsleak = final.callPackage ../../packages/dnsleak { };
-        gitlawb = final.callPackage ../../packages/gitlawb { };
-        opendirectorydownloader = final.callPackage ../../packages/opendirectorydownloader { };
-        malimite = final.callPackage ../../packages/malimite { };
-        claude-wpa = final.callPackage ../../packages/claude-wpa { };
-        codeburn = final.callPackage ../../packages/codeburn { };
-        rg-fzf = final.callPackage ../../packages/rg-fzf { };
-        sss-nix-repair = final.callPackage ../../packages/sss-nix-repair { };
-        source-map-explorer = final.callPackage ../../packages/source-map-explorer { };
-        webcrack = final.callPackage ../../packages/webcrack { };
-        wakaru = final.callPackage ../../packages/wakaru { };
-        restringer = final.callPackage ../../packages/restringer { };
-        tweakcc = final.callPackage ../../packages/tweakcc { };
-        video-cache = final.callPackage ../../packages/video-cache { };
-
-        # nixpkgs wfuzz silently drops the `screenshot` plugin on Python 3.13
-        # (removed `pipes` stdlib module) and ships netaddr as a test-only dep,
-        # leaving iprange/ipnet payloads broken with a misleading "pip install"
-        # message. Patches are pending upstream review at xmendez/wfuzz#380 and
-        # nixpkgs PR; remove this override once they land.
-        wfuzz = final.python3Packages.toPythonApplication (
-          final.python3Packages.callPackage ../../packages/wfuzz { }
-        );
-
-        # Bump librepods to v0.2.5 (nixpkgs pins v0.2.0). v0.2.5 swaps
-        # qtquick3d for qtdeclarative + qttools and adds Widgets/DBus.
-        librepods = prev.librepods.overrideAttrs (_old: rec {
-          version = "0.2.5";
-          src = prev.fetchFromGitHub {
-            owner = "kavishdevar";
-            repo = "librepods";
-            tag = "v${version}";
-            hash = "sha256-6l1WjwjDbv5e3tDaWo9+XSEjr9ge/hKysIkeUqyiO4U=";
-          };
-          buildInputs = [
-            prev.libpulseaudio
-            prev.openssl
-            prev.qt6.qtbase
-            prev.qt6.qtconnectivity
-            prev.qt6.qtdeclarative
-            prev.qt6.qttools
-          ];
-        });
-
-        # Workaround: marktext 0.17.0's native module rebuild can fail with
-        # `node-gyp: not found` under the current Node 24 toolchain.
-        marktext = prev.marktext.overrideAttrs (old: {
-          nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
-            prev."node-gyp"
-          ];
-          npm_config_node_gyp = "${prev."node-gyp"}/bin/node-gyp";
-          NODE_GYP = "${prev."node-gyp"}/bin/node-gyp";
-        });
-
-        # i3 window manager utilities
-        i3-focus-or-launch = final.callPackage ../../packages/i3-focus-or-launch { };
-        i3-scratchpad-show-or-create = final.callPackage ../../packages/i3-scratchpad-show-or-create { };
-        monitor-query = import ../../lib/shell/monitor-query.nix { inherit (final) writeText; };
-        # toggle-logseq is created in modules/apps/i3wm/config.nix (needs config.gui.scratchpad)
-      })
+      config.flake.lib.customPackagesOverlay
     ];
   };
 }

--- a/modules/tpnix/custom-packages-overlay.nix
+++ b/modules/tpnix/custom-packages-overlay.nix
@@ -2,7 +2,7 @@
 {
   configurations.nixos.tpnix.module = {
     nixpkgs.overlays = [
-      config.flake.lib.customPackagesOverlay
+      config.flake.lib.overlays.customPackages
     ];
   };
 }


### PR DESCRIPTION
## Summary

- Hoists the ~95% identical content of `modules/system76/custom-packages-overlay.nix` and `modules/tpnix/custom-packages-overlay.nix` into a single `config.flake.lib.customPackagesOverlay` defined in `modules/base/custom-packages.nix`. Hosts now compose the shared overlay with any host-specific extras (e.g., `system76-power` SCSI patch on system76).
- Mirrors the established `flake.lib.<namespace>` convention already used by `modules/security/sops-helpers.nix`, `modules/security/usbguard-lib.nix`, and `modules/meta/nixos-app-helpers.nix`.
- Eliminates the structural cause of the merge-conflict-marker class of bug fixed in PR #165 (which left literal `<<<<<<<` / `=======` / `>>>>>>>` markers in only one of the two host files when an upstream change touched the shared region).

This addresses the non-blocking observation from claude-review on PR #165 (run [25341374903](https://github.com/Bad3r/nixos/actions/runs/25341374903)): _"lift the common attrset into a single shared customPackages overlay imported by both hosts — would prevent the next merge from re-creating exactly this class of conflict."_

Stacked on top of #165 (`fix/tpnix-merge-conflict-markers`); rebases cleanly on `main` once that lands.

## Test plan

- [x] `nix flake check --accept-flake-config --no-build` reports `all checks passed!`
- [x] `nix eval .#nixosConfigurations.system76.config.system.build.toplevel.outPath` succeeds
- [x] `nix eval .#nixosConfigurations.tpnix.config.system.build.toplevel.outPath` succeeds
- [x] Per-package drvPath equality vs. pre-refactor on `brave-origin`, `system76-power`, `librepods` (all byte-identical)
- [x] `system.activationScripts.binsh` byte-identical pre/post-refactor
- [x] `environment.systemPackages` differs only on `nixos-version`, which embeds `system.configurationRevision` (dirty-tree suffix accounts for the hash diff during local validation)
- [x] Pre-commit hook chain green (`deadnix`, `statix`, `nix-parse`, `treefmt`, `gitleaks`, `managed-files-drift`)

## Diff overview

```
 modules/base/custom-packages.nix             | +80
 modules/system76/custom-packages-overlay.nix | -68 / +9   (now 16 lines)
 modules/tpnix/custom-packages-overlay.nix    | -73 / +1   (now 8 lines)
```