### PR TITLE
refactor(base): use final for dep lookups in envfs overlay override

### DIFF
--- a/modules/base/envfs.nix
+++ b/modules/base/envfs.nix
@@ -10,18 +10,22 @@ _: {
     # helper before the FUSE mount is visible in /proc/self/mountinfo, so systemd
     # logs usr-bin.mount as `result=protocol` even though the mount succeeds.
     # Fixed upstream in Mic92/envfs#216 (released as 1.2.0).
+    # Dep lookups (`fetchFromGitHub`, `rustPlatform.fetchCargoVendor`) go
+    # through `final` so any later overlay that rebinds them feeds into this
+    # build instead of being silently bypassed. The `prev.envfs.overrideAttrs`
+    # entry point stays on `prev` so we extend the unmodified upstream attrs.
     nixpkgs.overlays = [
-      (_final: prev: {
+      (final: prev: {
         envfs = prev.envfs.overrideAttrs (_oldAttrs: {
           version = "1.2.0";
-          src = prev.fetchFromGitHub {
+          src = final.fetchFromGitHub {
             owner = "Mic92";
             repo = "envfs";
             rev = "1.2.0";
             hash = "sha256-hj/6zS9ebF0IDqgc1Dne59nWx80nk6jn2gj8BzQUFIQ=";
           };
-          cargoDeps = prev.rustPlatform.fetchCargoVendor {
-            src = prev.fetchFromGitHub {
+          cargoDeps = final.rustPlatform.fetchCargoVendor {
+            src = final.fetchFromGitHub {
               owner = "Mic92";
               repo = "envfs";
               rev = "1.2.0";

--- a/modules/base/envfs.nix
+++ b/modules/base/envfs.nix
@@ -11,9 +11,11 @@ _: {
     # logs usr-bin.mount as `result=protocol` even though the mount succeeds.
     # Fixed upstream in Mic92/envfs#216 (released as 1.2.0).
     # Dep lookups (`fetchFromGitHub`, `rustPlatform.fetchCargoVendor`) go
-    # through `final` so any later overlay that rebinds them feeds into this
-    # build instead of being silently bypassed. The `prev.envfs.overrideAttrs`
-    # entry point stays on `prev` so we extend the unmodified upstream attrs.
+    # through `final` so any other overlay that rebinds them feeds into this
+    # build via the fixpoint instead of being silently bypassed (overlay
+    # registration order is irrelevant here — the fixpoint observes all
+    # overlays). The `prev.envfs.overrideAttrs` entry point stays on `prev`
+    # so we extend the unmodified upstream attrs.
     nixpkgs.overlays = [
       (final: prev: {
         envfs = prev.envfs.overrideAttrs (_oldAttrs: {

--- a/modules/base/envfs.nix
+++ b/modules/base/envfs.nix
@@ -18,24 +18,25 @@ _: {
     # so we extend the unmodified upstream attrs.
     nixpkgs.overlays = [
       (final: prev: {
-        envfs = prev.envfs.overrideAttrs (_oldAttrs: {
-          version = "1.2.0";
-          src = final.fetchFromGitHub {
-            owner = "Mic92";
-            repo = "envfs";
-            rev = "1.2.0";
-            hash = "sha256-hj/6zS9ebF0IDqgc1Dne59nWx80nk6jn2gj8BzQUFIQ=";
-          };
-          cargoDeps = final.rustPlatform.fetchCargoVendor {
+        envfs = prev.envfs.overrideAttrs (
+          _oldAttrs:
+          let
             src = final.fetchFromGitHub {
               owner = "Mic92";
               repo = "envfs";
               rev = "1.2.0";
               hash = "sha256-hj/6zS9ebF0IDqgc1Dne59nWx80nk6jn2gj8BzQUFIQ=";
             };
-            hash = "sha256-dz3gpE464jnmSDsAsmJHcxUsEKeUURNoUjgGU2214Xg=";
-          };
-        });
+          in
+          {
+            version = "1.2.0";
+            inherit src;
+            cargoDeps = final.rustPlatform.fetchCargoVendor {
+              inherit src;
+              hash = "sha256-dz3gpE464jnmSDsAsmJHcxUsEKeUURNoUjgGU2214Xg=";
+            };
+          }
+        );
       })
     ];
   };

--- a/modules/tpnix/custom-packages-overlay.nix
+++ b/modules/tpnix/custom-packages-overlay.nix
@@ -25,7 +25,6 @@ _: {
         tweakcc = final.callPackage ../../packages/tweakcc { };
         video-cache = final.callPackage ../../packages/video-cache { };
 
-<<<<<<< feat/csec-tools
         # nixpkgs wfuzz silently drops the `screenshot` plugin on Python 3.13
         # (removed `pipes` stdlib module) and ships netaddr as a test-only dep,
         # leaving iprange/ipnet payloads broken with a misleading "pip install"
@@ -34,7 +33,7 @@ _: {
         wfuzz = final.python3Packages.toPythonApplication (
           final.python3Packages.callPackage ../../packages/wfuzz { }
         );
-=======
+
         # Bump librepods to v0.2.5 (nixpkgs pins v0.2.0). v0.2.5 swaps
         # qtquick3d for qtdeclarative + qttools and adds Widgets/DBus.
         librepods = prev.librepods.overrideAttrs (_old: rec {
@@ -54,7 +53,6 @@ _: {
             prev.qt6.qttools
           ];
         });
->>>>>>> main
 
         # Workaround: marktext 0.17.0's native module rebuild can fail with
         # `node-gyp: not found` under the current Node 24 toolchain.


### PR DESCRIPTION
## Summary

- Pulls the same \`final\`-for-deps idiom into \`modules/base/envfs.nix\` that is being applied to \`librepods\` / \`marktext\` in PR #166's shared \`flake.lib.overlays.customPackages\` overlay.
- Within the \`envfs\` overlay's \`prev.envfs.overrideAttrs\` body, \`fetchFromGitHub\` and \`rustPlatform.fetchCargoVendor\` lookups now resolve through \`final\` instead of \`prev\`, so any other overlay that rebinds those builders is picked up via the fixpoint. The \`prev.envfs.overrideAttrs\` entry point stays on \`prev\` -- only the dep lookups inside the override body change.
- Adds a comment recording the rationale (matches the comment style applied in PR #166 to the \`librepods\` and \`marktext\` overrides).

This was suggested as an out-of-scope follow-up by claude-review on PR #166 (run [25344427322](https://github.com/Bad3r/nixos/actions/runs/25344427322)).

### Branch / merge order

This branch is based on \`fix/tpnix-merge-conflict-markers\` (PR #165) so that \`nix flake check\` evaluates -- without #165, the tree carries unresolved conflict markers in \`modules/tpnix/custom-packages-overlay.nix\` from the squash merge of #160. Land order: #165 -> #166 -> #167. Each PR rebases cleanly onto \`main\` once its predecessor lands.

The librepods / marktext \`final\`-for-deps adoption is intentionally **not** duplicated in this PR -- it is owned by #166, where the dedup refactor lifts those overrides into the shared \`flake.lib.overlays.customPackages\` definition with \`final.*\` already in place. Folding it in here would create a redundant churn that #166's dedup undoes.

## Test plan

- [x] \`nix flake check --accept-flake-config --no-build\` reports \`all checks passed!\`
- [x] \`envfs.drvPath\` byte-identical pre vs. post: \`/nix/store/f6npid91mdh5dpyxxbrn5wyzcn9dxf11-envfs-1.2.0.drv\` -- the change is purely defensive (no overlay in either host closure currently rebinds \`fetchFromGitHub\` or \`rustPlatform.fetchCargoVendor\`).
- [x] Pre-commit hook chain (deadnix, statix, nix-parse, treefmt, gitleaks, managed-files-drift) all green.