### PR TITLE
feat(stylix): generate qt6ct color scheme from Base16 palette

### DIFF
--- a/modules/base/custom-packages-overlay.nix
+++ b/modules/base/custom-packages-overlay.nix
@@ -51,14 +51,16 @@ _: {
     # the device falls through to the unknown-model defaults. Drop the patch
     # once upstream merges PR #519 and a release pinning it ships.
     #
-    # `QT_STYLE_OVERRIDE` is defaulted to `Fusion` because librepods is a
-    # pure QtQuick.Controls 2 app and Stylix sets the session-wide override
-    # to `kvantum`. Kvantum ships only a `QStyle`, not a QtQuick.Controls
-    # module, so QML loading fails with `module "kvantum" is not installed`.
-    # Fusion is palette-aware, so it picks up the Stylix Base16 colors via
-    # the qt6ct color scheme (see `modules/stylix/qt6ct-colors.nix`).
-    # `--set-default` lets users override at runtime
-    # (e.g. `QT_STYLE_OVERRIDE=Adwaita-Dark librepods` for debugging).
+    # librepods is a pure QtQuick.Controls 2 app and Stylix exports
+    # `QT_STYLE_OVERRIDE=kvantum` in the session env. Kvantum ships only
+    # a `QStyle`, not a QtQuick.Controls module, so QML loading fails with
+    # `module "kvantum" is not installed`. `--set-default` is a no-op
+    # because the session already exports the broken value, and
+    # `wrapQtAppsHook`'s `makeCWrapper` does not support `--run` for
+    # conditional rewrites. `--set` unconditionally forces Fusion before
+    # exec, so the broken value is always replaced. Fusion is palette-aware
+    # and picks up the Stylix Base16 colors via the qt6ct color scheme
+    # (see `modules/stylix/qt6ct-colors.nix`).
     librepods = prev.librepods.overrideAttrs (old: rec {
       version = "0.2.5";
       src = final.fetchFromGitHub {
@@ -79,7 +81,7 @@ _: {
         final.qt6.qttools
       ];
       qtWrapperArgs = (old.qtWrapperArgs or [ ]) ++ [
-        "--set-default"
+        "--set"
         "QT_STYLE_OVERRIDE"
         "Fusion"
       ];

--- a/modules/base/custom-packages-overlay.nix
+++ b/modules/base/custom-packages-overlay.nix
@@ -50,6 +50,13 @@ _: {
     # so AirPods Max 2 (BLE 0x2D20 / model A3454) is recognised; without it
     # the device falls through to the unknown-model defaults. Drop the patch
     # once upstream merges PR #519 and a release pinning it ships.
+    #
+    # `QT_STYLE_OVERRIDE` is forced to `Fusion` because librepods is a pure
+    # QtQuick.Controls 2 app and Stylix sets the session-wide override to
+    # `kvantum`. Kvantum ships only a `QStyle`, not a QtQuick.Controls
+    # module, so QML loading fails with `module "kvantum" is not installed`.
+    # Fusion is palette-aware, so it picks up the Stylix Base16 colors via
+    # the qt6ct color scheme (see `modules/stylix/qt6ct-colors.nix`).
     librepods = prev.librepods.overrideAttrs (old: rec {
       version = "0.2.5";
       src = final.fetchFromGitHub {
@@ -68,6 +75,11 @@ _: {
         final.qt6.qtconnectivity
         final.qt6.qtdeclarative
         final.qt6.qttools
+      ];
+      qtWrapperArgs = (old.qtWrapperArgs or [ ]) ++ [
+        "--set"
+        "QT_STYLE_OVERRIDE"
+        "Fusion"
       ];
     });
 

--- a/modules/base/custom-packages-overlay.nix
+++ b/modules/base/custom-packages-overlay.nix
@@ -51,12 +51,14 @@ _: {
     # the device falls through to the unknown-model defaults. Drop the patch
     # once upstream merges PR #519 and a release pinning it ships.
     #
-    # `QT_STYLE_OVERRIDE` is forced to `Fusion` because librepods is a pure
-    # QtQuick.Controls 2 app and Stylix sets the session-wide override to
-    # `kvantum`. Kvantum ships only a `QStyle`, not a QtQuick.Controls
+    # `QT_STYLE_OVERRIDE` is defaulted to `Fusion` because librepods is a
+    # pure QtQuick.Controls 2 app and Stylix sets the session-wide override
+    # to `kvantum`. Kvantum ships only a `QStyle`, not a QtQuick.Controls
     # module, so QML loading fails with `module "kvantum" is not installed`.
     # Fusion is palette-aware, so it picks up the Stylix Base16 colors via
     # the qt6ct color scheme (see `modules/stylix/qt6ct-colors.nix`).
+    # `--set-default` lets users override at runtime
+    # (e.g. `QT_STYLE_OVERRIDE=Adwaita-Dark librepods` for debugging).
     librepods = prev.librepods.overrideAttrs (old: rec {
       version = "0.2.5";
       src = final.fetchFromGitHub {
@@ -77,7 +79,7 @@ _: {
         final.qt6.qttools
       ];
       qtWrapperArgs = (old.qtWrapperArgs or [ ]) ++ [
-        "--set"
+        "--set-default"
         "QT_STYLE_OVERRIDE"
         "Fusion"
       ];

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -44,14 +44,49 @@ let
     c.base04 # PlaceholderText
   ];
 
+  # Disabled-state palette mutes the foreground/highlight roles so Fusion
+  # can render disabled controls with reduced contrast. qt6ct writes the
+  # `disabled_colors` row verbatim and Qt no longer auto-greys widgets
+  # under a custom palette, so identical active/disabled rows leave disabled
+  # buttons looking fully active. Background and accent roles match the
+  # active palette to preserve widget silhouettes.
+  disabledPaletteRoles = c: [
+    c.base04 # WindowText
+    c.base02 # Button
+    c.base04 # Light
+    c.base03 # Midlight
+    c.base00 # Dark
+    c.base01 # Mid
+    c.base04 # Text
+    c.base04 # BrightText
+    c.base04 # ButtonText
+    c.base00 # Base
+    c.base00 # Window
+    c.base00 # Shadow
+    c.base02 # Highlight
+    c.base04 # HighlightedText
+    c.base0D # Link
+    c.base0E # LinkVisited
+    c.base01 # AlternateBase
+    c.base00 # NoRole
+    c.base01 # ToolTipBase
+    c.base04 # ToolTipText
+    c.base03 # PlaceholderText
+  ];
+
   toArgb = colour: "#ff${lib.removePrefix "#" colour}";
   formatRow = colours: lib.concatStringsSep ", " (map toArgb colours);
-  schemeText = colours: ''
-    [ColorScheme]
-    active_colors=${formatRow colours}
-    inactive_colors=${formatRow colours}
-    disabled_colors=${formatRow colours}
-  '';
+  schemeText =
+    {
+      active,
+      disabled,
+    }:
+    ''
+      [ColorScheme]
+      active_colors=${formatRow active}
+      inactive_colors=${formatRow active}
+      disabled_colors=${formatRow disabled}
+    '';
 in
 {
   flake.homeManagerModules.base =
@@ -64,7 +99,10 @@ in
       relPath5 = "qt5ct/colors/stylix.conf";
       absPath6 = "${config.xdg.configHome}/${relPath6}";
       absPath5 = "${config.xdg.configHome}/${relPath5}";
-      schemeContents = schemeText (paletteRoles colours);
+      schemeContents = schemeText {
+        active = paletteRoles colours;
+        disabled = disabledPaletteRoles colours;
+      };
     in
     lib.mkIf (stylixEnabled && qtctActive) {
       xdg.configFile.${relPath6}.text = schemeContents;

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -44,12 +44,12 @@ let
     c.base04 # PlaceholderText
   ];
 
-  # Disabled-state palette mutes the foreground/highlight roles so Fusion
-  # can render disabled controls with reduced contrast. qt6ct writes the
-  # `disabled_colors` row verbatim and Qt no longer auto-greys widgets
+  # Disabled-state palette mutes the foreground/highlight/link roles so
+  # Fusion can render disabled controls with reduced contrast. qt6ct writes
+  # the `disabled_colors` row verbatim and Qt no longer auto-greys widgets
   # under a custom palette, so identical active/disabled rows leave disabled
-  # buttons looking fully active. Background and accent roles match the
-  # active palette to preserve widget silhouettes.
+  # buttons (and rich-text labels with hyperlinks) looking fully active.
+  # Background roles match the active palette to preserve widget silhouettes.
   disabledPaletteRoles = c: [
     c.base04 # WindowText
     c.base02 # Button
@@ -65,8 +65,8 @@ let
     c.base00 # Shadow
     c.base02 # Highlight
     c.base04 # HighlightedText
-    c.base0D # Link
-    c.base0E # LinkVisited
+    c.base04 # Link
+    c.base04 # LinkVisited
     c.base01 # AlternateBase
     c.base00 # NoRole
     c.base01 # ToolTipBase

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -11,6 +11,15 @@ let
   # QPalette role order matches qt6ct's color scheme parser (21 entries,
   # mirroring `QPalette::ColorRole` 0..20; `Accent` is omitted -- qt6ct 0.11
   # does not yet include it).
+  #
+  # `BrightText` is Qt's high-contrast text role (used when `Text` would
+  # render poorly on top of `Highlight`); it maps to `base07` (the brightest
+  # foreground in Base16) rather than an accent colour.
+  #
+  # `HighlightedText` maps to `base05` rather than `base00`: on Base16
+  # schemes where `base0D` (Highlight) and `base00` (background) collapse
+  # toward similar luminance, selected text becomes unreadable. `base05`
+  # keeps high contrast against any Highlight choice.
   paletteRoles = c: [
     c.base05 # WindowText
     c.base02 # Button
@@ -19,13 +28,13 @@ let
     c.base00 # Dark
     c.base01 # Mid
     c.base05 # Text
-    c.base08 # BrightText
+    c.base07 # BrightText
     c.base05 # ButtonText
     c.base00 # Base
     c.base00 # Window
     c.base00 # Shadow
     c.base0D # Highlight
-    c.base00 # HighlightedText
+    c.base05 # HighlightedText
     c.base0D # Link
     c.base0E # LinkVisited
     c.base01 # AlternateBase

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -49,6 +49,7 @@ in
     { config, ... }:
     let
       stylixEnabled = (config.stylix.enable or false) && (config.stylix.targets.qt.enable or false);
+      qtctActive = (config.qt.platformTheme.name or null) == "qtct";
       colours = config.lib.stylix.colors.withHashtag;
       relPath6 = "qt6ct/colors/stylix.conf";
       relPath5 = "qt5ct/colors/stylix.conf";
@@ -56,7 +57,7 @@ in
       absPath5 = "${config.xdg.configHome}/${relPath5}";
       schemeContents = schemeText (paletteRoles colours);
     in
-    lib.mkIf stylixEnabled {
+    lib.mkIf (stylixEnabled && qtctActive) {
       xdg.configFile.${relPath6}.text = schemeContents;
       xdg.configFile.${relPath5}.text = schemeContents;
 

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -1,0 +1,66 @@
+# Stylix's qt module sets `custom_palette = true` in the qt6ct/qt5ct configs
+# but never generates the matching color scheme file -- the Base16 colors are
+# baked only into Kvantum's kvconfig. Qt apps that don't load Kvantum (for
+# example any QtQuick.Controls 2 app falling back to Fusion or Basic, like
+# librepods) end up with default Qt colors instead of the Stylix palette.
+#
+# This module fills the gap by writing a qt6ct/qt5ct color scheme from the
+# Stylix Base16 palette and pointing both qtct configs at it.
+{ lib, ... }:
+let
+  # QPalette role order matches qt6ct's color scheme parser (21 entries,
+  # mirroring `QPalette::ColorRole` 0..20; `Accent` is omitted -- qt6ct 0.11
+  # does not yet include it).
+  paletteRoles = c: [
+    c.base05 # WindowText
+    c.base02 # Button
+    c.base04 # Light
+    c.base03 # Midlight
+    c.base00 # Dark
+    c.base01 # Mid
+    c.base05 # Text
+    c.base08 # BrightText
+    c.base05 # ButtonText
+    c.base00 # Base
+    c.base00 # Window
+    c.base00 # Shadow
+    c.base0D # Highlight
+    c.base00 # HighlightedText
+    c.base0D # Link
+    c.base0E # LinkVisited
+    c.base01 # AlternateBase
+    c.base00 # NoRole
+    c.base01 # ToolTipBase
+    c.base05 # ToolTipText
+    c.base04 # PlaceholderText
+  ];
+
+  toArgb = colour: "#ff${lib.removePrefix "#" colour}";
+  formatRow = colours: lib.concatStringsSep ", " (map toArgb colours);
+  schemeText = colours: ''
+    [ColorScheme]
+    active_colors=${formatRow colours}
+    inactive_colors=${formatRow colours}
+    disabled_colors=${formatRow colours}
+  '';
+in
+{
+  flake.homeManagerModules.base =
+    { config, ... }:
+    let
+      stylixEnabled = (config.stylix.enable or false) && (config.stylix.targets.qt.enable or false);
+      colours = config.lib.stylix.colors.withHashtag;
+      relPath6 = "qt6ct/colors/stylix.conf";
+      relPath5 = "qt5ct/colors/stylix.conf";
+      absPath6 = "${config.xdg.configHome}/${relPath6}";
+      absPath5 = "${config.xdg.configHome}/${relPath5}";
+      schemeContents = schemeText (paletteRoles colours);
+    in
+    lib.mkIf stylixEnabled {
+      xdg.configFile.${relPath6}.text = schemeContents;
+      xdg.configFile.${relPath5}.text = schemeContents;
+
+      qt.qt6ctSettings.Appearance.color_scheme_path = absPath6;
+      qt.qt5ctSettings.Appearance.color_scheme_path = absPath5;
+    };
+}


### PR DESCRIPTION
## Summary

- Stylix's `qt` module sets `custom_palette = true` in qt6ct/qt5ct but never writes the corresponding color scheme file; the Base16 palette is baked only into Kvantum's `kvconfig`. Any Qt app that doesn't load Kvantum (notably QtQuick.Controls 2 apps falling back to Fusion or Basic, like `librepods`) ends up with default Qt colors instead of the Stylix palette.
- Add `modules/stylix/qt6ct-colors.nix` (a `flake.homeManagerModules.base` contribution) that writes a qt6ct/qt5ct color scheme from `config.lib.stylix.colors.withHashtag` and points both qtct configs at it via `qt.qt{5,6}ctSettings.Appearance.color_scheme_path`. Gated on `stylix.enable && stylix.targets.qt.enable`.
- Force `QT_STYLE_OVERRIDE=Fusion` for `librepods` via `qtWrapperArgs` in `modules/base/custom-packages-overlay.nix`. The session-wide override Stylix sets is `kvantum`, but Kvantum has no QtQuick.Controls module, so QML loading fails with `module "kvantum" is not installed`. Fusion is palette-aware and now picks up the Stylix Base16 colors via the new qt6ct color scheme.

## Test plan

- [x] `nix flake check --accept-flake-config --no-build --offline` passes
- [x] `nix eval .#nixosConfigurations.{tpnix,system76}.config.home-manager.users.vx.qt.qt6ctSettings.Appearance.color_scheme_path` resolves to `/home/vx/.config/qt6ct/colors/stylix.conf`
- [x] Generated scheme file contains the expected OneDark Base16 colors in QPalette role order (21 entries, `#aaRRGGBB` format)
- [x] `nix build .#nixosConfigurations.tpnix.pkgs.librepods` builds; wrapper sets `QT_STYLE_OVERRIDE=Fusion`
- [x] `timeout 3 librepods` no longer prints `module "kvantum" is not installed`; the QML engine loads successfully
- [ ] Visual confirmation that QtQuick apps render with the Stylix dark palette (deploy to host and observe librepods window)