### PR TITLE
feat(kitty): grid layout as default with pane-navigation shortcuts

### DIFF
--- a/modules/hm-apps/kitty.nix
+++ b/modules/hm-apps/kitty.nix
@@ -168,6 +168,11 @@ _: {
             # Layout shortcuts
             "ctrl+alt+g" = "goto_layout grid";
             "ctrl+alt+s" = "goto_layout splits";
+            # Pane navigation — ctrl+alt avoids stealing shell word-movement (ctrl+arrow)
+            "ctrl+alt+left" = "neighboring_window left";
+            "ctrl+alt+right" = "neighboring_window right";
+            "ctrl+alt+up" = "neighboring_window up";
+            "ctrl+alt+down" = "neighboring_window down";
           };
 
           extraConfig = ''

--- a/modules/hm-apps/kitty.nix
+++ b/modules/hm-apps/kitty.nix
@@ -142,6 +142,8 @@ _: {
             clipboard_control = "write-clipboard write-primary";
             term = "xterm-kitty";
             kitty_mod = "ctrl+shift";
+            # Grid first makes it the default layout; all built-in layouts remain reachable via next_layout
+            enabled_layouts = "grid,splits,tall,fat,horizontal,vertical,stack";
           };
 
           keybindings = {
@@ -163,6 +165,9 @@ _: {
             "kitty_mod+a>1" = "set_background_opacity 1";
             "kitty_mod+a>d" = "set_background_opacity default";
             "kitty_mod+delete" = "clear_terminal reset active";
+            # Layout shortcuts
+            "ctrl+alt+g" = "goto_layout grid";
+            "ctrl+alt+s" = "goto_layout splits";
           };
 
           extraConfig = ''

--- a/modules/hm-apps/kitty.nix
+++ b/modules/hm-apps/kitty.nix
@@ -143,7 +143,15 @@ _: {
             term = "xterm-kitty";
             kitty_mod = "ctrl+shift";
             # Grid first makes it the default layout; all built-in layouts remain reachable via next_layout
-            enabled_layouts = "grid,splits,tall,fat,horizontal,vertical,stack";
+            enabled_layouts = lib.concatStringsSep "," [
+              "grid"
+              "splits"
+              "tall"
+              "fat"
+              "horizontal"
+              "vertical"
+              "stack"
+            ];
           };
 
           keybindings = {

--- a/modules/hm-apps/kitty.nix
+++ b/modules/hm-apps/kitty.nix
@@ -176,6 +176,13 @@ _: {
             # Layout shortcuts
             "ctrl+alt+g" = "goto_layout grid";
             "ctrl+alt+s" = "goto_layout splits";
+            # Splits-layout spawning — goto_layout only switches the active layout, so
+            # explicit hsplit/vsplit chords are needed to actually carve the active window.
+            # kitty_mod+enter (new_window) still spawns on the layout's default axis.
+            "kitty_mod+apostrophe" = "launch --location=hsplit --cwd=current";
+            "kitty_mod+backslash" = "launch --location=vsplit --cwd=current";
+            # Rotate uses kitty_mod+alt+r so the default kitty_mod+r (start_resizing_window) survives.
+            "kitty_mod+alt+r" = "layout_action rotate";
             # Pane navigation — ctrl+alt avoids stealing shell word-movement (ctrl+arrow)
             "ctrl+alt+left" = "neighboring_window left";
             "ctrl+alt+right" = "neighboring_window right";

--- a/modules/hm-apps/kitty.nix
+++ b/modules/hm-apps/kitty.nix
@@ -188,6 +188,11 @@ _: {
             "ctrl+alt+right" = "neighboring_window right";
             "ctrl+alt+up" = "neighboring_window up";
             "ctrl+alt+down" = "neighboring_window down";
+            # Pane resize — kitty_mod+ctrl+arrow pairs with the navigation chord above.
+            "kitty_mod+ctrl+left" = "resize_window narrower";
+            "kitty_mod+ctrl+right" = "resize_window wider";
+            "kitty_mod+ctrl+up" = "resize_window taller";
+            "kitty_mod+ctrl+down" = "resize_window shorter";
           };
 
           extraConfig = ''

--- a/modules/hm-apps/kitty.nix
+++ b/modules/hm-apps/kitty.nix
@@ -184,6 +184,9 @@ _: {
             # Rotate uses kitty_mod+alt+r so the default kitty_mod+r (start_resizing_window) survives.
             "kitty_mod+alt+r" = "layout_action rotate";
             # Pane navigation — ctrl+alt avoids stealing shell word-movement (ctrl+arrow)
+            # and the kitty_mod (ctrl+shift) chord space. Safe under i3, but ctrl+alt+arrow
+            # is the desktop-switch chord on GNOME / KDE / XFCE / Cinnamon — revisit before
+            # enabling this module on a host that runs a non-i3 desktop.
             "ctrl+alt+left" = "neighboring_window left";
             "ctrl+alt+right" = "neighboring_window right";
             "ctrl+alt+up" = "neighboring_window up";

--- a/modules/hm-apps/kitty.nix
+++ b/modules/hm-apps/kitty.nix
@@ -191,11 +191,13 @@ _: {
             "ctrl+alt+right" = "neighboring_window right";
             "ctrl+alt+up" = "neighboring_window up";
             "ctrl+alt+down" = "neighboring_window down";
-            # Pane resize — kitty_mod+ctrl+arrow pairs with the navigation chord above.
-            "kitty_mod+ctrl+left" = "resize_window narrower";
-            "kitty_mod+ctrl+right" = "resize_window wider";
-            "kitty_mod+ctrl+up" = "resize_window taller";
-            "kitty_mod+ctrl+down" = "resize_window shorter";
+            # Pane resize — kitty_mod+alt+arrow keeps a materially distinct chord. Adding
+            # ctrl on top of kitty_mod (ctrl+shift) would just deduplicate to kitty_mod+arrow
+            # in the GLFW modifier bitmask, leaving no headroom for a future kitty_mod+arrow.
+            "kitty_mod+alt+left" = "resize_window narrower";
+            "kitty_mod+alt+right" = "resize_window wider";
+            "kitty_mod+alt+up" = "resize_window taller";
+            "kitty_mod+alt+down" = "resize_window shorter";
           };
 
           extraConfig = ''


### PR DESCRIPTION
## Summary

- Sets `grid` as the default kitty layout by listing it first in `enabled_layouts` (built via `lib.concatStringsSep`); all seven built-in layouts remain reachable via `ctrl+shift+l` (`next_layout`)
- Adds `ctrl+alt+g` / `ctrl+alt+s` to jump directly to the grid or splits layout without cycling
- Adds splits-layout-aware spawning so `ctrl+alt+s` is actually usable: `kitty_mod+apostrophe` (`launch --location=hsplit`), `kitty_mod+backslash` (`launch --location=vsplit`), `kitty_mod+alt+r` (`layout_action rotate`)
- Adds `ctrl+alt+arrow` for `neighboring_window` pane navigation; `ctrl+alt` chosen because `ctrl+arrow` is shell word-movement and `ctrl+shift+arrow` is reserved (kitty_mod = ctrl+shift)
- Adds `kitty_mod+alt+arrow` resize counterpart so navigation has a same-shape resize partner

## Test plan

- [ ] Rebuild home-manager config and confirm kitty opens in grid layout by default
- [ ] Open 4 windows (`ctrl+shift+enter` x4) and verify 2x2 grid arrangement
- [ ] `ctrl+shift+l` (default `next_layout`) cycles through all seven layouts in the new order
- [ ] Press `ctrl+alt+g` from a non-grid layout and confirm switch to grid
- [ ] Press `ctrl+alt+s` and confirm switch to splits layout
- [ ] After `ctrl+alt+s`, `kitty_mod+apostrophe` and `kitty_mod+backslash` carve real horizontal / vertical splits from the active window
- [ ] `kitty_mod+alt+r` rotates the splits layout; `kitty_mod+r` still triggers `start_resizing_window`
- [ ] In a multi-pane layout, verify `ctrl+alt+arrow` moves focus to the correct neighboring pane
- [ ] `kitty_mod+alt+arrow` resizes the active window narrower / wider / taller / shorter
- [ ] Confirm `ctrl+arrow` still sends word-movement to the active shell (not intercepted)