### PR TITLE
refactor(fmt): replace prettier with biome

### DIFF
--- a/.treefmt.toml
+++ b/.treefmt.toml
@@ -19,28 +19,26 @@ excludes = [
 command = "nixfmt"
 includes = ["*.nix"]
 
-[formatter.prettier]
-command = "prettier"
-excludes = ["README.md"]
+[formatter.biome]
+command = "biome"
+options = ["format", "--write"]
 includes = [
-  "*.cjs",
-  "*.css",
-  "*.html",
   "*.js",
-  "*.json",
-  "*.json5",
-  "*.jsx",
-  "*.md",
-  "*.mdx",
+  "*.cjs",
   "*.mjs",
-  "*.scss",
   "*.ts",
+  "*.jsx",
   "*.tsx",
+  "*.json",
+  "*.jsonc",
+  "*.css",
+  "*.graphql",
+  "*.gql",
+  "*.html",
   "*.vue",
-  "*.yaml",
-  "*.yml",
+  "*.svelte",
+  "*.astro",
 ]
-options = ["--write"]
 
 [formatter.shfmt]
 command = "shfmt"

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
+  "formatter": {
+    "enabled": true
+  },
+  "html": {
+    "formatter": {
+      "enabled": true
+    }
+  }
+}

--- a/modules/apps/formatting.nix
+++ b/modules/apps/formatting.nix
@@ -6,7 +6,7 @@
   Repository: https://github.com/Bad3r/nixos
 
   Summary:
-    * Installs the project-standard formatter toolchain (e.g. `nixfmt`, `shfmt`, `prettier`) to ensure consistent styling across languages.
+    * Installs the project-standard formatter toolchain (e.g. `nixfmt`, `shfmt`, `biome`) to ensure consistent styling across languages.
     * Intended for developers entering the repo's `nix develop` environment or running `nix fmt` locally.
 
   Options:
@@ -42,7 +42,6 @@ let
           default = with pkgs; [
             biome
             nixfmt
-            prettier
             shellcheck
             shfmt
             stylua
@@ -53,9 +52,8 @@ let
             Code formatters and linters for the development environment.
 
             Included formatters:
-            - biome: JavaScript/TypeScript/JSON
+            - biome: JS/TS/JSX/TSX/JSON/JSONC/CSS/GraphQL/HTML/Vue/Svelte/Astro
             - nixfmt: Nix (RFC 166)
-            - prettier: Multi-language formatter (JS/TS/JSON/YAML/MD/HTML/CSS)
             - shellcheck: Shell script linter
             - shfmt: Shell script formatter
             - stylua: Lua formatter

--- a/modules/development/treefmt.nix
+++ b/modules/development/treefmt.nix
@@ -1,15 +1,9 @@
 _: {
-  # Ensure treefmt ignores vendored inputs to keep checks fast and focused
   perSystem = _: {
-    treefmt.settings = {
-      # Do not format vendored inputs or generated config files
-      global.excludes = [
-        "inputs/*"
-        ".pre-commit-config.yaml"
-        "nixos-manual/*"
-      ];
-      # Generated README must match write-files output exactly; exclude from prettier
-      formatter.prettier.excludes = [ "README.md" ];
-    };
+    treefmt.settings.global.excludes = [
+      "inputs/*"
+      ".pre-commit-config.yaml"
+      "nixos-manual/*"
+    ];
   };
 }


### PR DESCRIPTION
## Summary

- Replace `prettier` with `biome` as the treefmt multi-language formatter
- Enable all stable biome formats: JS/CJS/MJS, TS, JSX/TSX, JSON/JSONC, CSS, GraphQL
- Enable experimental formats (HTML/Vue/Svelte/Astro) via `biome.json` opt-in
- Drop formats biome does not yet support: YAML, SCSS, Markdown
- Remove the now-dead `formatter.prettier.excludes` from `treefmt.nix`
- Remove `prettier` from the `formatting` package bundle; `biome` was already present

## Test plan

- [ ] `nix flake check --accept-flake-config --no-build --offline` passes
- [ ] `nix fmt` runs without errors
- [ ] `nix develop` shell includes `biome` on `$PATH`, `prettier` is absent