### PR TITLE
fix(stylix): align qt6ct ToolTipBase with kvconfig (base00)

### DIFF
--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -12,23 +12,33 @@ let
   # mirroring `QPalette::ColorRole` 0..20; `Accent` is omitted -- qt6ct 0.11
   # does not yet include it).
   #
-  # Background and structural roles (`Window`, `Base`, `AlternateBase`,
-  # `Button`, `Midlight`, `Dark`, `Mid`, `ToolTipBase`, `Link`,
-  # `LinkVisited`, `WindowText`, `Text`, `ButtonText`, `ToolTipText`)
-  # mirror `kvconfig.mustache`'s `[GeneralColors]` block one-for-one so a
-  # Fusion-rendered Qt app sees the same palette Kvantum produces.
+  # Each role falls into one of three categories relative to Stylix's
+  # `kvconfig.mustache` (the source of truth for the Kvantum theme):
   #
-  # The roles below intentionally diverge from kvconfig:
+  # 1. Mirrors a kvconfig binding one-for-one. These roles produce the
+  #    same colour Kvantum-rendered Qt apps already see, so a Fusion or
+  #    Basic fallback inherits the same palette: `Window`, `Base`,
+  #    `AlternateBase`, `Button`, `Midlight`, `Dark`, `Mid`,
+  #    `ToolTipBase`, `Link`, `LinkVisited`, `WindowText`, `Text`,
+  #    `ButtonText`, `ToolTipText`.
   #
-  # `BrightText` is Qt's high-contrast text role (used when `Text` would
-  # render poorly on top of `Highlight`); it maps to `base07` (the brightest
-  # foreground in Base16) rather than an accent colour. kvconfig has no
-  # equivalent binding because Kvantum draws SVG frames instead of bevels.
+  # 2. Has a kvconfig binding but intentionally diverges from it. The
+  #    rationale is documented per-role below.
   #
-  # `HighlightedText` maps to `base05` rather than `base00`: on Base16
-  # schemes where `base0D` (Highlight) and `base00` (background) collapse
-  # toward similar luminance, selected text becomes unreadable. `base05`
-  # keeps high contrast against any Highlight choice.
+  # 3. Has no equivalent kvconfig binding. qt6ct's scheme format requires
+  #    all 21 entries, so Stylix picks a Base16 token directly: `Shadow`
+  #    (`base00`), `NoRole` (`base00`), `PlaceholderText` (`base04`
+  #    active / `base03` disabled), and `BrightText` (`base07`). Kvantum
+  #    routes high-contrast text and shadow drawing through SVG layers
+  #    rather than separate `[GeneralColors]` keys, so kvconfig has no
+  #    `bright.text.color` / `shadow.color` to mirror.
+  #
+  # Per-role rationale for category 2:
+  #
+  # `HighlightedText` maps to `base05` rather than kvconfig's `base00`:
+  # on Base16 schemes where `base0D` (Highlight) and `base00` (background)
+  # collapse toward similar luminance, selected text becomes unreadable.
+  # `base05` keeps high contrast against any Highlight choice.
   #
   # `Light` maps to `base04` rather than kvconfig's `base03`. Fusion uses
   # `Light`/`Midlight`/`Mid`/`Dark` to draw 3D bevels, and Base16 luminance

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -17,28 +17,24 @@ let
   #
   # 1. Mirrors a kvconfig binding one-for-one. These roles produce the
   #    same colour Kvantum-rendered Qt apps already see, so a Fusion or
-  #    Basic fallback inherits the same palette: `Window`, `Base`,
-  #    `AlternateBase`, `Button`, `Midlight`, `Dark`, `Mid`,
-  #    `ToolTipBase`, `Link`, `LinkVisited`, `WindowText`, `Text`,
-  #    `ButtonText`, `ToolTipText`.
+  #    Basic fallback inherits the same palette. Listed in source-file
+  #    order: `WindowText`, `Button`, `Midlight`, `Dark`, `Mid`, `Text`,
+  #    `ButtonText`, `Base`, `Window`, `Link`, `LinkVisited`,
+  #    `AlternateBase`, `ToolTipBase`, `ToolTipText`.
   #
   # 2. Has a kvconfig binding but intentionally diverges from it. The
-  #    rationale is documented per-role below.
+  #    rationale is documented per-role below in source-file order:
+  #    `Light`, `Highlight`, `HighlightedText`.
   #
   # 3. Has no equivalent kvconfig binding. qt6ct's scheme format requires
-  #    all 21 entries, so Stylix picks a Base16 token directly: `Shadow`
-  #    (`base00`), `NoRole` (`base00`), `PlaceholderText` (`base04`
-  #    active / `base03` disabled), and `BrightText` (`base07`). Kvantum
-  #    routes high-contrast text and shadow drawing through SVG layers
-  #    rather than separate `[GeneralColors]` keys, so kvconfig has no
-  #    `bright.text.color` / `shadow.color` to mirror.
+  #    all 21 entries, so Stylix picks a Base16 token directly. Listed in
+  #    source-file order: `BrightText` (`base07`), `Shadow` (`base00`),
+  #    `NoRole` (`base00`), `PlaceholderText` (`base04` active / `base03`
+  #    disabled). Kvantum routes high-contrast text and shadow drawing
+  #    through SVG layers rather than separate `[GeneralColors]` keys, so
+  #    kvconfig has no `bright.text.color` / `shadow.color` to mirror.
   #
-  # Per-role rationale for category 2:
-  #
-  # `HighlightedText` maps to `base05` rather than kvconfig's `base00`:
-  # on Base16 schemes where `base0D` (Highlight) and `base00` (background)
-  # collapse toward similar luminance, selected text becomes unreadable.
-  # `base05` keeps high contrast against any Highlight choice.
+  # Per-role rationale for category 2 (source-file order):
   #
   # `Light` maps to `base04` rather than kvconfig's `base03`. Fusion uses
   # `Light`/`Midlight`/`Mid`/`Dark` to draw 3D bevels, and Base16 luminance
@@ -50,6 +46,11 @@ let
   # is the conventional Qt blue-ish selection colour; `base0E` (purple) is
   # a Stylix design choice that conflicts with user expectations for
   # selection highlight in Fusion-rendered apps.
+  #
+  # `HighlightedText` maps to `base05` rather than kvconfig's `base00`:
+  # on Base16 schemes where `base0D` (Highlight) and `base00` (background)
+  # collapse toward similar luminance, selected text becomes unreadable.
+  # `base05` keeps high contrast against any Highlight choice.
   paletteRoles = c: [
     c.base05 # WindowText
     c.base02 # Button

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -12,14 +12,34 @@ let
   # mirroring `QPalette::ColorRole` 0..20; `Accent` is omitted -- qt6ct 0.11
   # does not yet include it).
   #
+  # Background and structural roles (`Window`, `Base`, `AlternateBase`,
+  # `Button`, `Midlight`, `Dark`, `Mid`, `ToolTipBase`, `Link`,
+  # `LinkVisited`, `WindowText`, `Text`, `ButtonText`, `ToolTipText`)
+  # mirror `kvconfig.mustache`'s `[GeneralColors]` block one-for-one so a
+  # Fusion-rendered Qt app sees the same palette Kvantum produces.
+  #
+  # The roles below intentionally diverge from kvconfig:
+  #
   # `BrightText` is Qt's high-contrast text role (used when `Text` would
   # render poorly on top of `Highlight`); it maps to `base07` (the brightest
-  # foreground in Base16) rather than an accent colour.
+  # foreground in Base16) rather than an accent colour. kvconfig has no
+  # equivalent binding because Kvantum draws SVG frames instead of bevels.
   #
   # `HighlightedText` maps to `base05` rather than `base00`: on Base16
   # schemes where `base0D` (Highlight) and `base00` (background) collapse
   # toward similar luminance, selected text becomes unreadable. `base05`
   # keeps high contrast against any Highlight choice.
+  #
+  # `Light` maps to `base04` rather than kvconfig's `base03`. Fusion uses
+  # `Light`/`Midlight`/`Mid`/`Dark` to draw 3D bevels, and Base16 luminance
+  # ordering is `base03 < base04`. Setting `Light = base03` would equate
+  # `Light` and `Midlight` and flatten the bright side of the bevel.
+  # Kvantum renders SVG frames so it does not depend on `Light != Midlight`.
+  #
+  # `Highlight` maps to `base0D` rather than kvconfig's `base0E`. `base0D`
+  # is the conventional Qt blue-ish selection colour; `base0E` (purple) is
+  # a Stylix design choice that conflicts with user expectations for
+  # selection highlight in Fusion-rendered apps.
   paletteRoles = c: [
     c.base05 # WindowText
     c.base02 # Button

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -31,7 +31,7 @@ let
     c.base07 # BrightText
     c.base05 # ButtonText
     c.base00 # Base
-    c.base00 # Window
+    c.base01 # Window
     c.base00 # Shadow
     c.base0D # Highlight
     c.base05 # HighlightedText
@@ -61,7 +61,7 @@ let
     c.base04 # BrightText
     c.base04 # ButtonText
     c.base00 # Base
-    c.base00 # Window
+    c.base01 # Window
     c.base00 # Shadow
     c.base02 # Highlight
     c.base04 # HighlightedText

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -26,7 +26,7 @@ let
     c.base04 # Light
     c.base03 # Midlight
     c.base00 # Dark
-    c.base01 # Mid
+    c.base00 # Mid
     c.base05 # Text
     c.base07 # BrightText
     c.base05 # ButtonText
@@ -56,7 +56,7 @@ let
     c.base04 # Light
     c.base03 # Midlight
     c.base00 # Dark
-    c.base01 # Mid
+    c.base00 # Mid
     c.base04 # Text
     c.base04 # BrightText
     c.base04 # ButtonText

--- a/modules/stylix/qt6ct-colors.nix
+++ b/modules/stylix/qt6ct-colors.nix
@@ -39,7 +39,7 @@ let
     c.base0E # LinkVisited
     c.base01 # AlternateBase
     c.base00 # NoRole
-    c.base01 # ToolTipBase
+    c.base00 # ToolTipBase
     c.base05 # ToolTipText
     c.base04 # PlaceholderText
   ];
@@ -69,7 +69,7 @@ let
     c.base04 # LinkVisited
     c.base01 # AlternateBase
     c.base00 # NoRole
-    c.base01 # ToolTipBase
+    c.base00 # ToolTipBase
     c.base04 # ToolTipText
     c.base03 # PlaceholderText
   ];


### PR DESCRIPTION
## Summary

- `ToolTipBase` (QPalette role 18) was set to `base01`, identical to `Window`, so Fusion-rendered tooltips had zero visual separation from the surrounding window background in Qt apps that bypass Kvantum (e.g. QtQuick.Controls 2 apps).
- Switch both the active and disabled `ToolTipBase` rows to `base00`, matching Stylix's Kvantum theme (`kvconfig.mustache:85` binds `tooltip.base.color = base00`) and restoring the `Window` vs. `ToolTipBase` contrast Kvantum-rendered Qt apps already had.
- Mirrors the equivalent fix landing upstream in Stylix's qt6ct color scheme generator, keeping the two implementations in sync.

## Test plan

- [ ] Rebuild a system that has `stylix.targets.qt.enable = true` and `qt.platformTheme.name = "qtct"`.
- [ ] Hover any Qt app's tooltip (Fusion-rendered) and confirm the tooltip background is visually distinct from the window background.
- [ ] `cat ~/.config/qt6ct/colors/stylix.conf | rg ToolTipBase` (or inspect index 18 of `active_colors`/`disabled_colors`) shows `#ff` followed by the resolved `base00` hex, not `base01`.