### PR TITLE
feat(cpc): copy command and output to clipboard via xsel

### DIFF
--- a/modules/apps/cpc.nix
+++ b/modules/apps/cpc.nix
@@ -1,0 +1,108 @@
+/*
+  Package: cpc (copy command + output)
+  Description: Interactive shell function that runs a command, streams its
+               combined stdout/stderr to the terminal live, and copies a
+               tagged record of the invocation and its output to the X
+               CLIPBOARD selection via xsel.
+
+  Usage:
+    cpc <command> [args...]
+    cpc sudo systemctl status nginx
+
+  Clipboard payload format:
+    <command>ip -br a</command>
+    <output>
+    lo               UNKNOWN        127.0.0.1/8
+    </output>
+
+  Notes:
+    * Requires xsel on PATH (provided by `programs.xsel.extended` on both
+      hosts). The function falls back to a clear error message if xsel is
+      absent.
+    * stdout and stderr are merged so utilities that diagnose to stderr
+      (rg, ip, systemctl) end up in the clipboard alongside their results.
+    * Sudo password prompts go to /dev/tty and are not captured.
+    * Argv is reconstructed with `printf '%q '` so the recorded command
+      round-trips through the shell. Both bash and zsh implement %q in
+      their builtin printf.
+    * XML-style tags are used for delimitation, not strict XML conformance:
+      payload contents are not entity-escaped, so output containing literal
+      `<` / `>` / `&` will not parse as XML but remains human-readable.
+*/
+_:
+let
+  cpcModule =
+    {
+      config,
+      lib,
+      ...
+    }:
+    let
+      cfg = config.programs.cpc.extended;
+
+      cpcFunction = ''
+        # cpc: run a command, tee output to the terminal, and copy a tagged
+        # <command>/<output> record to the X CLIPBOARD selection via xsel.
+        cpc() {
+          if [ "$#" -eq 0 ]; then
+            printf 'cpc: usage: cpc <command> [args...]\n' >&2
+            return 64
+          fi
+          if ! command -v xsel >/dev/null 2>&1; then
+            printf 'cpc: xsel not found on PATH\n' >&2
+            return 127
+          fi
+
+          # Reconstruct a shell-safe representation of the invocation so the
+          # recorded <command> round-trips through the shell. Both bash and
+          # zsh implement %q in their builtin printf.
+          local cmd_str
+          cmd_str=$(printf '%q ' "$@")
+          cmd_str=''${cmd_str% }
+
+          local tmp_out tmp_rc rc
+          tmp_out=$(mktemp -t cpc.out.XXXXXX) || return 1
+          tmp_rc=$(mktemp -t cpc.rc.XXXXXX) || { rm -f "$tmp_out"; return 1; }
+
+          # Subshell captures the command's exit code into tmp_rc; tee
+          # mirrors combined stdout+stderr to the terminal (live) and into
+          # tmp_out (for the clipboard payload). Sudo password prompts go to
+          # /dev/tty and bypass this pipe, so they are never captured.
+          ( "$@" 2>&1; printf '%s\n' "$?" >"$tmp_rc" ) | tee "$tmp_out"
+
+          rc=$(cat "$tmp_rc" 2>/dev/null)
+          : "''${rc:=1}"
+
+          {
+            printf '<command>%s</command>\n<output>\n' "$cmd_str"
+            cat "$tmp_out"
+            printf '</output>\n'
+          } | xsel --clipboard --input
+
+          rm -f "$tmp_out" "$tmp_rc"
+          return "$rc"
+        }
+      '';
+    in
+    {
+      options.programs.cpc.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to install the `cpc` interactive shell function in zsh
+            and bash. Requires xsel on PATH (provided by
+            `programs.xsel.extended.enable`).
+          '';
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        programs.zsh.interactiveShellInit = lib.mkAfter cpcFunction;
+        programs.bash.interactiveShellInit = lib.mkAfter cpcFunction;
+      };
+    };
+in
+{
+  flake.nixosModules.apps.cpc = cpcModule;
+}

--- a/modules/apps/cpc.nix
+++ b/modules/apps/cpc.nix
@@ -59,27 +59,36 @@ let
           cmd_str=$(printf '%q ' "$@")
           cmd_str=''${cmd_str% }
 
-          local tmp_out tmp_rc rc
-          tmp_out=$(mktemp -t cpc.out.XXXXXX) || return 1
-          tmp_rc=$(mktemp -t cpc.rc.XXXXXX) || { rm -f "$tmp_out"; return 1; }
+          local tmp_dir
+          tmp_dir=$(mktemp -d --tmpdir cpc.XXXXXX) || return 1
 
-          # Subshell captures the command's exit code into tmp_rc; tee
-          # mirrors combined stdout+stderr to the terminal (live) and into
-          # tmp_out (for the clipboard payload). Sudo password prompts go to
-          # /dev/tty and bypass this pipe, so they are never captured.
-          ( "$@" 2>&1; printf '%s\n' "$?" >"$tmp_rc" ) | tee "$tmp_out"
+          # Run the capture inside a subshell so an EXIT trap clears the
+          # temp directory even when the user interrupts the inner command
+          # with SIGINT, SIGTERM, or SIGHUP. The INT/TERM/HUP traps simply
+          # `exit`, which then fires EXIT and removes the directory.
+          (
+            trap 'rm -rf -- "$tmp_dir"' EXIT
+            trap 'exit' INT TERM HUP
 
-          rc=$(cat "$tmp_rc" 2>/dev/null)
-          : "''${rc:=1}"
+            # Inner subshell captures the command's exit code into rc; tee
+            # mirrors combined stdout+stderr to the terminal (live) and
+            # into out (for the clipboard payload). Sudo password prompts
+            # go to /dev/tty and bypass this pipe, so they are never
+            # captured.
+            ( "$@" 2>&1; printf '%s\n' "$?" >"$tmp_dir/rc" ) | tee "$tmp_dir/out"
 
-          {
-            printf '<command>%s</command>\n<output>\n' "$cmd_str"
-            cat "$tmp_out"
-            printf '</output>\n'
-          } | ${xselBin} --clipboard --input
+            local rc
+            rc=$(cat "$tmp_dir/rc" 2>/dev/null)
+            : "''${rc:=1}"
 
-          rm -f "$tmp_out" "$tmp_rc"
-          return "$rc"
+            {
+              printf '<command>%s</command>\n<output>\n' "$cmd_str"
+              cat "$tmp_dir/out"
+              printf '</output>\n'
+            } | ${xselBin} --clipboard --input
+
+            exit "$rc"
+          )
         }
       '';
     in

--- a/modules/apps/cpc.nix
+++ b/modules/apps/cpc.nix
@@ -63,16 +63,19 @@ let
           cmd_str=$(printf '%q ' "$@")
           cmd_str=''${cmd_str% }
 
-          local tmp_dir
-          tmp_dir=$(mktemp -d --tmpdir cpc.XXXXXX) || return 1
-
           # Run the capture inside a subshell so an EXIT trap clears the
-          # temp directory even when the user interrupts the inner command
-          # with SIGINT, SIGTERM, or SIGHUP. The INT/TERM/HUP traps simply
-          # `exit`, which then fires EXIT and removes the directory.
+          # temp directory even when the user interrupts the function with
+          # SIGINT, SIGTERM, or SIGHUP. INT/TERM/HUP simply `exit`, which
+          # then fires EXIT and removes the directory. The trap is
+          # installed before `mktemp` and guarded with `[ -n "$tmp_dir" ]`
+          # so an early signal cannot leak the directory between mktemp's
+          # creation and assignment.
           (
-            trap 'rm -rf -- "$tmp_dir"' EXIT
+            tmp_dir=""
+            trap '[ -n "$tmp_dir" ] && rm -rf -- "$tmp_dir"' EXIT
             trap 'exit' INT TERM HUP
+
+            tmp_dir=$(mktemp -d --tmpdir cpc.XXXXXX) || exit 1
 
             # Inner subshell captures the command's exit code into rc; tee
             # mirrors combined stdout+stderr to the terminal (live) and

--- a/modules/apps/cpc.nix
+++ b/modules/apps/cpc.nix
@@ -22,6 +22,10 @@
       `programs.xsel.extended.enable`.
     * stdout and stderr are merged so utilities that diagnose to stderr
       (rg, ip, systemctl) end up in the clipboard alongside their results.
+    * TTY-aware programs (`ls`, `git`, `grep --color=auto`, pagers) detect
+      a pipe on stdout and disable color, paging, and progress output
+      because the function captures via `tee`. Force colour with the
+      tool's flag if needed (e.g. `cpc git -c color.ui=always status`).
     * Sudo password prompts go to /dev/tty and are not captured.
     * Argv is reconstructed with `printf '%q '` so the recorded command
       round-trips through the shell. Both bash and zsh implement %q in

--- a/modules/apps/cpc.nix
+++ b/modules/apps/cpc.nix
@@ -86,6 +86,11 @@ let
               cat "$tmp_dir/out"
               printf '</output>\n'
             } | ${xselBin} --clipboard --input
+            local xsel_rc=$?
+            if [ "$xsel_rc" -ne 0 ]; then
+              printf 'cpc: xsel exited %s; clipboard not updated\n' \
+                "$xsel_rc" >&2
+            fi
 
             exit "$rc"
           )

--- a/modules/apps/cpc.nix
+++ b/modules/apps/cpc.nix
@@ -45,7 +45,7 @@ let
     }:
     let
       cfg = config.programs.cpc.extended;
-      xselBin = "${cfg.package}/bin/xsel";
+      xselBin = lib.getExe' cfg.package "xsel";
 
       cpcFunction = ''
         # cpc: run a command, tee output to the terminal, and copy a tagged

--- a/modules/apps/cpc.nix
+++ b/modules/apps/cpc.nix
@@ -16,9 +16,10 @@
     </output>
 
   Notes:
-    * Requires xsel on PATH (provided by `programs.xsel.extended` on both
-      hosts). The function falls back to a clear error message if xsel is
-      absent.
+    * The xsel binary is referenced by absolute store path through the
+      `programs.cpc.extended.package` option, so the function works
+      without xsel on the user's PATH and is independent of
+      `programs.xsel.extended.enable`.
     * stdout and stderr are merged so utilities that diagnose to stderr
       (rg, ip, systemctl) end up in the clipboard alongside their results.
     * Sudo password prompts go to /dev/tty and are not captured.
@@ -35,10 +36,12 @@ let
     {
       config,
       lib,
+      pkgs,
       ...
     }:
     let
       cfg = config.programs.cpc.extended;
+      xselBin = "${cfg.package}/bin/xsel";
 
       cpcFunction = ''
         # cpc: run a command, tee output to the terminal, and copy a tagged
@@ -47,10 +50,6 @@ let
           if [ "$#" -eq 0 ]; then
             printf 'cpc: usage: cpc <command> [args...]\n' >&2
             return 64
-          fi
-          if ! command -v xsel >/dev/null 2>&1; then
-            printf 'cpc: xsel not found on PATH\n' >&2
-            return 127
           fi
 
           # Reconstruct a shell-safe representation of the invocation so the
@@ -77,7 +76,7 @@ let
             printf '<command>%s</command>\n<output>\n' "$cmd_str"
             cat "$tmp_out"
             printf '</output>\n'
-          } | xsel --clipboard --input
+          } | ${xselBin} --clipboard --input
 
           rm -f "$tmp_out" "$tmp_rc"
           return "$rc"
@@ -91,10 +90,13 @@ let
           default = false;
           description = ''
             Whether to install the `cpc` interactive shell function in zsh
-            and bash. Requires xsel on PATH (provided by
-            `programs.xsel.extended.enable`).
+            and bash. The xsel dependency is pinned via
+            `programs.cpc.extended.package` and is not resolved from the
+            user's PATH.
           '';
         };
+
+        package = lib.mkPackageOption pkgs "xsel" { };
       };
 
       config = lib.mkIf cfg.enable {

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -84,6 +84,7 @@
       codex.extended.enable = lib.mkOverride 1100 true;
       coreutils.extended.enable = lib.mkOverride 1100 true;
       "cosmic-term".extended.enable = lib.mkOverride 1100 false;
+      cpc.extended.enable = lib.mkOverride 1100 true;
       cryptsetup.extended.enable = lib.mkOverride 1100 true;
       "csharp-ls".extended.enable = lib.mkOverride 1100 false;
       curl.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -69,6 +69,7 @@
       codex.extended.enable = lib.mkOverride 1100 true;
       coreutils.extended.enable = lib.mkOverride 1100 true;
       "cosmic-term".extended.enable = lib.mkOverride 1100 false;
+      cpc.extended.enable = lib.mkOverride 1100 true;
       cryptsetup.extended.enable = lib.mkOverride 1100 true;
       "csharp-ls".extended.enable = lib.mkOverride 1100 false;
       curl.extended.enable = lib.mkOverride 1100 true;


### PR DESCRIPTION
## Summary

- Adds a new `cpc <command> [args...]` shell function that runs the given command, streams combined `stdout`/`stderr` to the terminal live, and copies a tagged `<command>`/`<output>` record to the X CLIPBOARD selection via `xsel`.
- Argv is reconstructed with `printf '%q '` so quoted arguments round-trip through the shell. Sudo password prompts go to `/dev/tty` and are never captured.
- New module at `modules/apps/cpc.nix` exposes `programs.cpc.extended.enable`, appending the function to both `programs.zsh.interactiveShellInit` and `programs.bash.interactiveShellInit` via `lib.mkAfter`. Enabled on `system76` and `tpnix` via their respective `apps-enable.nix` files; the runtime dependency on `xsel` is satisfied by `programs.xsel.extended`, already enabled on both hosts.

Sample clipboard payload:

```
<command>ip -br a</command>
<output>
lo               UNKNOWN        127.0.0.1/8
enp5s0           UP             192.168.1.42/24
</output>
```

## Test plan

- [x] `nix-instantiate --parse modules/apps/cpc.nix`
- [x] `nix fmt` (no diff)
- [x] `nix flake check --accept-flake-config --no-build --offline` (all checks passed)
- [x] `nix build .#nixosConfigurations.system76.config.system.build.toplevel`
- [x] `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel`
- [x] Behavioral smoke test in bash (xsel stand-in): empty argv returns 64 with usage; simple/quoted/sudo-style invocations round-trip; `<html>` in args/output captured verbatim; non-zero exit codes propagate.
- [ ] Post-rebuild on a host: `cpc echo hello` then `xsel --clipboard --output` to confirm the payload; `cpc sudo whoami` to confirm the prompt reaches the TTY and the captured output is `root`.