### PR TITLE
docs(architecture): refresh per-host coverage and drop stale refs

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -8,7 +8,7 @@ This file governs the `docs/` subtree. Keep documentation scoped to existing fol
 - `guides/`, `usage/`, `reference/`: task-oriented instructions and reference material.
 - Domain folders (for example `cloudflare/`, `sops/`, `usbguard/`): product-specific docs.
 
-Prefer updating an existing page over adding a new one. Use clear, repo-relative links (for example `../architecture/index.md`) and keep host/user assumptions aligned to the single System76 host and `vx` user model.
+Prefer updating an existing page over adding a new one. Use clear, repo-relative links (for example `../architecture/index.md`) and keep host/user assumptions aligned to the per-host model under `modules/<host>/` and the `vx` user model. To enumerate the active hosts, run `nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames`.
 
 ## Build, Test, and Development Commands
 

--- a/docs/architecture/01-pattern-overview.md
+++ b/docs/architecture/01-pattern-overview.md
@@ -16,7 +16,9 @@ modules/
 │   ├── firefox.nix      ← Imported automatically
 │   └── _experimental.nix ← Ignored (underscore prefix)
 ├── system76/
-│   └── boot.nix         ← Imported automatically
+│   └── boot.nix         ← Imported automatically (system76 host)
+├── tpnix/
+│   └── boot.nix         ← Imported automatically (tpnix host)
 └── _scratch/            ← Entire directory ignored
 ```
 
@@ -49,12 +51,16 @@ The file:
 
 ## Aggregator Namespaces
 
-This flake exposes two primary aggregators:
+This flake exposes the following top-level aggregators (all declared in `modules/meta/flake-output.nix`):
 
-| Namespace                  | Purpose                    | Typical Exports                          |
-| -------------------------- | -------------------------- | ---------------------------------------- |
-| `flake.nixosModules`       | System-level configuration | `base`, hardware profiles, `apps.<name>` |
-| `flake.homeManagerModules` | Home Manager configuration | `base`, `gui`, `apps.<name>`             |
+| Namespace                  | Purpose                             | Typical Exports                                                                 |
+| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------- |
+| `flake.nixosModules`       | System-level configuration          | `base`, hardware profiles, `apps.<name>`                                        |
+| `flake.homeManagerModules` | Home Manager configuration          | `base`, `gui`, `apps.<name>`                                                    |
+| `flake.csec`               | Cybersecurity feature modules       | `wordlists` (per-feature, opt-in via host import + enable)                      |
+| `flake.lib.*`              | Helper functions and small metadata | `meta`, `nixos`, `homeManager`, `security`, `nixvim`, `xdg`, `agents`, `checks` |
+
+`flake.nixosModules` and `flake.homeManagerModules` collect modules that hosts compose by name. `flake.csec` is a separate `attrsOf deferredModule` so each feature is a first-class entry that hosts opt into individually. `flake.lib` holds pure helper data (see [NixOS Modules](03-nixos-modules.md#flakelib-namespaces) for the full breakdown).
 
 Modules register themselves under these namespaces. Consumers compose features by name rather than by file path.
 

--- a/docs/architecture/02-module-authoring.md
+++ b/docs/architecture/02-module-authoring.md
@@ -4,12 +4,12 @@ This document covers how to write modules correctly in this flake-parts + import
 
 ## File Placement
 
-| Location                     | Purpose               | Export Pattern                         |
-| ---------------------------- | --------------------- | -------------------------------------- |
-| `modules/apps/<name>.nix`    | Per-app modules       | `flake.nixosModules.apps.<name>`       |
-| `modules/hm-apps/<name>.nix` | Per-app HM modules    | `flake.homeManagerModules.apps.<name>` |
-| `modules/<domain>/`          | Higher-level features | `flake.nixosModules.<feature>`         |
-| `modules/system76/`          | Host-specific config  | `configurations.nixos.system76.module` |
+| Location                     | Purpose               | Export Pattern                                                                    |
+| ---------------------------- | --------------------- | --------------------------------------------------------------------------------- |
+| `modules/apps/<name>.nix`    | Per-app modules       | `flake.nixosModules.apps.<name>`                                                  |
+| `modules/hm-apps/<name>.nix` | Per-app HM modules    | `flake.homeManagerModules.apps.<name>`                                            |
+| `modules/<domain>/`          | Higher-level features | `flake.nixosModules.<feature>`                                                    |
+| `modules/<host>/`            | Host-specific config  | `configurations.nixos.<host>.module` (e.g. `modules/system76/`, `modules/tpnix/`) |
 
 **Rule:** If a module only installs packages, put it in `modules/apps/`. If it configures services or composes multiple apps, use a domain directory.
 
@@ -72,7 +72,7 @@ One file can populate both aggregators. Keep the scopes independent.
 { config, ... }:
 {
   config = {
-    nix.settings.experimental-features = [ "nix-command" "flakes" "pipe-operators" ];
+    nix.settings.experimental-features = [ "nix-command" "flakes" "pipe-operators" "recursive-nix" ];
 
     flake.nixosModules.base.nix = {
       inherit (config.nix) settings;
@@ -104,6 +104,36 @@ Use `lib.mkIf`, `lib.mkMerge`, and other option helpers to extend shared modules
 ```
 
 See [Host Composition](05-host-composition.md) for details.
+
+## Custom Module Arguments
+
+Hosts inject a small set of custom arguments via `_module.args` so that downstream modules can receive them as ordinary function parameters. Each host's `modules/<host>/imports.nix` sets them in two places: on the deferred `configurations.nixos.<host>.module` and on the wrapping `nixosSystem` call (so they are available to both flake-parts and the host evaluation).
+
+| Arg               | Type  | Source                               | Use                                                                           |
+| ----------------- | ----- | ------------------------------------ | ----------------------------------------------------------------------------- |
+| `metaOwner`       | attrs | `modules/meta/owner.nix`             | Owner identity (`username`, `sshKeys`); used by HM users, secret modules.     |
+| `secretsRoot`     | path  | Repo `secrets/` directory            | Base for `sopsFile` references; lets secrets modules guard with `pathExists`. |
+| `inputs`          | attrs | flake-parts `specialArgs`            | Flake inputs propagated into NixOS modules without re-importing the flake.    |
+| `nixosAppHelpers` | attrs | `modules/meta/nixos-app-helpers.nix` | Same helpers exposed at `config.flake.lib.nixos`; convenient inside hosts.    |
+
+```nix
+# modules/home/context7-secrets.nix
+{ lib, metaOwner, secretsRoot, ... }:
+let
+  ctxFile = "${secretsRoot}/context7.yaml";
+in
+{
+  config = lib.mkIf (builtins.pathExists ctxFile) {
+    sops.secrets."context7/api-key" = {
+      sopsFile = ctxFile;
+      owner = metaOwner.username;
+      # ...
+    };
+  };
+}
+```
+
+Treat custom args as the contract between hosts and downstream modules. Adding a new arg requires updating every `_module.args` block that sets it; missing args surface as evaluation-time errors that name the missing parameter.
 
 ## Common Pitfalls
 
@@ -192,8 +222,11 @@ in
 nix eval --accept-flake-config --json .#nixosModules --apply builtins.attrNames
 nix eval --accept-flake-config --json .#homeManagerModules.apps --apply builtins.attrNames
 
-# Evaluate specific host option
-nix eval .#nixosConfigurations.system76.config.boot.loader
+# Evaluate a specific host option (substitute the host name)
+nix eval .#nixosConfigurations.<host>.config.boot.loader
+
+# List the hosts available in the current checkout
+nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames
 ```
 
 ## Next Steps

--- a/docs/architecture/02-module-authoring.md
+++ b/docs/architecture/02-module-authoring.md
@@ -107,14 +107,16 @@ See [Host Composition](05-host-composition.md) for details.
 
 ## Custom Module Arguments
 
-Hosts inject a small set of custom arguments via `_module.args` so that downstream modules can receive them as ordinary function parameters. Each host's `modules/<host>/imports.nix` sets them in two places: on the deferred `configurations.nixos.<host>.module` and on the wrapping `nixosSystem` call (so they are available to both flake-parts and the host evaluation).
+NixOS modules can receive a small set of repo-specific arguments as ordinary function parameters. They reach the host evaluation through two layers:
 
-| Arg               | Type  | Source                               | Use                                                                           |
-| ----------------- | ----- | ------------------------------------ | ----------------------------------------------------------------------------- |
-| `metaOwner`       | attrs | `modules/meta/owner.nix`             | Owner identity (`username`, `sshKeys`); used by HM users, secret modules.     |
-| `secretsRoot`     | path  | Repo `secrets/` directory            | Base for `sopsFile` references; lets secrets modules guard with `pathExists`. |
-| `inputs`          | attrs | flake-parts `specialArgs`            | Flake inputs propagated into NixOS modules without re-importing the flake.    |
-| `nixosAppHelpers` | attrs | `modules/meta/nixos-app-helpers.nix` | Same helpers exposed at `config.flake.lib.nixos`; convenient inside hosts.    |
+1. The shared host helper `modules/configurations/nixos.nix` injects `metaOwner` and `secretsRoot` into every deferred host module (`_module.args`) and into the wrapping `nixosSystem` `specialArgs`. New hosts get these for free.
+2. Each host's `modules/<host>/imports.nix` re-asserts `metaOwner` and `secretsRoot` and additionally propagates `inputs` on the wrapping `nixosSystem` call, so flake inputs are reachable from inside NixOS modules.
+
+| Arg           | Type  | Source                                                               | Available where                                                                                                                     |
+| ------------- | ----- | -------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `metaOwner`   | attrs | `modules/meta/owner.nix` via shared helper + per-host `imports.nix`  | Every NixOS module (HM users, secrets); owner identity (`username`, `sshKeys`).                                                     |
+| `secretsRoot` | path  | Repo `secrets/` directory via shared helper + per-host `imports.nix` | Every NixOS module; base for `sopsFile` references and `pathExists` guards.                                                         |
+| `inputs`      | attrs | Per-host `imports.nix` wrapping `nixosSystem`                        | Every NixOS module reached through the host closure; lets modules use `inputs.<flake>.nixosModules` without re-importing the flake. |
 
 ```nix
 # modules/home/context7-secrets.nix
@@ -133,7 +135,9 @@ in
 }
 ```
 
-Treat custom args as the contract between hosts and downstream modules. Adding a new arg requires updating every `_module.args` block that sets it; missing args surface as evaluation-time errors that name the missing parameter.
+`config.flake.lib.nixos` (the `hasApp`, `getApp`, `getApps`, `getAllApps`, `getAppOr` helpers) is a separate flake-parts helper, not a NixOS module argument. Read it from the flake-parts outer scope when authoring host-side modules. The same helpers are also published as `_module.args.nixosAppHelpers` at flake-parts scope only, so a NixOS module that declares `{ nixosAppHelpers, ... }:` will fail to evaluate.
+
+Treat custom args as the contract between hosts and downstream modules. Adding a new arg requires updating either `modules/configurations/nixos.nix` (for shared args) or each host's `imports.nix` (for host-specific args), plus the wrapping `nixosSystem` block. Missing args surface as evaluation-time errors that name the missing parameter.
 
 ## Common Pitfalls
 

--- a/docs/architecture/03-nixos-modules.md
+++ b/docs/architecture/03-nixos-modules.md
@@ -71,16 +71,16 @@ in
 
 `flake.lib` exposes pure helper data and small utilities. All sub-namespaces are declared in `modules/meta/flake-output.nix` and populated by individual modules.
 
-| Namespace               | Type                   | Purpose                                                                                         |
-| ----------------------- | ---------------------- | ----------------------------------------------------------------------------------------------- |
-| `flake.lib.meta`        | `anything`             | Repo metadata (owner identity, hostnames, surface for `metaOwner` arg).                         |
-| `flake.lib.nixos`       | `lazyAttrsOf anything` | App-registry helpers (`hasApp`, `getApp`, ...) and host-conditional flags under `hosts.<name>`. |
-| `flake.lib.homeManager` | submodule (freeform)   | Helpers and metadata used by Home Manager modules.                                              |
-| `flake.lib.security`    | `attrsOf anything`     | Shared SOPS helpers (e.g. `sopsInstallSecretsService`).                                         |
-| `flake.lib.nixvim`      | `attrsOf anything`     | Helpers for NixVim integrations and shared module shape.                                        |
-| `flake.lib.xdg`         | `attrsOf anything`     | Desktop file mappings, MIME helpers (consumed by `modules/meta/ci.nix`).                        |
-| `flake.lib.agents`      | submodule (freeform)   | Registry and compiled outputs for MCP servers and skills (`modules/agents/*.nix`).              |
-| `flake.lib.checks`      | `attrsOf anything`     | Lightweight evaluation-only checks (no derivation builds).                                      |
+| Namespace               | Type                               | Purpose                                                                                         |
+| ----------------------- | ---------------------------------- | ----------------------------------------------------------------------------------------------- |
+| `flake.lib.meta`        | `anything`                         | Repo metadata (owner identity, hostnames, surface for `metaOwner` arg).                         |
+| `flake.lib.nixos`       | `lazyAttrsOf anything`             | App-registry helpers (`hasApp`, `getApp`, ...) and host-conditional flags under `hosts.<name>`. |
+| `flake.lib.homeManager` | `attrsOf anything` (via submodule) | Helpers and metadata used by Home Manager modules.                                              |
+| `flake.lib.security`    | `attrsOf anything`                 | Shared SOPS helpers (e.g. `sopsInstallSecretsService`).                                         |
+| `flake.lib.nixvim`      | `attrsOf anything`                 | Helpers for NixVim integrations and shared module shape.                                        |
+| `flake.lib.xdg`         | `attrsOf anything`                 | Desktop file mappings, MIME helpers (consumed by `modules/meta/ci.nix`).                        |
+| `flake.lib.agents`      | `attrsOf anything` (via submodule) | Registry and compiled outputs for MCP servers and skills (`modules/agents/*.nix`).              |
+| `flake.lib.checks`      | `attrsOf anything`                 | Lightweight evaluation-only checks (no derivation builds).                                      |
 
 Helpers should stay pure and idempotent; anything that needs heavy evaluation belongs in a module rather than a `flake.lib.*` entry.
 

--- a/docs/architecture/03-nixos-modules.md
+++ b/docs/architecture/03-nixos-modules.md
@@ -67,22 +67,40 @@ in
 }
 ```
 
+## `flake.lib` Namespaces
+
+`flake.lib` exposes pure helper data and small utilities. All sub-namespaces are declared in `modules/meta/flake-output.nix` and populated by individual modules.
+
+| Namespace               | Type                   | Purpose                                                                                         |
+| ----------------------- | ---------------------- | ----------------------------------------------------------------------------------------------- |
+| `flake.lib.meta`        | `anything`             | Repo metadata (owner identity, hostnames, surface for `metaOwner` arg).                         |
+| `flake.lib.nixos`       | `lazyAttrsOf anything` | App-registry helpers (`hasApp`, `getApp`, ...) and host-conditional flags under `hosts.<name>`. |
+| `flake.lib.homeManager` | submodule (freeform)   | Helpers and metadata used by Home Manager modules.                                              |
+| `flake.lib.security`    | `attrsOf anything`     | Shared SOPS helpers (e.g. `sopsInstallSecretsService`).                                         |
+| `flake.lib.nixvim`      | `attrsOf anything`     | Helpers for NixVim integrations and shared module shape.                                        |
+| `flake.lib.xdg`         | `attrsOf anything`     | Desktop file mappings, MIME helpers (consumed by `modules/meta/ci.nix`).                        |
+| `flake.lib.agents`      | submodule (freeform)   | Registry and compiled outputs for MCP servers and skills (`modules/agents/*.nix`).              |
+| `flake.lib.checks`      | `attrsOf anything`     | Lightweight evaluation-only checks (no derivation builds).                                      |
+
+Helpers should stay pure and idempotent; anything that needs heavy evaluation belongs in a module rather than a `flake.lib.*` entry.
+
 ## `perSystem` vs host overlays
 
 This repository uses both patterns, for different purposes:
 
-- `perSystem.packages` is used for flake-exposed tooling packages (for example, `generation-manager` and hook helpers).
-- Host app packages in `packages/<name>/default.nix` are injected through the System76 overlay in `modules/system76/custom-packages-overlay.nix`, then consumed as regular `pkgs.<name>` values by app modules.
+- `perSystem.packages` is used for flake-exposed tooling packages (for example, `generation-manager` and hook helpers in `modules/devshell.nix`).
+- Host app packages in `packages/<name>/default.nix` are injected through host-scoped overlays (e.g. `modules/system76/custom-packages-overlay.nix`), then consumed as regular `pkgs.<name>` values by app modules.
 
-This means many host-only packages are **not** available under `.#packages.<system>.<name>` directly; they are available inside the host evaluation (`nixosConfigurations.system76`) where the overlay is active.
+This means many host-only packages are **not** available under `.#packages.<system>.<name>` directly; they are available inside each `nixosConfigurations.<host>` evaluation where its overlay is active.
 
 ## Shared System Helpers
 
-| Module                                         | Export                                         | Purpose                           |
-| ---------------------------------------------- | ---------------------------------------------- | --------------------------------- |
-| `modules/system76/support.nix`                 | `flake.nixosModules."system76-support"`        | System76 kernel modules, firmware |
-| `modules/hardware/monitors/lenovo-y27q-20.nix` | `flake.nixosModules."hardware-lenovo-y27q-20"` | Monitor profile                   |
-| `modules/system76/virtualization.nix`          | host options under `system76.virtualization.*` | Virtualization app toggles        |
+| Module                                         | Export                                         | Scope           | Purpose                                           |
+| ---------------------------------------------- | ---------------------------------------------- | --------------- | ------------------------------------------------- |
+| `modules/system76/support.nix`                 | `flake.nixosModules."system76-support"`        | system76 only   | System76 kernel modules, firmware                 |
+| `modules/hardware/monitors/lenovo-y27q-20.nix` | `flake.nixosModules."hardware-lenovo-y27q-20"` | shared (opt-in) | Monitor profile                                   |
+| `modules/system76/virtualization.nix`          | host options under `system76.virtualization.*` | system76 only   | Virtualization app toggles                        |
+| `modules/tpnix/policy.nix`                     | `flake.lib.nixos.hosts.tpnix.*` flags          | tpnix only      | Host-conditional gating (e.g. `sopsRuntimeReady`) |
 
 ## The `flake.csec` Namespace
 

--- a/docs/architecture/04-home-manager.md
+++ b/docs/architecture/04-home-manager.md
@@ -61,7 +61,7 @@ loadAppModule = name:
 
 ### Default App Imports
 
-The following apps are loaded by default for `vx@system76`:
+The following apps are loaded by default for `vx` on each NixOS host (defined in `modules/home-manager/nixos.nix`):
 
 ```nix
 defaultAppImports = [
@@ -76,7 +76,21 @@ defaultAppImports = [
 
 ### Adding Extra Apps
 
-Hosts append to `home-manager.extraAppImports`. The System76 host also appends matching app modules to `home-manager.sharedModules` in `modules/system76/home-manager-apps.nix`.
+Each host appends to `home-manager.extraAppImports` and mirrors matching app modules into `home-manager.sharedModules` from its own `modules/<host>/home-manager-apps.nix`.
+
+### Per-Host Divergences
+
+The shared HM base is identical across hosts; per-host overrides live in each host's `imports.nix`. As a current snapshot:
+
+| HM toggle           | system76 default | tpnix default               | Notes                                                                                           |
+| ------------------- | ---------------- | --------------------------- | ----------------------------------------------------------------------------------------------- |
+| `context7Secrets`   | `mkDefault true` | `mkForce false`             | Context7 API key rendering.                                                                     |
+| `virustotalSecrets` | `mkDefault true` | `mkForce false`             | VirusTotal API key rendering.                                                                   |
+| `r2Secrets`         | `mkForce false`  | `mkForce false`             | NixOS-side `r2CloudSecrets` is also off in the current configuration.                           |
+| `repoGpg`           | `mkDefault true` | (not set, inherits)         | system76 also pulls `inputs.self.homeManagerModules.repoGpg` into `home-manager.sharedModules`. |
+| `services.espanso`  | Wayland defaults | `x11Support = mkForce true` | tpnix runs i3 on X11.                                                                           |
+
+Authoritative source for any host: that host's `imports.nix` (`modules/<host>/imports.nix`). When adding a new secret module, set both NixOS- and HM-side defaults explicitly per host so behavior is obvious from `imports.nix` rather than implicit through `mkDefault` chains.
 
 ## Authoring Rules
 
@@ -109,13 +123,20 @@ This ensures evaluation succeeds even when secret files are absent.
 
 ## HM Diagnostics
 
-Home Manager CLI is not bundled by default. Run via:
+Home Manager runs as a NixOS module per host (no standalone HM configuration). To inspect or build a host's HM tree, substitute the host name:
 
 ```bash
-nix develop -c nix run nixpkgs#home-manager -- --flake .#vx switch --dry-run
+# Evaluate a host's HM users tree
+nix eval .#nixosConfigurations.<host>.config.home-manager.users.vx.home.packages --apply builtins.length
+
+# Build the host closure (HM activation runs on switch)
+nix build .#nixosConfigurations.<host>.config.system.build.toplevel
+
+# List the hosts available in the current checkout
+nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames
 ```
 
-Or add `home-manager` to `modules/devshell.nix` for a persistent binary.
+Add `home-manager` to `modules/devshell.nix` if a standalone CLI is needed for ad-hoc diagnostics.
 
 ## Next Steps
 

--- a/docs/architecture/04-home-manager.md
+++ b/docs/architecture/04-home-manager.md
@@ -82,13 +82,13 @@ Each host appends to `home-manager.extraAppImports` and mirrors matching app mod
 
 The shared HM base is identical across hosts; per-host overrides live in each host's `imports.nix`. As a current snapshot:
 
-| HM toggle           | system76 default | tpnix default               | Notes                                                                                           |
-| ------------------- | ---------------- | --------------------------- | ----------------------------------------------------------------------------------------------- |
-| `context7Secrets`   | `mkDefault true` | `mkForce false`             | Context7 API key rendering.                                                                     |
-| `virustotalSecrets` | `mkDefault true` | `mkForce false`             | VirusTotal API key rendering.                                                                   |
-| `r2Secrets`         | `mkForce false`  | `mkForce false`             | NixOS-side `r2CloudSecrets` is also off in the current configuration.                           |
-| `repoGpg`           | `mkDefault true` | (not set, inherits)         | system76 also pulls `inputs.self.homeManagerModules.repoGpg` into `home-manager.sharedModules`. |
-| `services.espanso`  | Wayland defaults | `x11Support = mkForce true` | tpnix runs i3 on X11.                                                                           |
+| HM toggle           | system76 default       | tpnix default                          | Notes                                                                                                                                  |
+| ------------------- | ---------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `context7Secrets`   | `mkDefault true`       | `mkForce false`                        | Context7 API key rendering.                                                                                                            |
+| `virustotalSecrets` | `mkDefault true`       | `mkForce false`                        | VirusTotal API key rendering.                                                                                                          |
+| `r2Secrets`         | `mkForce false`        | `mkForce false`                        | NixOS-side `r2CloudSecrets` is also off in the current configuration.                                                                  |
+| `repoGpg`           | `mkDefault true`       | (not enabled, no shared module pulled) | system76 pulls `inputs.self.homeManagerModules.repoGpg` into `home-manager.sharedModules`; tpnix does not pull this shared module.     |
+| `services.espanso`  | (inherits HM upstream) | `x11Support = mkForce true`            | system76 leaves espanso's session-backend defaults alone; tpnix forces X11 via `home-manager.sharedModules` because it runs i3 on X11. |
 
 Authoritative source for any host: that host's `imports.nix` (`modules/<host>/imports.nix`). When adding a new secret module, set both NixOS- and HM-side defaults explicitly per host so behavior is obvious from `imports.nix` rather than implicit through `mkDefault` chains.
 

--- a/docs/architecture/05-host-composition.md
+++ b/docs/architecture/05-host-composition.md
@@ -1,28 +1,34 @@
 # Host Composition
 
-This document explains how the host configuration is assembled from modules.
+This document explains how host configurations are assembled from modules. Each host lives in its own `modules/<host>/` directory and feeds the `configurations.nixos.<host>` aggregator. To enumerate the active hosts at any time:
+
+```bash
+nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames
+```
 
 ## Host Definition Pattern
 
-Complete hosts live under `configurations.nixos.<name>.module`. The helper in `modules/configurations/nixos.nix` maps these to `nixosConfigurations.<name>` outputs.
+Complete hosts live under `configurations.nixos.<name>.module`. The helper in `modules/configurations/nixos.nix` maps each entry to a `nixosConfigurations.<name>` output by wrapping the deferred module in `inputs.nixpkgs.lib.nixosSystem`.
 
 ```nix
-# modules/system76/imports.nix
+# modules/system76/imports.nix (excerpt)
 { config, lib, inputs, ... }:
 {
   configurations.nixos.system76.module = {
     imports =
       [
         config.flake.nixosModules.base
+        config.flake.csec.wordlists
+        config.flake.nixosModules.sopsRuntime
+        config.flake.nixosModules.repoSecrets
         config.flake.nixosModules.lang
         config.flake.nixosModules.ssh
+        config.flake.nixosModules."duplicati-r2"
+        config.flake.nixosModules.mirror-root
+        inputs.nixos-hardware.nixosModules.system76
       ]
       ++ lib.optionals (lib.hasAttrByPath [ "flake" "nixosModules" "system76-support" ] config) [
-        config.flake.nixosModules."system76-support"
-      ]
-      ++ [
-        inputs.nixos-hardware.nixosModules.system76
-        inputs.nixos-hardware.nixosModules.system76-darp6
+        config.flake.nixosModules.system76-support
       ];
   };
 }
@@ -30,13 +36,16 @@ Complete hosts live under `configurations.nixos.<name>.module`. The helper in `m
 
 **Key points:**
 
-- `configurations.nixos.<host>.module` is `lib.types.deferredModule`
-- Optional imports are guarded with `lib.hasAttrByPath` + `lib.optionals`
-- Host composition uses aggregator names (`config.flake.nixosModules.*`), not literal file paths
+- `configurations.nixos.<host>.module` is `lib.types.deferredModule` (declared in `modules/configurations/nixos.nix`).
+- Optional imports are guarded with `lib.hasAttrByPath` + `lib.optionals` so a host evaluates even if a referenced module is gated out.
+- Host composition uses aggregator names (`config.flake.nixosModules.*`, `config.flake.csec.*`), not literal file paths.
+- Hardware profiles live under `inputs.nixos-hardware.nixosModules.<name>`. Use the most specific profile that exists upstream; do not invent suffixed names.
 
-## System76 Host Structure
+## Host File Structures
 
-The System76 host is composed by many files that all extend `configurations.nixos.system76.module`:
+Every host follows the same shape: each `modules/<host>/*.nix` file extends `configurations.nixos.<host>.module`. Common files (boot, sops, sudo, dbus, pipewire, hostname, security, etc.) tend to mirror across hosts; the divergent files are listed below for the hosts currently in the repo. To audit the current set of files for any host, run `ls modules/<host>/`.
+
+### system76 (Oryx Pro laptop)
 
 | File                                           | Purpose                                               |
 | ---------------------------------------------- | ----------------------------------------------------- |
@@ -48,38 +57,62 @@ The System76 host is composed by many files that all extend `configurations.nixo
 | `modules/system76/custom-packages-overlay.nix` | Injects local `packages/*` into host `pkgs` overlay   |
 | `modules/system76/r2-runtime.nix`              | Host runtime bindings for external `r2-flake` modules |
 | `modules/system76/hardware-config.nix`         | Filesystems, firmware, low-level hardware settings    |
-| `modules/system76/nvidia-gpu.nix`              | NVIDIA PRIME configuration                            |
+| `modules/system76/nvidia-gpu.nix`              | NVIDIA PRIME (system76-only)                          |
+| `modules/system76/pass-secret-service.nix`     | DBus secret-service for `pass` (system76-only)        |
 | `modules/system76/services.nix`                | Service-level host behavior                           |
+
+### tpnix (ThinkPad)
+
+| File                                        | Purpose                                                                 |
+| ------------------------------------------- | ----------------------------------------------------------------------- |
+| `modules/tpnix/imports.nix`                 | Baseline module imports, gated on `flake.lib.nixos.hosts.tpnix.*` flags |
+| `modules/tpnix/apps-base.nix`               | Imports all discovered NixOS app modules                                |
+| `modules/tpnix/apps-enable.nix`             | Per-app enable/disable defaults (different toggles than system76)       |
+| `modules/tpnix/home-manager-apps.nix`       | Extra HM app imports and shared module wiring                           |
+| `modules/tpnix/default-apps.nix`            | XDG default application selection + env vars                            |
+| `modules/tpnix/custom-packages-overlay.nix` | Injects local `packages/*` into host `pkgs` overlay                     |
+| `modules/tpnix/hardware-config.nix`         | Filesystems, firmware, low-level hardware settings                      |
+| `modules/tpnix/policy.nix`                  | Host-level policy flags exposed under `flake.lib.nixos.hosts.tpnix`     |
+| `modules/tpnix/power.nix`                   | tpnix power management (`powerprofilesctl` backend)                     |
+| `modules/tpnix/services.nix`                | Service-level host behavior                                             |
+
+### Host-conditional helpers
+
+When a module needs to behave differently for one host (or skip itself entirely), use `flake.lib.nixos.hosts.<hostname>.<flag>` rather than reading hostname strings. Example: `modules/tpnix/policy.nix` exports `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady`, and `modules/tpnix/imports.nix` reads it to gate `duplicati-r2` until SOPS runtime is wired.
+
+```nix
+inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
+duplicatiModuleExists = sopsRuntimeReady && lib.hasAttrByPath [ "flake" "nixosModules" "duplicati-r2" ] config;
+```
+
+Add new host-conditional flags by declaring them under `flake.lib.nixos.hosts.<hostname>` in a host-owned module; consumers read the path with `lib.hasAttrByPath` to stay safe across hosts.
 
 ## App and Home Manager Wiring
 
-This repo uses a two-stage app model:
+Each host uses the same two-stage app model:
 
-1. `modules/system76/apps-base.nix` imports all discovered NixOS app modules (`getAllApps`)
-2. `modules/system76/apps-enable.nix` toggles per-app `programs.<name>.extended.enable`
+1. `modules/<host>/apps-base.nix` imports all discovered NixOS app modules (`getAllApps`).
+2. `modules/<host>/apps-enable.nix` toggles per-app `programs.<name>.extended.enable`.
 
-Home Manager is wired similarly:
+Home Manager wiring follows the same shape:
 
-- `modules/home-manager/nixos.nix` provides HM base + default app imports
-- `modules/system76/home-manager-apps.nix` appends additional app keys via `home-manager.extraAppImports`
-- `modules/system76/imports.nix` appends external shared modules such as `inputs.r2-flake.homeManagerModules.default`
+- `modules/home-manager/nixos.nix` provides the shared HM base and default app imports for any host.
+- `modules/<host>/home-manager-apps.nix` appends additional app keys via `home-manager.extraAppImports`.
+- `modules/<host>/imports.nix` appends external shared modules (e.g. `inputs.r2-flake.homeManagerModules.default` on system76).
 
-For integration-specific details of the external R2 module chain, see
-[`../r2-cloud/input-and-module-wiring.md`](../r2-cloud/input-and-module-wiring.md).
-
-## Single-Host Repository Policy
-
-Although the architecture can represent multiple hosts, this repository intentionally manages only one host: `system76`. Do not add new hosts unless repository policy changes.
+For integration-specific details of the external R2 module chain, see [`../r2-cloud/input-and-module-wiring.md`](../r2-cloud/input-and-module-wiring.md). For tpnix-specific implementation notes, see [`../tpnix/IMPLEMENTATION_PLAN.md`](../tpnix/IMPLEMENTATION_PLAN.md).
 
 ## Validation
 
-After host-level changes, run:
+After host-level changes, build every affected host closure and run flake-level checks. Substitute the host name(s) you actually touched:
 
 ```bash
-nix build .#nixosConfigurations.system76.config.system.build.toplevel
+nix build .#nixosConfigurations.<host>.config.system.build.toplevel
 nix flake check --accept-flake-config --no-build --offline
 nix run .#generation-manager -- score   # target: 35/35
 ```
+
+Use `nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames` to enumerate the host names available in the current checkout.
 
 ## Next Steps
 

--- a/docs/architecture/06-reference.md
+++ b/docs/architecture/06-reference.md
@@ -27,11 +27,13 @@ nix flake check --accept-flake-config --no-build --offline
 
 ### Build Commands
 
-| Command                                                                 | Purpose                          |
-| ----------------------------------------------------------------------- | -------------------------------- |
-| `nix build .#nixosConfigurations.system76.config.system.build.toplevel` | Build System76 host closure      |
-| `./build.sh`                                                            | Full validation + deployment     |
-| `./build.sh --skip-all`                                                 | Skip validation (emergency only) |
+| Command                                                                                  | Purpose                                               |
+| ---------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| `nix build .#nixosConfigurations.<host>.config.system.build.toplevel`                    | Build any host closure (substitute `<host>`)          |
+| `nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames` | List the host names available in the current checkout |
+| `./build.sh`                                                                             | Full validation + deployment                          |
+| `./build.sh --host <name>`                                                               | Target a specific host                                |
+| `./build.sh --skip-all`                                                                  | Skip validation (emergency only)                      |
 
 ## Troubleshooting
 
@@ -55,9 +57,9 @@ nix eval --accept-flake-config --json .#nixosModules --apply builtins.attrNames
 nix eval --accept-flake-config --json .#homeManagerModules --apply builtins.attrNames
 nix eval --accept-flake-config --json .#homeManagerModules.apps --apply builtins.attrNames
 
-# Evaluate specific host options
-nix eval .#nixosConfigurations.system76.config.boot.loader
-nix eval .#nixosConfigurations.system76.config.system.build.toplevel
+# Evaluate specific host options (substitute the host name)
+nix eval .#nixosConfigurations.<host>.config.boot.loader
+nix eval .#nixosConfigurations.<host>.config.system.build.toplevel
 ```
 
 ## External Tooling
@@ -84,14 +86,15 @@ Available after `nix develop`:
 
 ## Glossary
 
-| Term                    | Definition                                                                                       |
-| ----------------------- | ------------------------------------------------------------------------------------------------ |
-| **Aggregator**          | Attribute subtree (e.g., `flake.nixosModules.apps`) that collects modules merged via flake-parts |
-| **Deferred module**     | Value of type `lib.types.deferredModule`, allowing later import into submodule fixpoints         |
-| **Dendritic Pattern**   | Repository pattern coupling import-tree auto-discovery with aggregator-based composition         |
-| **import-tree**         | Function that recursively imports all `.nix` files under a directory                             |
-| **perSystem**           | flake-parts construct yielding system-specific attrsets (packages, dev shells, checks)           |
-| **Two-Context Problem** | Issue where `config.flake.*` and `config.home.*` exist in different evaluation contexts          |
+| Term                    | Definition                                                                                                                                                                       |
+| ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Aggregator**          | Attribute subtree (e.g., `flake.nixosModules.apps`) that collects modules merged via flake-parts                                                                                 |
+| **Custom module args**  | Per-host arguments injected via `_module.args` (`metaOwner`, `secretsRoot`, `inputs`, `nixosAppHelpers`); see [Module Authoring](02-module-authoring.md#custom-module-arguments) |
+| **Deferred module**     | Value of type `lib.types.deferredModule`, allowing later import into submodule fixpoints                                                                                         |
+| **Dendritic Pattern**   | Repository pattern coupling import-tree auto-discovery with aggregator-based composition                                                                                         |
+| **import-tree**         | Function that recursively imports all `.nix` files under a directory                                                                                                             |
+| **perSystem**           | flake-parts construct yielding system-specific attrsets (packages, dev shells, checks)                                                                                           |
+| **Two-Context Problem** | Issue where `config.flake.*` and `config.home.*` exist in different evaluation contexts                                                                                          |
 
 ## Resource Links
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -31,3 +31,10 @@ This directory explains how the Dendritic Pattern organizes this NixOS configura
 - [Custom Packages Style Guide](../guides/custom-packages-style-guide.md) -- building packages under `packages/`
 - [Stylix Integration](../guides/stylix-integration.md) -- theming constraints
 - [SOPS Usage](../sops/README.md) -- secrets management
+
+## Per-Host Notes
+
+Architecture docs describe shared patterns; host-specific notes live in their own directories:
+
+- [docs/system76/](../system76/) -- system76 hardware reference, configuration walk-through, troubleshooting
+- [docs/tpnix/](../tpnix/) -- tpnix implementation notes

--- a/docs/guides/tray-icon-theming.md
+++ b/docs/guides/tray-icon-theming.md
@@ -1,11 +1,12 @@
 # Tray Icon Theming (i3/i3bar)
 
-This guide documents how tray icons are managed on this host and how to make
-them match the active theme.
+This guide documents how tray icons are managed on each i3-based host in this
+repo and how to make them match the active theme.
 
-Scope: single host (`system76`) and single user (`vx`).
+Scope: any host that enables `gui.i3` (currently `system76` and `tpnix`) and
+the `vx` user.
 
-## Runtime Model on This Host
+## Runtime Model
 
 Tray management is done by `i3bar`, not by `i3status-rust`:
 
@@ -87,9 +88,9 @@ Fix by either:
    (`overrideAttrs`, wrapper, patched resources), not direct `/nix/store` edits.
 5. Refresh icon caches and restart the tray app (or relogin/restart i3bar).
 
-For this host, keep XEmbed-compatible launch mode for native tray apps (for
-example plain `nm-applet`) and use the SNI bridge for apps that only publish
-StatusNotifierItem icons.
+On the i3-based hosts, keep XEmbed-compatible launch mode for native tray apps
+(for example plain `nm-applet`) and use the SNI bridge for apps that only
+publish StatusNotifierItem icons.
 
 ## Verification Commands
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,7 +13,7 @@
 - [architecture/04-home-manager.md](architecture/04-home-manager.md)
   - Covers the flake.homeManagerModules namespace, app loading mechanism, and secrets integration for user configuration.
 - [architecture/05-host-composition.md](architecture/05-host-composition.md)
-  - Explains host definition under configurations.nixos, the System76 host structure, and how to add new hosts.
+  - Explains host definition under configurations.nixos, the per-host file structure under `modules/<host>/`, host-conditional helpers, and validation.
 - [architecture/06-reference.md](architecture/06-reference.md)
   - Quick reference for validation commands, troubleshooting common issues, introspection via REPL, and glossary of terms.
 

--- a/modules/meta/flake-output.nix
+++ b/modules/meta/flake-output.nix
@@ -72,7 +72,7 @@
           };
         };
         default = { };
-        description = "Aggregated Home Manager modules for the single System76 host";
+        description = "Aggregated Home Manager modules consumed by every NixOS host's `home-manager.sharedModules`";
       };
 
       # Cybersecurity-tooling NixOS modules. Declared with attrsOf

--- a/modules/meta/flake-output.nix
+++ b/modules/meta/flake-output.nix
@@ -72,7 +72,7 @@
           };
         };
         default = { };
-        description = "Aggregated Home Manager modules consumed by every NixOS host's `home-manager.sharedModules`";
+        description = "Aggregated Home Manager modules loaded into each NixOS host's `home-manager.users.<owner>.imports` via `modules/home-manager/nixos.nix`";
       };
 
       # Cybersecurity-tooling NixOS modules. Declared with attrsOf


### PR DESCRIPTION
## Summary

Verification against the codebase surfaced four issues this refresh resolves:

- 02 quoted `experimental-features` without `recursive-nix`, and 05 quoted a nonexistent `nixos-hardware.nixosModules.system76-darp6` import. Both are corrected against `modules/base/nix-settings.nix` and `modules/system76/imports.nix`.
- 05 declared `system76` as the single managed host, but `configurations.nixos.tpnix` is fully wired in `modules/tpnix/imports.nix`. The single-host policy block is removed; per-host structure tables and a host-conditional helper section using `flake.lib.nixos.hosts.<hostname>` replace it.
- Only `flake.lib.nixos` was documented out of the eight `flake.lib.*` sub-namespaces declared in `modules/meta/flake-output.nix`. 03 now lists all of them with type and purpose.
- The per-host `_module.args` contract (`metaOwner`, `secretsRoot`, `inputs`, `nixosAppHelpers`) was referenced by examples but never explained. 02 documents it, and 06 cross-references it from the glossary.

Build/eval examples throughout switch to `<host>` placeholders so the docs do not encode a fixed host list. README and `docs/index.md` link to host-specific notes under `docs/system76/` and `docs/tpnix/` and update the entry-5 description.

## Test plan

- [x] `pre-commit run --files docs/architecture/*.md docs/architecture/README.md docs/index.md` (treefmt + typos pass)
- [x] `rg -n "system76-darp6|Single-Host Repository Policy" docs/architecture/` returns no matches
- [x] `rg -n "(\.nix|\.md):[0-9]+(-[0-9]+)?" docs/architecture/ docs/index.md` returns no matches (no path:line citations)
- [x] `rg -ni "(both hosts|two hosts|only one host|only manages|the only.*host|both system76.*and.*tpnix)" docs/architecture/` returns no matches (no hardcoded host counts)
- [x] Each updated doc reads end-to-end with cross-links resolving