### PR TITLE
fix(cutter): re-enable after nixpkgs ships shiboken6 6.11 patch

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1049,11 +1049,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1777946660,
-        "narHash": "sha256-iw3XDIG6xxk+AZTcawCLHf6i9i4tXRzLZEoV9xhRToQ=",
+        "lastModified": 1778124196,
+        "narHash": "sha256-pYEytCNic/czazbV9r3tbQ6BZzqRBg/41x2dIC5ymOo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc57abace07689cfd34203aa5fb4027514895987",
+        "rev": "68a8af93ff4297686cb68880845e61e5e2e41d92",
         "type": "github"
       },
       "original": {

--- a/modules/devshell/pentesting.nix
+++ b/modules/devshell/pentesting.nix
@@ -88,20 +88,18 @@ let
     }
     { name = "wappalyzer"; }
     # ghidra: installed system-wide via programs.ghidra.extended
-    # cutter: disabled — upstream cutter 2.4.1 fails to build against Qt/PySide6 6.11.
-    # Tracking: https://github.com/Bad3r/nixos/issues/156
-    # {
-    #   name = "cutter";
-    #   desktop = {
-    #     desktopName = "Cutter (Pentesting Shell)";
-    #     comment = "Reverse engineering platform powered by rizin";
-    #     categories = [
-    #       "Development"
-    #       "Security"
-    #     ];
-    #     icon = "cutter";
-    #   };
-    # }
+    {
+      name = "cutter";
+      desktop = {
+        desktopName = "Cutter (Pentesting Shell)";
+        comment = "Reverse engineering platform powered by rizin";
+        categories = [
+          "Development"
+          "Security"
+        ];
+        icon = "cutter";
+      };
+    }
     {
       name = "iaito";
       desktop = {
@@ -184,7 +182,7 @@ in
           john
           sqlmap
           hashcat
-          # cutter # disabled — see https://github.com/Bad3r/nixos/issues/156
+          cutter
           iaito
           radare2
           rizin

--- a/modules/devshell/pentesting.nix
+++ b/modules/devshell/pentesting.nix
@@ -29,6 +29,7 @@ let
       command = "loader";
       package = "burpsuitepro";
       wrapperOnly = true;
+      prefixOnly = true;
     }
     {
       # Raw burpsuitepro package for direct access (burpsuitepro, loader commands)
@@ -51,6 +52,7 @@ let
     }
     {
       name = "charles";
+      prefixOnly = true;
       desktop = {
         desktopName = "Charles Proxy (Pentesting Shell)";
         comment = "Debug HTTP(S) traffic using Charles via the pentesting dev shell";
@@ -67,10 +69,22 @@ let
       name = "nmap";
       prefixOnly = true; # Avoid conflict with system nmap
     }
-    { name = "aircrack-ng"; }
-    { name = "john"; }
-    { name = "sqlmap"; }
-    { name = "metasploit"; }
+    {
+      name = "aircrack-ng";
+      prefixOnly = true;
+    }
+    {
+      name = "john";
+      prefixOnly = true;
+    }
+    {
+      name = "sqlmap";
+      prefixOnly = true;
+    }
+    {
+      name = "metasploit";
+      prefixOnly = true;
+    }
     {
       # Raw metasploit package for msfconsole, msfvenom, etc.
       name = "metasploit-framework";
@@ -81,15 +95,20 @@ let
       name = "msfconsole";
       package = "metasploit-framework";
       wrapperOnly = true;
+      prefixOnly = true;
     }
     {
       name = "hashcat";
       prefixOnly = true; # Avoid conflict with system hashcat
     }
-    { name = "wappalyzer"; }
+    {
+      name = "wappalyzer";
+      prefixOnly = true;
+    }
     # ghidra: installed system-wide via programs.ghidra.extended
     {
       name = "cutter";
+      prefixOnly = true;
       desktop = {
         desktopName = "Cutter (Pentesting Shell)";
         comment = "Reverse engineering platform powered by rizin";
@@ -102,6 +121,7 @@ let
     }
     {
       name = "iaito";
+      prefixOnly = true;
       desktop = {
         desktopName = "Iaito (Pentesting Shell)";
         comment = "Official graphical interface for radare2";
@@ -112,14 +132,27 @@ let
         icon = "iaito";
       };
     }
-    { name = "radare2"; }
-    { name = "rizin"; }
-    { name = "mitmproxy"; }
-    { name = "whatweb"; }
+    {
+      name = "radare2";
+      prefixOnly = true;
+    }
+    {
+      name = "rizin";
+      prefixOnly = true;
+    }
+    {
+      name = "mitmproxy";
+      prefixOnly = true;
+    }
+    {
+      name = "whatweb";
+      prefixOnly = true;
+    }
     # frida-tools: installed system-wide via programs.frida-tools.extended
     # jadx: installed system-wide via programs.jadx.extended
     {
       name = "malimite";
+      prefixOnly = true;
       desktop = {
         desktopName = "Malimite (Pentesting Shell)";
         comment = "iOS and macOS binary analysis tool";

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -89,7 +89,7 @@
       "csharp-ls".extended.enable = lib.mkOverride 1100 false;
       curl.extended.enable = lib.mkOverride 1100 true;
       curlie.extended.enable = lib.mkOverride 1100 true;
-      cutter.extended.enable = lib.mkOverride 1100 false; # Disabled — see https://github.com/Bad3r/nixos/issues/156
+      cutter.extended.enable = lib.mkOverride 1100 true;
       "czkawka-cli".extended.enable = lib.mkOverride 1100 true;
       "czkawka-gui".extended.enable = lib.mkOverride 1100 true;
       ddrescue.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -74,7 +74,7 @@
       "csharp-ls".extended.enable = lib.mkOverride 1100 false;
       curl.extended.enable = lib.mkOverride 1100 true;
       curlie.extended.enable = lib.mkOverride 1100 true;
-      cutter.extended.enable = lib.mkOverride 1100 false; # Disabled — see https://github.com/Bad3r/nixos/issues/156
+      cutter.extended.enable = lib.mkOverride 1100 true;
       "czkawka-cli".extended.enable = lib.mkOverride 1100 false;
       "czkawka-gui".extended.enable = lib.mkOverride 1100 false;
       ddrescue.extended.enable = lib.mkOverride 1100 false;


### PR DESCRIPTION
## Summary

- Bumps the \`nixpkgs\` flake input from \`bc57abace0\` to \`68a8af93ff\` to pick up nixpkgs commit \`8545e0c2133\` (\"cutter: fix build with shiboken 6.11\"), which patches \`cutter\` 2.4.1 with \`rizinorg/cutter@07fea9c\`.
- Restores the \`cutter\` entry in \`modules/devshell/pentesting.nix\` (\`toolDefs\` and \`toolPackageMap\`) so the auto-derived \`packages/pentest-cutter\` check evaluates again.
- Flips \`programs.cutter.extended.enable\` from \`false\` to \`true\` on \`system76\` and \`tpnix\`.
- Sets \`prefixOnly = true\` on every non-\`devshellOnly\` entry in the pentesting devshell (including the \`wrapperOnly\` \`burpsuite-loader\` and \`msfconsole\` entries) so the Home Manager wrappers expose only the explicit \`pentest-<name>\` form. Without this, hosts that also enable the real package via \`programs.<name>.extended\` (cutter on \`system76\`/\`tpnix\`, etc.) had the unprefixed wrapper shadow the system binary, so \`cutter\` and its desktop entry resolved through \`nix shell .#pentest-cutter\` and lazy-rebuilt instead of running the already-installed system package.

The shiboken6 6.11 toolchain renames the generated type-index identifier from \`SBK_CUTTERPLUGIN_IDX\` (upper case) to \`SBK_CutterPlugin_IDX\` (camel case). Without the patch, \`cutter\` 2.4.1 fails to compile with:

\`\`\`
src/plugins/PluginManager.cpp:221:77: error: use of undeclared identifier 'SBK_CUTTERPLUGIN_IDX'
\`\`\`

Closes #156.

## Test plan

- [x] \`nix flake update nixpkgs\` (lockfile diff limited to \`nixpkgs\` node)
- [x] \`nix fmt\` (no diff)
- [x] \`nix flake check --accept-flake-config --no-build\` (\`all checks passed!\`)
- [x] \`nix build .#packages.x86_64-linux.pentest-cutter\` (\`/nix/store/9aijz59ilk9y56a4civd66fy0jbda5wv-cutter-2.4.1\`)
- [ ] \`nix build .#nixosConfigurations.system76.config.system.build.toplevel\` (skipped per maintainer request; covered by CI)
- [ ] \`nix build .#nixosConfigurations.tpnix.config.system.build.toplevel\` (skipped per maintainer request; covered by CI)