### PR TITLE
fix(ci): restore id-token write for claude-code-action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,6 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/claude-mention-assistant.yml
+++ b/.github/workflows/claude-mention-assistant.yml
@@ -35,6 +35,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
+      id-token: write
       actions: read
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary

- PR #188 dropped `id-token: write` from `claude-code-review.yml` and `claude-mention-assistant.yml` on the assumption that `claude_code_oauth_token` made OIDC unnecessary. The action's runtime fetches an OIDC token regardless, and the workflow now fails on every PR with `Action failed with error: Could not fetch an OIDC token. Did you remember to add 'id-token: write' to your workflow permissions?`. Reference: run 25514693203, job 74882534061, on PR #189.
- Restores `id-token: write` on both workflows. No other changes.

## Test plan

- [x] `pre-commit run --files .github/workflows/claude-code-review.yml .github/workflows/claude-mention-assistant.yml` (actionlint, treefmt, typos, yamllint)
- [ ] After merge: confirm the next PR triggers a successful Claude review run (no OIDC error).