### PR TITLE
feat(system76): enable cloudflare-warp (headless) and cloudflared daemons

### DIFF
--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -55,7 +55,10 @@ let
     };
 in
 {
-  nixpkgs.allowedUnfreePackages = [ "cloudflare-warp-headless" ];
+  nixpkgs.allowedUnfreePackages = [
+    "cloudflare-warp"
+    "cloudflare-warp-headless"
+  ];
 
   flake.nixosModules.apps.cloudflare-warp = CloudflareWarpModule;
 }

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -1,5 +1,6 @@
 /*
   Package: cloudflare-warp
+  Variant: headless (warp-cli + warp-svc; no GUI taskbar, no XDG autostart)
   Description: Cloudflare WARP client delivering encrypted consumer VPN and Zero Trust connectivity.
   Homepage: https://developers.cloudflare.com/warp-client/
   Documentation: https://developers.cloudflare.com/warp-client/get-started/linux/
@@ -34,7 +35,18 @@ let
           description = "Whether to enable cloudflare-warp.";
         };
 
-        package = lib.mkPackageOption pkgs "cloudflare-warp" { };
+        package = lib.mkOption {
+          type = lib.types.package;
+          default = pkgs.cloudflare-warp.override { headless = true; };
+          defaultText = lib.literalExpression "pkgs.cloudflare-warp.override { headless = true; }";
+          description = ''
+            Cloudflare WARP package. Defaults to the headless build, which
+            ships only `warp-cli` and `warp-svc` and omits the GUI taskbar,
+            `etc/xdg/autostart/com.cloudflare.WarpTaskbar.desktop`, and the
+            `share/systemd/user/warp-taskbar.service` user unit. Set to
+            `pkgs.cloudflare-warp` to install the GUI variant.
+          '';
+        };
       };
 
       config = lib.mkIf cfg.enable {
@@ -43,7 +55,7 @@ let
     };
 in
 {
-  nixpkgs.allowedUnfreePackages = [ "cloudflare-warp" ];
+  nixpkgs.allowedUnfreePackages = [ "cloudflare-warp-headless" ];
 
   flake.nixosModules.apps.cloudflare-warp = CloudflareWarpModule;
 }

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -41,7 +41,8 @@ let
           defaultText = lib.literalExpression "pkgs.cloudflare-warp.override { headless = true; }";
           description = ''
             Cloudflare WARP package. Defaults to the headless build, which
-            ships only `warp-cli` and `warp-svc` and omits the GUI taskbar,
+            ships `warp-cli`, `warp-svc`, `warp-dex`, and `warp-diag` and
+            omits the GUI taskbar,
             `etc/xdg/autostart/com.cloudflare.WarpTaskbar.desktop`, and the
             `share/systemd/user/warp-taskbar.service` user unit. Set to
             `pkgs.cloudflare-warp` to install the GUI variant.

--- a/modules/system76/services.nix
+++ b/modules/system76/services.nix
@@ -30,11 +30,13 @@ _: {
           '';
         };
 
-        # Disable samples and network clients until configured on this host
-        cloudflared.enable = lib.mkForce false;
-        cloudflare-warp.enable = lib.mkForce false;
+        cloudflared.enable = true;
 
-        # Disable printing by default on this host; remove Samsung driver
+        cloudflare-warp = {
+          enable = true;
+          package = pkgs.cloudflare-warp.override { headless = true; };
+        };
+
         printing = {
           enable = lib.mkForce false;
           drivers = with pkgs; [

--- a/modules/tpnix/services.nix
+++ b/modules/tpnix/services.nix
@@ -29,11 +29,8 @@ _: {
           '';
         };
 
-        # Disable samples and network clients until configured on this host
         cloudflared.enable = lib.mkForce false;
-        cloudflare-warp.enable = lib.mkForce false;
 
-        # Disable printing by default on this host; remove Samsung driver
         printing = {
           enable = lib.mkForce false;
           drivers = with pkgs; [


### PR DESCRIPTION
## Summary

Two related changes that together make `warp-cli` actually work on
`system76` while keeping the WARP GUI taskbar from autostarting.

1. **modules/apps/cloudflare-warp.nix**: default
   `programs.cloudflare-warp.extended.package` now resolves to
   `pkgs.cloudflare-warp.override { headless = true; }`. This drops
   `bin/warp-taskbar`, `lib/systemd/user`, `etc/`, `share/applications`,
   and `share/icons` from the package output, so installing it via
   `environment.systemPackages` no longer plants
   `etc/xdg/autostart/com.cloudflare.WarpTaskbar.desktop` or
   `share/systemd/user/warp-taskbar.service`. `nixpkgs.allowedUnfreePackages`
   is retargeted at `cloudflare-warp-headless` to match the headless
   build's `pname` (the global `allowUnfreePredicate` in
   `modules/meta/nixpkgs-allowed-unfree.nix` keys off
   `lib.getName pkg`).

2. **modules/system76/services.nix**:
   - `services.cloudflare-warp.enable` flipped from `lib.mkForce false`
     to `true` so `warp-svc` registers and `warp-cli` can connect. The
     module's `package` is pinned to
     `pkgs.cloudflare-warp.override { headless = true; }` so the
     upstream GUI default does not re-plant the taskbar autostart that
     change (1) just removed.
   - `services.cloudflared.enable` flipped from `lib.mkForce false`
     to `true`. Without `services.cloudflared.tunnels`, no per-tunnel
     units are generated; `cloudflared` is already on PATH via
     `cloudflared.extended.enable = true` in
     `modules/system76/apps-enable.nix`.

3. **modules/tpnix/services.nix**: keeps
   `cloudflared.enable = lib.mkForce false` and drops the now-redundant
   `cloudflare-warp.enable = lib.mkForce false` guard. That host has
   the package install disabled in `modules/tpnix/apps-enable.nix`, so
   the upstream-default `false` already keeps the daemon off.

Header-only comments in both `services.nix` files that just restated
the configuration blocks below them are removed.

## Firewall

The upstream `services.cloudflare-warp` module sets
`openFirewall = true` by default and adds UDP 2408 to
`networking.firewall.allowedUDPPorts` automatically. No edits needed in
`modules/system76/network.nix` or `modules/tpnix/network.nix`. Verified
by inspecting the generated `firewall-start` script in the system76
closure:

```
ip46tables -A nixos-fw -p udp --dport 2408 -j nixos-fw-accept
```

## Trade-off

The headless build also drops the
`x-scheme-handler/com.cloudflare.warp` desktop item, so browser-driven
team enrollment URLs no longer hand off to a terminal. Authenticate via
`warp-cli teams-enroll <team>` or `warp-cli registration token <token>`
instead.

## Test plan

- [x] `nix fmt`
- [x] `nix build .#nixosConfigurations.system76.config.system.build.toplevel`
- [x] `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel`
- [x] system76 closure has
  `etc/systemd/system/multi-user.target.wants/cloudflare-warp.service`
  with `ExecStart=` pointing at `cloudflare-warp-headless-2026.3.846.0/bin/warp-svc`.
- [x] system76 `firewall-start` opens UDP 2408 unconditionally.
- [x] system76 closure has no `bin/warp-taskbar`, no
  `etc/xdg/autostart/com.cloudflare.WarpTaskbar.desktop`, no
  `share/systemd/user/warp-taskbar.service`.
- [x] tpnix closure has no `cloudflare-warp.service`, no
  `cloudflared-tunnel-*.service`, and no UDP 2408 firewall rule.
- [ ] After activation on system76: `systemctl status cloudflare-warp.service`
  reports `active (running)`, `warp-cli status` connects, no
  `warp-taskbar` process appears after login.