### PR TITLE
fix(i3wm): patch snixembed icon resolution

### DIFF
--- a/docs/guides/tray-icon-theming.md
+++ b/docs/guides/tray-icon-theming.md
@@ -30,17 +30,22 @@ The active tray remains XEmbed-based (hosted by `i3bar`). `snixembed` provides
 the SNI watcher bridge so apps that only export StatusNotifierItem icons can
 still show up in the `i3bar` tray.
 
-Live inspection of tray child windows under `i3bar` shows `_XEMBED_INFO` for
-native XEmbed tray apps such as:
+Live inspection of tray child windows under `i3bar` distinguishes two groups.
+
+Native XEmbed tray apps (own window, `_XEMBED_INFO` set on the application's
+window):
 
 - `nm-applet`
 - `udiskie`
-- `flameshot`
 - `steam`
 - `ktailctl`
 
-SNI-only apps such as ProtonVPN should expose `org.kde.StatusNotifierItem-*` on
-the user bus and be proxied into that same XEmbed tray by `snixembed`.
+SNI items proxied through `snixembed` (each has a `snixembed` child window
+under `i3bar` whose `WM_CLASS` is the SNI `Id`):
+
+- `flameshot` (`Id: flameshot`, `IconName: flameshot-tray`)
+- `Remmina` (`Id: remmina-icon`, `IconName: org.remmina.Remmina-status`)
+- `ProtonVPN`
 
 ## Multi-Monitor Behavior
 
@@ -50,14 +55,15 @@ across all connected outputs is not supported in a reliable way.
 
 ## Protocol/Themeability Classification
 
-| App       | Current Protocol | Themeability Risk | Notes                                                                                         |
-| --------- | ---------------- | ----------------- | --------------------------------------------------------------------------------------------- |
-| nm-applet | XEmbed           | Low-Medium        | Running without `--indicator`; links Ayatana indicator libs, but current tray item is XEmbed. |
-| udiskie   | XEmbed           | Low               | Uses icon theme name lookup (`Gtk.IconTheme`) and supports custom `icon_names`.               |
-| flameshot | XEmbed           | Medium            | Qt tray icon path supports theme lookup and also bundles fallback resources.                  |
-| steam     | XEmbed           | High              | Tray icon behavior is app-controlled and often not fully theme-driven.                        |
-| ktailctl  | XEmbed           | Medium            | Qt app; verify whether icon comes from theme name or bundled resource.                        |
-| ProtonVPN | SNI via bridge   | Medium            | Exports a StatusNotifierItem; `snixembed` proxies it into the XEmbed tray hosted by `i3bar`.  |
+| App       | Current Protocol | Themeability Risk | Notes                                                                                                         |
+| --------- | ---------------- | ----------------- | ------------------------------------------------------------------------------------------------------------- |
+| nm-applet | XEmbed           | Low-Medium        | Running without `--indicator`; links Ayatana indicator libs, but current tray item is XEmbed.                 |
+| udiskie   | XEmbed           | Low               | Uses icon theme name lookup (`Gtk.IconTheme`) and supports custom `icon_names`.                               |
+| steam     | XEmbed           | High              | Tray icon behavior is app-controlled and often not fully theme-driven.                                        |
+| ktailctl  | XEmbed           | Medium            | Qt app; verify whether icon comes from theme name or bundled resource.                                        |
+| flameshot | SNI via bridge   | Medium            | Qt SNI; advertises IconName `flameshot-tray`. Resolved by `snixembed` against the active Gtk theme.           |
+| Remmina   | SNI via bridge   | Medium            | Ayatana SNI; advertises IconName `org.remmina.Remmina-status`. Icon files ship in `hicolor` (status context). |
+| ProtonVPN | SNI via bridge   | Medium            | Exports a StatusNotifierItem; `snixembed` proxies it into the XEmbed tray hosted by `i3bar`.                  |
 
 ## Broken Launcher Icons Found
 
@@ -91,6 +97,26 @@ Fix by either:
 On the i3-based hosts, keep XEmbed-compatible launch mode for native tray apps
 (for example plain `nm-applet`) and use the SNI bridge for apps that only
 publish StatusNotifierItem icons.
+
+## Bridge Patches
+
+`snixembed` is pinned to upstream 0.3.3 in nixpkgs. The `customPackages`
+overlay (`modules/base/custom-packages-overlay.nix`) layers
+`packages/snixembed/icon-resolution.patch` on top. The patch addresses two
+defects in `src/proxyicon.vala`:
+
+1. `set_icon_pixmap` iterates the ARGB->RGBA conversion with `i += 3` over a
+   4-byte buffer. The first pixel converts in place, then every later
+   iteration overwrites the previous pixel's alpha with the next pixel's
+   data. Fix: stride 4.
+2. `set_icon` falls through to the (now-broken) pixmap path whenever
+   `theme.has_icon(name)` returns false, replacing the IconName with the
+   corrupted pixmap before Gtk's own fallback machinery can render it.
+   Fix: trust IconName when set, fall back to pixmap only when IconName is
+   empty.
+
+Drop the override once upstream `~steef/snixembed` ships a release past
+0.3.3 with the equivalent fixes.
 
 ## Verification Commands
 

--- a/docs/guides/tray-icon-theming.md
+++ b/docs/guides/tray-icon-theming.md
@@ -109,11 +109,14 @@ defects in `src/proxyicon.vala`:
    4-byte buffer. The first pixel converts in place, then every later
    iteration overwrites the previous pixel's alpha with the next pixel's
    data. Fix: stride 4.
-2. `set_icon` falls through to the (now-broken) pixmap path whenever
-   `theme.has_icon(name)` returns false, replacing the IconName with the
-   corrupted pixmap before Gtk's own fallback machinery can render it.
-   Fix: trust IconName when set, fall back to pixmap only when IconName is
-   empty.
+2. `set_icon` falls through to the pixmap path whenever
+   `theme.has_icon(name)` returns false, even when the SNI item supplies no
+   `IconPixmap`. Without pixmap data the fall-through replaces the named
+   icon Gtk would render with `set_from_pixbuf(null)`. Fix: widen the
+   early-return guard to `theme.has_icon(name) || item.icon_pixmap == null
+   || item.icon_pixmap.length == 0`. The pixmap path stays reachable when
+   the theme misses AND the SNI item supplies real pixmap bytes, so apps
+   that depend on the bitmap fallback continue to work.
 
 Drop the override once upstream `~steef/snixembed` ships a release past
 0.3.3 with the equivalent fixes.

--- a/modules/base/custom-packages-overlay.nix
+++ b/modules/base/custom-packages-overlay.nix
@@ -98,6 +98,26 @@ _: {
       NODE_GYP = "${final."node-gyp"}/bin/node-gyp";
     });
 
+    # snixembed 0.3.3 (nixpkgs pin) ships two icon-resolution defects in
+    # `src/proxyicon.vala`:
+    #   * `set_icon_pixmap` iterates the ARGB->RGBA conversion with
+    #     `i += 3` over a 4-byte-per-pixel buffer, garbling every pixel
+    #     past the first.
+    #   * `set_icon` falls through to that broken pixmap path whenever
+    #     `theme.has_icon(name)` returns false, so a valid IconName gets
+    #     replaced by the corrupted pixmap before Gtk can render it.
+    # PR #103 introduced this bridge to surface ProtonVPN's
+    # StatusNotifierItem in `i3bar`. The same code path now renders
+    # other SNI items such as flameshot ("flameshot-tray") and Remmina
+    # ("org.remmina.Remmina-status") as identical blank squares.
+    # Drop this override once upstream ships a release past 0.3.3 with the
+    # fix.
+    snixembed = prev.snixembed.overrideAttrs (old: {
+      patches = (old.patches or [ ]) ++ [
+        ../../packages/snixembed/icon-resolution.patch
+      ];
+    });
+
     # i3 window manager utilities
     i3-focus-or-launch = final.callPackage ../../packages/i3-focus-or-launch { };
     i3-scratchpad-show-or-create = final.callPackage ../../packages/i3-scratchpad-show-or-create { };

--- a/modules/base/custom-packages-overlay.nix
+++ b/modules/base/custom-packages-overlay.nix
@@ -102,10 +102,14 @@ _: {
     # `src/proxyicon.vala`:
     #   * `set_icon_pixmap` iterates the ARGB->RGBA conversion with
     #     `i += 3` over a 4-byte-per-pixel buffer, garbling every pixel
-    #     past the first.
+    #     past the first. Fix: stride 4.
     #   * `set_icon` falls through to that broken pixmap path whenever
-    #     `theme.has_icon(name)` returns false, so a valid IconName gets
-    #     replaced by the corrupted pixmap before Gtk can render it.
+    #     `theme.has_icon(name)` returns false, even for SNI items that
+    #     publish no `IconPixmap`, replacing the named icon Gtk would
+    #     render with a corrupted pixmap. Fix: widen the early-return
+    #     guard so it also covers the no-pixmap case, leaving the
+    #     pixmap path reachable only when the theme misses AND the
+    #     SNI item supplied real pixmap bytes.
     # PR #103 introduced this bridge to surface ProtonVPN's
     # StatusNotifierItem in `i3bar`. The same code path now renders
     # other SNI items such as flameshot ("flameshot-tray") and Remmina

--- a/packages/snixembed/icon-resolution.patch
+++ b/packages/snixembed/icon-resolution.patch
@@ -1,0 +1,45 @@
+Fix two icon-resolution defects in src/proxyicon.vala (snixembed 0.3.3):
+
+  1. set_icon_pixmap iterates the ARGB->RGBA conversion with i += 3
+     over a 4-byte-per-pixel buffer. The first pixel converts in
+     place, then every subsequent iteration overwrites the previous
+     pixel's alpha with the next pixel's data, producing garbled
+     output for any pixmap larger than 1x1. Stride must be 4.
+
+  2. set_icon falls through to the (now-broken) pixmap path whenever
+     theme.has_icon(name) returns false. Gtk's set_from_icon_name has
+     its own fallback machinery and renders the named icon from the
+     active theme even when the upstream cache lookup misses. The
+     fall-through replaces a working named icon with the corrupted
+     pixmap. Trust IconName when set, and only fall back to pixmap
+     when the SNI item publishes no IconName.
+
+Reported against snixembed running on i3bar with the StatusNotifierItem
+items advertised by flameshot ("flameshot-tray") and Remmina
+("org.remmina.Remmina-status"): both rendered as identical blank squares
+before the patch.
+
+Upstream: https://git.sr.ht/~steef/snixembed (patches sent / pending).
+
+--- a/src/proxyicon.vala
++++ b/src/proxyicon.vala
+@@ -94,9 +94,7 @@
+             }
+
+             set_icon_name(name);
+-            if (theme.has_icon(name)) {
+-                return;
+-            }
++            return;
+         }
+
+         var pixmaps = item.icon_pixmap;
+@@ -115,7 +113,7 @@
+         var pixmap = pixmaps[0]; // TODO: choose the best one
+
+         // Convert from ARGB to RGBA
+-        for (int i = 0; i < pixmap.width * pixmap.height * 4; i += 3) {
++        for (int i = 0; i < pixmap.width * pixmap.height * 4; i += 4) {
+             var alpha = pixmap.data[i];
+             pixmap.data[i] = pixmap.data[i + 1];
+             pixmap.data[i + 1] = pixmap.data[i + 2];

--- a/packages/snixembed/icon-resolution.patch
+++ b/packages/snixembed/icon-resolution.patch
@@ -6,13 +6,15 @@ Fix two icon-resolution defects in src/proxyicon.vala (snixembed 0.3.3):
      pixel's alpha with the next pixel's data, producing garbled
      output for any pixmap larger than 1x1. Stride must be 4.
 
-  2. set_icon falls through to the (now-broken) pixmap path whenever
-     theme.has_icon(name) returns false. Gtk's set_from_icon_name has
-     its own fallback machinery and renders the named icon from the
-     active theme even when the upstream cache lookup misses. The
-     fall-through replaces a working named icon with the corrupted
-     pixmap. Trust IconName when set, and only fall back to pixmap
-     when the SNI item publishes no IconName.
+  2. set_icon falls through to the pixmap path whenever
+     theme.has_icon(name) returns false, even when the SNI item
+     supplies no IconPixmap data. In that case Gtk's
+     set_from_icon_name renders the named icon (or its own
+     missing-image fallback) and the pixmap branch corrupts that
+     output. Widen the early-return guard so we keep the named icon
+     when the theme resolves it OR when no pixmap data is available;
+     only fall through to set_icon_pixmap when the theme misses AND
+     the SNI item provides a real pixmap to render.
 
 Reported against snixembed running on i3bar with the StatusNotifierItem
 items advertised by flameshot ("flameshot-tray") and Remmina
@@ -23,18 +25,16 @@ Upstream: https://git.sr.ht/~steef/snixembed (patches sent / pending).
 
 --- a/src/proxyicon.vala
 +++ b/src/proxyicon.vala
-@@ -94,9 +94,7 @@
+@@ -94,7 +94,7 @@
              }
 
              set_icon_name(name);
 -            if (theme.has_icon(name)) {
--                return;
--            }
-+            return;
++            if (theme.has_icon(name) || item.icon_pixmap == null || item.icon_pixmap.length == 0) {
+                 return;
+             }
          }
-
-         var pixmaps = item.icon_pixmap;
-@@ -115,7 +113,7 @@
+@@ -115,7 +115,7 @@
          var pixmap = pixmaps[0]; // TODO: choose the best one
 
          // Convert from ARGB to RGBA


### PR DESCRIPTION
## Summary
- patch snixembed 0.3.3 via the `customPackages` overlay so flameshot and Remmina render their advertised icons in the i3bar tray instead of identical blank squares
- fix two upstream defects in `src/proxyicon.vala`: pixmap stride (`i += 3` over a 4-byte buffer) and `IconName` fall-through to the broken pixmap path
- correct `docs/guides/tray-icon-theming.md` so the protocol classification matches live introspection (flameshot and Remmina go through the bridge, not native XEmbed)

## Tracking
Upstream removal tracked in https://github.com/Bad3r/nixos/issues/194. Once upstream `~steef/snixembed` ships a release past 0.3.3 with equivalent fixes, the override entry, the patch file, and the **Bridge Patches** docs section all come out together; the tracker issue lists the exit criteria.

## Test plan
- [x] `nix develop -c pre-commit run --all-files --hook-stage manual`
- [x] `nix flake check --accept-flake-config --no-build --offline`
- [x] `nix build .#nixosConfigurations.system76.pkgs.snixembed` (patched store path: `/nix/store/xykyyplgycfv5v6dgvmlhv5i0wvfg3v2-snixembed-0.3.3`)
- [ ] `./build.sh --host system76`, then `systemctl --user restart snixembed`
- [ ] visual check: flameshot and Remmina show their proper icons in i3bar; nm-applet and udiskie remain unchanged