### PR TITLE
fix(snixembed): bundle librsvg + wrap with wrapGAppsHook3

### DIFF
--- a/modules/base/custom-packages-overlay.nix
+++ b/modules/base/custom-packages-overlay.nix
@@ -98,27 +98,45 @@ _: {
       NODE_GYP = "${final."node-gyp"}/bin/node-gyp";
     });
 
-    # snixembed 0.3.3 (nixpkgs pin) ships two icon-resolution defects in
-    # `src/proxyicon.vala`:
-    #   * `set_icon_pixmap` iterates the ARGB->RGBA conversion with
-    #     `i += 3` over a 4-byte-per-pixel buffer, garbling every pixel
-    #     past the first. Fix: stride 4.
-    #   * `set_icon` falls through to that broken pixmap path whenever
-    #     `theme.has_icon(name)` returns false, even for SNI items that
-    #     publish no `IconPixmap`, replacing the named icon Gtk would
-    #     render with a corrupted pixmap. Fix: widen the early-return
-    #     guard so it also covers the no-pixmap case, leaving the
-    #     pixmap path reachable only when the theme misses AND the
-    #     SNI item supplied real pixmap bytes.
-    # PR #103 introduced this bridge to surface ProtonVPN's
-    # StatusNotifierItem in `i3bar`. The same code path now renders
-    # other SNI items such as flameshot ("flameshot-tray") and Remmina
-    # ("org.remmina.Remmina-status") as identical blank squares.
-    # Drop this override once upstream ships a release past 0.3.3 with the
-    # fix.
+    # snixembed 0.3.3 (nixpkgs pin) renders SNI tray icons through GTK's
+    # `Gtk.StatusIcon`, which delegates raster decoding to gdk-pixbuf.
+    # Three defects compose into the symptom that flameshot
+    # ("flameshot-tray"), Remmina ("org.remmina.Remmina-status"), and
+    # ProtonVPN render as identical blank squares in `i3bar`:
+    #
+    #   1. `src/proxyicon.vala` `set_icon_pixmap` iterates the
+    #      ARGB->RGBA conversion with `i += 3` over a 4-byte-per-pixel
+    #      buffer, garbling every pixel after the first. Fix: stride 4.
+    #   2. Same file, `set_icon` falls through to that broken pixmap
+    #      path whenever `theme.has_icon(name)` returns false, even for
+    #      SNI items with no `IconPixmap`, replacing the named icon Gtk
+    #      would render with a corrupted pixmap. Fix: widen the
+    #      early-return guard so the pixmap path is reachable only when
+    #      the theme misses AND the SNI item supplied real pixmap bytes.
+    #   3. The upstream Nix package builds against gtk3 + libdbusmenu
+    #      without `wrapGAppsHook3` and without `librsvg` in scope, so
+    #      `GDK_PIXBUF_MODULE_FILE` is unset at runtime and gdk-pixbuf
+    #      lacks the SVG loader. Modern icon themes (Qogir, Adwaita,
+    #      Papirus, hicolor) ship status/panel icons exclusively as SVG;
+    #      gdk-pixbuf cannot decode them and Gtk falls back to
+    #      `image-missing`, which is the actual symptom seen on this
+    #      host. Fix: wrap with `wrapGAppsHook3` and add `librsvg` so
+    #      the resulting `GDK_PIXBUF_MODULE_FILE` cache registers
+    #      `libpixbufloader-svg.so`.
+    #
+    # PR #103 introduced this bridge for ProtonVPN; PR #193 added the
+    # source patch for items 1 + 2; this entry adds item 3. Drop the
+    # full override once upstream ships a release past 0.3.3 with both
+    # the source fixes and the librsvg dependency in place.
     snixembed = prev.snixembed.overrideAttrs (old: {
       patches = (old.patches or [ ]) ++ [
         ../../packages/snixembed/icon-resolution.patch
+      ];
+      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [
+        final.wrapGAppsHook3
+      ];
+      buildInputs = (old.buildInputs or [ ]) ++ [
+        final.librsvg
       ];
     });
 


### PR DESCRIPTION
## Summary
- PR #193 fixed two source defects in `snixembed` 0.3.3 but icons remain blank squares after deploy
- Real root cause confirmed via `GTK_DEBUG=icontheme`: snixembed has **no SVG loader** at runtime. The upstream nixpkgs derivation never wraps the binary and never pulls `librsvg`, so `GDK_PIXBUF_MODULE_FILE` is unset and gdk-pixbuf cannot decode SVG. Modern icon themes ship status and panel icons as SVG only, so every named lookup ends in `image-missing`.
- Add `wrapGAppsHook3` + `librsvg` to the existing override so the wrapper sets `GDK_PIXBUF_MODULE_FILE` to a `loaders.cache` that registers `libpixbufloader-svg.so`.

## Evidence

```
look up icon dir /etc/profiles/per-user/vx/share/icons/Qogir-Dark/22/panel
get icon suffix (cached): 2          # cache says SVG hit
...
looking up icon image-missing for scale 1   # but the file cannot be decoded
```

`/proc/$pid/environ` for the unwrapped snixembed shows no `GDK_PIXBUF_MODULE_FILE`. After this change the wrapped binary embeds `--set GDK_PIXBUF_MODULE_FILE /nix/store/.../librsvg-2.61.4/lib/gdk-pixbuf-2.0/2.10.0/loaders.cache`.

## Test plan
- [x] `nix develop -c pre-commit run --files modules/base/custom-packages-overlay.nix --hook-stage manual`
- [x] `nix flake check --accept-flake-config --no-build --offline`
- [x] `nix build .#nixosConfigurations.system76.pkgs.snixembed` produces `/nix/store/0i8phgxq14ixi69xra0rjhb4pfpbkzxw-snixembed-0.3.3` with a `bin/snixembed` wrapper plus `bin/.snixembed-wrapped`; `strings` on the wrapper shows the new env vars
- [x] `GDK_PIXBUF_MODULE_FILE` confirmed in the wrapped process environment
- [ ] `./build.sh --host system76`, then `systemctl --user restart snixembed`
- [ ] visual check: flameshot, Remmina, ProtonVPN show their proper icons in i3bar

Tracked alongside #193 in #194.