### PR TITLE
fix(system76/bluetooth): pin USB power/control=on for BT radios

### DIFF
--- a/modules/system76/bluetooth.nix
+++ b/modules/system76/bluetooth.nix
@@ -19,8 +19,11 @@
       # autosuspend combined with wakeup=disabled on the Intel 8087:0a2b
       # radio drops HID-over-GATT peripherals (symptom: MX Master 3
       # disconnects after idle and only re-pairing restores it).
+      # ACTION=="add|change" also catches udevadm trigger (nixos-rebuild
+      # switch) and resume-from-sleep events; DEVTYPE=="usb_device" scopes
+      # the match to device nodes so interface objects are not probed.
       services.udev.extraRules = ''
-        ACTION=="add", SUBSYSTEM=="usb", ATTR{bDeviceClass}=="e0", ATTR{bDeviceSubClass}=="01", ATTR{bDeviceProtocol}=="01", TEST=="power/control", ATTR{power/control}="on"
+        ACTION=="add|change", SUBSYSTEM=="usb", DEVTYPE=="usb_device", ATTR{bDeviceClass}=="e0", ATTR{bDeviceSubClass}=="01", ATTR{bDeviceProtocol}=="01", TEST=="power/control", ATTR{power/control}="on"
       '';
 
       environment.systemPackages = lib.mkAfter [ pkgs.bluetui ];

--- a/modules/system76/bluetooth.nix
+++ b/modules/system76/bluetooth.nix
@@ -15,6 +15,14 @@
         };
       };
 
+      # Bluetooth radios: disable USB autosuspend. The kernel default of 2s
+      # autosuspend combined with wakeup=disabled on the Intel 8087:0a2b
+      # radio drops HID-over-GATT peripherals (symptom: MX Master 3
+      # disconnects after idle and only re-pairing restores it).
+      services.udev.extraRules = ''
+        ACTION=="add", SUBSYSTEM=="usb", ATTR{bDeviceClass}=="e0", ATTR{bDeviceSubClass}=="01", ATTR{bDeviceProtocol}=="01", TEST=="power/control", ATTR{power/control}="on"
+      '';
+
       environment.systemPackages = lib.mkAfter [ pkgs.bluetui ];
     };
 }


### PR DESCRIPTION
## Summary

- Hold USB BT radios at runtime PM `on` via a class-matched udev rule (USB e0/01/01: Wireless / RF / Bluetooth) so `usbcore.autosuspend=2` cannot suspend `hci0` while a peripheral is paired.
- Scoped to `modules/system76/bluetooth.nix`. The `tpnix` host is unaffected.

## Why

On the system76 host the Intel `8087:0a2b` radio reports `power/control=auto`, `autosuspend_delay_ms=2000`, `wakeup=disabled`. After ~2s of mouse idle the kernel suspended the radio, the radio could not self-wake on link activity, and the link to the MX Master 3 (`38:de:ad:63:fe:33`) dropped. Recovery required removing and re-pairing the device.

Symptom in `bluetoothd` after the drop:

```
profiles/input/hog-lib.c:set_report_cb()        Error setting Report value: ... unlikely error
profiles/battery/battery.c:batt_io_ccc_written_cb() Battery Level: notifications not enabled
profiles/input/hog-lib.c:ccc_read_cb()          Error reading CCC value: ... unlikely error
```

`dmesg` showed the same MX Master 3 (`046D:B023`) re-binding many times in a single boot (`.0002` through `.0010`) as the link kept dying and re-establishing.

A class match (instead of VID/PID `8087:0a2b`) is used so the rule survives a future BT module swap.

## Test plan

- [ ] Build: `sudo ./build.sh`
- [ ] After activation, confirm `cat /sys/devices/pci0000:00/0000:00:14.0/usb1/1-14/power/control` reports `on`
- [ ] Pair MX Master 3, leave idle for >5 minutes, confirm pointer wakes the link without re-pair
- [ ] `journalctl -b -u bluetooth.service` shows no `hog-lib.c:set_report_cb` / `ccc_read_cb` "unlikely error" sequences after idle