### PR TITLE
docs(technical-writing): distill rules for senior-engineer reference

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -131,6 +131,21 @@
 - [system76/system76-troubleshooting.md](system76/system76-troubleshooting.md)
   - Troubleshooting guide covering thermal management, crash diagnostics, fan issues, and stress testing.
 
+## Technical Writing
+
+- [technical-writing/scope-and-audience.md](technical-writing/scope-and-audience.md)
+  - Rules for audience definition, content type selection, and information architecture.
+- [technical-writing/drafting.md](technical-writing/drafting.md)
+  - Rules for titles, structure, voice, paragraphs, lists, and callouts.
+- [technical-writing/editing.md](technical-writing/editing.md)
+  - Rules for multi-pass editing, peer review, and feedback discipline.
+- [technical-writing/code-samples.md](technical-writing/code-samples.md)
+  - Rules for sample trustworthiness, conciseness, naming, and autogeneration.
+- [technical-writing/visual-content.md](technical-writing/visual-content.md)
+  - Rules for diagram comprehension, accessibility, screenshots, and video.
+- [technical-writing/lifecycle.md](technical-writing/lifecycle.md)
+  - Rules for publishing, feedback triage, measurement, maintenance, and deprecation.
+
 ## Usage
 
 - [usage/README.md](usage/README.md)

--- a/docs/technical-writing/code-samples.md
+++ b/docs/technical-writing/code-samples.md
@@ -8,7 +8,7 @@
 
 ## Conciseness
 
-- Source lines MUST NOT exceed 80 characters; horizontal scroll is friction on every device.
+- Source lines SHOULD NOT exceed 80 characters where the language's idiomatic style guide allows; horizontal scroll is friction on every device. When the language style guide mandates a wider limit (e.g. `rustfmt` 100), the language style guide wins.
 - Use `...` to elide regions that are not the subject of the sample; the omission MUST be obvious to the reader.
 - Each sample MUST be a minimal reproducible example; strip unrelated setup, error handling, and styling that does not bear on the lesson.
 

--- a/docs/technical-writing/code-samples.md
+++ b/docs/technical-writing/code-samples.md
@@ -1,4 +1,4 @@
-# Code samples
+# Writing code samples
 
 ## Trustworthiness
 

--- a/docs/technical-writing/code-samples.md
+++ b/docs/technical-writing/code-samples.md
@@ -1,0 +1,28 @@
+# Code samples
+
+## Trustworthiness
+
+- Every executable sample MUST run unmodified except for clearly marked configuration values; CI MUST execute the sample on every change.
+- Explanatory output (returned values, error messages) MUST match production verbatim; users search for error strings and expect exact matches.
+- Pin versions explicitly in samples (language version, dependency version, API version); a sample without a version is a sample that will silently rot.
+
+## Conciseness
+
+- Source lines MUST NOT exceed 80 characters; horizontal scroll is friction on every device.
+- Use `...` to elide regions that are not the subject of the sample; the omission MUST be obvious to the reader.
+- Each sample MUST be a minimal reproducible example; strip unrelated setup, error handling, and styling that does not bear on the lesson.
+
+## Naming and placeholders
+
+- Placeholders MUST be self-describing (`replace_with_api_key`, `your-bucket-name`); never `foo`, `bar`, `baz`, or single-letter names.
+- Sample code MUST follow the language's idiomatic style guide (PEP 8, gofmt, rustfmt, etc.); style violations distract from the content.
+
+## Explanation
+
+- Surrounding prose MUST explain the "why" of a sample: intent, tradeoffs, and constraints; never narrate the "what" the code already states.
+- A non-obvious result, side effect, or failure mode MUST be called out explicitly; do not rely on the reader to infer it.
+
+## Layering and autogeneration
+
+- When a topic has progressive complexity, present samples in order: hello-world, intermediate, advanced; do not interleave levels on the same page.
+- Reference documentation SHOULD auto-generate from source (OpenAPI, Javadoc, rustdoc, doc comments); hand-maintained reference is the leading source of doc-versus-code drift.

--- a/docs/technical-writing/drafting.md
+++ b/docs/technical-writing/drafting.md
@@ -1,0 +1,36 @@
+# Drafting
+
+## Titles and headings
+
+- Titles MUST be verb phrases describing the goal ("Uploading files to S3"), never noun-only labels ("File upload", "S3 functionality").
+- Headings serve as signposts for skim readers; a reader who reads only the headings MUST be able to reconstruct the document's outline.
+- Use sentence case for all heading levels; avoid title case and ALL CAPS.
+
+## Structure and flow
+
+- Order content as prerequisites, then core task, then verification; never lead with explanation when the user is here to do something.
+- Lead with the most important information in the first paragraph; readers skim at roughly 28% of words and decide to leave or stay early.
+- Each paragraph MUST express one idea; if a paragraph needs a transition word ("however", "additionally") it usually needs to be split.
+
+## Paragraphs and lists
+
+- Paragraphs SHOULD NOT exceed 5 sentences; long blocks fail on mobile and in skim reading.
+- Numbered lists for procedures; each numbered item MUST contain exactly one action.
+- Bulleted lists for non-sequential items; order by usefulness or frequency, not alphabetically, unless lookup is the use case.
+
+## Voice and tense
+
+- Write in active voice; passive voice obscures the actor and inflates word count.
+- Use the imperative mood for instructions ("Run `nix flake check`", not "The user can run `nix flake check`").
+- Address the reader as "you" in second person; avoid first-person plural.
+- Use present tense; future tense ("will run") is rarely needed and adds noise.
+
+## Callouts
+
+- Reserve warning, caution, and note callouts for safety-critical or non-obvious information; routine notes belong in prose.
+- Alert fatigue degrades all callouts; if a page has more than two callouts, the page itself is the warning.
+
+## Templates
+
+- Use templates for repetitive document types (release notes, API endpoint pages, runbooks); consistency beats per-document creativity for reference content.
+- Mark unfinished sections with `[TODO]` or `[FIXME]` and ship the partial draft; iterating against feedback beats withholding for polish.

--- a/docs/technical-writing/drafting.md
+++ b/docs/technical-writing/drafting.md
@@ -1,4 +1,4 @@
-# Drafting
+# Drafting documentation
 
 ## Titles and headings
 

--- a/docs/technical-writing/editing.md
+++ b/docs/technical-writing/editing.md
@@ -1,4 +1,4 @@
-# Editing
+# Editing documentation
 
 ## Editing passes
 

--- a/docs/technical-writing/editing.md
+++ b/docs/technical-writing/editing.md
@@ -2,7 +2,7 @@
 
 ## Editing passes
 
-- Edit in distinct passes, in this order: technical accuracy, completeness, structure, clarity and brevity.
+- Edit in distinct passes, in this order: technical accuracy, completeness, structure, clarity, brevity.
 - One pass MUST focus on one aspect; combining passes causes all of them to suffer.
 - The technical-accuracy pass MUST involve executing every procedure and every code sample as a new user would, not as the author.
 - The structure pass MUST verify that title, headings, and section ordering signpost the document; if the outline reads like a maze, the document is too complex or contains multiple goals.

--- a/docs/technical-writing/editing.md
+++ b/docs/technical-writing/editing.md
@@ -1,0 +1,25 @@
+# Editing
+
+## Editing passes
+
+- Edit in distinct passes, in this order: technical accuracy, completeness, structure, clarity and brevity.
+- One pass MUST focus on one aspect; combining passes causes all of them to suffer.
+- The technical-accuracy pass MUST involve executing every procedure and every code sample as a new user would, not as the author.
+- The structure pass MUST verify that title, headings, and section ordering signpost the document; if the outline reads like a maze, the document is too complex or contains multiple goals.
+
+## Peer review
+
+- Peer review is mandatory; self-review misses gaps to curse-of-knowledge bias regardless of the author's experience.
+- A subject-matter technical reviewer MUST be assigned for any topic outside the author's direct expertise.
+- Reviewers verify that documented behavior matches actual product behavior; assertions without verification do not count as review.
+
+## Feedback discipline
+
+- Apply the "plussing" rule: a criticism MUST come with a specific suggestion, otherwise it is not actionable feedback.
+- Critique the document, never the author; review comments target text, not people.
+- When reviewers disagree, resolve by asking "what does the user need?" and document the answer in the review thread.
+
+## Style consistency
+
+- Define each product, feature, and domain term once and use the same form throughout; alias-free terminology is the cheapest correctness gain.
+- Adopt one external style guide (Chicago, AP, Google Developer, or similar) and reference it by name in the team's writing notes; do not reinvent grammar rules locally.

--- a/docs/technical-writing/lifecycle.md
+++ b/docs/technical-writing/lifecycle.md
@@ -1,4 +1,4 @@
-# Lifecycle
+# Managing the documentation lifecycle
 
 ## Publishing
 

--- a/docs/technical-writing/lifecycle.md
+++ b/docs/technical-writing/lifecycle.md
@@ -1,0 +1,46 @@
+# Lifecycle
+
+## Publishing
+
+- Documentation releases MUST align with the product release that introduces or changes the documented behavior; docs that ship later than the feature mislead users.
+- A single named approver MUST be responsible for blocking or releasing each doc change; diffuse approval produces stalled or broken releases.
+- Release-blocking criteria MUST be set in advance and written down (e.g. block on user-harm or data-loss-class issues; do not block on cosmetic typos).
+- Apply code-review standards to documentation changes: peer review, version control, CI; documentation that bypasses review will rot.
+- Manually rehearse the publication tooling at least once before relying on it for a release; tooling gaps surface only on the first real run.
+- Announce material doc changes through existing release-note channels; readers should not need a separate doc-release feed.
+
+## Feedback
+
+- Provide a page-level feedback channel that pre-fills the URL and title; feedback that requires the user to retype context will not arrive.
+- Integrate documentation feedback with the team's support and ticket queues; recurring support issues MUST surface as documentation gaps.
+- Apply a triage schema to every feedback item: P0 emergency (data loss, security, broken core flow), P1 release-blocker, P2 wanted, P3 not time-sensitive.
+- Reject feedback items that are duplicates, irreproducible, or out of scope; rejection MUST include a reason recorded on the issue.
+- Close the loop with the original reporter when an item is resolved; the loop is the incentive that produces the next report.
+
+## Measurement
+
+- Define documentation quality as "the document fulfills its purpose"; without that anchor, no metric is meaningful.
+- Functional quality (accessible, purposeful, findable, accurate, complete) outranks structural quality (clear, concise, consistent); fix functional defects first.
+- Reading level SHOULD measure at or below 10th grade on Flesch-Kincaid (or equivalent) for general-developer audiences.
+- For getting-started docs, track Time to Hello World (TTHW); a rising TTHW is the strongest single signal of doc decay.
+- Establish a baseline metric before making a change; a "before" without numbers cannot show an "after".
+- Use clusters of metrics, never a single metric in isolation; page views without bounce rate or task-completion rate misleads.
+- Correlate support ticket volume to specific doc pages; pages that generate disproportionate tickets are accuracy defects, not popularity wins.
+
+## Maintenance
+
+- Every doc page MUST have exactly one named owner accountable for accuracy and freshness; record ownership in `CODEOWNERS` or a metadata header.
+- A freshness-review interval (e.g. 6 months) MUST trigger owner re-certification; a doc with no review trigger is unowned.
+- A broken-link checker MUST gate CI; a 404 in published docs is a release defect.
+- A prose linter SHOULD run in CI for style consistency, terminology drift, and exclusionary language.
+- Reference documentation SHOULD auto-generate from source on every release; hand-maintained reference is the largest single source of doc-versus-code drift.
+- Build doc maintenance into sprint estimates and performance expectations; treating docs as "extra work" guarantees rot.
+
+## Deprecation
+
+- A deprecation callout MUST appear at the top of any deprecated page, stating the deprecation date and the replacement target; readers MUST see deprecation before content.
+- A migration guide MUST be published before the deprecation is announced; never leave users without a forward path.
+- Set up redirects on every URL move or removal; deletion without redirects strands users on 404s and search results.
+- Remove a deprecated page only when usage is low and issue rate is high, or when the underlying feature is fully removed; popularity alone is not a reason to keep a misleading page.
+- Document the deprecation timeline (announce date, end-of-support date, removal date) on the page itself; readers MUST be able to plan from the page without external context.
+- A removed page's URL MUST 301 to the closest replacement, not to a generic landing page; landing-page redirects discard the user's intent.

--- a/docs/technical-writing/scope-and-audience.md
+++ b/docs/technical-writing/scope-and-audience.md
@@ -1,4 +1,4 @@
-# Scope and audience
+# Defining scope and audience
 
 ## Audience and goals
 

--- a/docs/technical-writing/scope-and-audience.md
+++ b/docs/technical-writing/scope-and-audience.md
@@ -1,0 +1,33 @@
+# Scope and audience
+
+## Audience and goals
+
+- Every document MUST have one stated user goal (task outcome) and one stated organizational goal (business outcome); list both at the top of the planning notes, not in the doc itself.
+- Pick at most 3-5 user archetypes per product surface; documenting for everyone produces docs for no one.
+- Validate audience assumptions against support tickets, search logs, or a friction log before drafting; intuition about what users need is unreliable.
+- A friction log MUST be a first-person walkthrough of the product as a new user, recorded as written, with confusion points captured verbatim.
+- When user research is unavailable, name the assumed user and their assumed prior knowledge in the planning notes so reviewers can challenge it.
+
+## Content type selection
+
+- Match content to user need: getting-started for discovery to first action, how-to for a specific task, reference for lookup, conceptual for understanding, troubleshooting for fixing.
+- Each document MUST serve exactly one type; mixed types signal that the document needs to be split.
+- A how-to MUST fit in ≤10 numbered steps; longer procedures indicate product complexity that should be questioned, not documented around.
+- Prerequisites MUST be stated upfront ("requires admin access", "requires Nix 2.18+"); they act as an early filter for the wrong audience.
+- Reference docs SHOULD be auto-generated from source (OpenAPI specs, doc comments, type signatures); hand-maintained reference decays faster than the code it describes.
+- Troubleshooting and error-message tables MUST be searchable by the exact error string; users paste error text into search, not paraphrases.
+- Group error/troubleshooting entries by frequency or workflow position, not alphabetically.
+- Version applicability MUST be stated explicitly when behavior differs across versions ("applies to v2.1+", "deprecated in v3.0").
+
+## Information architecture
+
+- Choose the IA primitive that matches the content: sequence (chronological/alphabetical), hierarchy (parent-child), or web (cross-linked); few real docsets are pure one type.
+- Landing pages MUST link directly to documents, not to more landing pages; minimize click depth.
+- Navigation cues (breadcrumbs, side nav, "you are here") SHOULD surface the IA; too many cues compete and create decision fatigue.
+- Before adding a new page, run a content assessment on the existing set: keep, remove, update, merge, split.
+- Single source of truth beats automated content reuse; duplicating a section to multiple landing pages pollutes search.
+- Validate IA with card sorting or a comparable method before migrating content; layout decisions made in isolation tend to hide content from users.
+- Every user task MUST have a clear starting page, defined next step, and a verifiable end state.
+- Section depth SHOULD stay within 2-3 levels; merge or split sections that fall outside this range.
+- 301 redirects MUST be created on every URL move; a 404 is a documentation defect.
+- Each top-level section MUST have a named owner accountable for its IA decisions; ownership prevents IA drift.

--- a/docs/technical-writing/scope-and-audience.md
+++ b/docs/technical-writing/scope-and-audience.md
@@ -12,7 +12,7 @@
 
 - Match content to user need: getting-started for discovery to first action, how-to for a specific task, reference for lookup, conceptual for understanding, troubleshooting for fixing.
 - Each document MUST serve exactly one type; mixed types signal that the document needs to be split.
-- A how-to MUST fit in ≤10 numbered steps; longer procedures indicate product complexity that should be questioned, not documented around.
+- A how-to MUST fit in 10 or fewer numbered steps; longer procedures indicate product complexity that should be questioned, not documented around.
 - Prerequisites MUST be stated upfront ("requires admin access", "requires Nix 2.18+"); they act as an early filter for the wrong audience.
 - Reference docs SHOULD be auto-generated from source (OpenAPI specs, doc comments, type signatures); hand-maintained reference decays faster than the code it describes.
 - Troubleshooting and error-message tables MUST be searchable by the exact error string; users paste error text into search, not paraphrases.

--- a/docs/technical-writing/visual-content.md
+++ b/docs/technical-writing/visual-content.md
@@ -1,4 +1,4 @@
-# Visual content
+# Creating visual content
 
 ## Comprehension
 

--- a/docs/technical-writing/visual-content.md
+++ b/docs/technical-writing/visual-content.md
@@ -1,0 +1,31 @@
+# Visual content
+
+## Comprehension
+
+- Every visual MUST be introduced in body text; a standalone image without prose context is a documentation defect.
+- Each diagram MUST illustrate exactly one idea at one level of abstraction; split overloaded diagrams.
+- Use a consistent shape vocabulary across diagrams (rectangle = process, diamond = decision, cylinder = store); switching shapes mid-docset breaks reader pattern matching.
+- Avoid crossing lines, unlabeled arrows, and unspelled acronyms; have one non-author review the diagram for understandability before publishing.
+
+## Accessibility
+
+- Alt text MUST describe the visual as prose ("Flowchart routing requests through the rate limiter to either the cache or the API"), never "image of X" or "diagram".
+- Color contrast MUST meet WCAG ratio of at least 4.5:1 for text and 3:1 for graphical objects.
+- Color MUST NOT be the sole carrier of meaning; pair every color distinction with a label, pattern, or shape.
+- Video content MUST ship with captions and a text transcript; un-captioned video fails accessibility and search.
+
+## Performance and format
+
+- Use SVG for diagrams and icons; SVG scales without pixelation, zooms cleanly, and stays small.
+- Size and place visuals so they remain legible on mobile widths; layout that only works on desktop is a defect.
+
+## Screenshots
+
+- Include enough surrounding UI to orient the reader (window chrome, breadcrumb, sibling controls); a screenshot cropped tight to the click target is disorienting.
+- Never embed copy-paste data (URLs, IPs, tokens, code, commands) inside an image; users cannot select or search image text.
+- Treat all screenshots as expiring assets; product UI drifts faster than written prose.
+
+## Video
+
+- Avoid video by default; video is expensive to maintain, slow to scan, and a poor fit for reference content.
+- If video is justified, the page MUST also offer a written equivalent so readers can skim and copy.


### PR DESCRIPTION
## Summary

- Adds 6 standalone markdown files under `docs/technical-writing/` holding ~109 prescriptive rules (RFC-2119 keywords for hard rules, imperatives for guidance).
- Source: "Docs for Developers" (Bhatti, Corleissen, Lambourne, Nunez, Waterhouse, 2021), Apress. Compresses ~5,300 lines of source prose to ~14.7KB of rules.
- Files cover scope/audience, drafting, editing, code samples, visual content, and lifecycle (publishing, feedback, measurement, maintenance, deprecation).

## Files

| File | Section coverage | Rules |
|------|-----------------|------:|
| `scope-and-audience.md` | audience, content type selection, IA | 23 |
| `drafting.md` | titles, structure, voice, callouts | 17 |
| `editing.md` | multi-pass, peer review, feedback discipline | 12 |
| `code-samples.md` | testability, conciseness, autogeneration | 12 |
| `visual-content.md` | comprehension, accessibility, screenshots, video | 15 |
| `lifecycle.md` | publishing, feedback triage, measurement, maintenance, deprecation | 30 |

## Style notes

- No good/bad examples; rules only. Source book is not in this repo, so each file stands fully alone.
- No inter-file links between the six rule files.
- Voice: impersonal (no "we/our/us"); no em or en dashes per repo convention.

## Test plan

- [x] `rg -nw '(we|our|us)' docs/technical-writing/*.md` returns no matches
- [x] `rg -n '[—–]' docs/technical-writing/*.md` returns no matches
- [x] `rg -c '^- ' docs/technical-writing/*.md` totals ~109 rules
- [x] Pre-commit hooks (treefmt, typos, gitleaks) pass
- [ ] Reviewer skim: each file readable end-to-end in under 2 minutes