### PR TITLE
chore(mirrors): mirror duplicati/documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,6 +243,7 @@ Pause, summarize the issue, and ask for direction.
 | Stylix         | `/data/git/nix-community-stylix`       | Inspect source or apply local patches.                         |
 | Home Manager   | `/data/git/nix-community-home-manager` | Review module behavior or backport fixes.                      |
 | i3 Docs        | `/data/git/i3-i3.github.io`            | Reference i3 documentation offline.                            |
+| Duplicati Docs | `/data/git/duplicati-documentation`    | Look up `duplicati-cli` commands, options, or backup format.   |
 | nixpkgs        | `/data/git/NixOS-nixpkgs`              | Inspect/patch upstream expressions.                            |
 | nixos-hardware | `/data/git/NixOS-nixos-hardware`       | Pull hardware profiles and troubleshoot host hardware options. |
 | nixvim         | `/data/git/nix-community-nixvim`       | Examine NixVim modules and options.                            |

--- a/docs/duplicati/README.md
+++ b/docs/duplicati/README.md
@@ -47,6 +47,8 @@ The generator is the only piece that runs at activation. After it exits, all bac
 
 Cross-reference: the host composition pattern that imports this module is described in [../architecture/05-host-composition.md](../architecture/05-host-composition.md).
 
+Upstream documentation: the [`duplicati/documentation`](https://github.com/duplicati/documentation) source is mirrored locally at `/data/git/duplicati-documentation` for offline lookup of `duplicati-cli` flags, manifest fields, and the backup format. Sync is managed per host via `programs.gitMirror.repos`; see [../reference/local-mirrors.md](../reference/local-mirrors.md).
+
 ## Operating invariants
 
 - One R2 bucket holds backups for every host. Per-host isolation is by prefix (`<host>/`), per-target isolation is by sub-prefix (`<slug>/`).

--- a/modules/system76/mirrors.nix
+++ b/modules/system76/mirrors.nix
@@ -31,6 +31,7 @@
           "vic/import-tree"
 
           # Documentation
+          "duplicati/documentation"
           "github/docs"
           "i3/i3.github.io"
 

--- a/modules/tpnix/mirrors.nix
+++ b/modules/tpnix/mirrors.nix
@@ -31,6 +31,7 @@
           "vic/import-tree"
 
           # Documentation
+          "duplicati/documentation"
           "github/docs"
           "i3/i3.github.io"
 


### PR DESCRIPTION
## Summary

- Add `duplicati/documentation` to `programs.gitMirror.repos` on both `system76` and `tpnix` so the upstream Duplicati docs sync to `/data/git/duplicati-documentation` daily.
- Index the new mirror in the Local Mirrors table in `AGENTS.md` (use case: looking up `duplicati-cli` commands, options, or backup format).
- Cross-link the mirror from `docs/duplicati/README.md` next to the existing host-composition cross-reference, pointing at `docs/reference/local-mirrors.md` for the sync mechanism.

The infrastructure modules (`modules/git/mirror-root.nix`, `modules/hm-apps/git-mirror.nix`) and the generic mapping doc (`docs/reference/local-mirrors.md`) describe the mechanism without enumerating per-repo entries, so they are unchanged.

## Test plan

- [x] `treefmt` clean on touched files
- [x] `nix-instantiate --parse` passes on both `modules/<host>/mirrors.nix` files
- [x] Pre-commit hook chain (deadnix, nix-parse, statix, treefmt, typos, gitleaks, managed-files-drift, apps-catalog-sync) passes at commit time
- [ ] Post-deploy on each host: `systemctl --user start git-mirror.service` then verify `/data/git/duplicati-documentation` exists