### PR TITLE
feat(nixvim): route clipboard through kitten when kitty is enabled

### DIFF
--- a/modules/hm-apps/kitty.nix
+++ b/modules/hm-apps/kitty.nix
@@ -139,8 +139,11 @@ _: {
             listen_on = "none";
             update_check_interval = "24.0";
             startup_session = "none";
-            # Append -ask to read tokens to require permission prompts.
-            clipboard_control = "write-clipboard write-primary read-clipboard read-primary";
+            # `-ask` keeps kitty's permission prompt before honoring a
+            # clipboard read OSC, so a remote process inside kitty can't
+            # exfiltrate the clipboard silently. Plain `read-clipboard` /
+            # `read-primary` would skip the prompt.
+            clipboard_control = "write-clipboard write-primary read-clipboard-ask read-primary-ask";
             term = "xterm-kitty";
             kitty_mod = "ctrl+shift";
             # Grid first makes it the default layout; all built-in layouts remain reachable via next_layout

--- a/modules/hm-apps/kitty.nix
+++ b/modules/hm-apps/kitty.nix
@@ -139,7 +139,8 @@ _: {
             listen_on = "none";
             update_check_interval = "24.0";
             startup_session = "none";
-            clipboard_control = "write-clipboard write-primary";
+            # Append -ask to read tokens to require permission prompts.
+            clipboard_control = "write-clipboard write-primary read-clipboard read-primary";
             term = "xterm-kitty";
             kitty_mod = "ctrl+shift";
             # Grid first makes it the default layout; all built-in layouts remain reachable via next_layout

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -65,38 +65,36 @@ _: {
               # plugins listed in `nixpkgs.allowedUnfreePackages` are honored.
               nixpkgs.config.allowUnfreePredicate = pkgs.config.allowUnfreePredicate;
 
-              # Leader keys, plus the kitten-backed `vim.g.clipboard` when kitty
-              # is enabled. The non-kitty fallback (xsel/wl-copy) lives in the
-              # `clipboard` block below.
+              # Leader keys, plus a runtime-gated kitten-backed
+              # `vim.g.clipboard` when kitty is enabled on the host. The
+              # IIFE checks `KITTY_WINDOW_ID` so a host with kitty enabled
+              # but a current Neovim session reached via SSH from a non-kitty
+              # terminal (or running in a TTY) falls through to nixvim's
+              # `clipboard.providers` block below instead of trying to drive
+              # an absent kitty controller.
               globals = {
                 mapleader = mkDefault " ";
                 maplocalleader = mkDefault " ";
                 clipboard = mkIf kittyEnabled {
-                  name = "kitten";
-                  copy = {
-                    "+" = [
-                      "kitten"
-                      "clipboard"
-                    ];
-                    "*" = [
-                      "kitten"
-                      "clipboard"
-                      "--use-primary"
-                    ];
-                  };
-                  paste = {
-                    "+" = [
-                      "kitten"
-                      "clipboard"
-                      "--get-clipboard"
-                    ];
-                    "*" = [
-                      "kitten"
-                      "clipboard"
-                      "--get-clipboard"
-                      "--use-primary"
-                    ];
-                  };
+                  __raw = ''
+                    (function()
+                      if vim.env.KITTY_WINDOW_ID == nil then
+                        return nil
+                      end
+                      local kitten = "${lib.getExe' pkgs.kitty "kitten"}"
+                      return {
+                        name = "kitten",
+                        copy = {
+                          ["+"] = { kitten, "clipboard" },
+                          ["*"] = { kitten, "clipboard", "--use-primary" },
+                        },
+                        paste = {
+                          ["+"] = { kitten, "clipboard", "--get-clipboard" },
+                          ["*"] = { kitten, "clipboard", "--get-clipboard", "--use-primary" },
+                        },
+                      }
+                    end)()
+                  '';
                 };
               };
 
@@ -139,14 +137,15 @@ _: {
                 completeopt = "menu,menuone,noselect";
               };
 
-              # Clipboard integration. `globals.clipboard` above routes through
-              # kitten when kitty is enabled (works over SSH and inside
-              # multiplexers without a separate X11/Wayland helper). When kitty
-              # is disabled, fall back to nixvim's wl-copy/xsel providers so
-              # plain `nvim` outside kitty keeps working.
+              # Clipboard integration. `globals.clipboard` above sets the
+              # kitten provider only when Neovim is actually running inside
+              # kitty; outside kitty (TTY, SSH from a non-kitty terminal, or
+              # hosts with `programs.kitty.extended.enable = false`),
+              # `vim.g.clipboard` stays unset and Neovim picks one of the
+              # providers below via standard autodetection.
               clipboard = {
                 register = "unnamedplus,unnamed";
-                providers = mkIf (!kittyEnabled) {
+                providers = {
                   xsel.enable = true;
                   wl-copy.enable = true;
                 };

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -31,7 +31,7 @@ _: {
       ...
     }:
     let
-      inherit (lib) mkDefault;
+      inherit (lib) mkDefault mkIf;
       nvimEnabled = lib.attrByPath [ "programs" "neovim" "extended" "enable" ] false osConfig;
       nvimPkg = lib.attrByPath [
         "programs"
@@ -40,6 +40,7 @@ _: {
         "package"
       ] pkgs.neovim-unwrapped osConfig;
       hostname = osConfig.networking.hostName;
+      kittyEnabled = lib.attrByPath [ "programs" "kitty" "extended" "enable" ] false osConfig;
     in
     {
       imports = lib.optionals nvimEnabled [ inputs.nixvim.homeModules.nixvim ];
@@ -64,9 +65,40 @@ _: {
               # plugins listed in `nixpkgs.allowedUnfreePackages` are honored.
               nixpkgs.config.allowUnfreePredicate = pkgs.config.allowUnfreePredicate;
 
-              # Leader key
-              globals.mapleader = mkDefault " ";
-              globals.maplocalleader = mkDefault " ";
+              # Leader keys, plus the kitten-backed `vim.g.clipboard` when kitty
+              # is enabled. The non-kitty fallback (xsel/wl-copy) lives in the
+              # `clipboard` block below.
+              globals = {
+                mapleader = mkDefault " ";
+                maplocalleader = mkDefault " ";
+                clipboard = mkIf kittyEnabled {
+                  name = "kitten";
+                  copy = {
+                    "+" = [
+                      "kitten"
+                      "clipboard"
+                    ];
+                    "*" = [
+                      "kitten"
+                      "clipboard"
+                      "--use-primary"
+                    ];
+                  };
+                  paste = {
+                    "+" = [
+                      "kitten"
+                      "clipboard"
+                      "--get-clipboard"
+                    ];
+                    "*" = [
+                      "kitten"
+                      "clipboard"
+                      "--get-clipboard"
+                      "--use-primary"
+                    ];
+                  };
+                };
+              };
 
               # Editor options
               opts = {
@@ -107,13 +139,17 @@ _: {
                 completeopt = "menu,menuone,noselect";
               };
 
-              # Clipboard integration
+              # Clipboard integration. `globals.clipboard` above routes through
+              # kitten when kitty is enabled (works over SSH and inside
+              # multiplexers without a separate X11/Wayland helper). When kitty
+              # is disabled, fall back to nixvim's wl-copy/xsel providers so
+              # plain `nvim` outside kitty keeps working.
               clipboard = {
-                providers = {
+                register = "unnamedplus,unnamed";
+                providers = mkIf (!kittyEnabled) {
                   xsel.enable = true;
                   wl-copy.enable = true;
                 };
-                register = "unnamedplus,unnamed";
               };
 
               # Diagnostic display configuration

--- a/modules/tpnix/power.nix
+++ b/modules/tpnix/power.nix
@@ -81,7 +81,7 @@
           HandlePowerKey = "lock";
           HandleLidSwitch = "suspend";
           HandleLidSwitchExternalPower = "suspend";
-          HandleLidSwitchDocked = "suspend";
+          HandleLidSwitchDocked = "ignore";
         };
 
         journald = {

--- a/modules/tpnix/services.nix
+++ b/modules/tpnix/services.nix
@@ -17,7 +17,7 @@ _: {
         HandlePowerKey = lib.mkDefault "lock";
         HandleLidSwitch = lib.mkDefault "suspend"; # ignore, lock, suspend, poweroff, hibernate
         HandleLidSwitchExternalPower = lib.mkDefault "suspend"; # On AC power
-        HandleLidSwitchDocked = lib.mkDefault "suspend"; # External display connected
+        HandleLidSwitchDocked = lib.mkDefault "ignore"; # External display connected
       };
 
       services = {


### PR DESCRIPTION
## Summary

### Nixvim / kitten clipboard

- Adds a runtime-gated kitten-backed `vim.g.clipboard` to nixvim. The Lua IIFE checks `vim.env.KITTY_WINDOW_ID` at startup and only returns the kitten provider when Neovim is actually running inside a kitty session; otherwise it returns `nil` and Neovim falls back to its standard provider autodetection.
- Keeps `clipboard.providers.{xsel,wl-copy}.enable = true` unconditionally so the fallback path has something to land on (TTY sessions, SSH into a kitty host from a non-kitty terminal, hosts with `programs.kitty.extended.enable = false`).
- Pins the kitten binary to its absolute Nix-store path via `lib.getExe' pkgs.kitty "kitten"` so the provider does not rely on `PATH`.
- Extends kitty's `clipboard_control` with `read-clipboard-ask read-primary-ask` so the kitten paste path (`kitten clipboard --get-clipboard`) is permitted while kitty's permission prompt still gates each read. Plain `read-clipboard` / `read-primary` would suppress the prompt and let any process inside the kitty session read the clipboard silently.
- The host-level gate `mkIf kittyEnabled` is preserved so hosts without kitty do not pull `pkgs.kitty` into the nixvim closure.

### tpnix / lid-switch (separately auditable)

The branch also carries one unrelated atomic commit, `fix(tpnix/power): keep session alive on lid close while docked`, which switches `HandleLidSwitchDocked` from `suspend` to `ignore` in both `modules/tpnix/power.nix` (the active override) and `modules/tpnix/services.nix` (the `mkDefault` baseline). The previous value caused a docked lid close to suspend the session and trigger `xss-lock` through the logind suspend signal, which is undesirable when an external display is attached. Lid close on battery still suspends via `HandleLidSwitch`. Documented here per review feedback.

## Why kitten

The kitten provider routes copy/paste through kitty's terminal escape sequences, so it works over SSH and inside multiplexers without a separate X11/Wayland helper. The runtime check on `KITTY_WINDOW_ID` ensures the provider is only selected when a kitty controller is actually reachable.

## Test plan

- [x] `nix flake check --accept-flake-config --no-build --offline` passes.
- [x] `nix eval .#nixosConfigurations.system76.config.home-manager.users.vx.programs.nixvim.globals.clipboard` renders the IIFE that returns the kitten provider when `KITTY_WINDOW_ID` is set, `nil` otherwise.
- [x] `nix eval .#nixosConfigurations.system76.config.home-manager.users.vx.programs.nixvim.clipboard.providers --apply 'p: { xsel = p.xsel.enable; wl-copy = p.wl-copy.enable; }'` shows `{ wl-copy = true; xsel = true; }` (fallback providers stay enabled).
- [ ] Activate on `system76` and `tpnix`: `"+yy` / `"+p` and `"*yy` / `"*p` round-trip through kitty's clipboard and primary selection inside kitty; from a TTY or SSH session reached via a non-kitty terminal, the same registers fall through to xsel/wl-copy.
- [ ] Confirm kitty's permission prompt fires on a clipboard read OSC and that `kitten clipboard --get-clipboard` triggers it correctly.