### PR TITLE
fix(duplicati): harden R2 extraction and document mount plan

### DIFF
--- a/docs/drafts/duplicati-r2-readonly-mount-investigation.md
+++ b/docs/drafts/duplicati-r2-readonly-mount-investigation.md
@@ -8,7 +8,7 @@ Originally a design decision; Cut A and Cut B are now implemented in this branch
 
 - **Cut A (shipped)** (path-listing CLI from local SQLite, no decryption): low cost, no crypto dependency, immediate forensic value, reuses `services.duplicati-r2.stateDirReadableBy`.
 - **Cut B (implemented in this branch)** (single-file extract by path with on-demand R2 fetch + decrypt): solves the original "read one file without a full restore" problem at a fraction of the implementation cost of FUSE.
-- **Cut C (next in this branch/PR)** (read-only FUSE mount): adds the filesystem surface on top of the Cut B resolver, fetcher, decryptor, and cache. The remaining work is the FS-semantics layer: mount lifecycle, `getattr`/`readdir`/`open`/`read`/`release`, partial-range reads, and mount hardening.
+- **Cut C (next in this branch/PR)** (read-only FUSE mount): adds the filesystem surface on top of the Cut B resolver, fetcher, decryptor, and cache. The remaining work is the FS-semantics layer: `pyfuse3` packaging, Linux-only service wiring, foreground mount lifecycle, `getattr`/`readdir`/`open`/`read`/`release`, partial-range reads, mount hardening, and explicit FUSE `allow_other` gating.
 - **Reject** any approach that re-derives metadata from R2 instead of reusing the per-target SQLite databases. Recreate-from-remote is heavy (`repair` against a missing DB downloads every dindex) and the local DB is already exposed by the `stateDirReadableBy` ACL.
 
 **Local-storage budget**: none of the three cuts requires downloading the full archive. Cut A is zero-byte-ingress (reads only the local SQLite that already exists on disk). Cut B and Cut C download exactly the dblocks needed to satisfy the active read; the encrypted-dblock cache is bounded and configurable (default 1 GiB). See [Section 9](#9-storage-budget).
@@ -359,18 +359,43 @@ The marginal benefit of a separate read-only pair is small. Cut B reuses `/etc/d
 - After AES decryption, the inner bytes are a standard zip archive. Cut B opens it with `zipfile.ZipFile(io.BytesIO(...))` and reads each block via `.open(name).read()`. The first read of any volume parses and validates the `manifest` JSON entry; Cut C can cache central-directory byte ranges to avoid re-parsing on every block read.
 - Block-entry names are base64url of the block hash. The implementation in `duplicati_r2_extract.py:base64url_name` does `base64.urlsafe_b64encode(hash_bytes).rstrip(b'=').decode('ascii')`; the rstrip is required because Duplicati omits zip-name padding.
 
-### 4.5 FUSE bindings (Cut C only)
+### 4.5 FUSE mount runtime (Cut C only)
 
-- Linux only; macOS/FreeBSD parity is not a goal for this repo.
-- `fusepy` (Python) or `fuser` (Rust) both support read-only mounts with a small surface: `getattr`, `readdir`, `open`, `read`, `release`, `readlink` for symlinks.
-- One FUSE inode per `(snapshot_id, file_id)`. Inode 1 is the root; top-level directories are snapshot timestamps in `YYYYMMDDTHHMMSSZ` form.
-- Permissions: expose files mode 0400, directories 0500, owner = the maintainer that started the mount. Metadata (mtime, type) comes from `FilesetEntry.Lastmodified` and `Metadataset.Content`. Do not synthesise owner/group from the source mtime metadata; the maintainer started the mount and should own everything visible.
+- Use `pyfuse3` as the binding. Cut C is Linux-only for this repo; macOS/FreeBSD parity is not a goal.
+- `duplicati-r2-mount mount <slug> <mountpoint>` runs in the foreground by default. The NixOS service must run the same foreground process under systemd (`Type=simple`), so systemd owns restart, stop, and logging semantics.
+- `duplicati-r2-mount unmount <mountpoint>` performs the unmount operation. If unmounting requires the system helper, the command shells out to the packaged `${pkgs.fuse3}/bin/fusermount3 -u <mountpoint>` rather than requiring sudo.
+- `--debug` enables verbose lifecycle diagnostics for startup, open handles, read planning, cache hits/misses, busy unmounts, and stale-mount cleanup. Debug output must redact sensitive values: tokens, API keys, passphrases, env-file values, and signed request material.
+- Do not enable FUSE `allow_other` by default. Duplicati restore data is sensitive, and the default mount is visible only to the mounting user. `--allow-other` is an explicit CLI flag that adds the `allow_other` FUSE option only when present.
+- With `allow_other` enabled, the filesystem reports deliberate read-only attrs for cross-user access (for example directories 0550 and files 0440 for the configured mount group). `pyfuse3.default_options` includes `default_permissions`, so these attrs are the kernel-enforced access contract.
+- One FUSE inode is assigned per `(snapshot_id, file_id)`. Inode 1 is the root; top-level directories are snapshot timestamps in `YYYYMMDDTHHMMSSZ` form.
+- Metadata comes from `FilesetEntry.Lastmodified` and `Metadataset.Content`; do not synthesise owner/group from source metadata. The mounter owns private mounts; configured service user/group own managed mounts.
+- Plaintext exposure stays bounded by mount permissions and FUSE read responses. The mount may reuse the Cut B encrypted-dblock cache, but it must never write plaintext cache files.
 
-### 4.6 Per-invocation lifecycle (Cut B)
+### 4.6 Cut C NixOS/runtime packaging policy
+
+- Add `packages/duplicati-r2-tools/mount.nix` and expose it as `pkgs.duplicati-r2-tools.mount`. The binary name is `duplicati-r2-mount`.
+- The mount derivation includes `pyfuse3`, the existing R2/AES dependencies, and `fuse3` for the unmount helper. Mark it Linux-only with package metadata such as `meta.platforms = lib.platforms.linux`; list/extract remain mostly portable Python.
+- Add flake output `.#duplicati-r2-mount`.
+- Add `pkgs.duplicati-r2-tools.mount` to the default `programs.duplicati-r2-tools.extended.packages` list so enabling the tools installs list, extract, and mount.
+- `modules/apps/duplicati-r2-tools.nix` only installs binaries on `PATH`; it must not set host-wide FUSE policy merely because the package is installed.
+- `modules/services/duplicati-r2.nix` owns the mount runtime options and host policy. Add `services.duplicati-r2.mount.{enable,user,group,mountPoint,allowOther,debug}`.
+- `services.duplicati-r2.mount.allowOther` defaults to `false`. Only when `cfg.mount.enable && cfg.mount.allowOther` should the service module set `programs.fuse.userAllowOther = true;` and pass `--allow-other` to the mount command.
+- The service passes `--debug` only when `services.duplicati-r2.mount.debug = true`. Debug mode improves busy-unmount and dead-mount diagnostics, but still redacts credentials and passphrases.
+- Add an assertion that `services.duplicati-r2.mount.user` is listed in `services.duplicati-r2.stateDirReadableBy`; the mounting user must already have read ACLs for the SQLite state and env file. Normal mount use should not require sudo.
+- Create the mountpoint with `systemd.tmpfiles` using the configured user/group and restrictive mode. The service should stop via `duplicati-r2-mount unmount <mountpoint>` or `fusermount3 -u`, and should avoid leaving stale mountpoints or confusing dead mounts after stop/restart.
+- Enable the managed mount service on `system76` only. `tpnix` should not enable it unless that host later grants `stateDirReadableBy` and explicitly opts into the mount runtime.
+
+### 4.7 Cut C validation boundaries
+
+- A Nix build sandbox cannot perform a real FUSE mount here: a sandboxed `runCommand` check for `/dev/fuse` returned `missing`. Therefore `mount.nix` must not require `/dev/fuse` or a real mount during `installCheckPhase`.
+- In-package checks should cover import/compile, fake filesystem object tests, `getattr`/`readdir`/`read`/`readlink` behavior over fixture data, and reuse of the existing resolver/decrypt/cache code paths.
+- Host or VM validation on `system76` covers the real FUSE path: service foreground startup, `ls`, `stat`, `cat`, `readlink`, `grep`, partial reads, unmount, busy-unmount diagnostics with `--debug`, and recovery from dead/stale mount state.
+
+### 4.8 Per-invocation lifecycle (Cut B)
 
 - `duplicati-r2-extract <slug> <path> --output <dest>`: opens the SQLite DB (`mode=ro`), checks `Configuration.Version` is in the supported set, reads `Configuration.blockhash` / `Configuration.filehash` for the BlockHash and FileHash algorithms, sources `/etc/duplicati/r2.env` (or the file specified by `--env-file`) for credentials and the passphrase, then plans + fetches + decrypts + writes in one pass and exits. No background daemon, no mount, no FUSE.
 - The encrypted-dblock cache persists between invocations under `$XDG_CACHE_HOME/duplicati-r2-tools/<host>/<slug>/`. Move that directory aside with `rip` to drop it; subsequent runs re-fetch.
-- Cut C lifecycle (long-running mount, `up`/`down` subcommands, per-user systemd unit) remains as sketched here for the next implementation step.
+- Cut C lifecycle is the foreground `duplicati-r2-mount mount ...` process plus `duplicati-r2-mount unmount <mountpoint>`, optionally supervised by the NixOS systemd service described above. If `--allow-other` is passed, it must be visible in the CLI invocation and backed by the NixOS `services.duplicati-r2.mount.allowOther` gate.
 
 ## 5. The three cuts
 
@@ -423,37 +448,51 @@ duplicati-r2-extract <slug> ... --json                    # JSON summary on stde
 
 ### 5.3 Cut C: read-only FUSE mount
 
-**Scope**: `mount` the archive at a path; standard `ls`, `cat`, `grep`, `diff` work transparently.
+**Scope**: mount the archive at a path; standard `ls`, `cat`, `grep`, `diff` work transparently against a read-only snapshot tree.
 
-**Build cost**: 7..14 days additional on top of Cut B. Real cost is in the FUSE semantics layer:
+**Implementation sequence**:
 
+- Extract a mount package as `pkgs.duplicati-r2-tools.mount` with binary `duplicati-r2-mount`, using `pyfuse3` and Linux-only metadata (`meta.platforms = lib.platforms.linux`).
+- Reuse the Cut B resolver, R2/file source abstraction, AES decryptor, per-block verifier, and encrypted-dblock cache. Do not add a plaintext cache.
+- Implement `duplicati-r2-mount mount <slug> <mountpoint>` as a foreground process by default. The NixOS systemd service runs this same foreground process.
+- Implement `duplicati-r2-mount unmount <mountpoint>` and shell out to `${pkgs.fuse3}/bin/fusermount3 -u <mountpoint>` when that is the required unmount primitive.
+- Implement `--debug` for lifecycle/read/cache/unmount diagnostics, with mandatory redaction for tokens, API keys, passphrases, env-file values, and signed request material.
+- Implement `--allow-other` as a CLI opt-in. The NixOS service passes it only when `services.duplicati-r2.mount.allowOther = true`, and that same option is the only path that sets `programs.fuse.userAllowOther = true;`.
+- Add `services.duplicati-r2.mount.{enable,user,group,mountPoint,allowOther,debug}` and a `systemd` service in `modules/services/duplicati-r2.nix`. Assert the mount user is included in `stateDirReadableBy`, create the mountpoint via `systemd.tmpfiles`, and keep sudo out of normal operation by using the existing SQLite/env-file ACLs.
+- Add `pkgs.duplicati-r2-tools.mount` to the app module's default package list and expose flake output `.#duplicati-r2-mount`.
+- Enable the managed mount service from `modules/system76/duplicati.nix` only; `tpnix` should remain off unless it later gets matching state/env-file ACL access and explicitly opts in.
+
+**FUSE semantics work**:
+
+- `getattr`, `readdir`, `open`, `read`, `release`, and `readlink` for symlinks.
 - Range reads (`read(offset, len)` mid-block) require partial decompression of one zip entry plus a streaming concatenation across multiple blocks.
 - Caching policy decisions: per-block (small, granular) vs per-dblock (large, simple) vs hybrid.
 - Race conditions between `release` and active `read` calls.
 - Symlink loops, hard-link representation, special files.
 - `getxattr`/`listxattr` if the metadata blob is to be exposed.
-- Test plan: `fio` random reads, `find | xargs grep` over a non-trivial archive, kernel-level `mmap` on a large file.
+- Stale/dead mount handling: foreground process ownership, explicit unmount, systemd stop behavior, and debug diagnostics for busy mounts.
 
-**Risk**:
+**Test plan**:
 
-- FUSE-on-Linux is stable; FUSE-on-macOS via macFUSE is a moving target. Linux-only is acceptable per this repo's constraints.
-- A misbehaving mount can wedge a maintainer's terminal; need a `fusermount -uz` escape hatch and a clear systemd unit boundary.
-- Maintenance: every Duplicati format change risks breaking the mount silently. Cut B fails loudly on the first command; Cut C fails inside a FUSE handler under load.
+- In `installCheckPhase`: import/compile, fake filesystem object tests, `getattr`/`readdir`/`read`/`readlink` fixture tests, and resolver/decrypt/cache reuse tests. Do not perform a real FUSE mount in the Nix build sandbox because `/dev/fuse` is absent there.
+- On `system76`: service startup, foreground logging, `ls`, `stat`, `cat`, `readlink`, `grep`, partial reads, clean unmount, busy-unmount diagnostics under `--debug`, and restart after a stale/dead mount.
+
+**Risk**: FUSE-on-Linux is stable and acceptable for this repo, but the mount can fail inside kernel callbacks under load rather than at command startup. Cross-user exposure through `allow_other` is security-sensitive and must remain behind the two explicit gates above.
 
 **Value**: matches the Borg/Restic experience. For a single-host repo with two backup targets, the marginal value over Cut B is small.
 
 ## 6. Decision criteria
 
-| Criterion              | Weight | Cut A (shipped)                  | Cut B (shipped)                                  | Cut C (next)                    |
-| ---------------------- | ------ | -------------------------------- | ------------------------------------------------ | ------------------------------- |
-| Build cost (actual)    | high   | ~1 day                           | ~1 day on top of Cut A                           | est. 7..14 days additional      |
-| Format-drift risk      | high   | nil (no crypto/zip)              | low (AES v2->v3 only)                            | medium (zip + FS)               |
-| Maintenance over years | high   | trivial                          | small                                            | recurring                       |
-| Crypto risk            | high   | nil                              | low (PyPI pyAesCrypt 6.1.1, HMAC-verified)       | low (same as B)                 |
-| Operator value         | high   | medium (browse/grep)             | high (recover one file or glob)                  | high (browse/cat transparently) |
-| Packaging              | med    | Python + Nix (stdenvNoCC)        | Python + Nix (stdenvNoCC + python3.withPackages) | Python+FUSE + Nix               |
-| ACL interaction        | med    | uses `stateDirReadableBy` only   | extends `stateDirReadableBy` to env-file read    | extends env-file read           |
-| Bus-factor protection  | med    | high (works without crypto code) | high (synthetic-fixture test gates regressions)  | medium (FUSE expertise needed)  |
+| Criterion              | Weight | Cut A (shipped)                  | Cut B (shipped)                                  | Cut C (next)                                          |
+| ---------------------- | ------ | -------------------------------- | ------------------------------------------------ | ----------------------------------------------------- |
+| Build cost (actual)    | high   | ~1 day                           | ~1 day on top of Cut A                           | est. 7..14 days additional                            |
+| Format-drift risk      | high   | nil (no crypto/zip)              | low (AES v2->v3 only)                            | medium (zip + FS)                                     |
+| Maintenance over years | high   | trivial                          | small                                            | recurring                                             |
+| Crypto risk            | high   | nil                              | low (PyPI pyAesCrypt 6.1.1, HMAC-verified)       | low (same as B)                                       |
+| Operator value         | high   | medium (browse/grep)             | high (recover one file or glob)                  | high (browse/cat transparently)                       |
+| Packaging              | med    | Python + Nix (stdenvNoCC)        | Python + Nix (stdenvNoCC + python3.withPackages) | Python + `pyfuse3` + Nix; Linux-only                  |
+| ACL interaction        | med    | uses `stateDirReadableBy` only   | extends `stateDirReadableBy` to env-file read    | uses state/env-file ACLs; explicit `allow_other` gate |
+| Bus-factor protection  | med    | high (works without crypto code) | high (synthetic-fixture test gates regressions)  | medium (FUSE expertise needed)                        |
 
 Hard constraints from issue #204 carried through:
 
@@ -468,7 +507,9 @@ Hard constraints from issue #204 carried through:
 
 **Cut B is implemented in this branch** as `pkgs.duplicati-r2-tools.extract`. Reuses Cut A's resolver via the shared `duplicati_r2_common.py` module. Adds a local `pyAesCrypt` derivation, `boto3` for the R2 transport, an `EncryptedCache` LRU on disk, a `BlockResolver` that handles both `BlocksetEntry`-backed and `BlocklistHash`-chain-backed files, and pluggable `S3Source`/`FileSource` transports (the latter enables offline/mirror operation and underpins the synthetic-fixture test). The `installCheckPhase` exercises single-block, multi-block-without-blocklist, single-blocklist, and multi-blocklist code paths plus HMAC-corruption, missing-path, wrong-passphrase, include-glob, env-file, cache, invalid DB hash, manifest-validation, segment-aware streaming path globbing, and SQLite variable-limit contracts. The env-file ACL was widened in the same change so users in `stateDirReadableBy` can read `/etc/duplicati/r2.env` without sudo; the CLI opens that env file with `O_NOFOLLOW` and validates mode/owner via `fstat` on the opened descriptor.
 
-**Cut C is next in this same branch/PR**. It should reuse the Cut B resolver, R2/file source abstraction, AES decryption boundary, block verifier, and encrypted-dblock cache, then add the read-only FUSE surface on top. The key implementation risk is not backup-format parsing anymore; it is mount correctness under filesystem access patterns: lifecycle, stale handles, symlink/readlink behavior, partial reads, cache eviction, and safe unmount recovery.
+**Cut C is next in this same branch/PR**. It should reuse the Cut B resolver, R2/file source abstraction, AES decryption boundary, block verifier, and encrypted-dblock cache, then add the read-only `pyfuse3` surface on top. The key implementation risk is not backup-format parsing anymore; it is mount correctness under filesystem access patterns: lifecycle, stale handles, symlink/readlink behavior, partial reads, cache eviction, safe unmount recovery, and keeping cross-user mount exposure behind an explicit `allow_other` opt-in.
+
+Cut C's implementation should keep FUSE permissions private by default. Add `duplicati-r2-mount mount` as a foreground process, `duplicati-r2-mount unmount` backed by `fusermount3 -u`, and a `--debug` mode that improves diagnostics without leaking credentials. Add a CLI `--allow-other` flag, but only have the NixOS service path pass that flag when `services.duplicati-r2.mount.allowOther = true`. The same service option is the only place that should set `programs.fuse.userAllowOther = true;`; package installation and `programs.duplicati-r2-tools.extended.enable` must not change global FUSE policy.
 
 **Reject** any approach that:
 
@@ -644,4 +685,5 @@ A 44-path `*.torrent` restore from `bankdata` (~10 MiB plaintext) was performed 
 - Upstream FUSE feature request: <https://github.com/duplicati/duplicati/issues/3081>
 - `pyAesCrypt`: <https://github.com/marcobellaccini/pyAesCrypt>
 - `aescrypt-rs`: <https://crates.io/crates/aescrypt-rs>
+- `pyfuse3`: <https://github.com/libfuse/pyfuse3>
 - Comparable mount: `borg mount` <https://borgbackup.readthedocs.io/en/stable/usage/mount.html>; `restic mount` documentation in the restic project.

--- a/packages/duplicati-r2-tools/duplicati_r2_extract.py
+++ b/packages/duplicati-r2-tools/duplicati_r2_extract.py
@@ -33,7 +33,7 @@ import urllib.parse
 import zipfile
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from typing import Callable
 
 # Self-bootstrap: import the sibling duplicati_r2_common module regardless of
@@ -1595,6 +1595,39 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
+def _segment_globmatch(path: str, pattern: str) -> bool:
+    path_parts = tuple(path.split("/"))
+    pattern_parts = tuple(pattern.split("/"))
+    memo: dict[tuple[int, int], bool] = {}
+
+    def match(pattern_index: int, path_index: int) -> bool:
+        state = (pattern_index, path_index)
+        cached = memo.get(state)
+        if cached is not None:
+            return cached
+        if pattern_index == len(pattern_parts):
+            result = path_index == len(path_parts)
+        elif pattern_parts[pattern_index] == "**":
+            if pattern_index == len(pattern_parts) - 1:
+                result = path_index <= len(path_parts)
+            else:
+                result = any(
+                    match(pattern_index + 1, next_path_index)
+                    for next_path_index in range(path_index, len(path_parts) + 1)
+                )
+        elif path_index == len(path_parts):
+            result = False
+        else:
+            result = fnmatch.fnmatchcase(
+                path_parts[path_index],
+                pattern_parts[pattern_index],
+            ) and match(pattern_index + 1, path_index + 1)
+        memo[state] = result
+        return result
+
+    return match(0, 0)
+
+
 def _glob_paths(
     conn: sqlite3.Connection,
     snapshot_id: int,
@@ -1602,15 +1635,14 @@ def _glob_paths(
 ) -> Iterator[str]:
     """Yield File.Path entries matching ``pattern``.
 
-    Matching strategy: a pattern containing a ``/`` is interpreted as a
-    segment-aware full-path glob (``/data/*.bin`` matches direct children;
-    ``/data/**/*.bin`` matches descendants). A missing leading slash is added
-    so ``data/*.bin`` and ``/data/*.bin`` are equivalent. A pattern with no
-    ``/`` is matched against the file's basename (``*.bin`` matches every
-    ``.bin`` file at any depth). This mirrors how operators typically reach
-    for `find -name` without escaping every prefix.
+    ``pattern`` is expected to be pre-normalized by
+    ``_normalize_include_pattern``. A pattern containing a ``/`` is interpreted
+    as a segment-aware full-path glob (``/data/*.bin`` matches direct children;
+    ``/data/**/*.bin`` matches descendants). A pattern with no ``/`` is matched
+    against the file's basename (``*.bin`` matches every ``.bin`` file at any
+    depth). This mirrors how operators typically reach for `find -name` without
+    escaping every prefix.
     """
-    pattern = _normalize_include_pattern(pattern)
     is_basename_pattern = "/" not in pattern
     cursor = conn.execute(
         """
@@ -1631,7 +1663,7 @@ def _glob_paths(
                 pattern,
             )
         else:
-            matches_pattern = PurePosixPath(row["path"]).match(pattern)
+            matches_pattern = _segment_globmatch(row["path"], pattern)
         if matches_pattern:
             yield row["path"]
 

--- a/packages/duplicati-r2-tools/duplicati_r2_extract.py
+++ b/packages/duplicati-r2-tools/duplicati_r2_extract.py
@@ -89,6 +89,13 @@ _ACL_READ = 0x04
 _ACL_UNDEFINED_ID = 0xFFFFFFFF
 _ACL_XATTR_HEADER = struct.Struct("<I")
 _ACL_XATTR_ENTRY = struct.Struct("<HHI")
+_ACL_TAG_LABELS = {
+    _ACL_USER_OBJ: "owner",
+    _ACL_USER: "named user",
+    _ACL_GROUP_OBJ: "group-object",
+    _ACL_GROUP: "named group",
+    _ACL_OTHER: "other",
+}
 _NO_ACL_XATTR_ERRNOS = {
     code
     for code in (
@@ -101,7 +108,25 @@ _NO_ACL_XATTR_ERRNOS = {
 }
 
 
-def _posix_acl_insecure_access(acl_data: bytes, path: str) -> bool:
+def _acl_perm_string(perm: int) -> str:
+    return "".join(
+        label if perm & bit else "-"
+        for bit, label in (
+            (_ACL_READ, "r"),
+            (_ACL_WRITE, "w"),
+            (_ACL_EXECUTE, "x"),
+        )
+    )
+
+
+def _acl_entry_label(tag: int, entry_id: int) -> str:
+    label = _ACL_TAG_LABELS[tag]
+    if tag in {_ACL_USER, _ACL_GROUP}:
+        return f"{label} {entry_id}"
+    return label
+
+
+def _posix_acl_insecure_access_reason(acl_data: bytes, path: str) -> str | None:
     if (
         len(acl_data) < _ACL_XATTR_HEADER.size
         or (len(acl_data) - _ACL_XATTR_HEADER.size) % _ACL_XATTR_ENTRY.size
@@ -115,7 +140,7 @@ def _posix_acl_insecure_access(acl_data: bytes, path: str) -> bool:
             EXIT_OPEN_ERR,
         )
 
-    entries: list[tuple[int, int]] = []
+    entries: list[tuple[int, int, int]] = []
     mask_perm: int | None = None
     for offset in range(
         _ACL_XATTR_HEADER.size,
@@ -125,6 +150,7 @@ def _posix_acl_insecure_access(acl_data: bytes, path: str) -> bool:
         tag, perm, _entry_id = _ACL_XATTR_ENTRY.unpack_from(acl_data, offset)
         if tag == _ACL_MASK:
             mask_perm = perm
+            continue
         elif tag not in {
             _ACL_USER_OBJ,
             _ACL_USER,
@@ -136,28 +162,36 @@ def _posix_acl_insecure_access(acl_data: bytes, path: str) -> bool:
                 f"env file {path} has unknown POSIX ACL tag {tag}; refusing",
                 EXIT_OPEN_ERR,
             )
-        entries.append((tag, perm))
+        entries.append((tag, perm, _entry_id))
 
-    for tag, perm in entries:
+    for tag, perm, entry_id in entries:
         effective = perm
         if tag in {_ACL_USER, _ACL_GROUP_OBJ, _ACL_GROUP} and mask_perm is not None:
             effective &= mask_perm
         if tag in {_ACL_GROUP_OBJ, _ACL_GROUP, _ACL_OTHER} and effective:
-            return True
+            return (
+                f"POSIX ACL {_acl_entry_label(tag, entry_id)} entry grants "
+                f"{_acl_perm_string(effective)}"
+            )
         if tag == _ACL_USER and effective & (_ACL_WRITE | _ACL_EXECUTE):
-            return True
-    return False
+            return (
+                f"POSIX ACL {_acl_entry_label(tag, entry_id)} entry grants "
+                f"{_acl_perm_string(effective)}"
+            )
+    return None
 
 
-def _env_file_has_insecure_access(fd: int, path: str, st_mode: int) -> bool:
+def _env_file_insecure_access_reason(fd: int, path: str, st_mode: int) -> str | None:
     try:
         acl_data = os.getxattr(fd, _POSIX_ACL_XATTR)
     except OSError as exc:
         if exc.errno in _NO_ACL_XATTR_ERRNOS:
-            return bool(st_mode & 0o077)
+            if st_mode & 0o077:
+                return f"mode {oct(st_mode & 0o7777)} permits group or world access"
+            return None
         fail(f"failed to inspect env file ACL for {path}: {exc}", EXIT_OPEN_ERR)
 
-    return _posix_acl_insecure_access(acl_data, path)
+    return _posix_acl_insecure_access_reason(acl_data, path)
 
 
 def load_env_file(path: str) -> dict[str, str]:
@@ -193,9 +227,10 @@ def load_env_file(path: str) -> dict[str, str]:
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode):
             fail(f"env file {path} is not a regular file; refusing", EXIT_OPEN_ERR)
-        if _env_file_has_insecure_access(fd, path, st.st_mode):
+        insecure_reason = _env_file_insecure_access_reason(fd, path, st.st_mode)
+        if insecure_reason is not None:
             fail(
-                f"env file {path} grants group, world, or write/execute ACL access (mode {oct(st.st_mode & 0o7777)}); refusing",
+                f"env file {path} grants insecure access: {insecure_reason}; refusing",
                 EXIT_OPEN_ERR,
             )
         if st.st_uid not in (0, os.getuid()):

--- a/packages/duplicati-r2-tools/duplicati_r2_extract.py
+++ b/packages/duplicati-r2-tools/duplicati_r2_extract.py
@@ -26,6 +26,7 @@ import os
 import re
 import sqlite3
 import stat
+import struct
 import sys
 import time
 import urllib.parse
@@ -74,6 +75,89 @@ set_program_name("duplicati-r2-extract")
 
 
 _DOTENV_RE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)=(.*)$")
+_POSIX_ACL_XATTR = "system.posix_acl_access"
+_POSIX_ACL_XATTR_VERSION = 0x0002
+_ACL_USER_OBJ = 0x01
+_ACL_USER = 0x02
+_ACL_GROUP_OBJ = 0x04
+_ACL_GROUP = 0x08
+_ACL_MASK = 0x10
+_ACL_OTHER = 0x20
+_ACL_EXECUTE = 0x01
+_ACL_WRITE = 0x02
+_ACL_READ = 0x04
+_ACL_UNDEFINED_ID = 0xFFFFFFFF
+_ACL_XATTR_HEADER = struct.Struct("<I")
+_ACL_XATTR_ENTRY = struct.Struct("<HHI")
+_NO_ACL_XATTR_ERRNOS = {
+    code
+    for code in (
+        getattr(errno, "ENODATA", None),
+        getattr(errno, "ENOATTR", None),
+        getattr(errno, "ENOTSUP", None),
+        getattr(errno, "EOPNOTSUPP", None),
+    )
+    if code is not None
+}
+
+
+def _posix_acl_insecure_access(acl_data: bytes, path: str) -> bool:
+    if (
+        len(acl_data) < _ACL_XATTR_HEADER.size
+        or (len(acl_data) - _ACL_XATTR_HEADER.size) % _ACL_XATTR_ENTRY.size
+    ):
+        fail(f"env file {path} has malformed POSIX ACL data; refusing", EXIT_OPEN_ERR)
+
+    (version,) = _ACL_XATTR_HEADER.unpack_from(acl_data)
+    if version != _POSIX_ACL_XATTR_VERSION:
+        fail(
+            f"env file {path} has unsupported POSIX ACL version {version}; refusing",
+            EXIT_OPEN_ERR,
+        )
+
+    entries: list[tuple[int, int]] = []
+    mask_perm: int | None = None
+    for offset in range(
+        _ACL_XATTR_HEADER.size,
+        len(acl_data),
+        _ACL_XATTR_ENTRY.size,
+    ):
+        tag, perm, _entry_id = _ACL_XATTR_ENTRY.unpack_from(acl_data, offset)
+        if tag == _ACL_MASK:
+            mask_perm = perm
+        elif tag not in {
+            _ACL_USER_OBJ,
+            _ACL_USER,
+            _ACL_GROUP_OBJ,
+            _ACL_GROUP,
+            _ACL_OTHER,
+        }:
+            fail(
+                f"env file {path} has unknown POSIX ACL tag {tag}; refusing",
+                EXIT_OPEN_ERR,
+            )
+        entries.append((tag, perm))
+
+    for tag, perm in entries:
+        effective = perm
+        if tag in {_ACL_USER, _ACL_GROUP_OBJ, _ACL_GROUP} and mask_perm is not None:
+            effective &= mask_perm
+        if tag in {_ACL_GROUP_OBJ, _ACL_GROUP, _ACL_OTHER} and effective:
+            return True
+        if tag == _ACL_USER and effective & (_ACL_WRITE | _ACL_EXECUTE):
+            return True
+    return False
+
+
+def _env_file_has_insecure_access(fd: int, path: str, st_mode: int) -> bool:
+    try:
+        acl_data = os.getxattr(fd, _POSIX_ACL_XATTR)
+    except OSError as exc:
+        if exc.errno in _NO_ACL_XATTR_ERRNOS:
+            return bool(st_mode & 0o077)
+        fail(f"failed to inspect env file ACL for {path}: {exc}", EXIT_OPEN_ERR)
+
+    return _posix_acl_insecure_access(acl_data, path)
 
 
 def load_env_file(path: str) -> dict[str, str]:
@@ -109,9 +193,9 @@ def load_env_file(path: str) -> dict[str, str]:
         st = os.fstat(fd)
         if not stat.S_ISREG(st.st_mode):
             fail(f"env file {path} is not a regular file; refusing", EXIT_OPEN_ERR)
-        if st.st_mode & 0o077:
+        if _env_file_has_insecure_access(fd, path, st.st_mode):
             fail(
-                f"env file {path} permits group or world access (mode {oct(st.st_mode & 0o7777)}); refusing",
+                f"env file {path} grants group, world, or write/execute ACL access (mode {oct(st.st_mode & 0o7777)}); refusing",
                 EXIT_OPEN_ERR,
             )
         if st.st_uid not in (0, os.getuid()):
@@ -122,17 +206,21 @@ def load_env_file(path: str) -> dict[str, str]:
         with os.fdopen(fd, "r", encoding="utf-8") as fh:
             fd = -1
             for raw in fh:
-                line = raw.strip()
-                if not line or line.startswith("#"):
+                line = raw.rstrip("\r\n")
+                stripped_line = line.strip()
+                if not stripped_line or stripped_line.startswith("#"):
                     continue
                 m = _DOTENV_RE.match(line)
                 if not m:
                     continue
-                key, value = m.group(1), m.group(2).strip()
-                if (value.startswith('"') and value.endswith('"')) or (
-                    value.startswith("'") and value.endswith("'")
-                ):
-                    value = value[1:-1]
+                key, raw_value = m.group(1), m.group(2)
+                stripped_value = raw_value.strip()
+                if (
+                    stripped_value.startswith('"') and stripped_value.endswith('"')
+                ) or (stripped_value.startswith("'") and stripped_value.endswith("'")):
+                    value = stripped_value[1:-1]
+                else:
+                    value = raw_value
                 env[key] = value
     finally:
         if fd != -1:
@@ -295,6 +383,7 @@ def _resolve_endpoint_url(env: dict[str, str]) -> str | None:
         return url
     host = env.get("R2_S3_ENDPOINT")
     if host:
+        host = re.sub(r"^https?://", "", host.strip(), flags=re.IGNORECASE).rstrip("/")
         return f"https://{host}"
     account = env.get("R2_ACCOUNT_ID")
     if account:

--- a/packages/duplicati-r2-tools/duplicati_r2_extract.py
+++ b/packages/duplicati-r2-tools/duplicati_r2_extract.py
@@ -518,6 +518,7 @@ class EncryptedCache:
         self.bytes_fetched = 0
         self.fetches = 0
         self._order: collections.OrderedDict[str, int] = collections.OrderedDict()
+        self._used_bytes = 0
         if cap_bytes > 0:
             self._ensure_root()
             self._scan_existing()
@@ -541,40 +542,95 @@ class EncryptedCache:
         entries: list[tuple[float, str, int]] = []
         for entry in self.root.iterdir():
             try:
+                if entry.name.endswith(".partial"):
+                    try:
+                        entry.unlink()
+                    except FileNotFoundError:
+                        pass
+                    except OSError as exc:
+                        fail(
+                            f"failed to remove stale cache partial {entry}: {exc}",
+                            EXIT_OPEN_ERR,
+                        )
+                    continue
                 if not entry.is_file():
                     continue
                 st = entry.stat()
             except FileNotFoundError:
                 continue
+            except OSError as exc:
+                fail(f"failed to inspect cache entry {entry}: {exc}", EXIT_OPEN_ERR)
             entries.append((st.st_mtime, entry.name, st.st_size))
         for _mtime, name, size in sorted(entries):
-            self._order[name] = size
+            self._remember(name, size)
         self._evict_until_room(0)
 
+    def _remember(self, volume_name: str, size: int) -> None:
+        previous = self._order.get(volume_name)
+        if previous is not None:
+            self._used_bytes -= previous
+        self._order[volume_name] = size
+        self._used_bytes += size
+
+    def _forget(self, volume_name: str) -> bool:
+        size = self._order.pop(volume_name, None)
+        if size is None:
+            return False
+        self._used_bytes -= size
+        return True
+
     def _evict_until_room(self, incoming_size: int) -> None:
-        used = sum(self._order.values())
-        while used + incoming_size > self.cap_bytes and self._order:
+        while self._used_bytes + incoming_size > self.cap_bytes and self._order:
             name, n = self._order.popitem(last=False)
             try:
                 (self.root / name).unlink()
             except FileNotFoundError:
                 pass
-            used -= n
+            except OSError as exc:
+                fail(
+                    f"failed to evict cached volume {self.root / name}: {exc}",
+                    EXIT_OPEN_ERR,
+                )
+            self._used_bytes -= n
+
+    def evict(self, volume_name: str) -> bool:
+        validate_volume_name(volume_name)
+        known = self._forget(volume_name)
+        removed = False
+        try:
+            (self.root / volume_name).unlink()
+            removed = True
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            fail(
+                f"failed to evict cached volume {self.root / volume_name}: {exc}",
+                EXIT_OPEN_ERR,
+            )
+        return known or removed
 
     def get(self, volume_name: str, fetcher: Callable[[str], bytes]) -> bytes:
+        data, _cache_hit = self.get_with_status(volume_name, fetcher)
+        return data
+
+    def get_with_status(
+        self,
+        volume_name: str,
+        fetcher: Callable[[str], bytes],
+    ) -> tuple[bytes, bool]:
         validate_volume_name(volume_name)
         if self.cap_bytes <= 0:
             data = fetcher(volume_name)
             self.bytes_fetched += len(data)
             self.fetches += 1
-            return data
+            return data, False
         if volume_name in self._order:
             # Touch: move to end (most recently used).
             self._order.move_to_end(volume_name)
             try:
-                return (self.root / volume_name).read_bytes()
+                return (self.root / volume_name).read_bytes(), True
             except FileNotFoundError:
-                self._order.pop(volume_name, None)
+                self._forget(volume_name)
             except OSError as exc:
                 fail(
                     f"failed to read cached volume {self.root / volume_name}: {exc}",
@@ -587,7 +643,7 @@ class EncryptedCache:
         size = len(data)
         if size > self.cap_bytes:
             # Single object exceeds cache cap; bypass cache for it.
-            return data
+            return data, False
         self._evict_until_room(size)
         self._ensure_root()
         target = self.root / volume_name
@@ -611,13 +667,17 @@ class EncryptedCache:
         with os.fdopen(fd, "wb") as fh:
             fh.write(data)
         os.replace(tmp, target)
-        self._order[volume_name] = size
-        return data
+        self._remember(volume_name, size)
+        return data, False
 
 
 # ---------------------------------------------------------------------------
 # AES decrypter
 # ---------------------------------------------------------------------------
+
+
+class AesDecryptError(Exception):
+    pass
 
 
 class AesDecrypter:
@@ -642,7 +702,9 @@ class AesDecrypter:
             # or any "corrupted" failure mode; all of those are data errors,
             # not user errors. Surface the message verbatim alongside the
             # offending volume name (loud-failure contract per docs).
-            fail(f"AES decrypt failed for {volume_name}: {exc}", EXIT_DATA_ERR)
+            raise AesDecryptError(
+                f"AES decrypt failed for {volume_name}: {exc}"
+            ) from exc
         return plain.getvalue()
 
 
@@ -1006,8 +1068,22 @@ class Extractor:
         if cached is not None:
             self._open_volumes.move_to_end(volume_name)
             return cached
-        encrypted = self.cache.get(volume_name, self.source.fetch)
-        decrypted = self.decrypter.decrypt(encrypted, volume_name)
+        encrypted, cache_hit = self.cache.get_with_status(
+            volume_name, self.source.fetch
+        )
+        try:
+            decrypted = self.decrypter.decrypt(encrypted, volume_name)
+        except AesDecryptError as exc:
+            if not cache_hit or not self.cache.evict(volume_name):
+                fail(str(exc), EXIT_DATA_ERR)
+            encrypted, _cache_hit = self.cache.get_with_status(
+                volume_name,
+                self.source.fetch,
+            )
+            try:
+                decrypted = self.decrypter.decrypt(encrypted, volume_name)
+            except AesDecryptError as retry_exc:
+                fail(str(retry_exc), EXIT_DATA_ERR)
         vol = OpenedVolume(
             volume_name,
             decrypted,

--- a/packages/duplicati-r2-tools/duplicati_r2_extract.py
+++ b/packages/duplicati-r2-tools/duplicati_r2_extract.py
@@ -220,7 +220,7 @@ def load_env_file(path: str) -> dict[str, str]:
                 ) or (stripped_value.startswith("'") and stripped_value.endswith("'")):
                     value = stripped_value[1:-1]
                 else:
-                    value = raw_value
+                    value = stripped_value
                 env[key] = value
     finally:
         if fd != -1:

--- a/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
+++ b/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
@@ -573,7 +573,6 @@ def check_include_pattern_normalization() -> None:
     )
 
     def collect(pattern: str) -> list[str]:
-        pattern = extract_mod._normalize_include_pattern(pattern)
         matches = _glob_paths(conn, 7, pattern)
         assert iter(matches) is matches
         return list(matches)
@@ -584,7 +583,6 @@ def check_include_pattern_normalization() -> None:
         "/bankdata/sub/file.torrent",
     ]
     assert collect("/bankdata/*.torrent") == ["/bankdata/file.torrent"]
-    assert collect("bankdata/*.torrent") == ["/bankdata/file.torrent"]
     assert collect("/bankdata/**/*.torrent") == [
         "/bankdata/file.torrent",
         "/bankdata/sub/deep/file.torrent",
@@ -592,6 +590,82 @@ def check_include_pattern_normalization() -> None:
     ]
     assert extract_mod._segment_globmatch("/bankdata", "/bankdata/**")
     assert extract_mod._segment_globmatch("/foo", "/**/foo")
+
+
+def check_main_normalizes_include_pattern(work: Path) -> None:
+    db = work / "main-normalizes-include.sqlite"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE Configuration (
+          Key TEXT,
+          Value TEXT
+        );
+        CREATE TABLE Fileset (
+          ID INTEGER PRIMARY KEY,
+          Timestamp INTEGER,
+          IsFullBackup INTEGER
+        );
+        INSERT INTO Configuration VALUES ('Version', '19');
+        INSERT INTO Fileset VALUES (7, 1700000000, 1);
+        """
+    )
+    conn.close()
+
+    source_root = work / "main-normalizes-source"
+    output_dir = work / "main-normalizes-out"
+    cache_root = work / "main-normalizes-cache"
+    source_root.mkdir()
+    passphrase_env = "DUPLICATI_R2_TEST_PASSPHRASE"
+    old_passphrase = os.environ.get(passphrase_env)
+    captured: list[tuple[int, str]] = []
+    real_aes_decrypter = extract_mod.AesDecrypter
+    real_glob_paths = extract_mod._glob_paths
+
+    class DummyAesDecrypter:
+        def __init__(self, _passphrase: str):
+            pass
+
+    def capture_glob_paths(
+        _conn: sqlite3.Connection,
+        snapshot_id: int,
+        pattern: str,
+    ) -> list[str]:
+        captured.append((snapshot_id, pattern))
+        return []
+
+    os.environ[passphrase_env] = "test-passphrase"
+    extract_mod.AesDecrypter = DummyAesDecrypter
+    extract_mod._glob_paths = capture_glob_paths
+    try:
+        expect_exit_stderr_contains(
+            EXIT_OPEN_ERR,
+            "normalized to '/bankdata/*.torrent'",
+            extract_mod.main,
+            [
+                "test",
+                "--db",
+                str(db),
+                "--source",
+                f"file://{source_root}",
+                "--passphrase-env",
+                passphrase_env,
+                "--cache-dir",
+                str(cache_root),
+                "--include",
+                "bankdata/*.torrent",
+                "--output-dir",
+                str(output_dir),
+            ],
+        )
+        assert captured == [(7, "/bankdata/*.torrent")]
+    finally:
+        extract_mod.AesDecrypter = real_aes_decrypter
+        extract_mod._glob_paths = real_glob_paths
+        if old_passphrase is None:
+            os.environ.pop(passphrase_env, None)
+        else:
+            os.environ[passphrase_env] = old_passphrase
 
 
 def check_include_rejects_output_flag() -> None:
@@ -743,6 +817,7 @@ def main(argv: list[str] | None = None) -> int:
     check_blocklist_lookup_batches_sql_vars()
     check_blocksetentry_invalid_hash_exit_code()
     check_include_pattern_normalization()
+    check_main_normalizes_include_pattern(args.work)
     check_include_rejects_output_flag()
     check_open_volume_lru()
     check_open_volume_evicts_corrupt_cache_hit(args.work)

--- a/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
+++ b/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
@@ -12,6 +12,7 @@ import json
 import os
 import sqlite3
 import stat
+import struct
 import zipfile
 from collections.abc import Callable
 from pathlib import Path
@@ -34,6 +35,7 @@ from duplicati_r2_extract import (
     _ensure_private_dir,
     _glob_paths,
     _load_manifest_for_layout,
+    _resolve_endpoint_url,
     build_source,
     load_env_file,
     resolve_bucket_layout,
@@ -151,6 +153,98 @@ def check_env_symlink_rejected(work: Path) -> None:
     os.symlink(env_file, env_link)
 
     expect_exit(EXIT_OPEN_ERR, load_env_file, str(env_link))
+
+
+def _acl_data(entries: list[tuple[int, int, int]]) -> bytes:
+    return struct.pack("<I", extract_mod._POSIX_ACL_XATTR_VERSION) + b"".join(
+        struct.pack("<HHI", tag, perm, entry_id) for tag, perm, entry_id in entries
+    )
+
+
+def check_env_acl_mask_allows_named_user_read(work: Path) -> None:
+    env_file = work / "acl-readable.env"
+    env_file.write_text("DUPLICATI_PASSPHRASE=test\n", encoding="utf-8")
+    env_file.chmod(0o440)
+    acl = _acl_data(
+        [
+            (
+                extract_mod._ACL_USER_OBJ,
+                extract_mod._ACL_READ,
+                extract_mod._ACL_UNDEFINED_ID,
+            ),
+            (extract_mod._ACL_USER, extract_mod._ACL_READ, os.getuid()),
+            (extract_mod._ACL_GROUP_OBJ, 0, extract_mod._ACL_UNDEFINED_ID),
+            (
+                extract_mod._ACL_MASK,
+                extract_mod._ACL_READ,
+                extract_mod._ACL_UNDEFINED_ID,
+            ),
+            (extract_mod._ACL_OTHER, 0, extract_mod._ACL_UNDEFINED_ID),
+        ]
+    )
+    real_getxattr = extract_mod.os.getxattr
+    extract_mod.os.getxattr = lambda _fd, _name: acl
+    try:
+        assert load_env_file(str(env_file))["DUPLICATI_PASSPHRASE"] == "test"
+    finally:
+        extract_mod.os.getxattr = real_getxattr
+
+
+def check_env_acl_group_grant_rejected(work: Path) -> None:
+    env_file = work / "acl-group.env"
+    env_file.write_text("DUPLICATI_PASSPHRASE=test\n", encoding="utf-8")
+    env_file.chmod(0o440)
+    acl = _acl_data(
+        [
+            (
+                extract_mod._ACL_USER_OBJ,
+                extract_mod._ACL_READ,
+                extract_mod._ACL_UNDEFINED_ID,
+            ),
+            (
+                extract_mod._ACL_GROUP_OBJ,
+                extract_mod._ACL_READ,
+                extract_mod._ACL_UNDEFINED_ID,
+            ),
+            (
+                extract_mod._ACL_MASK,
+                extract_mod._ACL_READ,
+                extract_mod._ACL_UNDEFINED_ID,
+            ),
+            (extract_mod._ACL_OTHER, 0, extract_mod._ACL_UNDEFINED_ID),
+        ]
+    )
+    real_getxattr = extract_mod.os.getxattr
+    extract_mod.os.getxattr = lambda _fd, _name: acl
+    try:
+        expect_exit(EXIT_OPEN_ERR, load_env_file, str(env_file))
+    finally:
+        extract_mod.os.getxattr = real_getxattr
+
+
+def check_env_unquoted_values_preserve_whitespace(work: Path) -> None:
+    env_file = work / "whitespace.env"
+    env_file.write_text(
+        'DUPLICATI_PASSPHRASE=secret   \nQUOTED=" spaced "\n',
+        encoding="utf-8",
+    )
+    env_file.chmod(0o400)
+
+    env = load_env_file(str(env_file))
+
+    assert env["DUPLICATI_PASSPHRASE"] == "secret   "
+    assert env["QUOTED"] == " spaced "
+
+
+def check_endpoint_host_strips_pasted_scheme() -> None:
+    assert (
+        _resolve_endpoint_url({"R2_S3_ENDPOINT": "https://abc.r2.example.com/"})
+        == "https://abc.r2.example.com"
+    )
+    assert (
+        _resolve_endpoint_url({"R2_S3_ENDPOINT": "HTTPS://abc.r2.example.com/"})
+        == "https://abc.r2.example.com"
+    )
 
 
 def check_private_output_dirs(work: Path) -> None:
@@ -495,6 +589,10 @@ def main(argv: list[str] | None = None) -> int:
     check_db_override_still_loads_layout_manifest(args.work)
     check_env_owner_mismatch_fails(args.work)
     check_env_symlink_rejected(args.work)
+    check_env_acl_mask_allows_named_user_read(args.work)
+    check_env_acl_group_grant_rejected(args.work)
+    check_env_unquoted_values_preserve_whitespace(args.work)
+    check_endpoint_host_strips_pasted_scheme()
     check_private_output_dirs(args.work)
     check_sink_partial_cleanup_not_following_symlink(args.work)
     check_cache_partial_symlink_not_followed(args.work)

--- a/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
+++ b/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import base64
 import collections
+import contextlib
 import hashlib
 import io
 import json
@@ -51,6 +52,15 @@ def expect_exit(code: int, fn: Callable[..., object], *args: object) -> None:
         raise AssertionError(f"expected SystemExit({code})")
 
 
+def expect_exit_stderr_contains(
+    code: int, needle: str, fn: Callable[..., object], *args: object
+) -> None:
+    stderr = io.StringIO()
+    with contextlib.redirect_stderr(stderr):
+        expect_exit(code, fn, *args)
+    assert needle in stderr.getvalue()
+
+
 def check_cache_recovery(work: Path) -> None:
     cache_root = work / "unit-cache"
     seen_fetches: list[str] = []
@@ -76,10 +86,36 @@ def check_cache_cap_on_startup(work: Path) -> None:
     os.utime(old, (1, 1))
     os.utime(new, (2, 2))
 
-    EncryptedCache(str(cap_root), 100)
+    cache = EncryptedCache(str(cap_root), 100)
 
     assert not old.exists()
     assert new.exists()
+    assert cache._used_bytes == 60
+
+
+def check_cache_partial_removal_failure_message(work: Path) -> None:
+    cache_root = work / "partial-remove-fail-cache"
+    cache_root.mkdir()
+    partial = cache_root / "vol1.aes.partial"
+    partial.write_bytes(b"stale")
+    real_unlink = Path.unlink
+
+    def fail_unlink(self: Path, *args: object, **kwargs: object) -> None:
+        if os.fspath(self) == os.fspath(partial):
+            raise PermissionError("synthetic stale partial removal failure")
+        real_unlink(self, *args, **kwargs)
+
+    Path.unlink = fail_unlink
+    try:
+        expect_exit_stderr_contains(
+            EXIT_OPEN_ERR,
+            "failed to remove stale cache partial",
+            EncryptedCache,
+            str(cache_root),
+            1024,
+        )
+    finally:
+        Path.unlink = real_unlink
 
 
 def check_volume_name_rejection(work: Path) -> None:
@@ -288,6 +324,7 @@ def check_cache_partial_symlink_not_followed(work: Path) -> None:
     cache = EncryptedCache(str(cache_root), 1024)
     assert cache.get("vol1.aes", lambda _name: b"encrypted") == b"encrypted"
     assert victim.read_text(encoding="utf-8") == "unchanged"
+    assert not (cache_root / "vol1.aes.partial").exists()
     assert (cache_root / "vol1.aes").read_bytes() == b"encrypted"
 
 
@@ -528,8 +565,8 @@ def check_include_rejects_output_flag() -> None:
 
 def check_open_volume_lru() -> None:
     class DummyCache:
-        def get(self, name: str, _fetcher: object) -> bytes:
-            return b"encrypted-" + name.encode("ascii")
+        def get_with_status(self, name: str, _fetcher: object) -> tuple[bytes, bool]:
+            return b"encrypted-" + name.encode("ascii"), False
 
     class DummySource:
         def fetch(self, name: str) -> bytes:
@@ -576,6 +613,62 @@ def check_open_volume_lru() -> None:
         extract_mod.OpenedVolume = original_opened_volume
 
 
+def check_open_volume_evicts_corrupt_cache_hit(work: Path) -> None:
+    cache_root = work / "corrupt-hit-cache"
+    cache_root.mkdir()
+    (cache_root / "vol1.aes").write_bytes(b"bad")
+    cache = EncryptedCache(str(cache_root), 1024)
+    fetches: list[str] = []
+
+    class DummySource:
+        def fetch(self, name: str) -> bytes:
+            fetches.append(name)
+            return b"good"
+
+    class DummyDecrypter:
+        def decrypt(self, encrypted: bytes, name: str) -> bytes:
+            if encrypted == b"bad":
+                raise extract_mod.AesDecryptError(f"bad cache hit for {name}")
+            return encrypted
+
+    class DummyOpenedVolume:
+        def __init__(
+            self,
+            name: str,
+            decrypted: bytes,
+            _expected_blocksize: int | None,
+            _expected_block_hash: str,
+            _expected_file_hash: str,
+        ):
+            self.name = name
+            self.decrypted = decrypted
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    original_opened_volume = extract_mod.OpenedVolume
+    extract_mod.OpenedVolume = DummyOpenedVolume
+    try:
+        extractor = object.__new__(Extractor)
+        extractor.cache = cache
+        extractor.source = DummySource()
+        extractor.decrypter = DummyDecrypter()
+        extractor.blocksize = 1024
+        extractor.block_hash_algo = "SHA256"
+        extractor.file_hash_algo = "SHA256"
+        extractor._open_volumes = collections.OrderedDict()
+
+        opened = extractor._open_volume("vol1.aes")
+
+        assert opened.decrypted == b"good"
+        assert fetches == ["vol1.aes"]
+        assert (cache_root / "vol1.aes").read_bytes() == b"good"
+        assert cache._used_bytes == 4
+    finally:
+        extract_mod.OpenedVolume = original_opened_volume
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("--work", required=True, type=Path)
@@ -583,6 +676,7 @@ def main(argv: list[str] | None = None) -> int:
 
     check_cache_recovery(args.work)
     check_cache_cap_on_startup(args.work)
+    check_cache_partial_removal_failure_message(args.work)
     check_volume_name_rejection(args.work)
     check_file_source_requires_absolute_path(args.work)
     check_bucket_layout_uses_raw_subpath()
@@ -603,6 +697,7 @@ def main(argv: list[str] | None = None) -> int:
     check_include_pattern_normalization()
     check_include_rejects_output_flag()
     check_open_volume_lru()
+    check_open_volume_evicts_corrupt_cache_hit(args.work)
     return 0
 
 

--- a/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
+++ b/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
@@ -524,27 +524,37 @@ def check_include_pattern_normalization() -> None:
           (1, '/bankdata/sub/file.torrent', 101),
           (2, '/bankdata/file.torrent', 102),
           (3, '/bankdata/other.bin', 103),
-          (4, '/bankdata/sub/', -100);
+          (4, '/bankdata/sub/', -100),
+          (5, '/bankdata/sub/deep/file.torrent', 104);
         INSERT INTO FilesetEntry VALUES
           (7, 1),
           (7, 2),
           (7, 3),
-          (7, 4);
+          (7, 4),
+          (7, 5);
         """
     )
 
     def collect(pattern: str) -> list[str]:
+        pattern = extract_mod._normalize_include_pattern(pattern)
         matches = _glob_paths(conn, 7, pattern)
         assert iter(matches) is matches
         return list(matches)
 
     assert collect("*.torrent") == [
         "/bankdata/file.torrent",
+        "/bankdata/sub/deep/file.torrent",
         "/bankdata/sub/file.torrent",
     ]
     assert collect("/bankdata/*.torrent") == ["/bankdata/file.torrent"]
     assert collect("bankdata/*.torrent") == ["/bankdata/file.torrent"]
-    assert collect("/bankdata/**/*.torrent") == ["/bankdata/sub/file.torrent"]
+    assert collect("/bankdata/**/*.torrent") == [
+        "/bankdata/file.torrent",
+        "/bankdata/sub/deep/file.torrent",
+        "/bankdata/sub/file.torrent",
+    ]
+    assert extract_mod._segment_globmatch("/bankdata", "/bankdata/**")
+    assert extract_mod._segment_globmatch("/foo", "/**/foo")
 
 
 def check_include_rejects_output_flag() -> None:

--- a/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
+++ b/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
@@ -258,18 +258,25 @@ def check_env_acl_group_grant_rejected(work: Path) -> None:
         extract_mod.os.getxattr = real_getxattr
 
 
-def check_env_unquoted_values_preserve_whitespace(work: Path) -> None:
+def check_env_unquoted_values_strip_padding(work: Path) -> None:
     env_file = work / "whitespace.env"
     env_file.write_text(
-        'DUPLICATI_PASSPHRASE=secret   \nQUOTED=" spaced "\n',
+        (
+            "DUPLICATI_PASSPHRASE=secret   \n"
+            "R2_S3_ENDPOINT_URL=https://abc.r2.example.com   \n"
+            'DOUBLE_QUOTED=" spaced "\n'
+            "SINGLE_QUOTED=' padded '\n"
+        ),
         encoding="utf-8",
     )
     env_file.chmod(0o400)
 
     env = load_env_file(str(env_file))
 
-    assert env["DUPLICATI_PASSPHRASE"] == "secret   "
-    assert env["QUOTED"] == " spaced "
+    assert env["DUPLICATI_PASSPHRASE"] == "secret"
+    assert env["R2_S3_ENDPOINT_URL"] == "https://abc.r2.example.com"
+    assert env["DOUBLE_QUOTED"] == " spaced "
+    assert env["SINGLE_QUOTED"] == " padded "
 
 
 def check_endpoint_host_strips_pasted_scheme() -> None:
@@ -695,7 +702,7 @@ def main(argv: list[str] | None = None) -> int:
     check_env_symlink_rejected(args.work)
     check_env_acl_mask_allows_named_user_read(args.work)
     check_env_acl_group_grant_rejected(args.work)
-    check_env_unquoted_values_preserve_whitespace(args.work)
+    check_env_unquoted_values_strip_padding(args.work)
     check_endpoint_host_strips_pasted_scheme()
     check_private_output_dirs(args.work)
     check_sink_partial_cleanup_not_following_symlink(args.work)

--- a/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
+++ b/packages/duplicati-r2-tools/scripts/check_extract_regressions.py
@@ -7,6 +7,7 @@ import argparse
 import base64
 import collections
 import contextlib
+import errno
 import hashlib
 import io
 import json
@@ -197,6 +198,30 @@ def _acl_data(entries: list[tuple[int, int, int]]) -> bytes:
     )
 
 
+def check_env_mode_group_grant_rejected(work: Path) -> None:
+    env_file = work / "mode-group.env"
+    env_file.write_text("DUPLICATI_PASSPHRASE=test\n", encoding="utf-8")
+    env_file.chmod(0o440)
+    no_acl_errno = getattr(errno, "ENODATA", None)
+    if no_acl_errno is None:
+        no_acl_errno = next(iter(extract_mod._NO_ACL_XATTR_ERRNOS))
+    real_getxattr = extract_mod.os.getxattr
+
+    def missing_acl(_fd: int, _name: str) -> bytes:
+        raise OSError(no_acl_errno, "synthetic missing ACL")
+
+    extract_mod.os.getxattr = missing_acl
+    try:
+        expect_exit_stderr_contains(
+            EXIT_OPEN_ERR,
+            "mode 0o440 permits group or world access",
+            load_env_file,
+            str(env_file),
+        )
+    finally:
+        extract_mod.os.getxattr = real_getxattr
+
+
 def check_env_acl_mask_allows_named_user_read(work: Path) -> None:
     env_file = work / "acl-readable.env"
     env_file.write_text("DUPLICATI_PASSPHRASE=test\n", encoding="utf-8")
@@ -253,7 +278,12 @@ def check_env_acl_group_grant_rejected(work: Path) -> None:
     real_getxattr = extract_mod.os.getxattr
     extract_mod.os.getxattr = lambda _fd, _name: acl
     try:
-        expect_exit(EXIT_OPEN_ERR, load_env_file, str(env_file))
+        expect_exit_stderr_contains(
+            EXIT_OPEN_ERR,
+            "POSIX ACL group-object entry grants r--",
+            load_env_file,
+            str(env_file),
+        )
     finally:
         extract_mod.os.getxattr = real_getxattr
 
@@ -700,6 +730,7 @@ def main(argv: list[str] | None = None) -> int:
     check_db_override_still_loads_layout_manifest(args.work)
     check_env_owner_mismatch_fails(args.work)
     check_env_symlink_rejected(args.work)
+    check_env_mode_group_grant_rejected(args.work)
     check_env_acl_mask_allows_named_user_read(args.work)
     check_env_acl_group_grant_rejected(args.work)
     check_env_unquoted_values_strip_padding(args.work)


### PR DESCRIPTION
## Summary

Follow-up to #219, which closed #204. This PR carries the review-feedback fixes for the Duplicati R2 read-only archive extraction command on top of the merged branch, and records the follow-on read-only mount implementation plan.

Related: #204

The changes harden three runtime surfaces:

- Env and endpoint parsing: accept the intended `stateDirReadableBy` named-user read ACLs, reject unsafe env-file permissions, strip incidental unquoted env padding while preserving quoted values, and strip accidental endpoint URL schemes case-insensitively.
- Encrypted cache recovery: clean stale or corrupt cache entries during startup/accounting, report stale partial removal failures accurately, and retry one cached dblock by evicting and refetching it after decrypt failure.
- Include glob matching: replace Python-version-dependent `PurePosixPath.match()` behavior with deterministic segment matching for `**`, including zero-segment and nested descendants, while keeping `_glob_paths` responsible for already-normalized patterns.
- Read-only mount planning: document the Linux-only `pyfuse3` package, `duplicati-r2-mount` foreground/unmount CLI, systemd service shape, `--debug` redaction requirement, sandbox-safe test boundary, `system76` service enablement, and the two-gate `--allow-other`/`services.duplicati-r2.mount.allowOther` policy.

## Test plan

- [x] `python3 -m py_compile packages/duplicati-r2-tools/duplicati_r2_extract.py packages/duplicati-r2-tools/scripts/check_extract_regressions.py`
- [x] `PYTHONPATH=packages/duplicati-r2-tools python3 packages/duplicati-r2-tools/scripts/check_extract_regressions.py --work "$work"`
- [x] `git diff --check -- packages/duplicati-r2-tools/duplicati_r2_extract.py packages/duplicati-r2-tools/scripts/check_extract_regressions.py`
- [x] `nix build .#duplicati-r2-extract`
- [x] `nix-instantiate --parse packages/duplicati-r2-tools/extract.nix >/dev/null`
- [x] `SKIP=vulnix nix develop -c pre-commit run --files packages/duplicati-r2-tools/duplicati_r2_extract.py packages/duplicati-r2-tools/scripts/check_extract_regressions.py --hook-stage manual`
- [x] `git diff --check -- docs/drafts/duplicati-r2-readonly-mount-investigation.md`
- [x] `SKIP=vulnix nix develop -c pre-commit run --files docs/drafts/duplicati-r2-readonly-mount-investigation.md --hook-stage manual`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens three runtime surfaces of the Duplicati R2 extraction tool: POSIX ACL-aware env-file permission checking (allowing `stateDirReadableBy` named-user reads while rejecting group/world/write/execute grants), a cache-coherence fix that tracks `_used_bytes` incrementally and retries a single decrypt failure by evicting and re-fetching the suspected corrupt cache entry, and a deterministic `_segment_globmatch` implementation replacing the version-dependent `PurePosixPath.match()`.

- **ACL checking** (`_posix_acl_insecure_access`, `_env_file_has_insecure_access`): parses the Linux `system.posix_acl_access` xattr, applies the mask to named-user/group entries, and falls back to mode-bit checking when ACLs are absent or unsupported.
- **Cache integrity** (`_remember`, `_forget`, `evict`, `get_with_status`): `_used_bytes` replaces the O(n) `sum()` call, `.partial` files are cleaned on startup, and an `AesDecryptError` exception enables a single evict-and-retry cycle on a stale cache hit.
- **Glob matching** (`_segment_globmatch`): memoised DP matching handles `**` matching zero or more path segments deterministically; `_glob_paths` now expects the caller to pre-normalise patterns before invocation.

<h3>Confidence Score: 5/5</h3>

Safe to merge: all three hardened surfaces are implemented correctly, fail is typed NoReturn so the decrypted variable is always bound, and the retry path is gated correctly on a confirmed cache hit.

The control flow through the new AES retry path is sound: cache_hit=True guarantees the volume is still in _order when evict() is called. The _used_bytes counter is updated symmetrically in _remember, _forget, and _evict_until_room. The _segment_globmatch memoised DP correctly handles zero-segment ** matches and nested descendants.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/duplicati-r2-tools/duplicati_r2_extract.py | Major additions: POSIX ACL security check for env files, _used_bytes accounting in EncryptedCache, AesDecryptError exception with retry-on-cache-hit logic, and _segment_globmatch replacing PurePosixPath.match(). All features are implemented correctly and control flow is sound. |
| packages/duplicati-r2-tools/scripts/check_extract_regressions.py | New regression tests for ACL mask/named-user acceptance, group rejection, unquoted value whitespace stripping, endpoint scheme stripping, partial-file removal error messages, cache _used_bytes invariant, and the corrupt-cache-hit eviction+retry path. Coverage is thorough. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant E as Extractor._open_volume
    participant C as EncryptedCache
    participant S as Source (S3/File)
    participant D as AesDecrypter

    E->>C: get_with_status(volume_name, fetch)
    alt cache hit
        C-->>E: "(encrypted_bytes, cache_hit=True)"
    else cache miss
        C->>S: fetch(volume_name)
        S-->>C: encrypted_bytes
        C-->>E: "(encrypted_bytes, cache_hit=False)"
    end

    E->>D: decrypt(encrypted, volume_name)
    alt decrypt success
        D-->>E: decrypted_bytes
        E->>E: OpenedVolume(...)
    else AesDecryptError
        D-->>E: raises AesDecryptError
        alt NOT cache_hit OR evict fails
            E->>E: fail(EXIT_DATA_ERR)
        else cache_hit AND evict succeeds
            E->>C: evict(volume_name)
            C->>C: _forget + unlink
            E->>C: get_with_status (re-fetch)
            C->>S: fetch(volume_name)
            S-->>C: fresh encrypted_bytes
            C-->>E: "(encrypted_bytes, cache_hit=False)"
            E->>D: decrypt(encrypted, volume_name)
            alt retry success
                D-->>E: decrypted_bytes
                E->>E: OpenedVolume(...)
            else retry AesDecryptError
                E->>E: fail(EXIT_DATA_ERR)
            end
        end
    end
```

<sub>Reviews (3): Last reviewed commit: ["fix(duplicati): strip unquoted env paddi..."](https://github.com/bad3r/nixos/commit/199df07d24f011f2d7f0b50372cec432b7382389) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31935538)</sub>

<!-- /greptile_comment -->
