### PR TITLE
feat(apps): add git fork reset helper

### DIFF
--- a/modules/apps/git-fork-reset.nix
+++ b/modules/apps/git-fork-reset.nix
@@ -303,7 +303,6 @@ let
             if $has_local_state; then
               print_command git stash push --all --message "$stash_message"
             fi
-            print_command git switch "$branch"
             print_command git reset --hard "$target_ref"
             if $push; then
               print_command git push --force-with-lease "$origin_remote" "$branch:$branch"
@@ -334,7 +333,6 @@ let
             fi
           fi
 
-          git switch "$branch"
           git reset --hard "$target_ref"
 
           if $push; then

--- a/modules/apps/git-fork-reset.nix
+++ b/modules/apps/git-fork-reset.nix
@@ -1,0 +1,354 @@
+/*
+  Package: git-fork-reset
+  Description: Reset the current fork branch to the matching upstream branch.
+  Homepage: nil
+  Documentation: nil
+  Repository: nil
+
+  Summary:
+    * Provides `git-fork-reset`, also invocable as `git fork-reset`, for refreshing fork branches from upstream.
+    * Backs up dirty, untracked, and ignored local state with `git stash --all` before resetting.
+
+  Options:
+    --no-push: Reset locally without force-with-lease pushing to origin.
+    --yes: Confirm the destructive reset without an interactive prompt.
+    --dry-run: Print the Git operations that would run without changing the repository.
+    --upstream <repo>: Add the upstream remote when missing, accepting owner/repo or GitHub HTTPS URLs.
+    --upstream-remote <name>: Use a remote name other than upstream.
+    --origin-remote <name>: Use a push remote name other than origin.
+    -h, --help: Print usage information.
+
+  Notes:
+    * The old shell function name is intentionally not preserved.
+    * In Git subcommand form, use `git fork-reset -h`; Git handles `git fork-reset --help` as a manpage lookup.
+    * The backup stash is kept for recovery and is never dropped automatically.
+*/
+_:
+let
+  GitForkResetModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs."git-fork-reset".extended;
+
+      gitForkResetWrapper = pkgs.writeShellApplication {
+        name = "git-fork-reset";
+        runtimeInputs = [
+          cfg.package
+          pkgs.coreutils
+        ];
+        text = ''
+          usage() {
+            cat <<'EOF'
+          git-fork-reset - reset a fork branch to the matching upstream branch
+
+          Usage:
+            git-fork-reset [OPTIONS]
+            git fork-reset [OPTIONS]
+
+          Resets the current branch to upstream/<current-branch>. If local
+          tracked changes, untracked files, or ignored files are present, they
+          are first captured with `git stash --all` and the stash is kept for
+          recovery. By default, the refreshed branch is pushed to origin with
+          --force-with-lease.
+
+          Options:
+            --no-push                 Reset locally without pushing origin.
+            -y, --yes                 Confirm without an interactive prompt.
+            --dry-run                 Print operations without changing state.
+            --upstream REPO           Upstream repo to add when the remote is missing.
+                                      Accepts owner/repo, https://github.com/owner/repo,
+                                      or https://github.com/owner/repo.git.
+            --upstream-remote NAME    Upstream remote name. Default: upstream.
+            --origin-remote NAME      Push remote name. Default: origin.
+            -h, --help                Print this help and exit.
+
+          Examples:
+            git fork-reset --yes
+            git fork-reset --no-push
+            git fork-reset --upstream NixOS/nixpkgs --yes
+            git-fork-reset --dry-run
+
+          Note:
+            Git handles `git fork-reset --help` as a manpage lookup. Use
+            `git fork-reset -h` or `git-fork-reset --help` for this help text.
+          EOF
+          }
+
+          die() {
+            printf 'git fork-reset: %s\n' "$*" >&2
+            exit 1
+          }
+
+          print_command() {
+            printf '+'
+            printf ' %q' "$@"
+            printf '\n'
+          }
+
+          run() {
+            if $dry_run; then
+              print_command "$@"
+            else
+              "$@"
+            fi
+          }
+
+          confirm_reset() {
+            if $assume_yes; then
+              return 0
+            fi
+
+            if [[ ! -t 0 ]]; then
+              die 'refusing to prompt with non-tty stdin; pass --yes to confirm'
+            fi
+
+            local reply
+            read -r -p 'Reset this branch and discard the working tree? [y/N] ' reply
+            case "''${reply,,}" in
+              y|yes) ;;
+              *) die 'aborted' ;;
+            esac
+          }
+
+          normalize_upstream_url() {
+            local input="$1"
+            input="''${input%/}"
+
+            if [[ -z "$input" ]]; then
+              return 1
+            fi
+
+            case "$input" in
+              https://github.com/*.git|git@github.com:*.git)
+                printf '%s\n' "$input"
+                ;;
+              https://github.com/*|git@github.com:*)
+                printf '%s.git\n' "$input"
+                ;;
+              github.com/*)
+                printf 'https://%s.git\n' "''${input%.git}"
+                ;;
+              */*)
+                printf 'https://github.com/%s.git\n' "''${input%.git}"
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
+          validate_remote_name() {
+            local label="$1"
+            local name="$2"
+
+            if [[ -z "$name" || "$name" == -* || "$name" == *[[:space:]]* ]]; then
+              die "invalid $label remote name: $name"
+            fi
+          }
+
+          push=true
+          assume_yes=false
+          dry_run=false
+          upstream_input=""
+          upstream_remote="upstream"
+          origin_remote="origin"
+
+          while [[ $# -gt 0 ]]; do
+            case "$1" in
+              --no-push)
+                push=false
+                shift
+                ;;
+              -y|--yes)
+                assume_yes=true
+                shift
+                ;;
+              --dry-run)
+                dry_run=true
+                shift
+                ;;
+              --upstream)
+                if [[ -z "''${2:-}" ]]; then
+                  die '--upstream requires an argument'
+                fi
+                upstream_input="$2"
+                shift 2
+                ;;
+              --upstream=*)
+                upstream_input="''${1#*=}"
+                if [[ -z "$upstream_input" ]]; then
+                  die '--upstream= requires a non-empty argument'
+                fi
+                shift
+                ;;
+              --upstream-remote)
+                if [[ -z "''${2:-}" ]]; then
+                  die '--upstream-remote requires an argument'
+                fi
+                upstream_remote="$2"
+                shift 2
+                ;;
+              --upstream-remote=*)
+                upstream_remote="''${1#*=}"
+                shift
+                ;;
+              --origin-remote)
+                if [[ -z "''${2:-}" ]]; then
+                  die '--origin-remote requires an argument'
+                fi
+                origin_remote="$2"
+                shift 2
+                ;;
+              --origin-remote=*)
+                origin_remote="''${1#*=}"
+                shift
+                ;;
+              -h|--help)
+                usage
+                exit 0
+                ;;
+              --)
+                shift
+                if [[ $# -gt 0 ]]; then
+                  die 'unexpected positional arguments'
+                fi
+                break
+                ;;
+              -*)
+                die "unknown option: $1"
+                ;;
+              *)
+                die "unexpected argument: $1"
+                ;;
+            esac
+          done
+
+          validate_remote_name upstream "$upstream_remote"
+          validate_remote_name origin "$origin_remote"
+
+          repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" \
+            || die 'not inside a Git worktree'
+          branch="$(git symbolic-ref --quiet --short HEAD)" \
+            || die 'not on a branch; refusing to reset detached HEAD'
+
+          if ! git remote get-url "$upstream_remote" >/dev/null 2>&1; then
+            if [[ -z "$upstream_input" ]]; then
+              if [[ ! -t 0 ]]; then
+                die "no $upstream_remote remote found; pass --upstream"
+              fi
+              printf 'No %s remote found.\n' "$upstream_remote"
+              printf 'Enter upstream repo, e.g. NixOS/nixpkgs or https://github.com/NixOS/nixpkgs.git: '
+              IFS= read -r upstream_input
+            fi
+
+            upstream_url="$(normalize_upstream_url "$upstream_input")" \
+              || die "invalid upstream repo: $upstream_input"
+            run git remote add "$upstream_remote" "$upstream_url"
+          elif [[ -n "$upstream_input" ]]; then
+            printf 'git fork-reset: %s remote already exists; ignoring --upstream\n' "$upstream_remote" >&2
+          fi
+
+          if $push && ! git remote get-url "$origin_remote" >/dev/null 2>&1; then
+            die "no $origin_remote remote found"
+          fi
+
+          fetch_ref="+refs/heads/$branch:refs/remotes/$upstream_remote/$branch"
+          target_ref="refs/remotes/$upstream_remote/$branch"
+
+          run git fetch "$upstream_remote" "$fetch_ref"
+
+          if $dry_run; then
+            if git rev-parse --verify --quiet "$target_ref^{commit}" >/dev/null; then
+              target_commit="$(git rev-parse --short "$target_ref")"
+            else
+              target_commit='unknown until fetch'
+            fi
+          else
+            target_commit="$(git rev-parse --short "$target_ref")" \
+              || die "fetched branch was not available at $target_ref"
+          fi
+
+          dirty_output="$(git status --porcelain --untracked-files=all --ignored=matching)"
+          has_local_state=false
+          if [[ -n "$dirty_output" ]]; then
+            has_local_state=true
+          fi
+
+          printf 'Repository: %s\n' "$repo_root"
+          printf 'Branch: %s\n' "$branch"
+          printf 'Reset target: %s (%s)\n' "$target_ref" "$target_commit"
+          if $has_local_state; then
+            printf 'Local state: will be backed up with git stash --all before reset\n'
+          else
+            printf 'Local state: clean\n'
+          fi
+          if $push; then
+            printf 'Push: %s %s:%s with --force-with-lease\n' "$origin_remote" "$branch" "$branch"
+          else
+            printf 'Push: skipped because --no-push was passed\n'
+          fi
+
+          timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+          stash_message="git-fork-reset backup: $branch $timestamp"
+
+          if $dry_run; then
+            if $has_local_state; then
+              print_command git stash push --all --message "$stash_message"
+            fi
+            print_command git switch "$branch"
+            print_command git reset --hard "$target_ref"
+            if $push; then
+              print_command git push --force-with-lease "$origin_remote" "$branch:$branch"
+            fi
+            exit 0
+          fi
+
+          confirm_reset
+
+          if $has_local_state; then
+            stash_before="$(git rev-parse --verify --quiet refs/stash || true)"
+            git stash push --all --message "$stash_message"
+            stash_after="$(git rev-parse --verify --quiet refs/stash || true)"
+            if [[ -n "$stash_after" && "$stash_after" != "$stash_before" ]]; then
+              stash_line="$(git stash list --format='%gd %h %s' -n 1)"
+              printf 'Backup created: %s\n' "$stash_line"
+            else
+              die 'expected to create a backup stash, but refs/stash did not change'
+            fi
+          fi
+
+          git switch "$branch"
+          git reset --hard "$target_ref"
+
+          if $push; then
+            git push --force-with-lease "$origin_remote" "$branch:$branch"
+          else
+            printf 'Skipped push because --no-push was passed.\n'
+          fi
+        '';
+      };
+    in
+    {
+      options.programs."git-fork-reset".extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable the git fork reset helper.";
+        };
+
+        package = lib.mkPackageOption pkgs "git" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ gitForkResetWrapper ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps."git-fork-reset" = GitForkResetModule;
+}

--- a/modules/apps/git-fork-reset.nix
+++ b/modules/apps/git-fork-reset.nix
@@ -90,14 +90,6 @@ let
             printf '\n'
           }
 
-          run() {
-            if $dry_run; then
-              print_command "$@"
-            else
-              "$@"
-            fi
-          }
-
           confirm_reset() {
             if $assume_yes; then
               return 0
@@ -248,7 +240,10 @@ let
           branch="$(git symbolic-ref --quiet --short HEAD)" \
             || die 'not on a branch; refusing to reset detached HEAD'
 
+          upstream_missing=false
+          upstream_url=""
           if ! git remote get-url "$upstream_remote" >/dev/null 2>&1; then
+            upstream_missing=true
             if [[ -z "$upstream_input" ]]; then
               if [[ ! -t 0 ]]; then
                 die "no $upstream_remote remote found; pass --upstream"
@@ -260,7 +255,6 @@ let
 
             upstream_url="$(normalize_upstream_url "$upstream_input")" \
               || die "invalid upstream repo: $upstream_input"
-            run git remote add "$upstream_remote" "$upstream_url"
           elif [[ -n "$upstream_input" ]]; then
             printf 'git fork-reset: %s remote already exists; ignoring --upstream\n' "$upstream_remote" >&2
           fi
@@ -272,17 +266,10 @@ let
           fetch_ref="+refs/heads/$branch:refs/remotes/$upstream_remote/$branch"
           target_ref="refs/remotes/$upstream_remote/$branch"
 
-          run git fetch "$upstream_remote" "$fetch_ref"
-
-          if $dry_run; then
-            if git rev-parse --verify --quiet "$target_ref^{commit}" >/dev/null; then
-              target_commit="$(git rev-parse --short "$target_ref")"
-            else
-              target_commit='unknown until fetch'
-            fi
+          if git rev-parse --verify --quiet "$target_ref^{commit}" >/dev/null; then
+            target_commit="$(git rev-parse --short "$target_ref")"
           else
-            target_commit="$(git rev-parse --short "$target_ref")" \
-              || die "fetched branch was not available at $target_ref"
+            target_commit='unknown until fetch'
           fi
 
           dirty_output="$(git status --porcelain --untracked-files=all --ignored=matching)"
@@ -309,6 +296,10 @@ let
           stash_message="git-fork-reset backup: $branch $timestamp"
 
           if $dry_run; then
+            if $upstream_missing; then
+              print_command git remote add "$upstream_remote" "$upstream_url"
+            fi
+            print_command git fetch "$upstream_remote" "$fetch_ref"
             if $has_local_state; then
               print_command git stash push --all --message "$stash_message"
             fi
@@ -321,6 +312,15 @@ let
           fi
 
           confirm_reset
+
+          if $upstream_missing; then
+            git remote add "$upstream_remote" "$upstream_url"
+          fi
+
+          git fetch "$upstream_remote" "$fetch_ref"
+          target_commit="$(git rev-parse --short "$target_ref")" \
+            || die "fetched branch was not available at $target_ref"
+          printf 'Fetched target: %s (%s)\n' "$target_ref" "$target_commit"
 
           if $has_local_state; then
             stash_before="$(git rev-parse --verify --quiet refs/stash || true)"

--- a/modules/apps/git-fork-reset.nix
+++ b/modules/apps/git-fork-reset.nix
@@ -201,6 +201,9 @@ let
                 ;;
               --upstream-remote=*)
                 upstream_remote="''${1#*=}"
+                if [[ -z "$upstream_remote" ]]; then
+                  die '--upstream-remote= requires a non-empty argument'
+                fi
                 shift
                 ;;
               --origin-remote)
@@ -212,6 +215,9 @@ let
                 ;;
               --origin-remote=*)
                 origin_remote="''${1#*=}"
+                if [[ -z "$origin_remote" ]]; then
+                  die '--origin-remote= requires a non-empty argument'
+                fi
                 shift
                 ;;
               -h|--help)

--- a/modules/apps/git-fork-reset.nix
+++ b/modules/apps/git-fork-reset.nix
@@ -13,7 +13,7 @@
     --no-push: Reset locally without force-with-lease pushing to origin.
     --yes: Confirm the destructive reset without an interactive prompt.
     --dry-run: Print the Git operations that would run without changing the repository.
-    --upstream <repo>: Add the upstream remote when missing, accepting owner/repo or GitHub HTTPS URLs.
+    --upstream <repo>: Add the upstream remote when missing, accepting owner/repo, GitHub URLs, or fully qualified Git remotes.
     --upstream-remote <name>: Use a remote name other than upstream.
     --origin-remote <name>: Use a push remote name other than origin.
     -h, --help: Print usage information.
@@ -61,8 +61,8 @@ let
             -y, --yes                 Confirm without an interactive prompt.
             --dry-run                 Print operations without changing state.
             --upstream REPO           Upstream repo to add when the remote is missing.
-                                      Accepts owner/repo, https://github.com/owner/repo,
-                                      or https://github.com/owner/repo.git.
+                                      Accepts owner/repo, GitHub URLs, or fully
+                                      qualified Git remotes.
             --upstream-remote NAME    Upstream remote name. Default: upstream.
             --origin-remote NAME      Push remote name. Default: origin.
             -h, --help                Print this help and exit.
@@ -133,7 +133,13 @@ let
               github.com/*)
                 printf 'https://%s.git\n' "''${input%.git}"
                 ;;
-              */*)
+              *://*|*@*:*)
+                printf '%s\n' "$input"
+                ;;
+              [!./]*/[!./]*)
+                if [[ "$input" == */*/* ]]; then
+                  return 1
+                fi
                 printf 'https://github.com/%s.git\n' "''${input%.git}"
                 ;;
               *)

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -162,6 +162,7 @@ let
       gimp.extended.enable = lib.mkOverride 1100 false;
       git.extended.enable = lib.mkOverride 1100 true;
       "git-filter-repo".extended.enable = lib.mkOverride 1100 true;
+      "git-fork-reset".extended.enable = lib.mkOverride 1100 true;
       gitlawb.extended.enable = lib.mkOverride 1100 false;
       glab.extended.enable = lib.mkOverride 1100 true;
       glow.extended.enable = lib.mkOverride 1100 true;


### PR DESCRIPTION
## Summary

- add a Nix-managed `git-fork-reset` wrapper, invocable directly or as `git fork-reset`
- replace the shell-function workflow with explicit flags for dry-run, no-push, remote selection, and non-interactive confirmation
- back up dirty, untracked, and ignored local state with `git stash --all` before reset, keeping the stash for recovery
- enable the helper in the common app catalog for managed hosts

## Test plan

- `nix fmt`
- `nix-instantiate --parse modules/apps/git-fork-reset.nix`
- `nix eval .#nixosConfigurations.system76.config.programs.git-fork-reset.extended.enable`
- `nix eval .#nixosConfigurations.tpnix.config.programs.git-fork-reset.extended.enable`
- `nix eval .#nixosConfigurations.system76.config.environment.systemPackages --apply 'pkgs: builtins.any (p: (p.pname or p.name or "") == "git-fork-reset") pkgs'`
- `nix eval .#nixosConfigurations.tpnix.config.environment.systemPackages --apply 'pkgs: builtins.any (p: (p.pname or p.name or "") == "git-fork-reset") pkgs'`
- `nix-store -r /nix/store/2j42bh5h6qkmyksrch1gm3blxqfw2lb7-git-fork-reset.drv`
- `/nix/store/3r9ix257pnpm6pagr7h1g645hh97napj-git-fork-reset/bin/git-fork-reset --help`
- `PATH=/nix/store/3r9ix257pnpm6pagr7h1g645hh97napj-git-fork-reset/bin:$PATH git fork-reset -h`
- dry-run integration test in a temporary Git repo, covering dirty/untracked/ignored state and `--no-push` without `origin`
- `nix develop --no-write-lock-file -c hook-apps-catalog-sync`
- `nix develop -c pre-commit run --all-files --hook-stage manual`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces `git-fork-reset`, a Nix-managed shell helper that resets a fork branch to its upstream counterpart, replacing an older shell-function workflow with explicit flags, stash-based backup, and dry-run support.

- **`modules/apps/git-fork-reset.nix`**: New module using `writeShellApplication`; implements argument parsing, `normalize_upstream_url` URL normalization, stash verification (compares `refs/stash` before/after), dry-run mode, and interactive confirmation — all under bash strict mode.
- **`modules/hosts/common/apps-enable.nix`**: Single-line opt-in at `lib.mkOverride 1100` to include the new package in the shared host baseline.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the script is well-guarded and no operation mutates the repository without explicit user confirmation or a verified stash backup.

The shell script handles all destructive paths (reset, push) behind stash verification, dry-run preview, and an interactive prompt. The only gap found is in normalize_upstream_url: the github.com/* and https://github.com/* arms accept multi-segment browser URLs without a depth guard, producing an invalid remote URL that fails visibly at fetch time rather than silently corrupting state. No data loss or silent wrong behavior is possible from this gap.

The normalize_upstream_url function in modules/apps/git-fork-reset.nix warrants a second look for the missing depth guards on the two github.com prefix arms.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| modules/apps/git-fork-reset.nix | New Nix module wrapping a 300-line shell script for resetting fork branches; well-structured with dry-run, stash verification, and interactive/non-interactive support. The `normalize_upstream_url` function is missing depth guards on the `github.com/*` and `https://github.com/*` prefix arms, allowing browser-style URLs with extra path segments to pass through silently. |
| modules/hosts/common/apps-enable.nix | One-line addition enabling `git-fork-reset` at `lib.mkOverride 1100` in the common app catalog, consistent with surrounding entries. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[git-fork-reset invoked] --> B[Parse flags]
    B --> C[validate_remote_name upstream/origin]
    C --> D{Inside Git worktree?}
    D -->|No| FAIL1[die: not inside a Git worktree]
    D -->|Yes| E{On a branch?}
    E -->|No| FAIL2[die: detached HEAD]
    E -->|Yes| F{upstream remote exists?}
    F -->|No| G{upstream_input provided?}
    G -->|No + TTY| H[Prompt for upstream URL]
    G -->|No + no TTY| FAIL3[die: pass --upstream]
    H --> I[normalize_upstream_url]
    G -->|Yes| I
    I --> J{Valid URL?}
    J -->|No| FAIL4[die: invalid upstream repo]
    J -->|Yes| K[upstream_url set]
    F -->|Yes, --upstream ignored| K
    K --> L{push and no origin remote?}
    L -->|Yes| FAIL5[die: no origin remote found]
    L -->|No| M[Snapshot local state via git status]
    M --> N[Print operation summary]
    N --> O{--dry-run?}
    O -->|Yes| P[Print commands and exit 0]
    O -->|No| Q[confirm_reset]
    Q --> R[git remote add upstream if missing]
    R --> S[git fetch upstream refspec]
    S --> T{has_local_state?}
    T -->|Yes| U[git stash push --all]
    U --> V{refs/stash changed?}
    V -->|No| FAIL6[die: stash did not change]
    V -->|Yes| W[git reset --hard target_ref]
    T -->|No| W
    W --> X{push?}
    X -->|Yes| Y[git push --force-with-lease origin]
    X -->|No| Z[Print: skipped push]
    Y --> DONE[Done]
    Z --> DONE
```

<a href="https://app.greptile.com/ide/claude-code?prompt=Fix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodules%2Fapps%2Fgit-fork-reset.nix%3A122-127%0A**Missing%20depth%20guard%20for%20%60github.com%2F%60%20and%20%60https%3A%2F%2Fgithub.com%2F%60%20prefix%20forms**%0A%0AThe%20bare%20%60owner%2Frepo%60%20arm%20%28the%20%60%5B!.%2F%5D*%2F%5B!.%2F%5D*%60%20branch%29%20already%20guards%20against%20multi-segment%20paths%20with%20%60if%20%5B%5B%20%22%24input%22%20%3D%3D%20*%2F*%2F*%20%5D%5D%3B%20then%20return%201%3B%20fi%60%2C%20but%20the%20two%20prefix%20arms%20that%20strip%20and%20re-add%20%60github.com%60%20do%20not.%20A%20browser%20URL%20like%20%60https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Ftree%2Fmain%60%20matches%20%60https%3A%2F%2Fgithub.com%2F*%60%20and%20silently%20produces%20%60https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Ftree%2Fmain.git%60%3B%20similarly%2C%20%60github.com%2FNixOS%2Fnixpkgs%2Ftree%2Fmain%60%20matches%20%60github.com%2F*%60%20and%20produces%20the%20same%20invalid%20URL.%20The%20error%20only%20surfaces%20later%20during%20%60git%20fetch%60%20with%20a%20confusing%20server-side%20message%20instead%20of%20a%20clear%20%22invalid%20upstream%20repo%22%20rejection%20here.%0A%0A&repo=bad3r%2Fnixos&pr=221&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaudeDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2"><img alt="Fix All in Claude Code" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInClaude.svg?v=2" height="20"></picture></a> <a href="https://chatgpt.com/codex/deeplink?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22bad3r%2Fnixos%22%20on%20the%20existing%20branch%20%22feat%2Fgit-fork-reset%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Fgit-fork-reset%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Amodules%2Fapps%2Fgit-fork-reset.nix%3A122-127%0A**Missing%20depth%20guard%20for%20%60github.com%2F%60%20and%20%60https%3A%2F%2Fgithub.com%2F%60%20prefix%20forms**%0A%0AThe%20bare%20%60owner%2Frepo%60%20arm%20%28the%20%60%5B!.%2F%5D*%2F%5B!.%2F%5D*%60%20branch%29%20already%20guards%20against%20multi-segment%20paths%20with%20%60if%20%5B%5B%20%22%24input%22%20%3D%3D%20*%2F*%2F*%20%5D%5D%3B%20then%20return%201%3B%20fi%60%2C%20but%20the%20two%20prefix%20arms%20that%20strip%20and%20re-add%20%60github.com%60%20do%20not.%20A%20browser%20URL%20like%20%60https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Ftree%2Fmain%60%20matches%20%60https%3A%2F%2Fgithub.com%2F*%60%20and%20silently%20produces%20%60https%3A%2F%2Fgithub.com%2FNixOS%2Fnixpkgs%2Ftree%2Fmain.git%60%3B%20similarly%2C%20%60github.com%2FNixOS%2Fnixpkgs%2Ftree%2Fmain%60%20matches%20%60github.com%2F*%60%20and%20produces%20the%20same%20invalid%20URL.%20The%20error%20only%20surfaces%20later%20during%20%60git%20fetch%60%20with%20a%20confusing%20server-side%20message%20instead%20of%20a%20clear%20%22invalid%20upstream%20repo%22%20rejection%20here.%0A%0A"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=2" height="20"></picture></a>

<sub>Reviews (2): Last reviewed commit: ["refactor(git-fork-reset): drop redundant..."](https://github.com/bad3r/nixos/commit/8defe6cb879986a9e8fa4085a4e3a2a413433c1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31937751)</sub>

<!-- /greptile_comment -->