### PR TITLE
feat(packages): add searchfox-cli

### DIFF
--- a/docs/guides/custom-packages-style-guide.md
+++ b/docs/guides/custom-packages-style-guide.md
@@ -10,7 +10,7 @@ Create a custom package when:
 - The nixpkgs version is outdated or broken and upstream hasn't merged a fix
 - You need custom build flags, patches, or configuration not suitable for upstream
 
-When a package becomes available in nixpkgs, deprecate the custom package by prefixing the file with `_` (e.g., `_default.nix`) and adding a deprecation comment.
+When a package becomes available in nixpkgs, switch the app module to the nixpkgs package, remove or disable its `modules/custom-overlays/<name>.nix` entry, and deprecate the old package file by prefixing it with `_` (e.g., `_default.nix`) plus a short deprecation comment.
 
 ## File Structure
 
@@ -26,10 +26,16 @@ Use lowercase, hyphenated names matching the package's `pname`. Keep the directo
 packages/
 ├── age-plugin-fido2prf/
 │   └── default.nix
+├── searchfox-cli/
+│   ├── default.nix
+│   ├── hashes.json
+│   └── update.py
 └── malimite/
     ├── default.nix
     └── fix-classpath.patch
 ```
+
+Use `hashes.json` when a package has multiple update-managed pins, such as `version`, `srcHash`, and `cargoHash`. Add `update.py` when the package can be updated mechanically from upstream release metadata. Expose it from the derivation with `passthru.updateScript = ./update.py;`.
 
 ## Package Template
 
@@ -46,21 +52,26 @@ Use the appropriate builder for your package type. All packages must include a `
   openssl,
 }:
 
+let
+  pin = lib.importJSON ./hashes.json;
+in
 rustPlatform.buildRustPackage rec {
   pname = "example-tool";
-  version = "1.0.0";
+  inherit (pin) version;
 
   src = fetchFromGitHub {
     owner = "example";
     repo = "example-tool";
     rev = "v${version}";
-    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+    hash = pin.srcHash;
   };
 
-  cargoHash = "sha256-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=";
+  cargoHash = pin.cargoHash;
 
   nativeBuildInputs = [ pkg-config ];
   buildInputs = [ openssl ];
+
+  passthru.updateScript = ./update.py;
 
   meta = {
     description = "Short one-line description";
@@ -257,25 +268,55 @@ Optional but recommended:
 | `longDescription` | Multi-line description for complex packages |
 | `maintainers`     | Upstream nixpkgs maintainers if applicable  |
 
-## Registering in the Overlay
+## Registering in an Overlay
 
-In-tree custom packages are exposed through the shared `customPackages` overlay at `modules/base/custom-packages-overlay.nix`. Add a single entry there for each new package:
+User-facing in-tree packages are exposed through one overlay module per package under `modules/custom-overlays/`. Add a file named after the package:
 
 ```nix
-_: {
-  flake.lib.overlays.customPackages = final: prev: {
-    # Existing packages...
-    my-new-package = final.callPackage ../../packages/my-new-package { };
-  };
+_:
+let
+  Overlay =
+    { config, lib, ... }:
+    let
+      cfg = config.programs."my-new-package".extended;
+    in
+    {
+      config = lib.mkIf cfg.enable {
+        nixpkgs.overlays = [
+          (final: _prev: {
+            "my-new-package" = final.callPackage ../../packages/my-new-package { };
+          })
+        ];
+      };
+    };
+in
+{
+  flake.customOverlays."my-new-package" = Overlay;
 }
 ```
 
-Hosts opt in by composing the shared overlay into `nixpkgs.overlays`. The wiring already exists for both managed hosts:
+`modules/hosts/common/custom-overlays-base.nix` imports every module registered under `flake.customOverlays.*`. Each overlay gates itself on the matching app option, so the package is added to `pkgs` only when the app is enabled:
 
-- `modules/system76/custom-packages-overlay.nix` composes the shared overlay and layers host-specific patches on top (e.g., the `system76-power` patch).
-- `modules/tpnix/custom-packages-overlay.nix` composes the shared overlay alone.
+```nix
+programs."my-new-package".extended.enable = true;
+```
 
-Use the per-host files only for host-only patches, version overrides, or hardware-specific tweaks; new in-tree packages belong in the shared overlay so every host that opts in sees them. After registration the package is available as `pkgs.my-new-package` on every host whose `custom-packages-overlay` module is loaded.
+Use a custom overlay only for packages that must exist in `pkgs` for host builds or app modules. If a custom package is used only inside one module and does not need a reusable `pkgs.<name>` attribute, a local `pkgs.callPackage ../../packages/<name> { }` inside that module may be enough.
+
+After registration the package is available as `pkgs.my-new-package` on every host where the app is enabled. For the managed hosts, the common baseline lives in `modules/hosts/common/apps-enable.nix`, and host-specific divergences live in `modules/<host>/apps-enable.nix`.
+
+For non-user-facing derivations exposed as flake outputs, register them through a `perSystem` module under `modules/packages/` instead:
+
+```nix
+{ ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      packages.my-tool = pkgs.callPackage ../../packages/my-tool { };
+    };
+}
+```
 
 ## Hash Fetching Workflow
 
@@ -287,13 +328,17 @@ Use the per-host files only for host-only patches, version overrides, or hardwar
    hash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
    ```
 
-2. Attempt to build the package through the overlay-aware host `pkgs`:
+2. Attempt to build the package through an overlay-aware host `pkgs`:
 
    ```bash
-   nix build .#nixosConfigurations.system76.pkgs.my-package
+   nix build .#nixosConfigurations.<host>.pkgs.my-package
    ```
 
-   Overlay-backed packages are not exposed as top-level flake outputs, so `nix build .#my-package` will fail with `does not provide attribute packages.x86_64-linux.my-package`. Always go through `nixosConfigurations.<host>.pkgs.<name>` to apply the overlay.
+   Overlay-backed packages are not exposed as top-level flake outputs, so `nix build .#my-package` will fail with `does not provide attribute packages.x86_64-linux.my-package`. Always go through `nixosConfigurations.<host>.pkgs.<name>` to apply host overlays. If this is a new app module or overlay module, mark the new files as tracked first:
+
+   ```bash
+   git add -N packages/my-package/default.nix modules/apps/my-package.nix modules/custom-overlays/my-package.nix
+   ```
 
 3. Copy the `got:` hash from the error message into your file.
 
@@ -314,6 +359,15 @@ nix-prefetch-github owner repo --rev v1.0.0
 2. Attempt to build and copy the `got:` hash from the error.
 
 **Important:** Do not use `cargoLock.lockFile` with a path inside `${src}` as this requires the source to be fetched during evaluation, breaking offline/pure evaluation. Always use `cargoHash`.
+
+For packages with `passthru.updateScript`, prefer implementing the cargo hash update with `scripts/updater.calculate_dependency_hash`. The usual flow is:
+
+1. Load `packages/<name>/hashes.json`
+2. Fetch the latest upstream version
+3. Recalculate `srcHash`
+4. Write a temporary dummy `cargoHash`
+5. Build `.#nixosConfigurations.system76.pkgs.<name>` and extract the `got:` hash
+6. Save the final `hashes.json`
 
 ### Vendor Hash (Go packages)
 
@@ -362,7 +416,7 @@ Skip the app module when:
 - The package is only used in devshells
 - The package is a library or build tool
 
-The `apps-catalog-sync` pre-commit hook (`modules/meta/hooks/apps-catalog-sync.nix`) enforces that every app module under `modules/apps/` has a matching entry in each host's `apps-enable.nix`. After adding the app module, register it in `modules/system76/apps-enable.nix` and `modules/tpnix/apps-enable.nix`. Use `lib.mkOverride 1100 false` as the default and flip individual host catalogs to `true` only where the tool should be installed.
+The `apps-catalog-sync` pre-commit hook (`modules/meta/hooks/apps-catalog-sync.nix`) enforces that every app module under `modules/apps/` is represented in the app catalog. Add the shared default to `modules/hosts/common/apps-enable.nix` with `lib.mkOverride 1100`, then add entries to `modules/<host>/apps-enable.nix` only when a host must diverge from the common baseline.
 
 See [Apps Module Style Guide](apps-module-style-guide.md) for the app module format.
 
@@ -371,11 +425,17 @@ See [Apps Module Style Guide](apps-module-style-guide.md) for the app module for
 Before committing a new package:
 
 - [ ] File exists at `packages/<name>/default.nix`
+- [ ] `passthru.updateScript = ./update.py;` is present when the package has a mechanical updater
 - [ ] All required meta fields are present
-- [ ] Package is registered in `modules/base/custom-packages-overlay.nix` (shared `customPackages` overlay)
-- [ ] `nix build .#nixosConfigurations.<host>.pkgs.<name>` succeeds (overlay-backed packages are not exposed as top-level flake outputs)
-- [ ] `nix flake check --accept-flake-config` passes
-- [ ] App module created if user-facing or host-visible (see [Apps Module Style Guide](apps-module-style-guide.md)); `apps-catalog-sync` will fail the push if `modules/apps/<name>.nix` lacks a matching entry in every host's `apps-enable.nix`
+- [ ] Package is registered in `modules/custom-overlays/<name>.nix` when it must be exposed as `pkgs.<name>`
+- [ ] New files are staged or intent-to-added before flake/import-tree evaluation
+- [ ] App module created if user-facing or host-visible (see [Apps Module Style Guide](apps-module-style-guide.md))
+- [ ] App catalog default added to `modules/hosts/common/apps-enable.nix`, with host override entries only for real divergences
+- [ ] `nix build .#nixosConfigurations.<host>.pkgs.<name>` succeeds for overlay-backed packages
+- [ ] `./packages/<name>/update.py --force` succeeds when an updater is present
+- [ ] `script=$(nix eval --accept-flake-config --raw .#nixosConfigurations.system76.pkgs.<name>.passthru.updateScript); "$script" --force` succeeds when an updater is present
+- [ ] `nix develop --no-write-lock-file -c hook-apps-catalog-sync` passes when app catalog files changed
+- [ ] `nix flake check --accept-flake-config` passes for structural package/module changes
 
 ## Reference Implementations
 
@@ -383,6 +443,7 @@ Before committing a new package:
 | ---------------- | ------------------------------------------ |
 | Go               | `packages/age-plugin-fido2prf/default.nix` |
 | Python           | `packages/wappalyzer-next/default.nix`     |
+| Rust             | `packages/searchfox-cli/default.nix`       |
 | Binary download  | `packages/charles/default.nix`             |
 | Shell wrapper    | `packages/dnsleak/default.nix`             |
 | Complex Java     | `packages/malimite/default.nix`            |

--- a/modules/apps/searchfox-cli.nix
+++ b/modules/apps/searchfox-cli.nix
@@ -1,7 +1,7 @@
 /*
   Package: searchfox-cli
   Description: Command-line interface for searching Mozilla codebases through searchfox.org.
-  Homepage: nil
+  Homepage: https://github.com/padenot/searchfox-cli
   Documentation: https://github.com/padenot/searchfox-cli#readme
   Repository: https://github.com/padenot/searchfox-cli
 

--- a/modules/apps/searchfox-cli.nix
+++ b/modules/apps/searchfox-cli.nix
@@ -1,0 +1,50 @@
+/*
+  Package: searchfox-cli
+  Description: Command-line interface for searching Mozilla codebases through searchfox.org.
+  Homepage: nil
+  Documentation: https://github.com/padenot/searchfox-cli#readme
+  Repository: https://github.com/padenot/searchfox-cli
+
+  Summary:
+    * Searches Mozilla repositories through Searchfox text, symbol, path, and identifier queries.
+    * Retrieves files and definitions, and inspects call graphs or C++ field layouts from the terminal.
+
+  Options:
+    -q, --query: Search for text or advanced Searchfox query syntax.
+    -R, --repo: Select the Searchfox repository, defaulting to mozilla-central.
+    --get-file: Fetch and print a file from the selected repository.
+    --define: Find and display a symbol definition.
+    --calls-from, --calls-to, --calls-between: Inspect Searchfox call graph relationships.
+    --field-layout: Display C++ class or struct field layout information.
+*/
+_:
+let
+  SearchfoxCliModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs."searchfox-cli".extended;
+    in
+    {
+      options.programs.searchfox-cli.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable searchfox-cli.";
+        };
+
+        package = lib.mkPackageOption pkgs "searchfox-cli" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.searchfox-cli = SearchfoxCliModule;
+}

--- a/modules/custom-overlays/searchfox-cli.nix
+++ b/modules/custom-overlays/searchfox-cli.nix
@@ -1,0 +1,20 @@
+_:
+let
+  Overlay =
+    { config, lib, ... }:
+    let
+      cfg = config.programs."searchfox-cli".extended;
+    in
+    {
+      config = lib.mkIf cfg.enable {
+        nixpkgs.overlays = [
+          (final: _prev: {
+            "searchfox-cli" = final.callPackage ../../packages/searchfox-cli { };
+          })
+        ];
+      };
+    };
+in
+{
+  flake.customOverlays."searchfox-cli" = Overlay;
+}

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -357,6 +357,7 @@ let
       "s-tui".extended.enable = lib.mkOverride 1100 true;
       s5cmd.extended.enable = lib.mkOverride 1100 true;
       screenkey.extended.enable = lib.mkOverride 1100 true;
+      "searchfox-cli".extended.enable = lib.mkOverride 1100 true;
       seclists.extended.enable = lib.mkOverride 1100 true;
       selenium.extended.enable = lib.mkOverride 1100 true;
       "signal-desktop".extended.enable = lib.mkOverride 1100 true;

--- a/packages/searchfox-cli/default.nix
+++ b/packages/searchfox-cli/default.nix
@@ -1,0 +1,56 @@
+{
+  lib,
+  rustPlatform,
+  fetchFromGitHub,
+}:
+
+let
+  pin = lib.importJSON ./hashes.json;
+in
+rustPlatform.buildRustPackage rec {
+  pname = "searchfox-cli";
+  inherit (pin) version;
+
+  src = fetchFromGitHub {
+    owner = "padenot";
+    repo = "searchfox-cli";
+    rev = "v${version}";
+    hash = pin.srcHash;
+  };
+
+  inherit (pin) cargoHash;
+
+  # These integration tests query live searchfox.org endpoints. Keep the
+  # offline unit tests and query-construction integration tests enabled.
+  checkFlags = [
+    "--skip=calls_from_returns_results"
+    "--skip=can_gc_fully_qualified_can_gc"
+    "--skip=can_gc_fully_qualified_cannot_gc"
+    "--skip=can_gc_partial_name_resolves"
+    "--skip=can_gc_unknown_symbol_returns_empty"
+    "--skip=find_definition_c_function_without_namespace"
+    "--skip=find_definition_returns_result"
+    "--skip=find_definition_unknown_symbol_returns_empty"
+    "--skip=get_file_nonexistent_returns_error"
+    "--skip=get_file_returns_content"
+    "--skip=get_head_hash_returns_valid_hash"
+    "--skip=search_category_filter_excludes_tests"
+    "--skip=search_id_returns_results"
+    "--skip=search_path_only_returns_files"
+    "--skip=search_text_returns_results"
+  ];
+
+  passthru.updateScript = ./update.py;
+
+  meta = {
+    description = "CLI for https://searchfox.org";
+    homepage = "https://github.com/padenot/searchfox-cli";
+    changelog = "https://github.com/padenot/searchfox-cli/releases/tag/v${version}";
+    license = with lib.licenses; [
+      asl20
+      mit
+    ];
+    mainProgram = "searchfox-cli";
+    platforms = lib.platforms.unix;
+  };
+}

--- a/packages/searchfox-cli/default.nix
+++ b/packages/searchfox-cli/default.nix
@@ -51,6 +51,6 @@ rustPlatform.buildRustPackage rec {
       mit
     ];
     mainProgram = "searchfox-cli";
-    platforms = lib.platforms.unix;
+    platforms = lib.platforms.linux;
   };
 }

--- a/packages/searchfox-cli/hashes.json
+++ b/packages/searchfox-cli/hashes.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.10.11",
+  "srcHash": "sha256-POrrGpZ4ZpFgunYynZCJdLdv4In35Ds6x/0XSOt1WNU=",
+  "cargoHash": "sha256-ZQ7C5CSOiNqqzRgU/urCID0MtrJl0J2LaYS0J3BgOh8="
+}

--- a/packages/searchfox-cli/update.py
+++ b/packages/searchfox-cli/update.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env nix
+#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+"""Update script for searchfox-cli."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+
+PACKAGE_NAME = "searchfox-cli"
+REPO = "padenot/searchfox-cli"
+
+
+def _flake_root(start: Path) -> Path | None:
+    """Walk up from ``start`` until this checkout's flake root is found."""
+    for parent in [start, *start.parents]:
+        if (
+            (parent / "flake.nix").is_file()
+            and (parent / "scripts" / "updater").is_dir()
+            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
+        ):
+            return parent
+    return None
+
+
+def _checkout_root() -> Path:
+    """Find the editable checkout from either cwd or the script path."""
+    starts = [
+        Path.cwd().resolve(),
+        Path(__file__).resolve().parent,
+    ]
+    for start in starts:
+        root = _flake_root(start)
+        if root is not None:
+            return root
+
+    msg = (
+        "Could not find the nixos checkout root. Run this updater from the "
+        "repository checkout, or execute the checkout copy under "
+        f"packages/{PACKAGE_NAME}/."
+    )
+    raise RuntimeError(msg)
+
+
+FLAKE_ROOT = _checkout_root()
+HASHES_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "hashes.json"
+PACKAGE_ATTR = f"{FLAKE_ROOT}#nixosConfigurations.system76.pkgs.{PACKAGE_NAME}"
+sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
+
+from updater import (  # noqa: E402
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_json,
+    load_hashes,
+    save_hashes,
+)
+
+
+def latest_crate_version() -> str:
+    """Fetch the latest published searchfox-cli version from crates.io."""
+    data = fetch_json(f"https://crates.io/api/v1/crates/{PACKAGE_NAME}")
+    if not isinstance(data, dict):
+        msg = f"Expected dict from crates.io API, got {type(data)}"
+        raise TypeError(msg)
+
+    crate = cast("dict[str, Any]", data["crate"])
+    return cast("str", crate["max_version"])
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="recalculate hashes even when the version is unchanged",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Update searchfox-cli to the latest crates.io release."""
+    args = parse_args()
+    data = load_hashes(HASHES_FILE)
+    current = cast("str", data["version"])
+    latest = latest_crate_version()
+
+    print(f"Current: {current}")
+    print(f"Latest:  {latest}")
+
+    if current == latest and not args.force:
+        print("Already up to date")
+        return
+
+    print("Calculating source hash...")
+    src_hash = calculate_url_hash(
+        f"https://github.com/{REPO}/archive/refs/tags/v{latest}.tar.gz",
+        unpack=True,
+    )
+
+    new_data: dict[str, Any] = {
+        "version": latest,
+        "srcHash": src_hash,
+        "cargoHash": data.get("cargoHash", ""),
+    }
+
+    new_data["cargoHash"] = calculate_dependency_hash(
+        PACKAGE_ATTR,
+        "cargoHash",
+        HASHES_FILE,
+        new_data,
+    )
+    save_hashes(HASHES_FILE, new_data)
+    print(f"Updated {HASHES_FILE.relative_to(FLAKE_ROOT)} to {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/searchfox-cli/update.py
+++ b/packages/searchfox-cli/update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#! nix shell --inputs-from .# nixpkgs#python3 --command python3
 """Update script for searchfox-cli."""
 
 from __future__ import annotations
@@ -67,7 +67,11 @@ def latest_crate_version() -> str:
         raise TypeError(msg)
 
     crate = cast("dict[str, Any]", data["crate"])
-    return cast("str", crate["max_version"])
+    version = crate.get("max_stable_version") or crate["max_version"]
+    if not isinstance(version, str):
+        msg = f"Expected string version from crates.io API, got {type(version)}"
+        raise TypeError(msg)
+    return version
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Summary
- add a custom `searchfox-cli` Rust package pinned at `0.10.11`
- add a repo-local updater, gated custom overlay, app module, and shared app-catalog enablement
- update the custom package guide for current per-package overlay and updater workflows
- keep offline Rust checks enabled while skipping only live `searchfox.org` integration tests by name

## Test plan
- `nix fmt`
- `nix develop --no-write-lock-file -c hook-apps-catalog-sync`
- `uvx ruff format --check packages/searchfox-cli/update.py`
- `uvx ruff check packages/searchfox-cli/update.py`
- `python3 -m py_compile packages/searchfox-cli/update.py`
- `nix eval --accept-flake-config --raw '.#nixosConfigurations.system76.options.programs."searchfox-cli".extended.enable.type.name'`
- `nix eval --accept-flake-config '.#nixosConfigurations.system76.config.programs."searchfox-cli".extended.enable'`
- `nix eval --accept-flake-config --raw '.#nixosConfigurations.system76.pkgs.searchfox-cli.passthru.updateScript'`
- `nix build .#nixosConfigurations.system76.pkgs.searchfox-cli --no-link --accept-flake-config`
- `nix run .#nixosConfigurations.system76.pkgs.searchfox-cli --accept-flake-config -- --version`
- `./packages/searchfox-cli/update.py --force`

Note: after the final style-only `inherit (pin) cargoHash` hook fix, I did not rerun the package build per reviewer direction to avoid rebuilding after simple Nix style changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new `searchfox-cli` custom Rust package (v0.10.11) to the NixOS configuration following the repo's established per-package overlay pattern, along with a mechanical updater script and updated style guide documentation.

- **New package** (`packages/searchfox-cli/`): Builds via `rustPlatform.buildRustPackage`, pins version/hashes in `hashes.json`, skips 15 live-network integration tests by name via `checkFlags`, and exposes `passthru.updateScript = ./update.py`.
- **New modules**: A gated custom overlay (`modules/custom-overlays/searchfox-cli.nix`) adds the package to `pkgs` only when the app is enabled, and an app module (`modules/apps/searchfox-cli.nix`) installs it via `environment.systemPackages`.
- **Style guide & catalog**: `docs/guides/custom-packages-style-guide.md` is updated to reflect the current per-package overlay workflow, and the common app catalog (`modules/hosts/common/apps-enable.nix`) enables `searchfox-cli` by default.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all components follow established repo patterns and the previously flagged issues have been resolved.

The package derivation, overlay, app module, updater script, and catalog entry are all consistent with each other and with the documented workflow. The live-network integration tests are excluded by name while offline tests remain active. The crates.io version fetch correctly prefers max_stable_version. No defects found across the seven changed files.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| packages/searchfox-cli/default.nix | Well-formed Rust derivation: uses hashes.json pinning, skips 15 live-network tests via checkFlags, exposes passthru.updateScript, and includes all required meta fields. |
| packages/searchfox-cli/update.py | Mechanical updater using max_stable_version (with max_version fallback), fetches src tarball hash and recalculates cargoHash via calculate_dependency_hash; previously flagged pre-release version issue is resolved. |
| modules/apps/searchfox-cli.nix | Standard app module: defines enable/package options under programs."searchfox-cli".extended and installs via environment.systemPackages; header comment now has correct Homepage URL. |
| modules/custom-overlays/searchfox-cli.nix | Correctly gates overlay activation on cfg.enable, consistent with the documented per-package overlay pattern. |
| modules/hosts/common/apps-enable.nix | Adds searchfox-cli to common baseline with mkOverride 1100 true, alphabetically ordered correctly between screenkey and seclists. |
| docs/guides/custom-packages-style-guide.md | Documentation updated to reflect per-package overlay workflow, hashes.json pattern, and expanded pre-commit checklist; adds searchfox-cli as a Rust reference implementation. |
| packages/searchfox-cli/hashes.json | Pinned at v0.10.11 with srcHash and cargoHash; format matches the pattern expected by lib.importJSON in the derivation. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["programs.searchfox-cli\n.extended.enable = true"] --> B["modules/custom-overlays/\nsearchfox-cli.nix"]
    B --> C["nixpkgs.overlays:\npkgs.searchfox-cli"]
    C --> D["packages/searchfox-cli/\ndefault.nix"]
    D --> E["lib.importJSON hashes.json\nversion / srcHash / cargoHash"]
    D --> F["fetchFromGitHub\npadenot/searchfox-cli"]
    D --> G["rustPlatform.buildRustPackage\nskip live tests via checkFlags\npassthru.updateScript"]
    A --> H["modules/apps/searchfox-cli.nix"]
    H --> I["environment.systemPackages"]
    J["update.py"] --> K["crates.io API\nmax_stable_version"]
    J --> L["calculate_url_hash\nGitHub tarball"]
    J --> M["calculate_dependency_hash\nnix build to get hash"]
    M --> N["hashes.json updated"]
    O["modules/hosts/common/\napps-enable.nix\nmkOverride 1100 true"] --> A
```

<sub>Reviews (2): Last reviewed commit: ["fix(searchfox-cli): align package metada..."](https://github.com/bad3r/nixos/commit/c831d564868a67a6b848d11a0140e2e02800c580) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31955081)</sub>

<!-- /greptile_comment -->