### PR TITLE
fix(john): overlay updated jumbo snapshot

### DIFF
--- a/modules/custom-overlays/john-opencl.patch
+++ b/modules/custom-overlays/john-opencl.patch
@@ -1,0 +1,18 @@
+diff --git a/src/opencl_generate_dynamic_loader.py b/src/opencl_generate_dynamic_loader.py
+index 790705330..2acedbc56 100755
+--- a/src/opencl_generate_dynamic_loader.py
++++ b/src/opencl_generate_dynamic_loader.py
+@@ -134,12 +134,7 @@ static void load_opencl_dll(void)
+ 
+ 	/* Names to try to load */
+ 	const char * const opencl_names[] = {
+-		"libOpenCL.so.1",	/* Linux/others */
+-		"libOpenCL.so",		/* Linux/others, hack via "development" sub-package's symlink */
+-		"OpenCL",		/* _WIN */
+-		"/System/Library/Frameworks/OpenCL.framework/OpenCL", /* __APPLE__ */
+-		"opencl.dll",		/* __CYGWIN__ */
+-		"cygOpenCL-1.dll"	/* __CYGWIN__ */
++		"@ocl_icd@/lib/libOpenCL.so"	/* NixOS */
+ 	};
+ 
+ 	for (i = 0; i < sizeof(opencl_names)/sizeof(opencl_names[0]); i++) {

--- a/modules/custom-overlays/john.nix
+++ b/modules/custom-overlays/john.nix
@@ -1,0 +1,29 @@
+_:
+let
+  Overlay =
+    { config, lib, ... }:
+    let
+      cfg = config.programs.john.extended;
+    in
+    {
+      config = lib.mkIf cfg.enable {
+        nixpkgs.overlays = [
+          (final: prev: {
+            john = prev.john.overrideAttrs (_old: {
+              version = "1.9.0-Jumbo-1-unstable-2026-04-13";
+
+              src = final.fetchFromGitHub {
+                owner = "openwall";
+                repo = "john";
+                rev = "f514ece8ec4ae5e38ad75aaa322eac86d73dcd76";
+                hash = "sha256-zO1/KUJe3LvYCGlwVpNg5uDwPRD0ql/7anErb7tywC0=";
+              };
+            });
+          })
+        ];
+      };
+    };
+in
+{
+  flake.customOverlays.john = Overlay;
+}

--- a/modules/custom-overlays/john.nix
+++ b/modules/custom-overlays/john.nix
@@ -9,7 +9,7 @@ let
       config = lib.mkIf cfg.enable {
         nixpkgs.overlays = [
           (final: prev: {
-            john = prev.john.overrideAttrs (_old: {
+            john = (prev.john.override { withOpenCL = true; }).overrideAttrs (_old: {
               version = "1.9.0-Jumbo-1-unstable-2026-04-13";
 
               src = final.fetchFromGitHub {
@@ -18,6 +18,14 @@ let
                 rev = "f514ece8ec4ae5e38ad75aaa322eac86d73dcd76";
                 hash = "sha256-zO1/KUJe3LvYCGlwVpNg5uDwPRD0ql/7anErb7tywC0=";
               };
+
+              # nixpkgs ships opencl.patch keyed to the rolling-2604 layout
+              # (libOpenCL.so.1 first); the locked input still pins
+              # rolling-2404, so inherit-via-overrideAttrs would try to apply
+              # the old patch context against the bumped source and fail.
+              patches = [
+                (final.replaceVars ./john-opencl.patch { ocl_icd = final.ocl-icd; })
+              ];
             });
           })
         ];


### PR DESCRIPTION
## Summary

- Add `modules/custom-overlays/john.nix` pinning `john` to upstream Jumbo snapshot `f514ece` (2026-04-13).
- Overlay applies only when `programs.john.extended.enable` is set, leaving stock builds untouched on hosts that do not opt in.

## Test plan

- [x] `nix develop --no-write-lock-file -c pre-commit run --all-files --hook-stage manual`
- [x] `nix eval --accept-flake-config --no-write-lock-file --raw .#nixosConfigurations.system76.pkgs.john.version`
- [x] `nix eval --accept-flake-config --no-write-lock-file --raw .#nixosConfigurations.tpnix.pkgs.john.version`
- [x] `nix eval --accept-flake-config --no-write-lock-file --json .#nixosConfigurations.system76.config.programs.john.extended.enable`
- [x] `nix eval --accept-flake-config --no-write-lock-file --json .#nixosConfigurations.tpnix.config.programs.john.extended.enable`