### PR TITLE
feat(gecko): seed Violentmonkey userscript

### DIFF
--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -85,11 +85,7 @@ let
   userscripts = builtins.fromJSON (builtins.readFile ./_gecko-userscripts.json);
   nixpkgsReviewGhaScript = userscripts."nixpkgs-review-gha";
   nixpkgsReviewGhaScriptId = builtins.toString nixpkgsReviewGhaScript.id;
-  nixpkgsReviewGhaSource = pkgs.fetchurl {
-    name = "nixpkgs-review-gha.user.js";
-    url = "https://raw.githubusercontent.com/${nixpkgsReviewGhaScript.repo}/${nixpkgsReviewGhaScript.rev}/${nixpkgsReviewGhaScript.path}";
-    inherit (nixpkgsReviewGhaScript) hash;
-  };
+  nixpkgsReviewGhaCode = builtins.readFile (./. + "/${nixpkgsReviewGhaScript.sourceFile}");
   nixpkgsReviewGhaRecord = {
     config = {
       enabled = 1;
@@ -327,7 +323,7 @@ in
   };
 
   extensionStorage."${violentmonkeyId}".settings = {
-    "code:${nixpkgsReviewGhaScriptId}" = builtins.readFile nixpkgsReviewGhaSource;
+    "code:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaCode;
     "scr:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaRecord;
   };
 }

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -53,6 +53,7 @@ let
   stylusId = "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}";
   tabStashId = "tab-stash@condordes.net";
   tridactylId = "tridactyl.vim@cmcaine.co.uk";
+  violentmonkeyId = "{aecec67f-0d10-4fa7-b7c7-609a2db280cf}";
 
   # SVG Gobbler is not packaged in the rycee NUR firefox-addons set, so it is
   # delivered via AMO force-install instead. The GUID below comes from the
@@ -80,6 +81,38 @@ let
   librewolfUblockOriginLists = builtins.filter (
     list: !(builtins.elem list disabledLibrewolfLists)
   ) librewolfUblockOriginListData.lists;
+
+  userscripts = builtins.fromJSON (builtins.readFile ./_gecko-userscripts.json);
+  nixpkgsReviewGhaScript = userscripts."nixpkgs-review-gha";
+  nixpkgsReviewGhaScriptId = builtins.toString nixpkgsReviewGhaScript.id;
+  nixpkgsReviewGhaSource = pkgs.fetchurl {
+    name = "nixpkgs-review-gha.user.js";
+    url = "https://raw.githubusercontent.com/${nixpkgsReviewGhaScript.repo}/${nixpkgsReviewGhaScript.rev}/${nixpkgsReviewGhaScript.path}";
+    inherit (nixpkgsReviewGhaScript) hash;
+  };
+  nixpkgsReviewGhaRecord = {
+    config = {
+      enabled = 1;
+      removed = 0;
+      shouldUpdate = 0;
+    };
+    custom = {
+      origInclude = true;
+      origExclude = true;
+      origMatch = true;
+      origExcludeMatch = true;
+      origTag = true;
+      lastInstallURL = nixpkgsReviewGhaScript.installUrl;
+      pathMap = { };
+    };
+    inherit (nixpkgsReviewGhaScript) meta;
+    props = {
+      position = nixpkgsReviewGhaScript.id;
+      inherit (nixpkgsReviewGhaScript) uuid;
+      lastModified = nixpkgsReviewGhaScript.updatedAt;
+      lastUpdated = nixpkgsReviewGhaScript.updatedAt;
+    };
+  };
 
   # uBO "medium mode": block third-party scripts and frames by default.
   # Commonly-used sites are pre-whitelisted; other sites need interactive
@@ -206,6 +239,7 @@ let
     stylus
     tab-stash
     languagetool
+    violentmonkey
     web-archives
     tridactyl
     darkreader
@@ -216,7 +250,6 @@ let
     primaryPackages
     ++ (with firefox-addons; [
       foxyproxy-standard
-      violentmonkey
       wappalyzer
     ]);
 
@@ -291,5 +324,10 @@ in
       "adguard-popup-overlays"
       "adguard-widgets"
     ];
+  };
+
+  extensionStorage."${violentmonkeyId}".settings = {
+    "code:${nixpkgsReviewGhaScriptId}" = builtins.readFile nixpkgsReviewGhaSource;
+    "scr:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaRecord;
   };
 }

--- a/modules/hm-apps/_gecko-nixpkgs-review-gha.user.js
+++ b/modules/hm-apps/_gecko-nixpkgs-review-gha.user.js
@@ -1,0 +1,162 @@
+// ==UserScript==
+// @name        nixpkgs-review-gha
+// @match       https://github.com/*
+// @run-at      document-idle
+// ==/UserScript==
+
+const user = document.querySelector("header.GlobalNav button[data-login]")?.getAttribute("data-login") ?? null;
+
+const repo = user ? `${user}/nixpkgs-review-gha` : null;
+
+const reviewDefaults = ({ title, commits, labels, author, authoredByMe, hasLinuxRebuilds, hasDarwinRebuilds }) => {
+  const darwinSandbox = "relaxed";
+
+  const hasRebuilds = hasLinuxRebuilds || hasDarwinRebuilds;
+
+  return {
+    // "branch": "main",
+    "x86_64-linux": !hasRebuilds || hasLinuxRebuilds,
+    "aarch64-linux": !hasRebuilds || hasLinuxRebuilds,
+    "x86_64-darwin": !hasRebuilds || hasDarwinRebuilds ? `yes_sandbox_${darwinSandbox}` : "no",
+    "aarch64-darwin": !hasRebuilds || hasDarwinRebuilds ? `yes_sandbox_${darwinSandbox}` : "no",
+    // "riscv64-linux": false,
+    // "extra-args": "",
+    // "push-to-cache": true,
+    // "upterm": false,
+    // "post-result": true,
+    // "on-success": "nothing",
+  };
+};
+
+const prTrackers = [
+  { name: "nixpk.gs", toUrl: pr => `https://nixpk.gs/pr-tracker.html?pr=${pr}` },
+  { name: "ocfox.me", toUrl: pr => `https://nixpkgs-tracker.ocfox.me/?pr=${pr}` },
+];
+
+const sleep = duration => new Promise(resolve => setTimeout(resolve, duration));
+const query = async (doc, sel) => {
+  await sleep(0);
+  while (true) {
+    const elem = doc.querySelector(sel);
+    if (elem !== null) return elem;
+    await sleep(100);
+  }
+};
+
+const getPrDetails = pr => {
+  const title = document.querySelector(
+    "div[data-component=TitleArea] .text-normal.markdown-title, bdi.js-issue-title.markdown-title",
+  ).innerText;
+  const commits = [...document.querySelectorAll(".TimelineItem-body a.markdown-title[href*='/commits/']")].flatMap(
+    ({ title, href }) => {
+      const match = /\/NixOS\/nixpkgs\/pull\/(\d+)\/commits\/([0-9a-f]+)$/i.exec(href);
+      return match === null || match[1] !== pr
+        ? []
+        : [
+            {
+              commit_id: match[2],
+              subject: title.split("\n")[0],
+              description: title,
+            },
+          ];
+    },
+  );
+  const labels = [...document.querySelectorAll("div.js-issue-labels > a")].map(x => x.innerText);
+  const author = document.querySelector(".js-discussion > :first-child a.author").href.split("/").at(-1);
+  const authoredByMe = author === user;
+  const hasLinuxRebuilds = !labels.some(l => /rebuild-linux: 0$/.test(l));
+  const hasDarwinRebuilds = !labels.some(l => /rebuild-darwin: 0$/.test(l));
+  const state = document
+    .querySelector("div[data-component=TitleArea] div[data-component=PH_LeadingVisual] span, span.State")
+    .innerText.trim()
+    .toUpperCase();
+
+  return { title, commits, labels, author, authoredByMe, hasLinuxRebuilds, hasDarwinRebuilds, state };
+};
+
+const setupActionsPage = async () => {
+  const match = /^https:\/\/github.com\/([^/]+\/[^/]+)\/actions\/workflows\/review.yml#dispatch:(.*)$/.exec(
+    location.href,
+  );
+  if (match === null || match[1] !== repo) return;
+
+  const inputs = new URLSearchParams(match[2]);
+
+  (await query(document, "details > summary.btn")).click();
+  await query(document, "details .workflow-dispatch");
+
+  const setBranch = async branch => {
+    (await query(document, "details .workflow-dispatch")).classList.add("old-branch");
+    document.querySelector("details .workflow-dispatch .branch-selection > details > summary").click();
+    (await query(document, `ref-selector[type=branch] button[value="${branch}"]`)).click();
+    while ((await query(document, "details .workflow-dispatch")).classList.contains("old-branch")) await sleep(100);
+  };
+
+  const setInput = (name, value) => {
+    const selector = `details .workflow-dispatch [name='inputs[${name}]']`;
+    const input = document.querySelector(`${selector}:not([type=hidden])`);
+
+    if (!input) {
+      alert(`workflow_dispatch input '${name}' does not exist`);
+      return;
+    }
+
+    if (input.type === "checkbox") {
+      if (!["true", "false"].includes(value)) {
+        alert(`workflow_dispatch input '${name}' expects a boolean ('true' or 'false) but is set to '${value}'`);
+        return;
+      }
+      input.checked = value === "true";
+    } else {
+      input.value = value;
+    }
+  };
+
+  const branch = inputs.get("branch");
+  if (branch) await setBranch(branch);
+
+  [...inputs].filter(([name]) => name !== "branch").forEach(([name, value]) => setInput(name, value));
+
+  document.querySelector("details .workflow-dispatch button[type=submit]").focus();
+};
+
+const setupPrPage = async () => {
+  const match = /^https:\/\/github.com\/NixOS\/nixpkgs\/pull\/(\d+)([?#].*)?$/i.exec(location.href);
+  if (match === null) return;
+
+  const pr = match[1];
+  const actions = await query(document, "div[data-component=PH_Actions], .gh-header-show .gh-header-actions");
+
+  if (actions.querySelector(".run-nixpkgs-review") === null && repo) {
+    const btn = document.createElement("button");
+    btn.classList.add("Button", "Button--secondary", "Button--small", "run-nixpkgs-review");
+    btn.innerText = "Run nixpkgs-review";
+    actions.prepend(btn);
+    btn.onclick = () => {
+      const params = new URLSearchParams({ ...reviewDefaults(getPrDetails(pr)), pr });
+      window.open(`https://github.com/${repo}/actions/workflows/review.yml#dispatch:${params}`);
+    };
+  }
+
+  const { hasLinuxRebuilds, hasDarwinRebuilds, state } = getPrDetails(pr);
+  if ((!hasLinuxRebuilds && !hasDarwinRebuilds) || state == "MERGED") {
+    actions.querySelector(".run-nixpkgs-review").setAttribute("aria-disabled", true);
+  }
+
+  if (actions.querySelector(".goto-pr-tracker") === null) {
+    for (const { name, toUrl } of prTrackers) {
+      const btn = document.createElement("button");
+      btn.classList.add("Button", "Button--secondary", "Button--small", "goto-pr-tracker");
+      btn.innerText = prTrackers.length === 1 ? "PR Tracker" : `PR Tracker (${name})`;
+      actions.prepend(btn);
+      btn.onclick = () => {
+        window.open(toUrl(pr));
+      };
+    }
+  }
+};
+
+new MutationObserver(setupPrPage).observe(document, { subtree: true, childList: true });
+
+setupActionsPage();
+setupPrPage();

--- a/modules/hm-apps/_gecko-userscripts.json
+++ b/modules/hm-apps/_gecko-userscripts.json
@@ -3,6 +3,7 @@
     "repo": "Defelo/nixpkgs-review-gha",
     "branch": "main",
     "path": "shortcut.user.js",
+    "sourceFile": "_gecko-nixpkgs-review-gha.user.js",
     "rev": "b63b6762cf354c468cb8deaf12ddea257053b36c",
     "hash": "sha256-tdACiiyQW0OwYreM/MULycuL0QxX20kQwCCJpt5fgjg=",
     "id": 1,

--- a/modules/hm-apps/_gecko-userscripts.json
+++ b/modules/hm-apps/_gecko-userscripts.json
@@ -1,0 +1,26 @@
+{
+  "nixpkgs-review-gha": {
+    "repo": "Defelo/nixpkgs-review-gha",
+    "branch": "main",
+    "path": "shortcut.user.js",
+    "rev": "b63b6762cf354c468cb8deaf12ddea257053b36c",
+    "hash": "sha256-tdACiiyQW0OwYreM/MULycuL0QxX20kQwCCJpt5fgjg=",
+    "id": 1,
+    "uuid": "cb37dedd-9092-44f6-8073-8ab7c9431918",
+    "updatedAt": 1777345205000,
+    "installUrl": "https://raw.githubusercontent.com/Defelo/nixpkgs-review-gha/refs/heads/main/shortcut.user.js",
+    "meta": {
+      "include": [],
+      "exclude": [],
+      "match": [
+        "https://github.com/*"
+      ],
+      "excludeMatch": [],
+      "require": [],
+      "grant": [],
+      "resources": {},
+      "name": "nixpkgs-review-gha",
+      "runAt": "document-idle"
+    }
+  }
+}

--- a/scripts/update-gecko-userscripts.py
+++ b/scripts/update-gecko-userscripts.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+
+"""Update Gecko Violentmonkey userscript pins."""
+
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Any, cast
+from urllib.parse import urlencode
+
+
+def _flake_root(start: Path) -> Path:
+    """Walk up from ``start`` until ``flake.nix`` is found."""
+    for parent in [start, *start.parents]:
+        if (parent / "flake.nix").is_file():
+            return parent
+    msg = f"Could not find flake.nix above {start}"
+    raise RuntimeError(msg)
+
+
+FLAKE_ROOT = _flake_root(Path(__file__).resolve().parent)
+sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
+
+from updater import calculate_url_hash, fetch_json, fetch_text, load_hashes, save_hashes  # noqa: E402
+
+PINS_FILE = FLAKE_ROOT / "modules" / "hm-apps" / "_gecko-userscripts.json"
+META_BLOCK_RE = re.compile(
+    r"(?:^|\n).*?//[\x20\t]*==UserScript==(?P<body>[\s\S]*?\n).*?//[\x20\t]*==/UserScript=="
+)
+META_ITEM_RE = re.compile(r"(?:^|\n).*?//[\x20\t]*@(?P<key>\S+)(?P<value>.*)")
+
+LIST_KEYS = {
+    "include",
+    "exclude",
+    "match",
+    "excludeMatch",
+    "require",
+    "grant",
+}
+
+
+def camel_case_meta_key(key: str) -> str:
+    """Convert userscript metadata keys to Violentmonkey's storage keys."""
+    result = key.replace("-", "_")
+    while "_" in result:
+        left, right = result.split("_", 1)
+        result = left + right[:1].upper() + right[1:]
+    return result
+
+
+def parse_userscript_meta(code: str) -> dict[str, Any]:
+    """Parse a userscript metadata block into Violentmonkey's JSON shape."""
+    match = META_BLOCK_RE.search(code)
+    if match is None:
+        msg = "Could not find a ==UserScript== metadata block"
+        raise RuntimeError(msg)
+
+    meta: dict[str, Any] = {
+        "include": [],
+        "exclude": [],
+        "match": [],
+        "excludeMatch": [],
+        "require": [],
+        "grant": [],
+        "resources": {},
+    }
+
+    for item in META_ITEM_RE.finditer(match.group("body")):
+        key = camel_case_meta_key(item.group("key"))
+        value = item.group("value").strip()
+
+        if key == "resource":
+            name, _, url = value.partition(" ")
+            if name and url:
+                cast("dict[str, str]", meta["resources"])[name] = url
+            continue
+
+        if key in LIST_KEYS:
+            cast("list[str]", meta[key]).append(value)
+            continue
+
+        if key in meta:
+            current = meta[key]
+            if isinstance(current, list):
+                current.append(value)
+            continue
+
+        meta[key] = value
+
+    name = meta.get("name")
+    if not isinstance(name, str) or not name:
+        msg = "Userscript metadata is missing @name"
+        raise RuntimeError(msg)
+
+    return meta
+
+
+def github_path_commit(repo: str, branch: str, path: str) -> dict[str, Any]:
+    """Fetch the latest commit on ``branch`` that changed ``path``."""
+    query = urlencode({"sha": branch, "path": path, "per_page": "1"})
+    url = f"https://api.github.com/repos/{repo}/commits?{query}"
+    commits = cast("list[dict[str, Any]]", fetch_json(url))
+    if not commits:
+        msg = f"No commits found for {repo}:{branch}:{path}"
+        raise RuntimeError(msg)
+    return commits[0]
+
+
+def raw_github_url(repo: str, rev: str, path: str) -> str:
+    """Build an immutable raw.githubusercontent.com URL."""
+    return f"https://raw.githubusercontent.com/{repo}/{rev}/{path}"
+
+
+def date_to_epoch_ms(value: str) -> int:
+    """Convert a GitHub ISO timestamp to epoch milliseconds."""
+    return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp() * 1000)
+
+
+def update_pin(name: str, pin: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+    """Refresh one userscript pin."""
+    repo = cast("str", pin["repo"])
+    branch = cast("str", pin["branch"])
+    path = cast("str", pin["path"])
+    current_rev = cast("str", pin["rev"])
+
+    commit = github_path_commit(repo, branch, path)
+    latest_rev = cast("str", commit["sha"])
+    commit_date = cast("str", commit["commit"]["author"]["date"])
+    url = raw_github_url(repo, latest_rev, path)
+    code = fetch_text(url)
+    latest_hash = calculate_url_hash(url)
+    latest_meta = parse_userscript_meta(code)
+
+    print(f"{name}:")
+    print(f"  Current: {current_rev[:12]} {pin['hash']}")
+    print(f"  Latest:  {latest_rev[:12]} {latest_hash}")
+
+    new_pin = {
+        **pin,
+        "rev": latest_rev,
+        "hash": latest_hash,
+        "updatedAt": date_to_epoch_ms(commit_date),
+        "meta": latest_meta,
+    }
+    changed = new_pin != pin
+    print("  Updated" if changed else "  Already up to date")
+    return new_pin, changed
+
+
+def main() -> None:
+    """Update all Gecko userscript pins."""
+    pins = load_hashes(PINS_FILE)
+    changed = False
+
+    for name, pin in list(pins.items()):
+        pins[name], pin_changed = update_pin(name, cast("dict[str, Any]", pin))
+        changed = changed or pin_changed
+
+    if changed:
+        save_hashes(PINS_FILE, pins)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update-gecko-userscripts.py
+++ b/scripts/update-gecko-userscripts.py
@@ -117,11 +117,21 @@ def date_to_epoch_ms(value: str) -> int:
     return int(datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp() * 1000)
 
 
+def save_script_source(path: Path, code: str) -> bool:
+    """Write a vendored userscript source file when its content changed."""
+    if path.exists() and path.read_text() == code:
+        return False
+
+    path.write_text(code)
+    return True
+
+
 def update_pin(name: str, pin: dict[str, Any]) -> tuple[dict[str, Any], bool]:
     """Refresh one userscript pin."""
     repo = cast("str", pin["repo"])
     branch = cast("str", pin["branch"])
     path = cast("str", pin["path"])
+    source_file = cast("str", pin["sourceFile"])
     current_rev = cast("str", pin["rev"])
 
     commit = github_path_commit(repo, branch, path)
@@ -136,6 +146,7 @@ def update_pin(name: str, pin: dict[str, Any]) -> tuple[dict[str, Any], bool]:
     print(f"  Current: {current_rev[:12]} {pin['hash']}")
     print(f"  Latest:  {latest_rev[:12]} {latest_hash}")
 
+    source_changed = save_script_source(PINS_FILE.parent / source_file, code)
     new_pin = {
         **pin,
         "rev": latest_rev,
@@ -143,7 +154,7 @@ def update_pin(name: str, pin: dict[str, Any]) -> tuple[dict[str, Any], bool]:
         "updatedAt": date_to_epoch_ms(commit_date),
         "meta": latest_meta,
     }
-    changed = new_pin != pin
+    changed = new_pin != pin or source_changed
     print("  Updated" if changed else "  Already up to date")
     return new_pin, changed
 


### PR DESCRIPTION
## Summary
- install Violentmonkey in every shared Gecko profile instead of work-only
- seed the nixpkgs-review-gha userscript into Violentmonkey storage for primary, work, and ephemeral profiles
- add a hash-pinned userscript metadata file plus an updater for refreshing the pinned raw GitHub script

## Test plan
- nix fmt
- ./scripts/update-gecko-userscripts.py
- nix-instantiate --parse modules/hm-apps/_gecko-extensions.nix
- python3 -m py_compile scripts/update-gecko-userscripts.py
- ruff check scripts/update-gecko-userscripts.py
- ruff format --check scripts/update-gecko-userscripts.py
- statix check modules/hm-apps/_gecko-extensions.nix
- nix eval checks for Firefox, Floorp, and LibreWolf profile storage
- git diff --check
- nix flake check --accept-flake-config --no-build --offline
- commit hooks
- pre-push hooks