### PR TITLE
feat(mirrors): build Firefox source docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,7 +297,10 @@ Pause, summarize the issue, and ask for direction.
   - Use when: Review module behavior or backport fixes.
 - Firefox source/docs
   - Path: `/data/git/mozilla-firefox-firefox`
-  - Use when: Inspect Firefox source behavior, Gecko internals, preferences, or generated source docs.
+  - Use when: Inspect Firefox source behavior, Gecko internals, or preferences.
+- Firefox built docs
+  - Path: `/data/git/mozilla-firefox-firefox-docs/current`
+  - Use when: Browse generated Firefox source docs built by `git-mirror-firefox-docs.service`.
 - MDN Web Docs
   - Path: `/data/git/mdn-content`
   - Use when: Reference MDN Web/API documentation offline.

--- a/docs/architecture/06-reference.md
+++ b/docs/architecture/06-reference.md
@@ -101,6 +101,7 @@ Available after `nix develop`:
 | Resource                   | Location                                            |
 | -------------------------- | --------------------------------------------------- |
 | Firefox source/docs        | `/data/git/mozilla-firefox-firefox`                 |
+| Firefox built docs         | `/data/git/mozilla-firefox-firefox-docs/current`    |
 | MDN Web Docs               | `/data/git/mdn-content`                             |
 | NixOS manual mirror        | `nixos-manual/`                                     |
 | Home Manager manual        | `/data/git/nix-community-home-manager/docs/manual/` |

--- a/docs/reference/local-mirrors.md
+++ b/docs/reference/local-mirrors.md
@@ -86,6 +86,8 @@ checkout so `git-mirror` can keep the source tree clean.
 - Built docs: `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/current`
 - Revision builds: `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/revisions/<sha>`
 - State marker: `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/last-built-revision`
+- Retention: `programs.gitMirror.firefoxDocs.maxRevisions` keeps the newest
+  revision and linkcheck output directories, defaulting to `2`
 
 Run or inspect the docs service directly:
 
@@ -96,7 +98,8 @@ test -f /data/git/mozilla-firefox-firefox-docs/current/index.html
 ```
 
 The service skips incomplete mirrors, dirty Firefox checkouts, and revisions
-that already have a successful generated docs tree.
+that already have a successful generated docs tree. After publishing a new
+`current` symlink, it prunes old revision and linkcheck output directories.
 
 ## Adding Repositories
 

--- a/docs/reference/local-mirrors.md
+++ b/docs/reference/local-mirrors.md
@@ -15,6 +15,9 @@ Repositories sync to flat paths under `/data/git`.
 - **Environment variable**: `$LOCAL_MIRRORS` points to `/data/git`
 - **Sync schedule**: Daily via systemd timer
 - **Manual sync**: `systemctl --user start git-mirror.service`
+- **Firefox source docs**: `git-mirror.service` queues
+  `git-mirror-firefox-docs.service` after sync when
+  `programs.gitMirror.firefoxDocs.enable = true;`
 
 ## Enable On Hosts
 
@@ -25,6 +28,7 @@ localMirrors.enable = true;
 
 home-manager.users.${metaOwner.username}.programs.gitMirror = {
   enable = true;
+  firefoxDocs.enable = true;
   repos = [
     "owner/repo"
     # ...
@@ -67,9 +71,32 @@ Full URLs include a normalized host prefix and strip common host suffixes such a
 | `mdn/content`                                 | `$LOCAL_MIRRORS/mdn-content`                        |
 | `mozilla/enterprise-admin-reference`          | `$LOCAL_MIRRORS/mozilla-enterprise-admin-reference` |
 | `mozilla-firefox/firefox`                     | `$LOCAL_MIRRORS/mozilla-firefox-firefox`            |
+| Firefox built docs                            | `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs`       |
 | `mozilla/policy-templates`                    | `$LOCAL_MIRRORS/mozilla-policy-templates`           |
 | `openai/codex`                                | `$LOCAL_MIRRORS/openai-codex`                       |
 | `https://codeberg.org/librewolf/settings.git` | `$LOCAL_MIRRORS/codeberg-librewolf-settings`        |
+
+## Firefox Source Docs
+
+The Firefox mirror can build source documentation with `./mach doc` after the
+mirror updates. Generated docs are intentionally published outside the Firefox
+checkout so `git-mirror` can keep the source tree clean.
+
+- Source checkout: `$LOCAL_MIRRORS/mozilla-firefox-firefox`
+- Built docs: `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/current`
+- Revision builds: `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/revisions/<sha>`
+- State marker: `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/last-built-revision`
+
+Run or inspect the docs service directly:
+
+```bash
+systemctl --user start git-mirror-firefox-docs.service
+journalctl --user -u git-mirror-firefox-docs.service -n 100 --no-pager
+test -f /data/git/mozilla-firefox-firefox-docs/current/index.html
+```
+
+The service skips incomplete mirrors, dirty Firefox checkouts, and revisions
+that already have a successful generated docs tree.
 
 ## Adding Repositories
 

--- a/docs/reference/local-mirrors.md
+++ b/docs/reference/local-mirrors.md
@@ -86,6 +86,8 @@ checkout so `git-mirror` can keep the source tree clean.
 - Built docs: `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/current`
 - Revision builds: `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/revisions/<sha>`
 - State marker: `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/last-built-revision`
+  records the revision plus selected `mach doc` options that affect generated
+  output
 - Retention: `programs.gitMirror.firefoxDocs.maxRevisions` keeps the newest
   revision and linkcheck output directories, defaulting to `2`
 

--- a/modules/hm-apps/_firefox-docs-builder.nix
+++ b/modules/hm-apps/_firefox-docs-builder.nix
@@ -135,9 +135,8 @@ pkgs.writeShellApplication {
 
     dirty_after=$(git -C "$repo_path" status --porcelain --untracked-files=all)
     if [ -n "$dirty_after" ]; then
-      log "Firefox checkout became dirty while building docs"
+      log "warning: Firefox checkout became dirty while building docs; git-mirror will clean it during the next sync"
       printf '%s\n' "$dirty_after" >&2
-      exit 1
     fi
 
     tmp_link="$output_root/current.tmp"

--- a/modules/hm-apps/_firefox-docs-builder.nix
+++ b/modules/hm-apps/_firefox-docs-builder.nix
@@ -75,14 +75,52 @@ pkgs.writeShellApplication {
     fi
 
     marker="$output_root/last-built-revision"
-    current_index="$output_root/current/index.html"
-    if [ -r "$marker" ] && [ "$(cat "$marker")" = "$sha" ] && [ -f "$current_index" ]; then
-      log "skipping; docs for $sha are already current"
+    revision_root="$output_root/revisions/$sha"
+    savedir="$revision_root/$format_name"
+    ${lib.optionalString firefoxDocs.linkcheck ''
+      linkcheck_root="$output_root/linkcheck/$sha"
+    ''}
+    build_inputs=${
+      lib.escapeShellArg (
+        builtins.toJSON {
+          inherit (firefoxDocs)
+            archive
+            disableWarningsCheck
+            format
+            jobs
+            linkcheck
+            noAutodoc
+            path
+            verbose
+            ;
+        }
+      )
+    }
+    build_marker="$sha $build_inputs"
+    current_target=$(readlink "$output_root/current" 2>/dev/null || true)
+    already_current=false
+    if [ -r "$marker" ] &&
+      [ "$(cat "$marker")" = "$build_marker" ] &&
+      [ "$current_target" = "$savedir" ] &&
+      [ -f "$savedir/index.html" ]; then
+      already_current=true
+    fi
+    ${lib.optionalString firefoxDocs.linkcheck ''
+      if [ "$already_current" = true ] && [ ! -d "$linkcheck_root" ]; then
+        already_current=false
+      fi
+    ''}
+    if [ "$already_current" = true ]; then
+      touch "$revision_root"
+      ${lib.optionalString firefoxDocs.linkcheck ''
+        touch "$linkcheck_root"
+      ''}
+      prune_artifacts "$output_root/revisions" "revision"
+      prune_artifacts "$output_root/linkcheck" "linkcheck"
+      log "skipping; docs for $sha ($format_name) are already current"
       exit 0
     fi
 
-    revision_root="$output_root/revisions/$sha"
-    savedir="$revision_root/$format_name"
     mkdir -p "$output_root/revisions" "$output_root/state" "$output_root/cache"
 
     args=(
@@ -121,7 +159,6 @@ pkgs.writeShellApplication {
     )
 
     ${lib.optionalString firefoxDocs.linkcheck ''
-      linkcheck_root="$output_root/linkcheck/$sha"
       linkcheck_args=(
         doc
         --outdir "$linkcheck_root"
@@ -161,7 +198,7 @@ pkgs.writeShellApplication {
     ln -sfnT "$savedir" "$tmp_link"
     mv -Tf "$tmp_link" "$output_root/current"
 
-    printf '%s\n' "$sha" > "$marker.tmp"
+    printf '%s\n' "$build_marker" > "$marker.tmp"
     mv -Tf "$marker.tmp" "$marker"
 
     touch "$revision_root"

--- a/modules/hm-apps/_firefox-docs-builder.nix
+++ b/modules/hm-apps/_firefox-docs-builder.nix
@@ -13,6 +13,7 @@ pkgs.writeShellApplication {
     gnugrep
     nodejs
     python3
+    util-linux
   ];
   text = ''
     set -euo pipefail
@@ -20,8 +21,13 @@ pkgs.writeShellApplication {
     repo_path=${lib.escapeShellArg firefoxDocs.repoPath}
     output_root=${lib.escapeShellArg firefoxDocs.outputRoot}
     format_name=${lib.escapeShellArg firefoxDocs.format}
+    lock_file=${lib.escapeShellArg firefoxDocs.lockPath}
 
     log() { printf '%s firefox-docs: %s\n' "$(date -Is)" "$*" >&2; }
+
+    mkdir -p "$(dirname "$lock_file")"
+    exec 9>"$lock_file"
+    flock 9
 
     if [ ! -d "$repo_path/.git" ]; then
       log "skipping; $repo_path is not a git checkout"

--- a/modules/hm-apps/_firefox-docs-builder.nix
+++ b/modules/hm-apps/_firefox-docs-builder.nix
@@ -7,13 +7,18 @@
 pkgs.writeShellApplication {
   name = "git-mirror-build-firefox-docs";
   runtimeInputs = with pkgs; [
+    bash
+    binutils
     coreutils
     findutils
     git
     gnugrep
+    gnused
     nodejs
+    patch
     python3
     util-linux
+    which
   ];
   text = ''
     set -euo pipefail

--- a/modules/hm-apps/_firefox-docs-builder.nix
+++ b/modules/hm-apps/_firefox-docs-builder.nix
@@ -26,9 +26,27 @@ pkgs.writeShellApplication {
     repo_path=${lib.escapeShellArg firefoxDocs.repoPath}
     output_root=${lib.escapeShellArg firefoxDocs.outputRoot}
     format_name=${lib.escapeShellArg firefoxDocs.format}
+    max_revisions=${lib.escapeShellArg (toString firefoxDocs.maxRevisions)}
     lock_file=${lib.escapeShellArg firefoxDocs.lockPath}
 
     log() { printf '%s firefox-docs: %s\n' "$(date -Is)" "$*" >&2; }
+
+    prune_artifacts() {
+      prune_root="$1"
+      label="$2"
+
+      [ -d "$prune_root" ] || return 0
+
+      find "$prune_root" -mindepth 1 -maxdepth 1 -type d -printf '%T@ %p\0' |
+        sort -z -nr |
+        tail -z -n +"$((max_revisions + 1))" |
+        while IFS= read -r -d "" entry; do
+          old_path=''${entry#* }
+          log "pruning old Firefox docs $label: $old_path"
+          find "$old_path" -depth -mindepth 1 -delete
+          rmdir "$old_path"
+        done
+    }
 
     mkdir -p "$(dirname "$lock_file")"
     exec 9>"$lock_file"
@@ -145,6 +163,14 @@ pkgs.writeShellApplication {
 
     printf '%s\n' "$sha" > "$marker.tmp"
     mv -Tf "$marker.tmp" "$marker"
+
+    touch "$revision_root"
+    ${lib.optionalString firefoxDocs.linkcheck ''
+      touch "$linkcheck_root"
+    ''}
+    prune_artifacts "$output_root/revisions" "revision"
+    prune_artifacts "$output_root/linkcheck" "linkcheck"
+
     log "published $output_root/current"
   '';
 }

--- a/modules/hm-apps/_firefox-docs-builder.nix
+++ b/modules/hm-apps/_firefox-docs-builder.nix
@@ -1,0 +1,140 @@
+{
+  lib,
+  pkgs,
+  firefoxDocs,
+}:
+
+pkgs.writeShellApplication {
+  name = "git-mirror-build-firefox-docs";
+  runtimeInputs = with pkgs; [
+    coreutils
+    findutils
+    git
+    gnugrep
+    nodejs
+    python3
+  ];
+  text = ''
+    set -euo pipefail
+
+    repo_path=${lib.escapeShellArg firefoxDocs.repoPath}
+    output_root=${lib.escapeShellArg firefoxDocs.outputRoot}
+    format_name=${lib.escapeShellArg firefoxDocs.format}
+
+    log() { printf '%s firefox-docs: %s\n' "$(date -Is)" "$*" >&2; }
+
+    if [ ! -d "$repo_path/.git" ]; then
+      log "skipping; $repo_path is not a git checkout"
+      exit 0
+    fi
+
+    if [ ! -x "$repo_path/mach" ]; then
+      log "skipping; $repo_path/mach is missing or not executable"
+      exit 0
+    fi
+
+    if ! sha=$(git -C "$repo_path" rev-parse --verify HEAD 2>/dev/null); then
+      log "skipping; $repo_path has no valid HEAD"
+      exit 0
+    fi
+
+    dirty_before=$(git -C "$repo_path" status --porcelain --untracked-files=all)
+    if [ -n "$dirty_before" ]; then
+      log "refusing to build from a dirty Firefox checkout"
+      printf '%s\n' "$dirty_before" >&2
+      exit 1
+    fi
+
+    marker="$output_root/last-built-revision"
+    current_index="$output_root/current/index.html"
+    if [ -r "$marker" ] && [ "$(cat "$marker")" = "$sha" ] && [ -f "$current_index" ]; then
+      log "skipping; docs for $sha are already current"
+      exit 0
+    fi
+
+    revision_root="$output_root/revisions/$sha"
+    savedir="$revision_root/$format_name"
+    mkdir -p "$output_root/revisions" "$output_root/state" "$output_root/cache"
+
+    args=(
+      doc
+      --format "$format_name"
+      --outdir "$revision_root"
+      --no-open
+      --no-serve
+    )
+    ${lib.optionalString firefoxDocs.archive ''
+      args+=(--archive)
+    ''}
+    ${lib.optionalString (firefoxDocs.jobs != null) ''
+      args+=(-j ${lib.escapeShellArg (toString firefoxDocs.jobs)})
+    ''}
+    ${lib.optionalString firefoxDocs.disableWarningsCheck ''
+      args+=(--disable-warnings-check)
+    ''}
+    ${lib.optionalString firefoxDocs.verbose ''
+      args+=(--verbose)
+    ''}
+    ${lib.optionalString firefoxDocs.noAutodoc ''
+      args+=(--no-autodoc)
+    ''}
+    ${lib.optionalString (firefoxDocs.path != null) ''
+      args+=(${lib.escapeShellArg firefoxDocs.path})
+    ''}
+
+    log "building Firefox docs for $sha"
+    (
+      cd "$repo_path"
+      MOZ_AUTOMATION=1 \
+        MOZBUILD_STATE_PATH="$output_root/state" \
+        XDG_CACHE_HOME="$output_root/cache" \
+        ./mach "''${args[@]}"
+    )
+
+    ${lib.optionalString firefoxDocs.linkcheck ''
+      linkcheck_root="$output_root/linkcheck/$sha"
+      linkcheck_args=(
+        doc
+        --outdir "$linkcheck_root"
+        --no-open
+        --no-serve
+        --linkcheck
+      )
+      ${lib.optionalString firefoxDocs.verbose ''
+        linkcheck_args+=(--verbose)
+      ''}
+      ${lib.optionalString (firefoxDocs.path != null) ''
+        linkcheck_args+=(${lib.escapeShellArg firefoxDocs.path})
+      ''}
+
+      log "checking Firefox docs links for $sha"
+      (
+        cd "$repo_path"
+        MOZ_AUTOMATION=1 \
+          MOZBUILD_STATE_PATH="$output_root/state" \
+          XDG_CACHE_HOME="$output_root/cache" \
+          ./mach "''${linkcheck_args[@]}"
+      )
+    ''}
+
+    if [ ! -f "$savedir/index.html" ]; then
+      log "expected $savedir/index.html after docs build"
+      exit 1
+    fi
+
+    dirty_after=$(git -C "$repo_path" status --porcelain --untracked-files=all)
+    if [ -n "$dirty_after" ]; then
+      log "Firefox checkout became dirty while building docs"
+      printf '%s\n' "$dirty_after" >&2
+      exit 1
+    fi
+
+    tmp_link="$output_root/current.tmp"
+    ln -sfnT "$savedir" "$tmp_link"
+    mv -Tf "$tmp_link" "$output_root/current"
+
+    printf '%s\n' "$sha" > "$marker.tmp"
+    mv -Tf "$marker.tmp" "$marker"
+    log "published $output_root/current"
+  '';
+}

--- a/modules/hm-apps/_firefox-docs-builder.nix
+++ b/modules/hm-apps/_firefox-docs-builder.nix
@@ -31,6 +31,10 @@ pkgs.writeShellApplication {
 
     log() { printf '%s firefox-docs: %s\n' "$(date -Is)" "$*" >&2; }
 
+    has_docs_output() {
+      [ -d "$1" ] && [ -n "$(find "$1" -mindepth 1 -maxdepth 1 -print -quit)" ]
+    }
+
     prune_artifacts() {
       prune_root="$1"
       label="$2"
@@ -102,7 +106,7 @@ pkgs.writeShellApplication {
     if [ -r "$marker" ] &&
       [ "$(cat "$marker")" = "$build_marker" ] &&
       [ "$current_target" = "$savedir" ] &&
-      [ -f "$savedir/index.html" ]; then
+      has_docs_output "$savedir"; then
       already_current=true
     fi
     ${lib.optionalString firefoxDocs.linkcheck ''
@@ -183,8 +187,8 @@ pkgs.writeShellApplication {
       )
     ''}
 
-    if [ ! -f "$savedir/index.html" ]; then
-      log "expected $savedir/index.html after docs build"
+    if ! has_docs_output "$savedir"; then
+      log "expected $savedir to contain generated docs"
       exit 1
     fi
 

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -14,6 +14,7 @@
     }:
     let
       cfg = config.programs.gitMirror;
+      inherit (cfg) firefoxDocs;
       reposFile = pkgs.writeText "repos.txt" (lib.concatStringsSep "\n" cfg.repos);
 
       # Helper script for syncing a single repo (called by parallel)
@@ -113,6 +114,10 @@
         '';
       };
 
+      firefoxDocsScript = import ./_firefox-docs-builder.nix {
+        inherit lib pkgs firefoxDocs;
+      };
+
       # Main entry point
       mirrorScript = pkgs.writeShellApplication {
         name = "git-mirror";
@@ -158,6 +163,76 @@
           description = "Repositories to mirror as GitHub owner/repo shorthand or full HTTP(S) Git URLs.";
         };
 
+        firefoxDocs = {
+          enable = lib.mkEnableOption "building Firefox source documentation after mirror sync";
+
+          repoSpec = lib.mkOption {
+            type = lib.types.str;
+            default = "mozilla-firefox/firefox";
+            description = "Repository spec from programs.gitMirror.repos that provides Firefox source docs.";
+          };
+
+          repoPath = lib.mkOption {
+            type = lib.types.str;
+            default = "${cfg.root}/mozilla-firefox-firefox";
+            description = "Local Firefox checkout used as the mach doc source tree.";
+          };
+
+          outputRoot = lib.mkOption {
+            type = lib.types.str;
+            default = "${cfg.root}/mozilla-firefox-firefox-docs";
+            description = "Directory where generated Firefox source docs are published.";
+          };
+
+          format = lib.mkOption {
+            type = lib.types.str;
+            default = "html";
+            description = "Sphinx builder format passed to mach doc.";
+          };
+
+          path = lib.mkOption {
+            type = lib.types.nullOr lib.types.str;
+            default = null;
+            description = "Optional Firefox documentation path passed to mach doc.";
+          };
+
+          jobs = lib.mkOption {
+            type = lib.types.nullOr lib.types.ints.positive;
+            default = null;
+            description = "Optional parallelism value passed to mach doc with -j.";
+          };
+
+          archive = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Whether to ask mach doc to write a tarball of the generated docs.";
+          };
+
+          linkcheck = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Whether to run a second mach doc linkcheck pass after generating HTML docs.";
+          };
+
+          noAutodoc = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Whether to pass --no-autodoc to mach doc.";
+          };
+
+          disableWarningsCheck = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Whether to pass --disable-warnings-check to mach doc.";
+          };
+
+          verbose = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Whether to pass --verbose to mach doc.";
+          };
+        };
+
         maxBackups = lib.mkOption {
           type = lib.types.ints.positive;
           default = 5;
@@ -178,24 +253,57 @@
       };
 
       config = lib.mkIf cfg.enable {
-        home.packages = [ mirrorScript ];
+        assertions = [
+          {
+            assertion = !firefoxDocs.enable || builtins.elem firefoxDocs.repoSpec cfg.repos;
+            message = "programs.gitMirror.firefoxDocs.repoSpec must be present in programs.gitMirror.repos.";
+          }
+          {
+            assertion = !(firefoxDocs.noAutodoc && firefoxDocs.disableWarningsCheck);
+            message = "programs.gitMirror.firefoxDocs.noAutodoc cannot be combined with disableWarningsCheck.";
+          }
+        ];
 
-        systemd.user.services.git-mirror = {
-          Unit.Description = "Sync git mirrors";
-          Service = {
-            Type = "oneshot";
-            ExecStart = "${mirrorScript}/bin/git-mirror";
-            Environment = [ "GIT_TERMINAL_PROMPT=0" ];
-          };
-        };
+        home.packages = [ mirrorScript ] ++ lib.optional firefoxDocs.enable firefoxDocsScript;
 
-        systemd.user.timers.git-mirror = {
-          Unit.Description = "Git mirror sync timer";
-          Timer = {
-            OnCalendar = cfg.timer;
-            Persistent = true;
+        systemd.user = {
+          services = {
+            git-mirror = {
+              Unit.Description = "Sync git mirrors";
+              Service = {
+                Type = "oneshot";
+                ExecStart = "${mirrorScript}/bin/git-mirror";
+                Environment = [ "GIT_TERMINAL_PROMPT=0" ];
+              }
+              // lib.optionalAttrs firefoxDocs.enable {
+                ExecStartPost = "${pkgs.systemd}/bin/systemctl --user --no-block start git-mirror-firefox-docs.service";
+              };
+            };
+
+            git-mirror-firefox-docs = lib.mkIf firefoxDocs.enable {
+              Unit = {
+                Description = "Build Firefox source docs";
+                After = [ "git-mirror.service" ];
+              };
+              Service = {
+                Type = "oneshot";
+                ExecStart = "${firefoxDocsScript}/bin/git-mirror-build-firefox-docs";
+                Environment = [ "GIT_TERMINAL_PROMPT=0" ];
+                TimeoutStartSec = "6h";
+                Nice = 10;
+                IOSchedulingClass = "idle";
+              };
+            };
           };
-          Install.WantedBy = [ "timers.target" ];
+
+          timers.git-mirror = {
+            Unit.Description = "Git mirror sync timer";
+            Timer = {
+              OnCalendar = cfg.timer;
+              Persistent = true;
+            };
+            Install.WantedBy = [ "timers.target" ];
+          };
         };
       };
     };

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -232,6 +232,12 @@
             description = "Directory where generated Firefox source docs are published.";
           };
 
+          maxRevisions = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 2;
+            description = "Maximum generated Firefox documentation revisions and linkcheck outputs to keep.";
+          };
+
           format = lib.mkOption {
             type = lib.types.str;
             default = "html";

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -234,8 +234,8 @@
 
           outputRoot = lib.mkOption {
             type = lib.types.str;
-            default = "${cfg.root}/mozilla-firefox-firefox-docs";
-            description = "Directory where generated Firefox source docs are published.";
+            default = "${cfg.root}/${mirrorDirName firefoxDocs.repoSpec}-docs";
+            description = "Directory where generated Firefox source docs are published. Defaults to the mirror path derived from repoSpec with a -docs suffix.";
           };
 
           maxRevisions = lib.mkOption {

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -53,6 +53,7 @@
           urlToDirName spec
         else
           builtins.replaceStrings [ "/" ] [ "-" ] spec;
+      mirrorLockPath = "${cfg.root}/.git-mirror.lock";
       reposFile = pkgs.writeText "repos.txt" (lib.concatStringsSep "\n" cfg.repos);
 
       # Helper script for syncing a single repo (called by parallel)
@@ -153,7 +154,10 @@
       };
 
       firefoxDocsScript = import ./_firefox-docs-builder.nix {
-        inherit lib pkgs firefoxDocs;
+        inherit lib pkgs;
+        firefoxDocs = firefoxDocs // {
+          lockPath = mirrorLockPath;
+        };
       };
 
       # Main entry point
@@ -164,10 +168,16 @@
           gnugrep
           parallel
           syncRepoScript
+          util-linux
         ];
         text = ''
           set -eu
           umask 002
+          lock_file=${lib.escapeShellArg mirrorLockPath}
+          mkdir -p "$(dirname "$lock_file")"
+          exec 9>"$lock_file"
+          flock 9
+
           export GIT_MIRROR_ROOT="${cfg.root}"
           export GIT_MIRROR_MAX_BACKUPS=${toString cfg.maxBackups}
           grep -vE '^[[:space:]]*(#|$)' "${reposFile}" | \
@@ -303,14 +313,16 @@
         systemd.user = {
           services = {
             git-mirror = {
-              Unit.Description = "Sync git mirrors";
+              Unit = {
+                Description = "Sync git mirrors";
+              }
+              // lib.optionalAttrs firefoxDocs.enable {
+                Wants = [ "git-mirror-firefox-docs.service" ];
+              };
               Service = {
                 Type = "oneshot";
                 ExecStart = "${mirrorScript}/bin/git-mirror";
                 Environment = [ "GIT_TERMINAL_PROMPT=0" ];
-              }
-              // lib.optionalAttrs firefoxDocs.enable {
-                ExecStartPost = "${pkgs.systemd}/bin/systemctl --user --no-block start git-mirror-firefox-docs.service";
               };
             };
 

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -15,6 +15,44 @@
     let
       cfg = config.programs.gitMirror;
       inherit (cfg) firefoxDocs;
+      allowedUrlDirChars = lib.stringToCharacters "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-";
+      stripAfter = separator: value: builtins.head (lib.splitString separator value);
+      sanitizeUrlDirName =
+        value:
+        lib.concatMapStrings (char: if builtins.elem char allowedUrlDirChars then char else "-") (
+          lib.stringToCharacters value
+        );
+      collapseDashes =
+        value:
+        let
+          next = builtins.replaceStrings [ "--" ] [ "-" ] value;
+        in
+        if next == value then value else collapseDashes next;
+      trimDashes = value: lib.removePrefix "-" (lib.removeSuffix "-" value);
+      urlToDirName =
+        spec:
+        let
+          withoutScheme = lib.removePrefix "http://" (lib.removePrefix "https://" spec);
+          withoutQuery = stripAfter "#" (stripAfter "?" withoutScheme);
+          normalized = lib.removeSuffix ".git" (lib.removeSuffix "/" withoutQuery);
+          parts = lib.filter (part: part != "") (lib.splitString "/" normalized);
+          host = if parts == [ ] then "" else builtins.head parts;
+          hostName =
+            host
+            |> lib.removePrefix "www."
+            |> lib.removeSuffix ".com"
+            |> lib.removeSuffix ".org"
+            |> lib.removeSuffix ".net";
+          pathParts = if parts == [ ] then [ ] else builtins.tail parts;
+          rawName = lib.concatStringsSep "-" ([ hostName ] ++ pathParts);
+        in
+        rawName |> sanitizeUrlDirName |> collapseDashes |> trimDashes;
+      mirrorDirName =
+        spec:
+        if lib.hasPrefix "http://" spec || lib.hasPrefix "https://" spec then
+          urlToDirName spec
+        else
+          builtins.replaceStrings [ "/" ] [ "-" ] spec;
       reposFile = pkgs.writeText "repos.txt" (lib.concatStringsSep "\n" cfg.repos);
 
       # Helper script for syncing a single repo (called by parallel)
@@ -174,8 +212,8 @@
 
           repoPath = lib.mkOption {
             type = lib.types.str;
-            default = "${cfg.root}/mozilla-firefox-firefox";
-            description = "Local Firefox checkout used as the mach doc source tree.";
+            default = "${cfg.root}/${mirrorDirName firefoxDocs.repoSpec}";
+            description = "Local Firefox checkout used as the mach doc source tree. Defaults to the mirror path derived from repoSpec.";
           };
 
           outputRoot = lib.mkOption {

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -53,7 +53,7 @@
           urlToDirName spec
         else
           builtins.replaceStrings [ "/" ] [ "-" ] spec;
-      mirrorLockPath = "${cfg.root}/.git-mirror.lock";
+      firefoxDocsLockPath = "${firefoxDocs.repoPath}.git-mirror.lock";
       reposFile = pkgs.writeText "repos.txt" (lib.concatStringsSep "\n" cfg.repos);
 
       # Helper script for syncing a single repo (called by parallel)
@@ -63,6 +63,7 @@
           git
           coreutils
           gawk
+          util-linux
         ];
         text = ''
           set -eu
@@ -106,6 +107,13 @@
               dir="$GIT_MIRROR_ROOT/$(printf '%s' "$spec" | tr '/' '-')"
               ;;
           esac
+
+          if [ "''${GIT_MIRROR_FIREFOX_DOCS_REPO_SPEC:-}" = "$spec" ] && [ -n "''${GIT_MIRROR_FIREFOX_DOCS_LOCK_PATH:-}" ]; then
+            lock_file="$GIT_MIRROR_FIREFOX_DOCS_LOCK_PATH"
+            mkdir -p "$(dirname "$lock_file")"
+            exec 9>"$lock_file"
+            flock 9
+          fi
 
           log "$spec: syncing"
 
@@ -156,7 +164,7 @@
       firefoxDocsScript = import ./_firefox-docs-builder.nix {
         inherit lib pkgs;
         firefoxDocs = firefoxDocs // {
-          lockPath = mirrorLockPath;
+          lockPath = firefoxDocsLockPath;
         };
       };
 
@@ -168,18 +176,16 @@
           gnugrep
           parallel
           syncRepoScript
-          util-linux
         ];
         text = ''
           set -eu
           umask 002
-          lock_file=${lib.escapeShellArg mirrorLockPath}
-          mkdir -p "$(dirname "$lock_file")"
-          exec 9>"$lock_file"
-          flock 9
-
           export GIT_MIRROR_ROOT="${cfg.root}"
           export GIT_MIRROR_MAX_BACKUPS=${toString cfg.maxBackups}
+          ${lib.optionalString firefoxDocs.enable ''
+            export GIT_MIRROR_FIREFOX_DOCS_REPO_SPEC=${lib.escapeShellArg firefoxDocs.repoSpec}
+            export GIT_MIRROR_FIREFOX_DOCS_LOCK_PATH=${lib.escapeShellArg firefoxDocsLockPath}
+          ''}
           grep -vE '^[[:space:]]*(#|$)' "${reposFile}" | \
             parallel --line-buffer -j${toString cfg.jobs} ${syncRepoScript}/bin/git-mirror-sync-repo
         '';

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -258,10 +258,6 @@
             assertion = !firefoxDocs.enable || builtins.elem firefoxDocs.repoSpec cfg.repos;
             message = "programs.gitMirror.firefoxDocs.repoSpec must be present in programs.gitMirror.repos.";
           }
-          {
-            assertion = !(firefoxDocs.noAutodoc && firefoxDocs.disableWarningsCheck);
-            message = "programs.gitMirror.firefoxDocs.noAutodoc cannot be combined with disableWarningsCheck.";
-          }
         ];
 
         home.packages = [ mirrorScript ] ++ lib.optional firefoxDocs.enable firefoxDocsScript;

--- a/modules/hosts/common/mirrors.nix
+++ b/modules/hosts/common/mirrors.nix
@@ -12,6 +12,7 @@ let
 
       home-manager.users.${metaOwner.username}.programs.gitMirror = {
         enable = true;
+        firefoxDocs.enable = true;
         repos = [
           # NixOS
           "NixOS/nixos-hardware"


### PR DESCRIPTION
## Summary
- add a Firefox docs builder for `programs.gitMirror.firefoxDocs` that runs `mach doc` after mirror syncs
- publish generated docs under `/data/git/mozilla-firefox-firefox-docs/current` instead of inside the Firefox checkout
- document the generated docs path and service workflow in local mirror references and agent guidance

## Test plan
- `nix fmt`
- `nix-instantiate --parse modules/hm-apps/git-mirror.nix`
- `nix-instantiate --parse modules/hm-apps/_firefox-docs-builder.nix`
- `nix-instantiate --parse modules/hosts/common/mirrors.nix`
- `git diff --check -- modules/hm-apps/git-mirror.nix modules/hm-apps/_firefox-docs-builder.nix modules/hosts/common/mirrors.nix docs/reference/local-mirrors.md docs/architecture/06-reference.md AGENTS.md`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config.home-manager.users.vx.systemd.user.services.git-mirror-firefox-docs.Service`
- `nix eval --accept-flake-config --json .#nixosConfigurations.tpnix.config.home-manager.users.vx.systemd.user.services.git-mirror-firefox-docs.Service`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config.home-manager.users.vx.systemd.user.services.git-mirror.Service`
- `nix eval --accept-flake-config --json .#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.gitMirror.firefoxDocs.enable`
- `nix build --accept-flake-config --no-link --print-out-paths .#nixosConfigurations.system76.config.home-manager.users.vx.home.activationPackage`
- `git-mirror-build-firefox-docs` smoke test against the current incomplete Firefox mirror
- `nix flake check --accept-flake-config --no-build --offline`