### PR TITLE
fix(services): restart recoverable units after transient failures

### DIFF
--- a/docs/drafts/duplicati-r2-readonly-mount-investigation.md
+++ b/docs/drafts/duplicati-r2-readonly-mount-investigation.md
@@ -362,7 +362,7 @@ The marginal benefit of a separate read-only pair is small. Cut B reuses `/etc/d
 ### 4.5 FUSE mount runtime (Cut C only)
 
 - Use `pyfuse3` as the binding. Cut C is Linux-only for this repo; macOS/FreeBSD parity is not a goal.
-- `duplicati-r2-mount mount <slug> <mountpoint>` runs in the foreground by default. The NixOS service must run the same foreground process under systemd (`Type=simple`), so systemd owns restart, stop, and logging semantics.
+- `duplicati-r2-mount mount <slug> <mountpoint>` runs in the foreground by default. The NixOS service must run the same foreground process under systemd (`Type=simple`), so systemd owns stop, logging, and failure-recovery semantics. The managed unit must set `restartIfChanged = false;` and `stopIfChanged = false;` so configuration activation does not restart or stop an active mount, and `Restart = "on-failure";` so unexpected FUSE/process failures are supervised.
 - `duplicati-r2-mount unmount <mountpoint>` performs the unmount operation. If unmounting requires the system helper, the command shells out to the packaged `${pkgs.fuse3}/bin/fusermount3 -u <mountpoint>` rather than requiring sudo.
 - `--debug` enables verbose lifecycle diagnostics for startup, open handles, read planning, cache hits/misses, busy unmounts, and stale-mount cleanup. Debug output must redact sensitive values: tokens, API keys, passphrases, env-file values, and signed request material.
 - Do not enable FUSE `allow_other` by default. Duplicati restore data is sensitive, and the default mount is visible only to the mounting user. `--allow-other` is an explicit CLI flag that adds the `allow_other` FUSE option only when present.
@@ -381,6 +381,7 @@ The marginal benefit of a separate read-only pair is small. Cut B reuses `/etc/d
 - `modules/services/duplicati-r2.nix` owns the mount runtime options and host policy. Add `services.duplicati-r2.mount.{enable,user,group,mountPoint,allowOther,debug}`.
 - `services.duplicati-r2.mount.allowOther` defaults to `false`. Only when `cfg.mount.enable && cfg.mount.allowOther` should the service module set `programs.fuse.userAllowOther = true;` and pass `--allow-other` to the mount command.
 - The service passes `--debug` only when `services.duplicati-r2.mount.debug = true`. Debug mode improves busy-unmount and dead-mount diagnostics, but still redacts credentials and passphrases.
+- The managed mount unit sets `restartIfChanged = false;`, `stopIfChanged = false;`, and `serviceConfig.Restart = "on-failure";`. The switch flags prevent rebuilds from tearing down or restarting a live mount during activation; `Restart=on-failure` restarts only after unexpected process failure, not after an operator-initiated stop/unmount.
 - Add an assertion that `services.duplicati-r2.mount.user` is listed in `services.duplicati-r2.stateDirReadableBy`; the mounting user must already have read ACLs for the SQLite state and env file. Normal mount use should not require sudo.
 - Create the mountpoint with `systemd.tmpfiles` using the configured user/group and restrictive mode. The service should stop via `duplicati-r2-mount unmount <mountpoint>` or `fusermount3 -u`, and should avoid leaving stale mountpoints or confusing dead mounts after stop/restart.
 - Enable the managed mount service on `system76` only. `tpnix` should not enable it unless that host later grants `stateDirReadableBy` and explicitly opts into the mount runtime.
@@ -389,13 +390,13 @@ The marginal benefit of a separate read-only pair is small. Cut B reuses `/etc/d
 
 - A Nix build sandbox cannot perform a real FUSE mount here: a sandboxed `runCommand` check for `/dev/fuse` returned `missing`. Therefore `mount.nix` must not require `/dev/fuse` or a real mount during `installCheckPhase`.
 - In-package checks should cover import/compile, fake filesystem object tests, `getattr`/`readdir`/`read`/`readlink` behavior over fixture data, and reuse of the existing resolver/decrypt/cache code paths.
-- Host or VM validation on `system76` covers the real FUSE path: service foreground startup, `ls`, `stat`, `cat`, `readlink`, `grep`, partial reads, unmount, busy-unmount diagnostics with `--debug`, and recovery from dead/stale mount state.
+- Host or VM validation on `system76` covers the real FUSE path: service foreground startup, no activation-time stop/restart due to `restartIfChanged=false` and `stopIfChanged=false`, `ls`, `stat`, `cat`, `readlink`, `grep`, partial reads, unmount, busy-unmount diagnostics with `--debug`, and recovery from dead/stale mount state through `Restart=on-failure`.
 
 ### 4.8 Per-invocation lifecycle (Cut B)
 
 - `duplicati-r2-extract <slug> <path> --output <dest>`: opens the SQLite DB (`mode=ro`), checks `Configuration.Version` is in the supported set, reads `Configuration.blockhash` / `Configuration.filehash` for the BlockHash and FileHash algorithms, sources `/etc/duplicati/r2.env` (or the file specified by `--env-file`) for credentials and the passphrase, then plans + fetches + decrypts + writes in one pass and exits. No background daemon, no mount, no FUSE.
 - The encrypted-dblock cache persists between invocations under `$XDG_CACHE_HOME/duplicati-r2-tools/<host>/<slug>/`. Move that directory aside with `rip` to drop it; subsequent runs re-fetch.
-- Cut C lifecycle is the foreground `duplicati-r2-mount mount ...` process plus `duplicati-r2-mount unmount <mountpoint>`, optionally supervised by the NixOS systemd service described above. If `--allow-other` is passed, it must be visible in the CLI invocation and backed by the NixOS `services.duplicati-r2.mount.allowOther` gate.
+- Cut C lifecycle is the foreground `duplicati-r2-mount mount ...` process plus `duplicati-r2-mount unmount <mountpoint>`, optionally supervised by the NixOS systemd service described above. The managed service keeps existing mounts across activation with `restartIfChanged=false` and `stopIfChanged=false`, and restarts after unexpected failures with `Restart=on-failure`. If `--allow-other` is passed, it must be visible in the CLI invocation and backed by the NixOS `services.duplicati-r2.mount.allowOther` gate.
 
 ## 5. The three cuts
 
@@ -454,11 +455,11 @@ duplicati-r2-extract <slug> ... --json                    # JSON summary on stde
 
 - Extract a mount package as `pkgs.duplicati-r2-tools.mount` with binary `duplicati-r2-mount`, using `pyfuse3` and Linux-only metadata (`meta.platforms = lib.platforms.linux`).
 - Reuse the Cut B resolver, R2/file source abstraction, AES decryptor, per-block verifier, and encrypted-dblock cache. Do not add a plaintext cache.
-- Implement `duplicati-r2-mount mount <slug> <mountpoint>` as a foreground process by default. The NixOS systemd service runs this same foreground process.
+- Implement `duplicati-r2-mount mount <slug> <mountpoint>` as a foreground process by default. The NixOS systemd service runs this same foreground process with `restartIfChanged = false;`, `stopIfChanged = false;`, and `Restart = "on-failure";`.
 - Implement `duplicati-r2-mount unmount <mountpoint>` and shell out to `${pkgs.fuse3}/bin/fusermount3 -u <mountpoint>` when that is the required unmount primitive.
 - Implement `--debug` for lifecycle/read/cache/unmount diagnostics, with mandatory redaction for tokens, API keys, passphrases, env-file values, and signed request material.
 - Implement `--allow-other` as a CLI opt-in. The NixOS service passes it only when `services.duplicati-r2.mount.allowOther = true`, and that same option is the only path that sets `programs.fuse.userAllowOther = true;`.
-- Add `services.duplicati-r2.mount.{enable,user,group,mountPoint,allowOther,debug}` and a `systemd` service in `modules/services/duplicati-r2.nix`. Assert the mount user is included in `stateDirReadableBy`, create the mountpoint via `systemd.tmpfiles`, and keep sudo out of normal operation by using the existing SQLite/env-file ACLs.
+- Add `services.duplicati-r2.mount.{enable,user,group,mountPoint,allowOther,debug}` and a `systemd` service in `modules/services/duplicati-r2.nix`. Assert the mount user is included in `stateDirReadableBy`, create the mountpoint via `systemd.tmpfiles`, set `restartIfChanged = false;`, `stopIfChanged = false;`, and `serviceConfig.Restart = "on-failure";`, and keep sudo out of normal operation by using the existing SQLite/env-file ACLs.
 - Add `pkgs.duplicati-r2-tools.mount` to the app module's default package list and expose flake output `.#duplicati-r2-mount`.
 - Enable the managed mount service from `modules/system76/duplicati.nix` only; `tpnix` should remain off unless it later gets matching state/env-file ACL access and explicitly opts in.
 
@@ -470,12 +471,12 @@ duplicati-r2-extract <slug> ... --json                    # JSON summary on stde
 - Race conditions between `release` and active `read` calls.
 - Symlink loops, hard-link representation, special files.
 - `getxattr`/`listxattr` if the metadata blob is to be exposed.
-- Stale/dead mount handling: foreground process ownership, explicit unmount, systemd stop behavior, and debug diagnostics for busy mounts.
+- Stale/dead mount handling: foreground process ownership, explicit unmount, `restartIfChanged=false` and `stopIfChanged=false` activation behavior, `Restart=on-failure` recovery, systemd stop behavior, and debug diagnostics for busy mounts.
 
 **Test plan**:
 
 - In `installCheckPhase`: import/compile, fake filesystem object tests, `getattr`/`readdir`/`read`/`readlink` fixture tests, and resolver/decrypt/cache reuse tests. Do not perform a real FUSE mount in the Nix build sandbox because `/dev/fuse` is absent there.
-- On `system76`: service startup, foreground logging, `ls`, `stat`, `cat`, `readlink`, `grep`, partial reads, clean unmount, busy-unmount diagnostics under `--debug`, and restart after a stale/dead mount.
+- On `system76`: service startup, foreground logging, activation that leaves a running mount alone, `ls`, `stat`, `cat`, `readlink`, `grep`, partial reads, clean unmount, busy-unmount diagnostics under `--debug`, and restart after a stale/dead mount.
 
 **Risk**: FUSE-on-Linux is stable and acceptable for this repo, but the mount can fail inside kernel callbacks under load rather than at command startup. Cross-user exposure through `allow_other` is security-sensitive and must remain behind the two explicit gates above.
 
@@ -509,7 +510,7 @@ Hard constraints from issue #204 carried through:
 
 **Cut C is next in this same branch/PR**. It should reuse the Cut B resolver, R2/file source abstraction, AES decryption boundary, block verifier, and encrypted-dblock cache, then add the read-only `pyfuse3` surface on top. The key implementation risk is not backup-format parsing anymore; it is mount correctness under filesystem access patterns: lifecycle, stale handles, symlink/readlink behavior, partial reads, cache eviction, safe unmount recovery, and keeping cross-user mount exposure behind an explicit `allow_other` opt-in.
 
-Cut C's implementation should keep FUSE permissions private by default. Add `duplicati-r2-mount mount` as a foreground process, `duplicati-r2-mount unmount` backed by `fusermount3 -u`, and a `--debug` mode that improves diagnostics without leaking credentials. Add a CLI `--allow-other` flag, but only have the NixOS service path pass that flag when `services.duplicati-r2.mount.allowOther = true`. The same service option is the only place that should set `programs.fuse.userAllowOther = true;`; package installation and `programs.duplicati-r2-tools.extended.enable` must not change global FUSE policy.
+Cut C's implementation should keep FUSE permissions private by default. Add `duplicati-r2-mount mount` as a foreground process, `duplicati-r2-mount unmount` backed by `fusermount3 -u`, and a `--debug` mode that improves diagnostics without leaking credentials. The managed service should set `restartIfChanged = false;` and `stopIfChanged = false;` so config activation does not bounce live mounts, and `Restart = "on-failure";` so failed foreground mount processes are restarted by systemd. Add a CLI `--allow-other` flag, but only have the NixOS service path pass that flag when `services.duplicati-r2.mount.allowOther = true`. The same service option is the only place that should set `programs.fuse.userAllowOther = true;`; package installation and `programs.duplicati-r2-tools.extended.enable` must not change global FUSE policy.
 
 **Reject** any approach that:
 

--- a/docs/reference/local-mirrors.md
+++ b/docs/reference/local-mirrors.md
@@ -19,6 +19,12 @@ Repositories sync to flat paths under `/data/git`.
   `git-mirror-firefox-docs.service` with `OnSuccess=` after sync when
   `programs.gitMirror.firefoxDocs.enable = true;`, so the docs build is not
   part of the mirror sync start transaction
+- **Switch behavior**: The mirror sync and Firefox docs build services use
+  `X-SwitchMethod=keep-old`; rebuilds update the unit files without starting
+  or restarting long-running mirror jobs during Home Manager activation
+- **Failure recovery**: `git-mirror.service` restarts on failure after 5
+  minutes so transient Git or network failures retry without manual
+  intervention
 
 ## Enable On Hosts
 

--- a/docs/reference/local-mirrors.md
+++ b/docs/reference/local-mirrors.md
@@ -23,8 +23,8 @@ Repositories sync to flat paths under `/data/git`.
   `X-SwitchMethod=keep-old`; rebuilds update the unit files without starting
   or restarting long-running mirror jobs during Home Manager activation
 - **Failure recovery**: `git-mirror.service` restarts on failure after 5
-  minutes so transient Git or network failures retry without manual
-  intervention
+  minutes, bounded to three attempts per hour, so transient Git or network
+  failures retry without churning forever
 
 ## Enable On Hosts
 

--- a/modules/agents/claude-code/CLAUDE.md
+++ b/modules/agents/claude-code/CLAUDE.md
@@ -35,6 +35,10 @@ Before reading any file, check its **size** and extension. Use structured tools 
 
 Failures must surface, not swallow. Concretely: do not replace `raise`/`throw` with a no-op `pass`/`catch`, do not return placeholder data on exception, and do not add `--no-verify` or `|| true` to silence a failing step. If suppression is genuinely intended, log the cause first.
 
+## Root cause fixes
+
+Fix the producer of bad output, not downstream consumers. If the current codebase controls the producer of a bad generated artifact, package, build output, API response, fixture, cache, lockfile, release asset, or similar output, repair that producer and add a regression check that would fail on the bad output. If the producer is external or cannot be changed in the current task, surface that constraint instead of masking it. Do not add compatibility shims, fallback paths, post-processing steps, or artifact rewrites unless the user explicitly approves a temporary mitigation. Label any mitigation as temporary, explain what blocks the source fix, and state the removal condition.
+
 ## Python
 
 Use `uv` and `uvx` for all Python work. No `pip`, no `venv`, no direct `python` invocations. For inline or one-off dependencies, use `uv run --with <pkg> <script>`.

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -327,6 +327,7 @@
             git-mirror = {
               Unit = {
                 Description = "Sync git mirrors";
+                X-SwitchMethod = "keep-old";
               }
               // lib.optionalAttrs firefoxDocs.enable {
                 OnSuccess = [ "git-mirror-firefox-docs.service" ];
@@ -335,6 +336,8 @@
                 Type = "oneshot";
                 ExecStart = "${mirrorScript}/bin/git-mirror";
                 Environment = [ "GIT_TERMINAL_PROMPT=0" ];
+                Restart = "on-failure";
+                RestartSec = "5m";
               };
             };
 
@@ -342,6 +345,7 @@
               Unit = {
                 Description = "Build Firefox source docs";
                 After = [ "git-mirror.service" ];
+                X-SwitchMethod = "keep-old";
               };
               Service = {
                 Type = "oneshot";

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -328,6 +328,8 @@
               Unit = {
                 Description = "Sync git mirrors";
                 X-SwitchMethod = "keep-old";
+                StartLimitBurst = 3;
+                StartLimitIntervalSec = "1h";
               }
               // lib.optionalAttrs firefoxDocs.enable {
                 OnSuccess = [ "git-mirror-firefox-docs.service" ];

--- a/modules/password-managers/pass-secret-service.nix
+++ b/modules/password-managers/pass-secret-service.nix
@@ -23,6 +23,10 @@ let
           Alias = [ "dbus-org.freedesktop.secrets.service" ];
           WantedBy = lib.mkForce [ "graphical-session.target" ];
         };
+        Service = {
+          Restart = "on-failure";
+          RestartSec = 3;
+        };
       };
     };
 in

--- a/modules/password-managers/pass-secret-service.nix
+++ b/modules/password-managers/pass-secret-service.nix
@@ -18,6 +18,8 @@ let
         Unit = {
           After = [ "graphical-session.target" ];
           PartOf = lib.mkForce [ "graphical-session.target" ];
+          StartLimitBurst = 3;
+          StartLimitIntervalSec = "1h";
         };
         Install = {
           Alias = [ "dbus-org.freedesktop.secrets.service" ];

--- a/modules/services/duplicati-r2.nix
+++ b/modules/services/duplicati-r2.nix
@@ -581,9 +581,13 @@ let
           Description=Duplicati R2 backup ($slug)
           After=${generatedUnitAfter}${generatedUnitRequiresLine}
           Wants=network-online.target
+          StartLimitBurst=3
+          StartLimitIntervalSec=1h
 
           [Service]
           Type=oneshot
+          Restart=on-failure
+          RestartSec=10m
           Environment=DUPLICATI_R2_CONFIG=$config_dest
           Environment=DUPLICATI_R2_TARGET=$slug
           Environment=DUPLICATI_R2_DEFAULT_BUCKET=$bucket
@@ -617,9 +621,13 @@ let
           Description=Duplicati R2 verification ($slug)
           After=${generatedUnitAfter}${generatedUnitRequiresLine}
           Wants=network-online.target
+          StartLimitBurst=3
+          StartLimitIntervalSec=1h
 
           [Service]
           Type=oneshot
+          Restart=on-failure
+          RestartSec=10m
           Environment=DUPLICATI_R2_CONFIG=$config_dest
           Environment=DUPLICATI_R2_TARGET=$slug
           Environment=DUPLICATI_R2_DEFAULT_BUCKET=$bucket
@@ -888,6 +896,8 @@ let
             serviceConfig = {
               Type = "oneshot";
               ExecStart = "${generatorScript}/bin/duplicati-r2-generate-units";
+              Restart = "on-failure";
+              RestartSec = "30s";
             };
           };
 

--- a/modules/services/duplicati-r2.nix
+++ b/modules/services/duplicati-r2.nix
@@ -882,6 +882,8 @@ let
               backupScript
               verifyScript
             ];
+            startLimitBurst = 3;
+            startLimitIntervalSec = 3600;
             environment = {
               DUPLICATI_R2_CONFIG_SOURCE = manifestSource;
               DUPLICATI_R2_CONFIG_DEST = manifestDest;

--- a/modules/system76/services.nix
+++ b/modules/system76/services.nix
@@ -117,6 +117,8 @@ _: {
         serviceConfig = {
           Type = "oneshot";
           ExecStart = "${pkgs.system76-power}/bin/system76-power profile performance";
+          Restart = "on-failure";
+          RestartSec = 3;
         };
       };
 

--- a/modules/system76/services.nix
+++ b/modules/system76/services.nix
@@ -114,6 +114,8 @@ _: {
           "dbus.service"
         ];
         wants = [ "system76-power.service" ];
+        startLimitBurst = 3;
+        startLimitIntervalSec = 3600;
         serviceConfig = {
           Type = "oneshot";
           ExecStart = "${pkgs.system76-power}/bin/system76-power profile performance";

--- a/modules/tpnix/services.nix
+++ b/modules/tpnix/services.nix
@@ -92,6 +92,8 @@ _: {
           Type = "oneshot";
           ExecStart = "${pkgs.power-profiles-daemon}/bin/powerprofilesctl set performance";
           RemainAfterExit = true;
+          Restart = "on-failure";
+          RestartSec = 3;
         };
       };
 

--- a/modules/tpnix/services.nix
+++ b/modules/tpnix/services.nix
@@ -88,6 +88,8 @@ _: {
         wantedBy = [ "graphical.target" ];
         wants = [ "power-profiles-daemon.service" ];
         after = [ "power-profiles-daemon.service" ];
+        startLimitBurst = 3;
+        startLimitIntervalSec = 3600;
         serviceConfig = {
           Type = "oneshot";
           ExecStart = "${pkgs.power-profiles-daemon}/bin/powerprofilesctl set performance";


### PR DESCRIPTION
## Summary

- keep git mirror jobs stable across Home Manager switches and retry transient sync failures
- add bounded restart behavior for recoverable Duplicati R2, power-profile, and secret-service units
- document Duplicati Cut C mount lifecycle expectations for switch behavior and failure recovery
- add Claude Code guidance to fix owned bad-output producers instead of downstream shims

## Test plan

- `git diff --check`
- `nix develop -c bash -lc 'for f in modules/hm-apps/git-mirror.nix modules/password-managers/pass-secret-service.nix modules/services/duplicati-r2.nix modules/system76/services.nix modules/tpnix/services.nix; do nix-instantiate --parse "$f" >/dev/null || exit; done'`
- commit hooks on each commit
- pre-push hooks from `git push -u origin fix/service-restart-policy`