### PR TITLE
fix(meta): harden flake-checker health checks

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -3,6 +3,22 @@ name: Dendritic Pattern Compliance Check
 "on":
   workflow_dispatch:
 jobs:
+  flake-lock-health:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+        with:
+          submodules: true
+          fetch-depth: 0
+      - name: Check Nixpkgs lock health
+        uses: DeterminateSystems/flake-checker-action@v12
+        with:
+          send-statistics: false
+          fail-mode: true
+          condition: >-
+            supportedRefs.contains(gitRef) && has(numDaysOld)
+            && numDaysOld < 30 && owner == 'NixOS'
+
   check-compliance:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -58,6 +58,15 @@ jobs:
             echo "Flake inputs updated (excluding secrets)"
           fi
 
+      - name: Check Nixpkgs lock health
+        uses: DeterminateSystems/flake-checker-action@v12
+        with:
+          send-statistics: false
+          fail-mode: true
+          condition: >-
+            supportedRefs.contains(gitRef) && has(numDaysOld)
+            && numDaysOld < 30 && owner == 'NixOS'
+
       - name: Run flake check
         if: steps.update.outputs.changed == 'true'
         run: nix flake check --accept-flake-config

--- a/docs/guides/apps-module-style-guide.md
+++ b/docs/guides/apps-module-style-guide.md
@@ -599,11 +599,11 @@ This pattern aligns with CLAUDE.md guidance: "Use `lib.hasAttrByPath` + `lib.get
 
 ### Stylix
 
-| Check                    | Command                                                     |
-| ------------------------ | ----------------------------------------------------------- |
-| General support          | `grep -r "<tool>" /data/git/nix-community-stylix/modules/`  |
-| Firefox/LibreWolf        | `cat /data/git/nix-community-stylix/modules/firefox/hm.nix` |
-| Available options        | `cat /data/git/nix-community-stylix/modules/<tool>/`        |
+| Check             | Command                                                     |
+| ----------------- | ----------------------------------------------------------- |
+| General support   | `grep -r "<tool>" /data/git/nix-community-stylix/modules/`  |
+| Firefox/LibreWolf | `cat /data/git/nix-community-stylix/modules/firefox/hm.nix` |
+| Available options | `cat /data/git/nix-community-stylix/modules/<tool>/`        |
 
 ### NUR Firefox Addons
 

--- a/modules/apps/flake-checker.nix
+++ b/modules/apps/flake-checker.nix
@@ -1,0 +1,48 @@
+/*
+  Package: flake-checker
+  Description: Health checks for your Nix flakes.
+  Homepage: nil
+  Documentation: nil
+  Repository: https://github.com/DeterminateSystems/flake-checker
+
+  Summary:
+    * Checks flake.lock Nixpkgs inputs for freshness, supported refs, and upstream ownership.
+    * Supports explicit Common Expression Language policies for repository-specific lockfile rules.
+
+  Options:
+    --no-telemetry: Disable aggregate diagnostic reporting.
+    --fail-mode: Exit non-zero when the checker finds policy issues.
+    --condition <CONDITION>: Apply a CEL policy to each checked Nixpkgs input.
+    --nixpkgs-keys <KEY_LIST>: Check a comma-separated list of Nixpkgs input keys.
+*/
+_:
+let
+  FlakeCheckerModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.flake-checker.extended;
+    in
+    {
+      options.programs.flake-checker.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable flake-checker.";
+        };
+
+        package = lib.mkPackageOption pkgs "flake-checker" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.flake-checker = FlakeCheckerModule;
+}

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -145,6 +145,7 @@ let
       filezilla.extended.enable = lib.mkOverride 1100 true;
       findutils.extended.enable = lib.mkOverride 1100 true;
       firefox.extended.enable = lib.mkOverride 1100 true;
+      "flake-checker".extended.enable = lib.mkOverride 1100 true;
       flarectl.extended.enable = lib.mkOverride 1100 true;
       fonttools.extended.enable = lib.mkOverride 1100 true;
       foremost.extended.enable = lib.mkOverride 1100 true;

--- a/modules/meta/pre-commit.nix
+++ b/modules/meta/pre-commit.nix
@@ -1,6 +1,14 @@
 _: {
   perSystem =
-    { config, ... }:
+    { config, pkgs, ... }:
+    let
+      flakeCheckerCondition = builtins.concatStringsSep " " [
+        "supportedRefs.contains(gitRef)"
+        "&& has(numDaysOld)"
+        "&& numDaysOld < 30"
+        "&& owner == 'NixOS'"
+      ];
+    in
     {
       pre-commit = {
         # Custom hooks rely on git metadata; skip sandboxed flake checks.
@@ -77,6 +85,25 @@ _: {
               description = "Detect hardcoded secrets in repository history.";
               entry = "${config.packages.hook-gitleaks}/bin/hook-gitleaks";
               pass_filenames = false;
+              always_run = true;
+              stages = [
+                "pre-push"
+                "manual"
+              ];
+            };
+
+            flake-checker = {
+              enable = true;
+              name = "flake-checker";
+              description = "Check flake.lock Nixpkgs inputs for supported upstream freshness.";
+              entry = builtins.concatStringsSep " " [
+                "${pkgs.flake-checker}/bin/flake-checker"
+                "--no-telemetry"
+                "--fail-mode"
+                "--condition \"${flakeCheckerCondition}\""
+              ];
+              pass_filenames = false;
+              files = "";
               always_run = true;
               stages = [
                 "pre-push"


### PR DESCRIPTION
## Summary

- add `flake-checker` as a package-only app module and enable it in the shared host app baseline
- enforce the nixpkgs lock health policy in local hooks and GitHub workflows with a CEL condition that accepts same-day locks while requiring timestamp presence
- make the pre-push flake-checker hook run independently of changed paths so stale locks are caught on unrelated pushes
- keep the incidental Stylix table formatting cleanup in its own docs commit

## Test plan

- `nix develop -c flake-checker --no-telemetry --fail-mode --condition "supportedRefs.contains(gitRef) && has(numDaysOld) && numDaysOld < 30 && owner == 'NixOS'" flake.lock`
- `nix develop -c pre-commit run flake-checker --hook-stage pre-push --files docs/guides/apps-module-style-guide.md`
- `nix flake check --accept-flake-config --no-build --offline`