### PR TITLE
fix(gecko): apply declarative browser configs

### DIFF
--- a/modules/apps/firefox.nix
+++ b/modules/apps/firefox.nix
@@ -25,15 +25,13 @@ _:
 let
   FirefoxModule =
     {
-      config,
       lib,
       pkgs,
       ...
     }:
-    let
-      cfg = config.programs.firefox.extended;
-    in
     {
+      # Home Manager owns installation for Firefox so the launched package is
+      # the wrapped finalPackage carrying enterprise policies and profile files.
       options.programs.firefox.extended = {
         enable = lib.mkOption {
           type = lib.types.bool;
@@ -42,10 +40,6 @@ let
         };
 
         package = lib.mkPackageOption pkgs "firefox" { };
-      };
-
-      config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
       };
     };
 in

--- a/modules/apps/librewolf.nix
+++ b/modules/apps/librewolf.nix
@@ -20,15 +20,13 @@ _:
 let
   LibrewolfModule =
     {
-      config,
       lib,
       pkgs,
       ...
     }:
-    let
-      cfg = config.programs.librewolf.extended;
-    in
     {
+      # Home Manager owns installation for LibreWolf so the launched package is
+      # the wrapped finalPackage carrying enterprise policies and profile files.
       options.programs.librewolf.extended = {
         enable = lib.mkOption {
           type = lib.types.bool;
@@ -37,10 +35,6 @@ let
         };
 
         package = lib.mkPackageOption pkgs "librewolf" { };
-      };
-
-      config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
       };
     };
 in

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -180,6 +180,14 @@ let
     newElementCount = 4;
   };
 
+  onePasswordToolbarIcon = ../stylix/icons/1password-outline.svg;
+  userChrome = ''
+    #${widgetIds.onePassword} > .toolbarbutton-icon,
+    #${widgetIds.onePassword} > .toolbarbutton-badge-stack > .toolbarbutton-icon {
+      list-style-image: url("file://${onePasswordToolbarIcon}") !important;
+    }
+  '';
+
   horizontalTabsBackup = toolbarState // {
     placements = toolbarPlacements // {
       TabsToolbar = [
@@ -408,6 +416,8 @@ in
     "browser.uiCustomization.navBarWhenVerticalTabs" = builtins.toJSON navBarWidgets;
     "browser.uiCustomization.state" = builtins.toJSON toolbarState;
   };
+
+  inherit userChrome;
 
   extensionStorage."${ublockOriginId}".settings = {
     advancedUserEnabled = true;

--- a/modules/hm-apps/_gecko-mk-profile.nix
+++ b/modules/hm-apps/_gecko-mk-profile.nix
@@ -63,6 +63,7 @@ let
         // (geckoBookmarks.settings bookmarksFile)
         // extraSettings;
       inherit (geckoContainers) containers;
+      inherit (geckoExtensions) userChrome;
       extensions = {
         force = true;
         inherit packages;

--- a/modules/home/gecko-secrets.nix
+++ b/modules/home/gecko-secrets.nix
@@ -168,41 +168,42 @@
               assignment_path="$1"
               storage_dir="$2"
               storage_path="$storage_dir/storage.js"
-              tmp_existing="$(mktemp)"
-              tmp_merged="$(mktemp)"
 
               if [ ! -r "$assignment_path" ]; then
-                echo "ERROR: missing Gecko container assignment file: $assignment_path" >&2
-                rm -f "$tmp_existing" "$tmp_merged"
-                exit 1
+                echo "Skipping Gecko container assignment merge; assignment file is not readable yet: $assignment_path" >&2
+                return 0
               fi
 
               install -d -m 700 "$storage_dir"
+              tmp_merged="$(mktemp -p "$storage_dir" ".storage.js.tmp.XXXXXXXXXX")"
 
               if [ -e "$storage_path" ]; then
                 existing_path="$storage_path"
               else
-                printf '{}\n' > "$tmp_existing"
-                existing_path="$tmp_existing"
+                existing_path="/dev/null"
               fi
 
-              if ! ${pkgs.jq}/bin/jq -S -s '
-                if (.[0] | type) != "object" then
+              if ! ${pkgs.jq}/bin/jq -S -n \
+                --slurpfile existing "$existing_path" \
+                --slurpfile declared "$assignment_path" \
+                '
+                ($existing[0] // {}) as $ex |
+                ($declared[0] // {}) as $dec |
+                if ($ex | type) != "object" then
                   error("existing Gecko container storage is not a JSON object")
-                elif (.[1] | type) != "object" then
+                elif ($dec | type) != "object" then
                   error("declared Gecko container assignments are not a JSON object")
                 else
-                  .[0] * .[1]
+                  $ex * $dec
                 end
-              ' "$existing_path" "$assignment_path" > "$tmp_merged"; then
+              ' > "$tmp_merged"; then
                 echo "ERROR: failed to merge Gecko container assignments into $storage_path" >&2
-                rm -f "$tmp_existing" "$tmp_merged"
+                rm -f "$tmp_merged"
                 exit 1
               fi
 
-              mv "$tmp_merged" "$storage_path"
+              mv -f "$tmp_merged" "$storage_path"
               chmod 600 "$storage_path"
-              rm -f "$tmp_existing"
             }
 
             ${lib.concatMapStringsSep "\n" (

--- a/modules/home/gecko-secrets.nix
+++ b/modules/home/gecko-secrets.nix
@@ -3,6 +3,7 @@
     {
       lib,
       config,
+      pkgs,
       secretsRoot,
       ...
     }:
@@ -108,13 +109,16 @@
       storageDir =
         target:
         "${homeDirectory}/${target.profilesPath}/${target.path}/browser-extension-data/@testpilot-containers";
-      storagePath = target: "${storageDir target}/storage.js";
 
-      storageTemplates = builtins.listToAttrs (
+      assignmentRoot = "${homeDirectory}/.local/share/gecko/container-assignments";
+      assignmentDir = target: "${assignmentRoot}/${target.browser}";
+      assignmentPath = target: "${assignmentDir target}/${target.profile}.json";
+
+      assignmentTemplates = builtins.listToAttrs (
         map (
           target:
           lib.nameValuePair "gecko/${target.browser}/${target.profile}/multi-account-containers" {
-            path = storagePath target;
+            path = assignmentPath target;
             content = multiAccountContainersStorage;
             mode = "0600";
           }
@@ -144,14 +148,67 @@
               mode = "0600";
             };
           }
-          // storageTemplates;
+          // assignmentTemplates;
 
           home.activation.ensureGeckoSecretDirs =
             lib.hm.dag.entryBetween [ "sops-nix" ] [ "writeBoundary" ]
               ''
                 install -d -m 700 '${homeDirectory}/.local/share/gecko'
-                ${lib.concatMapStringsSep "\n" (target: "install -d -m 700 '${storageDir target}'") enabledTargets}
+                ${lib.concatMapStringsSep "\n" (target: ''
+                  install -d -m 700 '${assignmentDir target}'
+                  install -d -m 700 '${storageDir target}'
+                '') enabledTargets}
               '';
+
+          # Multi-Account Containers rewrites storage.js at runtime, so keep
+          # the secret source outside the profile and merge declared assignments
+          # into the browser-owned file after sops-nix renders templates.
+          home.activation.applyGeckoContainerAssignments = lib.hm.dag.entryAfter [ "sops-nix" ] ''
+            merge_gecko_container_assignments() {
+              assignment_path="$1"
+              storage_dir="$2"
+              storage_path="$storage_dir/storage.js"
+              tmp_existing="$(mktemp)"
+              tmp_merged="$(mktemp)"
+
+              if [ ! -r "$assignment_path" ]; then
+                echo "ERROR: missing Gecko container assignment file: $assignment_path" >&2
+                rm -f "$tmp_existing" "$tmp_merged"
+                exit 1
+              fi
+
+              install -d -m 700 "$storage_dir"
+
+              if [ -e "$storage_path" ]; then
+                existing_path="$storage_path"
+              else
+                printf '{}\n' > "$tmp_existing"
+                existing_path="$tmp_existing"
+              fi
+
+              if ! ${pkgs.jq}/bin/jq -S -s '
+                if (.[0] | type) != "object" then
+                  error("existing Gecko container storage is not a JSON object")
+                elif (.[1] | type) != "object" then
+                  error("declared Gecko container assignments are not a JSON object")
+                else
+                  .[0] * .[1]
+                end
+              ' "$existing_path" "$assignment_path" > "$tmp_merged"; then
+                echo "ERROR: failed to merge Gecko container assignments into $storage_path" >&2
+                rm -f "$tmp_existing" "$tmp_merged"
+                exit 1
+              fi
+
+              mv "$tmp_merged" "$storage_path"
+              chmod 600 "$storage_path"
+              rm -f "$tmp_existing"
+            }
+
+            ${lib.concatMapStringsSep "\n" (
+              target: "merge_gecko_container_assignments '${assignmentPath target}' '${storageDir target}'"
+            ) enabledTargets}
+          '';
         })
 
         (lib.mkIf (cfg.enable && !geckoFileExists) {


### PR DESCRIPTION
## Summary
- route Firefox and LibreWolf installation through Home Manager's wrapped final packages so policies and profile files are applied by the launched browser
- move encrypted Multi-Account Containers assignments out of browser-owned extension storage and merge them into live profile storage during activation
- wire shared Gecko userChrome into profiles so the 1Password toolbar icon customization is installed declaratively

## Test plan
- previously ran targeted Nix parse checks for the touched Gecko modules
- previously built the system76 Home Manager activation package
- previously ran `nix flake check --accept-flake-config --no-build --offline --impure`
- commit hooks passed: deadnix, nix-parse, statix, treefmt, typos
- push hooks passed: apps-catalog-sync, flake-checker, gitleaks, managed-files-drift