### PR TITLE
fix(gecko): allow bookmark import and container new tabs

### DIFF
--- a/modules/apps/i3wm/window-rules.nix
+++ b/modules/apps/i3wm/window-rules.nix
@@ -15,12 +15,11 @@
       qHeight = toString ((cfg.screenHeight / 2) - (cfg.fontSize * 2) - 1);
       xPos = toString ((cfg.screenWidth / 2) + cfg.borderWidth);
       yPos = toString cfg.barHeight;
-      borderWidth = toString cfg.borderWidth;
 
       # Quarter-screen top-right corner with exact pixel positioning
       topRight = "resize set ${qWidth} px ${qHeight} px, move position ${xPos} px ${yPos} px";
 
-      onePassword = "resize set 949 px 765 px, move position center, border pixel ${borderWidth}";
+      onePassword = "resize set 949 px 765 px, move position center";
 
       # ProtonVPN window positioning (known size: 408x600)
       protonvpnX = toString (cfg.screenWidth - 408 - (cfg.borderWidth * 2) - 1);
@@ -110,7 +109,7 @@
           # Default styling for all windows
           {
             criteria.all = true;
-            command = ''border pixel ${borderWidth}, title_format "<b>%title</b>", title_window_icon padding 3px'';
+            command = ''border pixel ${toString cfg.borderWidth}, title_format "<b>%title</b>", title_window_icon padding 3px'';
           }
         ];
       };

--- a/modules/apps/i3wm/window-rules.nix
+++ b/modules/apps/i3wm/window-rules.nix
@@ -15,9 +15,12 @@
       qHeight = toString ((cfg.screenHeight / 2) - (cfg.fontSize * 2) - 1);
       xPos = toString ((cfg.screenWidth / 2) + cfg.borderWidth);
       yPos = toString cfg.barHeight;
+      borderWidth = toString cfg.borderWidth;
 
       # Quarter-screen top-right corner with exact pixel positioning
       topRight = "resize set ${qWidth} px ${qHeight} px, move position ${xPos} px ${yPos} px";
+
+      onePassword = "resize set 949 px 765 px, move position center, border pixel ${borderWidth}";
 
       # ProtonVPN window positioning (known size: 408x600)
       protonvpnX = toString (cfg.screenWidth - 408 - (cfg.borderWidth * 2) - 1);
@@ -65,6 +68,11 @@
             command = "floating enable, ${topRight}";
           }
           {
+            # 1Password main window (WM_CLASS: "1password", "1Password")
+            criteria.class = "(?i)^1password$";
+            command = "floating enable, ${onePassword}";
+          }
+          {
             # Bitwarden browser extension popup window
             criteria = {
               window_type = "dialog";
@@ -102,7 +110,7 @@
           # Default styling for all windows
           {
             criteria.all = true;
-            command = ''border pixel 5, title_format "<b>%title</b>", title_window_icon padding 3px'';
+            command = ''border pixel ${borderWidth}, title_format "<b>%title</b>", title_window_icon padding 3px'';
           }
         ];
       };

--- a/modules/hm-apps/_gecko-policies.nix
+++ b/modules/hm-apps/_gecko-policies.nix
@@ -9,6 +9,8 @@
   Notes:
     * Includes only upstream policy entries that set a non-default value.
     * Omits LibreWolf's inert localhost WebsiteFilter sentinel.
+    * Omits NoDefaultBookmarks because it disables the same defaultBookmarks
+      feature used by browser.bookmarks.file imports.
 */
 
 _:
@@ -26,7 +28,6 @@ in
     DisableTelemetry = true;
     DisableFeedbackCommands = true;
     DisablePocket = true;
-    NoDefaultBookmarks = true;
     ExtensionSettings = {
       "*" = {
         blocked_install_message = "Extensions are managed through Nix and cannot be installed from the browser.";

--- a/modules/hm-apps/_gecko-prefs.nix
+++ b/modules/hm-apps/_gecko-prefs.nix
@@ -75,6 +75,12 @@ in
       # New tabs are brought to the foreground when opened.
       "browser.tabs.loadInBackground" = false;
 
+      # Declare container UI state here so browsers do not depend on extension
+      # side effects or LibreWolf package defaults.
+      "privacy.userContext.enabled" = true;
+      "privacy.userContext.ui.enabled" = true;
+      "privacy.userContext.newTabContainerOnLeftClick.enabled" = true;
+
       # Keep cookie / certificate management buttons enabled in preferences.
       "pref.privacy.disable_button.cookie_exceptions" = false;
       "pref.privacy.disable_button.view_cookies" = false;


### PR DESCRIPTION
## Summary
- remove the shared Gecko `NoDefaultBookmarks` policy so `browser.bookmarks.file` imports are not blocked
- declare container identity UI prefs and the new-tab container chooser across Firefox and LibreWolf profiles

## Test plan
- `nix fmt`
- `nix-instantiate --parse modules/hm-apps/_gecko-policies.nix`
- `nix-instantiate --parse modules/hm-apps/_gecko-prefs.nix`
- `nix eval --accept-flake-config --offline --json '.#nixosConfigurations.system76.config.home-manager.users.vx.programs.firefox.policies' | jq '{hasNoDefaultBookmarks: has("NoDefaultBookmarks"), hasSearch: has("SearchEngines")}'`
- `nix eval --accept-flake-config --offline --json '.#nixosConfigurations.system76.config.home-manager.users.vx.programs.librewolf.policies' | jq '{hasNoDefaultBookmarks: has("NoDefaultBookmarks"), hasSearch: has("SearchEngines")}'`
- targeted per-profile settings evals for Firefox and LibreWolf `primary`, `pentesting`, and `work` profiles confirmed the shared bookmark file, bookmark import flag, and all three container prefs