### PR TITLE
fix(browsers): pin Gecko HM profiles to legacy roots

### DIFF
--- a/docs/architecture/04-home-manager.md
+++ b/docs/architecture/04-home-manager.md
@@ -137,6 +137,25 @@ nix build .#nixosConfigurations.<host>.config.system.build.toplevel
 nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames
 ```
 
+For NixOS-managed Home Manager, inspect the active generation through
+`~/.local/state/home-manager/gcroots/current-home/home-files`. The standalone
+`~/.local/state/nix/profiles/home-manager` profile can be stale and should not
+be used as the source of truth for NixOS module activation.
+
+If a Home Manager-managed file or directory is removed but the system
+generation does not change, `nh os switch` / `switch-to-configuration` may not
+rerun `home-manager-<user>.service`. Restart the system service directly to
+relink the active generation:
+
+```bash
+sudo systemctl restart home-manager-vx.service
+```
+
+Gecko browser profiles are intentionally managed only at `~/.mozilla/firefox`
+and `~/.librewolf`. Runtime-generated XDG profiles under `~/.config/mozilla` or
+`~/.config/librewolf` are unmanaged drift; remove them recoverably with `rip`
+before relinking the Home Manager generation.
+
 Add `home-manager` to `modules/devshell.nix` if a standalone CLI is needed for ad-hoc diagnostics.
 
 ## Next Steps

--- a/docs/architecture/04-home-manager.md
+++ b/docs/architecture/04-home-manager.md
@@ -148,7 +148,7 @@ rerun `home-manager-<user>.service`. Restart the system service directly to
 relink the active generation:
 
 ```bash
-sudo systemctl restart home-manager-vx.service
+sudo systemctl restart home-manager-$USER.service
 ```
 
 Gecko browser profiles are intentionally managed only at `~/.mozilla/firefox`

--- a/docs/guides/nix-debugging-manual.md
+++ b/docs/guides/nix-debugging-manual.md
@@ -168,13 +168,13 @@ error: cannot coerce null to a string: null
 ### 4.1 Activation Issues
 
 - Run `home-manager switch --show-trace` to expand evaluation backtraces for option type or dependency errors before activation aborts.
-- Inspect the systemd user unit with `systemctl --user status home-manager-$USER.service` and stream logs via `journalctl --user -fu home-manager-$USER.service` on NixOS installations that manage activation as a service.
+- Inspect the NixOS Home Manager service with `systemctl status home-manager-$USER.service` and stream logs via `journalctl -fu home-manager-$USER.service` on NixOS installations that manage activation as a system service.
 - Use `home-manager switch --dry-run` (or `--activation-trace`) to preview file links without touching the live home directory, then rerun with `--show-trace` if validation fails.
 
 ```bash
 home-manager switch --show-trace
-systemctl --user status "home-manager-$USER.service"
-journalctl --user -fu "home-manager-$USER.service"
+systemctl status "home-manager-$USER.service"
+journalctl -fu "home-manager-$USER.service"
 ```
 
 ### 4.2 Inspecting Generated Files
@@ -182,6 +182,9 @@ journalctl --user -fu "home-manager-$USER.service"
 - Build without activating using `home-manager build` and inspect the `result` symlink for rendered dotfiles under `result/home-files` or scripts via `result/activate`.
 - Diff generations with `home-manager generations` followed by `nix store diff-closures $oldGen $newGen` to understand configuration drift before promoting an update.
 - When conflicts arise (e.g., existing files), the activation check lists blocking paths; resolve by moving or adopting them into `home.file.*.source`.
+- On this NixOS repo, inspect `~/.local/state/home-manager/gcroots/current-home/home-files` for the active Home Manager files. The standalone `~/.local/state/nix/profiles/home-manager` profile can be stale.
+- If managed files were deleted and the NixOS generation did not change, rerun `sudo systemctl restart home-manager-$USER.service`; a same-generation switch may only run NixOS activation units and leave deleted Home Manager links absent.
+- Firefox and LibreWolf profiles are managed only under `~/.mozilla/firefox` and `~/.librewolf`; XDG profiles under `~/.config/mozilla` or `~/.config/librewolf` are unmanaged drift and should be removed recoverably with `rip` before relinking.
 
 ### 4.3 Debugging Modules
 

--- a/modules/hm-apps/firefox.nix
+++ b/modules/hm-apps/firefox.nix
@@ -21,15 +21,21 @@ _: {
     in
     {
       config = lib.mkIf nixosEnabled {
+        assertions = [
+          {
+            assertion = config.programs.firefox.profilesPath == ".mozilla/firefox";
+            message = "Firefox Home Manager profiles must stay under ~/.mozilla/firefox; XDG profile roots are unsupported.";
+          }
+        ];
+
         home.file = gecko.mkCustomKeysFiles config.programs.firefox;
 
         programs.firefox = {
           enable = true;
-          # nixpkgs wraps Firefox with MOZ_LEGACY_PROFILES=1, which forces
-          # reads from ~/.mozilla/firefox. Home Manager stateVersion 26.05
-          # switched this default to $XDG_CONFIG_HOME/mozilla/firefox, which
-          # Firefox ignores. Pin to the legacy path so HM writes where
-          # Firefox reads.
+          # This repo intentionally keeps Firefox on the legacy profile root.
+          # The XDG path would split policy-applied browser state from
+          # Home Manager's declarative user.js, customKeys.json, extension
+          # storage, and profile-scoped packages.
           configPath = ".mozilla/firefox";
           package = osConfig.programs.firefox.extended.package;
           # `home.packages` is not on Firefox's native-messaging discovery

--- a/modules/hm-apps/librewolf.nix
+++ b/modules/hm-apps/librewolf.nix
@@ -40,13 +40,22 @@ _: {
     in
     {
       config = lib.mkIf nixosEnabled {
+        assertions = [
+          {
+            assertion = config.programs.librewolf.profilesPath == ".librewolf";
+            message = "LibreWolf Home Manager profiles must stay under ~/.librewolf; XDG profile roots are unsupported.";
+          }
+        ];
+
         home.file = gecko.mkCustomKeysFiles config.programs.librewolf;
 
         programs.librewolf = {
           enable = true;
-          # Point HM at the path LibreWolf reads so declarative profile
-          # seeding reaches the running browser.
-          # configPath = ".config/librewolf/librewolf";
+          # This repo intentionally keeps LibreWolf on the legacy profile root.
+          # The XDG path would split policy-applied browser state from
+          # Home Manager's declarative user.js, customKeys.json, extension
+          # storage, and profile-scoped packages.
+          configPath = ".librewolf";
           package = osConfig.programs.librewolf.extended.package;
           # See modules/hm-apps/firefox.nix for why this uses the browser
           # native-messaging option instead of `home.packages`.


### PR DESCRIPTION
## Summary
- keep Firefox Home Manager profile files under `~/.mozilla/firefox`
- restore explicit LibreWolf Home Manager profile seeding under `~/.librewolf`
- document the same-generation Home Manager relink trap and stale standalone profile pointer

## Test plan
- `nix fmt -- --fail-on-change modules/hm-apps/firefox.nix modules/hm-apps/librewolf.nix docs/architecture/04-home-manager.md docs/guides/nix-debugging-manual.md`
- `nix-instantiate --parse modules/hm-apps/firefox.nix`
- `nix-instantiate --parse modules/hm-apps/librewolf.nix`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.system76.config.home-manager.users.vx.programs.firefox.profilesPath`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.system76.config.home-manager.users.vx.programs.librewolf.profilesPath`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config.home-manager.users.vx.assertions | jq '[.[] | select(.message | test("Firefox|LibreWolf"))]'`
- `git diff --check -- modules/hm-apps/firefox.nix modules/hm-apps/librewolf.nix docs/architecture/04-home-manager.md docs/guides/nix-debugging-manual.md`