### PR TITLE
fix(gecko): manage XDG profile root shims

### DIFF
--- a/docs/architecture/04-home-manager.md
+++ b/docs/architecture/04-home-manager.md
@@ -151,10 +151,12 @@ relink the active generation:
 sudo systemctl restart home-manager-$USER.service
 ```
 
-Gecko browser profiles are intentionally managed only at `~/.mozilla/firefox`
-and `~/.librewolf`. Runtime-generated XDG profiles under `~/.config/mozilla` or
-`~/.config/librewolf` are unmanaged drift; remove them recoverably with `rip`
-before relinking the Home Manager generation.
+Gecko browser profiles are intentionally rooted at `~/.mozilla/firefox` and
+`~/.librewolf`. Home Manager also manages compatibility symlinks from
+`~/.config/mozilla/firefox` to `~/.mozilla/firefox` and from
+`~/.config/librewolf/librewolf` to `~/.librewolf`. Real directories at those XDG
+leaves are unmanaged drift; activation refuses them so they can be moved
+recoverably with `rip` before relinking the Home Manager generation.
 
 Add `home-manager` to `modules/devshell.nix` if a standalone CLI is needed for ad-hoc diagnostics.
 

--- a/docs/guides/nix-debugging-manual.md
+++ b/docs/guides/nix-debugging-manual.md
@@ -184,7 +184,7 @@ journalctl -fu "home-manager-$USER.service"
 - When conflicts arise (e.g., existing files), the activation check lists blocking paths; resolve by moving or adopting them into `home.file.*.source`.
 - On this NixOS repo, inspect `~/.local/state/home-manager/gcroots/current-home/home-files` for the active Home Manager files. The standalone `~/.local/state/nix/profiles/home-manager` profile can be stale.
 - If managed files were deleted and the NixOS generation did not change, rerun `sudo systemctl restart home-manager-$USER.service`; a same-generation switch may only run NixOS activation units and leave deleted Home Manager links absent.
-- Firefox and LibreWolf profiles are managed only under `~/.mozilla/firefox` and `~/.librewolf`; XDG profiles under `~/.config/mozilla` or `~/.config/librewolf` are unmanaged drift and should be removed recoverably with `rip` before relinking.
+- Firefox and LibreWolf profiles are rooted under `~/.mozilla/firefox` and `~/.librewolf`; `~/.config/mozilla/firefox` and `~/.config/librewolf/librewolf` are managed compatibility symlinks. Real directories at those XDG leaves are unmanaged drift and should be moved recoverably with `rip` before relinking.
 
 ### 4.3 Debugging Modules
 

--- a/modules/hm-apps/_gecko-mk-profile.nix
+++ b/modules/hm-apps/_gecko-mk-profile.nix
@@ -77,7 +77,7 @@ let
     let
       legacyProfilesRoot = "${config.home.homeDirectory}/${legacyProfilesPath}";
       xdgProfilesRoot = "${config.home.homeDirectory}/${xdgProfilesPath}";
-      readlink = "${pkgs.coreutils}/bin/readlink";
+      readlink = lib.getExe' pkgs.coreutils "readlink";
     in
     {
       activation = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''

--- a/modules/hm-apps/_gecko-mk-profile.nix
+++ b/modules/hm-apps/_gecko-mk-profile.nix
@@ -67,9 +67,51 @@ let
         settings = geckoExtensions.extensionStorage;
       };
     };
+
+  mkXdgProfileRoot =
+    {
+      browserName,
+      legacyProfilesPath,
+      xdgProfilesPath,
+    }:
+    let
+      legacyProfilesRoot = "${config.home.homeDirectory}/${legacyProfilesPath}";
+      xdgProfilesRoot = "${config.home.homeDirectory}/${xdgProfilesPath}";
+      readlink = "${pkgs.coreutils}/bin/readlink";
+    in
+    {
+      activation = lib.hm.dag.entryBefore [ "checkLinkTargets" ] ''
+        browser_name=${lib.escapeShellArg browserName}
+        xdg_root=${lib.escapeShellArg xdgProfilesRoot}
+        legacy_root=${lib.escapeShellArg legacyProfilesRoot}
+
+        if [ -e "$xdg_root" ] || [ -L "$xdg_root" ]; then
+          if [ ! -L "$xdg_root" ]; then
+            echo "$browser_name XDG profile root must be a symlink to $legacy_root: $xdg_root" >&2
+            echo "Move the existing path recoverably with: rip $xdg_root" >&2
+            exit 1
+          fi
+
+          xdg_resolved="$(${readlink} -m "$xdg_root")"
+          legacy_resolved="$(${readlink} -m "$legacy_root")"
+
+          if [ "$xdg_resolved" != "$legacy_resolved" ]; then
+            echo "$browser_name XDG profile root resolves to $xdg_resolved, expected $legacy_resolved" >&2
+            echo "Move or relink $xdg_root so it points at $legacy_root" >&2
+            exit 1
+          fi
+        fi
+      '';
+      file = {
+        "${xdgProfilesPath}" = {
+          source = config.lib.file.mkOutOfStoreSymlink legacyProfilesRoot;
+          force = true;
+        };
+      };
+    };
 in
 {
-  inherit mkProfile policies;
+  inherit mkProfile mkXdgProfileRoot policies;
   inherit (geckoShortcuts) mkCustomKeysFiles;
   inherit (geckoExtensions)
     nativeMessagingHosts

--- a/modules/hm-apps/firefox.nix
+++ b/modules/hm-apps/firefox.nix
@@ -9,6 +9,8 @@ _: {
       ...
     }:
     let
+      legacyProfilesPath = ".mozilla/firefox";
+      xdgProfilesPath = ".config/mozilla/firefox";
       nixosEnabled = lib.attrByPath [ "programs" "firefox" "extended" "enable" ] false osConfig;
       gecko = import ./_gecko-mk-profile.nix {
         inherit
@@ -18,25 +20,31 @@ _: {
           config
           ;
       };
+      xdgProfileRoot = gecko.mkXdgProfileRoot {
+        browserName = "Firefox";
+        inherit legacyProfilesPath xdgProfilesPath;
+      };
     in
     {
       config = lib.mkIf nixosEnabled {
         assertions = [
           {
-            assertion = config.programs.firefox.profilesPath == ".mozilla/firefox";
-            message = "Firefox Home Manager profiles must stay under ~/.mozilla/firefox; XDG profile roots are unsupported.";
+            assertion = config.programs.firefox.profilesPath == legacyProfilesPath;
+            message = "Firefox Home Manager profiles must stay under ~/.mozilla/firefox; the XDG profile root is only a compatibility symlink.";
           }
         ];
 
-        home.file = gecko.mkCustomKeysFiles config.programs.firefox;
+        home.activation.checkFirefoxXdgProfileRoot = xdgProfileRoot.activation;
+
+        home.file = gecko.mkCustomKeysFiles config.programs.firefox // xdgProfileRoot.file;
 
         programs.firefox = {
           enable = true;
           # This repo intentionally keeps Firefox on the legacy profile root.
-          # The XDG path would split policy-applied browser state from
+          # A real XDG profile root would split policy-applied browser state from
           # Home Manager's declarative user.js, customKeys.json, extension
-          # storage, and profile-scoped packages.
-          configPath = ".mozilla/firefox";
+          # storage, and profile-scoped packages, so the XDG leaf is a symlink.
+          configPath = legacyProfilesPath;
           package = osConfig.programs.firefox.extended.package;
           # `home.packages` is not on Firefox's native-messaging discovery
           # path. Use HM's browser-native option so manifests land in

--- a/modules/hm-apps/librewolf.nix
+++ b/modules/hm-apps/librewolf.nix
@@ -28,6 +28,8 @@ _: {
       ...
     }:
     let
+      legacyProfilesPath = ".librewolf";
+      xdgProfilesPath = ".config/librewolf/librewolf";
       nixosEnabled = lib.attrByPath [ "programs" "librewolf" "extended" "enable" ] false osConfig;
       gecko = import ./_gecko-mk-profile.nix {
         inherit
@@ -37,25 +39,31 @@ _: {
           config
           ;
       };
+      xdgProfileRoot = gecko.mkXdgProfileRoot {
+        browserName = "LibreWolf";
+        inherit legacyProfilesPath xdgProfilesPath;
+      };
     in
     {
       config = lib.mkIf nixosEnabled {
         assertions = [
           {
-            assertion = config.programs.librewolf.profilesPath == ".librewolf";
-            message = "LibreWolf Home Manager profiles must stay under ~/.librewolf; XDG profile roots are unsupported.";
+            assertion = config.programs.librewolf.profilesPath == legacyProfilesPath;
+            message = "LibreWolf Home Manager profiles must stay under ~/.librewolf; the XDG profile root is only a compatibility symlink.";
           }
         ];
 
-        home.file = gecko.mkCustomKeysFiles config.programs.librewolf;
+        home.activation.checkLibreWolfXdgProfileRoot = xdgProfileRoot.activation;
+
+        home.file = gecko.mkCustomKeysFiles config.programs.librewolf // xdgProfileRoot.file;
 
         programs.librewolf = {
           enable = true;
           # This repo intentionally keeps LibreWolf on the legacy profile root.
-          # The XDG path would split policy-applied browser state from
+          # A real XDG profile root would split policy-applied browser state from
           # Home Manager's declarative user.js, customKeys.json, extension
-          # storage, and profile-scoped packages.
-          configPath = ".librewolf";
+          # storage, and profile-scoped packages, so the XDG leaf is a symlink.
+          configPath = legacyProfilesPath;
           package = osConfig.programs.librewolf.extended.package;
           # See modules/hm-apps/firefox.nix for why this uses the browser
           # native-messaging option instead of `home.packages`.


### PR DESCRIPTION
## Summary
- keep Firefox and LibreWolf Home Manager profile ownership on `~/.mozilla/firefox` and `~/.librewolf`
- add managed XDG leaf symlinks for `~/.config/mozilla/firefox` and `~/.config/librewolf/librewolf`
- reject real XDG profile directories before Home Manager link activation, and document the drift handling path

## Test plan
- `git diff --check`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.system76.config.home-manager.users.vx.programs.firefox.configPath`
- `nix eval --accept-flake-config --raw .#nixosConfigurations.system76.config.home-manager.users.vx.programs.librewolf.configPath`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config.home-manager.users.vx.home.file.\".config/mozilla/firefox\".force`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config.home-manager.users.vx.home.file.\".config/librewolf/librewolf\".force`
- `nix build --accept-flake-config .#nixosConfigurations.system76.config.home-manager.users.vx.home.activationPackage --no-link --print-out-paths`
- `bash -n /nix/store/d6lc1lzr311f75hw3d53gryx15ibmixz-home-manager-generation/activate`
- generated Home Manager `check-link-targets.sh` against `/nix/store/d6lc1lzr311f75hw3d53gryx15ibmixz-home-manager-generation/home-files`
- skipped validator/prewarm by request