### PR TITLE
feat(gecko): manage Tridactyl rc declaratively

### DIFF
--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -395,12 +395,10 @@ in
         tabStashId
         stylusId
         tridactylId
-        onePasswordId
       ];
       sidebarTools = [
         raindropId
         tabStashId
-        onePasswordId
         "history"
       ];
     in

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -394,12 +394,12 @@ in
         raindropId
         tabStashId
         stylusId
-        tridactylId
+        onePasswordId
       ];
       sidebarTools = [
         raindropId
         tabStashId
-        tridactylId
+        onePasswordId
         "history"
       ];
     in

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -394,6 +394,7 @@ in
         raindropId
         tabStashId
         stylusId
+        tridactylId
         onePasswordId
       ];
       sidebarTools = [

--- a/modules/hm-apps/_gecko-tridactyl.nix
+++ b/modules/hm-apps/_gecko-tridactyl.nix
@@ -1,0 +1,61 @@
+/*
+  Internal: shared Tridactyl configuration
+  Description: Declarative rc file consumed by the Tridactyl native messenger
+  from $XDG_CONFIG_HOME/tridactyl/tridactylrc.
+*/
+
+{ lib }:
+let
+  upstreamTemplate = {
+    source = "https://github.com/tridactyl/tridactyl/blob/master/.tridactylrc";
+    note = "The upstream template is almost entirely commented example config; active local commands are generated below.";
+  };
+
+  bindings = [
+    {
+      key = "/";
+      command = "fillcmdline find";
+    }
+    {
+      key = "?";
+      command = "fillcmdline find --reverse";
+    }
+    {
+      key = "n";
+      command = "findnext --search-from-view";
+    }
+    {
+      key = "N";
+      command = "findnext --search-from-view --reverse";
+    }
+    {
+      key = "gn";
+      command = "findselect";
+    }
+    {
+      key = "gN";
+      command = "composite findnext --search-from-view --reverse; findselect";
+    }
+    {
+      key = ",<Space>";
+      command = "nohlsearch";
+    }
+  ];
+
+  renderBinding = binding: "bind ${binding.key} ${binding.command}";
+
+  tridactylrc = ''
+    " Source template: ${upstreamTemplate.source}
+    " Note: ${upstreamTemplate.note}
+    "
+    " Vim-style page search using Tridactyl's own find mode.
+  ''
+  + lib.concatMapStringsSep "\n" renderBinding bindings
+  + "\n";
+in
+{
+  configFile."tridactyl/tridactylrc" = {
+    text = tridactylrc;
+    force = true;
+  };
+}

--- a/modules/hm-apps/tridactyl.nix
+++ b/modules/hm-apps/tridactyl.nix
@@ -1,0 +1,14 @@
+_: {
+  flake.homeManagerModules.apps.tridactyl =
+    { osConfig, lib, ... }:
+    let
+      firefoxEnabled = lib.attrByPath [ "programs" "firefox" "extended" "enable" ] false osConfig;
+      librewolfEnabled = lib.attrByPath [ "programs" "librewolf" "extended" "enable" ] false osConfig;
+      geckoTridactyl = import ./_gecko-tridactyl.nix { inherit lib; };
+    in
+    {
+      config = lib.mkIf (firefoxEnabled || librewolfEnabled) {
+        xdg.configFile = geckoTridactyl.configFile;
+      };
+    };
+}

--- a/modules/hosts/common/home-manager-apps.nix
+++ b/modules/hosts/common/home-manager-apps.nix
@@ -56,6 +56,7 @@ let
     "stylix-gui"
     "tealdeer"
     "thunderbird"
+    "tridactyl"
     "tree"
     "ungoogled-chromium"
     "usbguard-notifier"


### PR DESCRIPTION
## Summary
- add a Home Manager app module that writes Tridactyl rc config for Gecko browsers
- declare Vim-style page search bindings under XDG config
- include the Tridactyl app module in the common Home Manager imports
- keep Gecko sidebar tools focused on sidebar-capable extension IDs

## Test plan
- git diff --cached --check
- nix-instantiate --parse modules/hm-apps/_gecko-extensions.nix
- nix-instantiate --parse modules/hm-apps/_gecko-tridactyl.nix
- nix-instantiate --parse modules/hm-apps/tridactyl.nix
- nix-instantiate --parse modules/hosts/common/home-manager-apps.nix
- commit hooks: deadnix, nix-parse, statix, treefmt, typos
- nix flake check skipped here because it was already run across the split before PR publication