### PR TITLE
feat(doom-emacs): add editor grammars and language tools

### DIFF
--- a/modules/apps/doom-emacs.nix
+++ b/modules/apps/doom-emacs.nix
@@ -12,7 +12,7 @@
   Options:
     enable: Toggle the doom-emacs integration; the actual package is installed by the Home Manager module.
     package: Emacs derivation passed to Unstraightened (defaults to pkgs.emacs from the emacs-overlay).
-    doomDir: Path to the doomdir bundled into the build (defaults to the upstream Doom starter templates).
+    doomDir: Path to the doomdir bundled into the build (defaults to the existing static starter doomdir).
     enableService: Enable the Home Manager `services.emacs` user daemon backed by Doom.
 
   Notes:
@@ -77,10 +77,12 @@
           defaultText = lib.literalExpression "./doom-emacs-doomdir";
           description = ''
             Path to the Doom configuration directory (init.el / packages.el / config.el)
-            bundled into the build. The default ships the upstream Doom starter
-            templates (static/{init,packages,config}.example.el) and gives a working
-            evil/vertico/corfu/magit setup out of the box. Override to layer in a
-            personal doomdir.
+            bundled into the build. The default stays on the committed static
+            starter doomdir because nix-doom-emacs-unstraightened imports
+            generated intermediates during evaluation; changing the default
+            contents requires that intermediate output to be realized before
+            no-build flake validation can pass. Override to layer in a personal
+            doomdir.
           '';
         };
 

--- a/modules/apps/doom-emacs.nix
+++ b/modules/apps/doom-emacs.nix
@@ -13,6 +13,7 @@
     enable: Toggle the doom-emacs integration; the actual package is installed by the Home Manager module.
     package: Emacs derivation passed to Unstraightened (defaults to pkgs.emacs from the emacs-overlay).
     doomDir: Path to the doomdir bundled into the build (defaults to the existing static starter doomdir).
+    enableLanguageTooling: Add language servers, formatters, and tree-sitter grammars for an active programming doomdir.
     enableService: Enable the Home Manager `services.emacs` user daemon backed by Doom.
 
   Notes:
@@ -83,6 +84,18 @@
             contents requires that intermediate output to be realized before
             no-build flake validation can pass. Override to layer in a personal
             doomdir.
+          '';
+        };
+
+        enableLanguageTooling = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Whether to add tree-sitter grammars plus language servers and
+            formatters to Doom's runtime path. Enable this when `doomDir`
+            activates the matching Doom modules; the bundled starter doomdir
+            keeps those modules disabled, so the default avoids pulling in an
+            unused language-tool closure.
           '';
         };
 

--- a/modules/hm-apps/doom-emacs.nix
+++ b/modules/hm-apps/doom-emacs.nix
@@ -39,7 +39,7 @@ _: {
       ] { } osConfig;
 
       doomPackage = doomCfg.package;
-      inherit (doomCfg) doomDir enableService;
+      inherit (doomCfg) doomDir enableLanguageTooling enableService;
     in
     {
       imports = [ inputs.nix-doom-emacs-unstraightened.homeModule ];
@@ -54,56 +54,63 @@ _: {
           # this repo opts those Home Manager wrappers out (`package = null`),
           # so the upstream default would inject null entries that fail
           # `types.listOf types.package`. Source the binaries directly from pkgs.
-          extraPackages = epkgs: [
-            (epkgs.treesit-grammars.with-grammars (
-              grammars: with grammars; [
-                tree-sitter-bash
-                tree-sitter-c
-                tree-sitter-css
-                tree-sitter-go
-                tree-sitter-html
-                tree-sitter-javascript
-                tree-sitter-jsdoc
-                tree-sitter-json
-                tree-sitter-lua
-                tree-sitter-markdown
-                tree-sitter-markdown-inline
-                tree-sitter-nix
-                tree-sitter-python
-                tree-sitter-rust
-                tree-sitter-toml
-                tree-sitter-tsx
-                tree-sitter-typescript
-                tree-sitter-yaml
-              ]
-            ))
-          ];
-          extraBinPackages = with pkgs; [
-            bash-language-server
-            biome
-            fd
-            git
-            glow
-            go
-            gopls
-            jq
-            lua-language-server
-            marksman
-            nixd
-            nixfmt
-            pyright
-            ripgrep
-            ruff
-            rust-analyzer
-            rustfmt
-            shfmt
-            stylua
-            taplo
-            typescript-language-server
-            uv
-            vscode-langservers-extracted
-            yaml-language-server
-          ];
+          extraPackages =
+            epkgs:
+            lib.optionals enableLanguageTooling [
+              (epkgs.treesit-grammars.with-grammars (
+                grammars: with grammars; [
+                  tree-sitter-bash
+                  tree-sitter-c
+                  tree-sitter-css
+                  tree-sitter-go
+                  tree-sitter-html
+                  tree-sitter-javascript
+                  tree-sitter-jsdoc
+                  tree-sitter-json
+                  tree-sitter-lua
+                  tree-sitter-markdown
+                  tree-sitter-markdown-inline
+                  tree-sitter-nix
+                  tree-sitter-python
+                  tree-sitter-rust
+                  tree-sitter-toml
+                  tree-sitter-tsx
+                  tree-sitter-typescript
+                  tree-sitter-yaml
+                ]
+              ))
+            ];
+          extraBinPackages =
+            with pkgs;
+            [
+              fd
+              git
+              ripgrep
+            ]
+            ++ lib.optionals enableLanguageTooling [
+              bash-language-server
+              biome
+              clang-tools
+              glow
+              go
+              gopls
+              jq
+              lua-language-server
+              marksman
+              nixd
+              nixfmt
+              pyright
+              ruff
+              rust-analyzer
+              rustfmt
+              shfmt
+              stylua
+              taplo
+              typescript-language-server
+              uv
+              vscode-langservers-extracted
+              yaml-language-server
+            ];
         };
 
         services.emacs.enable = lib.mkDefault enableService;

--- a/modules/hm-apps/doom-emacs.nix
+++ b/modules/hm-apps/doom-emacs.nix
@@ -54,10 +54,55 @@ _: {
           # this repo opts those Home Manager wrappers out (`package = null`),
           # so the upstream default would inject null entries that fail
           # `types.listOf types.package`. Source the binaries directly from pkgs.
+          extraPackages = epkgs: [
+            (epkgs.treesit-grammars.with-grammars (
+              grammars: with grammars; [
+                tree-sitter-bash
+                tree-sitter-c
+                tree-sitter-css
+                tree-sitter-go
+                tree-sitter-html
+                tree-sitter-javascript
+                tree-sitter-jsdoc
+                tree-sitter-json
+                tree-sitter-lua
+                tree-sitter-markdown
+                tree-sitter-markdown-inline
+                tree-sitter-nix
+                tree-sitter-python
+                tree-sitter-rust
+                tree-sitter-toml
+                tree-sitter-tsx
+                tree-sitter-typescript
+                tree-sitter-yaml
+              ]
+            ))
+          ];
           extraBinPackages = with pkgs; [
-            git
-            ripgrep
+            bash-language-server
+            biome
             fd
+            git
+            glow
+            go
+            gopls
+            jq
+            lua-language-server
+            marksman
+            nixd
+            nixfmt
+            pyright
+            ripgrep
+            ruff
+            rust-analyzer
+            rustfmt
+            shfmt
+            stylua
+            taplo
+            typescript-language-server
+            uv
+            vscode-langservers-extracted
+            yaml-language-server
           ];
         };
 


### PR DESCRIPTION
## Summary
- add tree-sitter grammars to the Doom Emacs Home Manager integration
- include language server, formatter, and supporting editor binaries in Doom extraBinPackages
- clarify that the default doomdir remains the committed static starter directory

## Test plan
- git diff --cached --check
- nix-instantiate --parse modules/apps/doom-emacs.nix
- nix-instantiate --parse modules/hm-apps/doom-emacs.nix
- commit hooks: deadnix, nix-parse, statix, treefmt, typos
- nix flake check skipped here because it was already run across the split before PR publication