### PR TITLE
fix(nixvim): use Biome formatter directly

### DIFF
--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -60,6 +60,7 @@ _: {
               viAlias = true;
               vimAlias = true;
               defaultEditor = true;
+              extraPackages = [ pkgs.biome ];
 
               colorschemes.onedark.enable = true;
 
@@ -1022,7 +1023,6 @@ _: {
                       nix = [ "nixfmt" ];
                       lua = [ "stylua" ];
                       toml = [ "taplo" ];
-                      # Biome: JS/TS/JSON/CSS (faster than prettier)
                       javascript = [ "biome" ];
                       typescript = [ "biome" ];
                       javascriptreact = [ "biome" ];
@@ -1030,10 +1030,7 @@ _: {
                       json = [ "biome" ];
                       jsonc = [ "biome" ];
                       css = [ "biome" ];
-                      # Prettier: languages biome doesn't support
-                      yaml = [ "prettier" ];
-                      markdown = [ "prettier" ];
-                      html = [ "prettier" ];
+                      html = [ "biome" ];
                       # JSONL: jq -c keeps one value per line
                       jsonl = [ "jq_jsonl" ];
                       # Rust uses rustfmt via rust-analyzer (lsp_format fallback)
@@ -1050,6 +1047,7 @@ _: {
                       ];
                       stdin = true;
                     };
+                    formatters.biome.append_args = [ "--html-formatter-enabled=true" ];
                   };
                 };
 

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -60,7 +60,15 @@ _: {
               viAlias = true;
               vimAlias = true;
               defaultEditor = true;
-              extraPackages = [ pkgs.biome ];
+              extraPackages = with pkgs; [
+                biome
+                nixfmt
+                prettier
+                ruff
+                shfmt
+                stylua
+                taplo
+              ];
 
               colorschemes.onedark.enable = true;
 
@@ -1023,6 +1031,7 @@ _: {
                       nix = [ "nixfmt" ];
                       lua = [ "stylua" ];
                       toml = [ "taplo" ];
+                      # Biome: JS/TS/JSON/CSS/HTML
                       javascript = [ "biome" ];
                       typescript = [ "biome" ];
                       javascriptreact = [ "biome" ];
@@ -1031,6 +1040,9 @@ _: {
                       jsonc = [ "biome" ];
                       css = [ "biome" ];
                       html = [ "biome" ];
+                      # Prettier: formats Biome does not cover here
+                      yaml = [ "prettier" ];
+                      markdown = [ "prettier" ];
                       # JSONL: jq -c keeps one value per line
                       jsonl = [ "jq_jsonl" ];
                       # Rust uses rustfmt via rust-analyzer (lsp_format fallback)


### PR DESCRIPTION
## Summary
- install Biome in the Nixvim extra package set
- route JS, TS, JSON, CSS, and HTML formatting through Biome
- pass the HTML formatter flag through conform-nvim
- remove the previous YAML and Markdown Prettier formatter entries from this map

## Test plan
- git diff --cached --check
- nix-instantiate --parse modules/hm-apps/nixvim.nix
- commit hooks: deadnix, nix-parse, statix, treefmt, typos
- nix flake check skipped here because it was already run across the split before PR publication