### PR TITLE
feat(editors): update Doom Emacs and NixVim config

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -20,6 +20,7 @@ Autorize = "Autorize" # Burp Suite extension
 Hashi = "Hashi" # HashiCorp (company name prefix)
 Laf = "Laf" # FlatLaf Java look-and-feel suffix
 gost = "gost" # GO Simple Tunnel (ginuerzh/gost)
+noice = "noice" # Neovim UI plugin (folke/noice.nvim)
 
 # NixOS/nixpkgs terms
 facter = "facter" # nixos-facter-modules

--- a/modules/apps/doom-emacs-doomdir/init.el
+++ b/modules/apps/doom-emacs-doomdir/init.el
@@ -107,7 +107,7 @@
        ;;pdf               ; pdf enhancements
        ;;terraform         ; infrastructure as code
        ;;tmux              ; an API for interacting with tmux
-       ;;tree-sitter       ; syntax and parsing, sitting in a tree...
+       tree-sitter       ; syntax and parsing, sitting in a tree...
        ;;upload            ; map local to remote projects via ssh/ftp
 
        :os
@@ -155,7 +155,7 @@
        ;;lua               ; one-based indices? one-based indices
        markdown          ; writing docs for people to ignore
        ;;nim               ; python + lisp at the speed of c
-       ;;nix               ; I hereby declare "nix geht mehr!"
+       (nix +tree-sitter) ; I hereby declare "nix geht mehr!"
        ;;ocaml             ; an objective camel
        ;;odin              ; C, minus its footguns
        org               ; organize your plain life in plain text

--- a/modules/apps/doom-emacs.nix
+++ b/modules/apps/doom-emacs.nix
@@ -119,9 +119,9 @@ in
           description = ''
             Whether to add tree-sitter grammars plus language servers and
             formatters to Doom's runtime path. Enable this when `doomDir`
-            activates the matching Doom modules; the bundled starter doomdir
-            keeps those modules disabled, so the default avoids pulling in an
-            unused language-tool closure.
+            activates the matching Doom modules. The bundled starter doomdir
+            enables Nix tree-sitter syntax only, so the default avoids pulling
+            in the broader language-tool closure.
           '';
         };
 

--- a/modules/hm-apps/doom-emacs.nix
+++ b/modules/hm-apps/doom-emacs.nix
@@ -54,32 +54,36 @@ _: {
           # this repo opts those Home Manager wrappers out (`package = null`),
           # so the upstream default would inject null entries that fail
           # `types.listOf types.package`. Source the binaries directly from pkgs.
-          extraPackages =
-            epkgs:
-            lib.optionals enableLanguageTooling [
-              (epkgs.treesit-grammars.with-grammars (
-                grammars: with grammars; [
-                  tree-sitter-bash
-                  tree-sitter-c
-                  tree-sitter-css
-                  tree-sitter-go
-                  tree-sitter-html
-                  tree-sitter-javascript
-                  tree-sitter-jsdoc
-                  tree-sitter-json
-                  tree-sitter-lua
-                  tree-sitter-markdown
-                  tree-sitter-markdown-inline
-                  tree-sitter-nix
-                  tree-sitter-python
-                  tree-sitter-rust
-                  tree-sitter-toml
-                  tree-sitter-tsx
-                  tree-sitter-typescript
-                  tree-sitter-yaml
-                ]
-              ))
-            ];
+          extraPackages = epkgs: [
+            # The bundled doomdir enables tree-sitter syntax for Nix, so keep
+            # that grammar available even when broader language tooling is off.
+            (epkgs.treesit-grammars.with-grammars (
+              grammars:
+              with grammars;
+              [
+                tree-sitter-nix
+              ]
+              ++ lib.optionals enableLanguageTooling [
+                tree-sitter-bash
+                tree-sitter-c
+                tree-sitter-css
+                tree-sitter-go
+                tree-sitter-html
+                tree-sitter-javascript
+                tree-sitter-jsdoc
+                tree-sitter-json
+                tree-sitter-lua
+                tree-sitter-markdown
+                tree-sitter-markdown-inline
+                tree-sitter-python
+                tree-sitter-rust
+                tree-sitter-toml
+                tree-sitter-tsx
+                tree-sitter-typescript
+                tree-sitter-yaml
+              ]
+            ))
+          ];
           extraBinPackages =
             with pkgs;
             [

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -643,7 +643,7 @@ _: {
                   enable = true;
                   setupLspCapabilities = false;
                   settings = {
-                    enabled.__raw = "function() return false end";
+                    enabled.__raw = "function() return vim.fn.getcmdtype() == ':' end";
 
                     completion.ghost_text = {
                       show_without_selection = true;

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -177,6 +177,71 @@ _: {
 
               dependencies.glow.enable = true;
 
+              extraConfigLuaPre = ''
+                package.preload["nixvim.cmdline_history_source"] = function()
+                  local source = {}
+
+                  function source.new(opts)
+                    local self = setmetatable({}, { __index = source })
+                    self.opts = opts or {}
+                    self.limit = self.opts.limit or 200
+                    return self
+                  end
+
+                  function source:enabled()
+                    return vim.fn.getcmdtype() == ":"
+                  end
+
+                  local function starts_with(value, prefix)
+                    return value:sub(1, #prefix) == prefix
+                  end
+
+                  function source:get_completions(ctx, callback)
+                    local line = ctx.line or (ctx.get_line and ctx.get_line()) or vim.fn.getcmdline()
+                    local latest = vim.fn.histnr(":")
+                    local floor = math.max(1, latest - self.limit + 1)
+                    local seen = {}
+                    local items = {}
+                    local line_pos = ctx.cursor and (ctx.cursor[1] - 1) or 0
+
+                    for index = latest, floor, -1 do
+                      local command = vim.fn.histget(":", index)
+                      if
+                        command ~= nil
+                        and command ~= ""
+                        and command ~= line
+                        and starts_with(command, line)
+                        and not seen[command]
+                      then
+                        seen[command] = true
+                        items[#items + 1] = {
+                          label = command,
+                          filterText = command,
+                          sortText = string.format("%06d", latest - index),
+                          textEdit = {
+                            newText = command,
+                            range = {
+                              start = { line = line_pos, character = 0 },
+                              ["end"] = { line = line_pos, character = #line },
+                            },
+                          },
+                          insertTextFormat = vim.lsp.protocol.InsertTextFormat.PlainText,
+                          kind = require("blink.cmp.types").CompletionItemKind.Text,
+                        }
+                      end
+                    end
+
+                    callback({
+                      items = items,
+                      is_incomplete_backward = true,
+                      is_incomplete_forward = true,
+                    })
+                  end
+
+                  return source
+                end
+              '';
+
               # Otter configuration:
               # 1. Deferred activation - prevents blocking UI while otter creates buffers/attaches LSPs
               # 2. Automatic activation is limited to buffers that actually contain injected languages,
@@ -543,6 +608,92 @@ _: {
                       "<leader>rn" = "rename";
                       "<leader>ca" = "code_action";
                       "<leader>f" = "format";
+                    };
+                  };
+                };
+
+                noice = {
+                  enable = true;
+                  settings = {
+                    cmdline = {
+                      enabled = true;
+                      view = "cmdline";
+                    };
+                    messages.enabled = false;
+                    popupmenu.enabled = false;
+                    notify.enabled = false;
+                    lsp = {
+                      progress.enabled = false;
+                      hover.enabled = false;
+                      signature.enabled = false;
+                      message.enabled = false;
+                    };
+                    smart_move.enabled = false;
+                    presets = {
+                      bottom_search = false;
+                      command_palette = false;
+                      long_message_to_split = false;
+                      inc_rename = false;
+                      lsp_doc_border = false;
+                    };
+                  };
+                };
+
+                blink-cmp = {
+                  enable = true;
+                  setupLspCapabilities = false;
+                  settings = {
+                    enabled.__raw = "function() return false end";
+
+                    completion.ghost_text = {
+                      show_without_selection = true;
+                      show_without_menu = true;
+                    };
+
+                    cmdline = {
+                      enabled = true;
+                      keymap = {
+                        preset = "cmdline";
+                        "<CR>" = [
+                          "select_accept_and_enter"
+                          "fallback"
+                        ];
+                        "<Right>" = [
+                          "select_and_accept"
+                          "fallback"
+                        ];
+                        "<C-y>" = [
+                          "select_and_accept"
+                          "fallback"
+                        ];
+                      };
+                      sources.__raw = ''
+                        function()
+                          if vim.fn.getcmdtype() == ":" then
+                            return { "cmdline_history", "cmdline" }
+                          end
+                          return {}
+                        end
+                      '';
+                      completion = {
+                        menu.auto_show = false;
+                        ghost_text = {
+                          enabled.__raw = ''
+                            function()
+                              local ghost_text = package.loaded["blink.cmp.completion.windows.ghost_text"]
+                              local item = ghost_text and ghost_text.selected_item
+                              return item ~= nil and item.source_id == "cmdline_history"
+                            end
+                          '';
+                        };
+                      };
+                    };
+
+                    sources.providers.cmdline_history = {
+                      name = "Cmdline History";
+                      module = "nixvim.cmdline_history_source";
+                      score_offset = 100;
+                      opts.limit = 200;
                     };
                   };
                 };


### PR DESCRIPTION
## Summary

- enable Doom's Nix tree-sitter module and keep tree-sitter-nix available without the broader language-tool closure
- add NixVim command-line history ghost completion through noice and blink-cmp
- allow noice in the typos dictionary because it is the plugin name used by folke/noice.nvim
- gate blink-cmp on the ':' command line so the command-line source path works without insert-mode completion

## Test plan

- nix fmt
- nix develop --accept-flake-config -c pre-commit run typos --files .typos.toml modules/hm-apps/nixvim.nix
- nix eval --accept-flake-config --offline --json .#nixosConfigurations --apply builtins.attrNames
- nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.programs.doom-emacs.extended.enable
- nix eval --accept-flake-config --offline --json .#nixosConfigurations.tpnix.config.programs.doom-emacs.extended.enable
- nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.home-manager.users.vx.programs.nixvim.plugins.blink-cmp.enable
- nix eval --accept-flake-config --offline --json .#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.nixvim.plugins.blink-cmp.enable
- nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.home-manager.users.vx.programs.nixvim.plugins.blink-cmp.settings.enabled.__raw
- nix eval --accept-flake-config --offline --json .#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.nixvim.plugins.blink-cmp.settings.enabled.__raw
- nix flake check --accept-flake-config --no-build --offline
- git push -u origin feat/editor-config-updates
- git push