### PR TITLE
fix(git): add safe submodule worktree cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,8 @@ Rule: Use a dedicated worktree and PR for changes. Do not commit directly to `ma
   - Why: the repository has the initialized `secrets/` submodule. Plain
     `git worktree remove` can fail on clean worktrees with
     `working trees containing submodules cannot be moved or removed`; the helper
-    refuses dirty or locked worktrees before using `--force` for that Git guard.
+    refuses dirty, ignored, or locked worktrees before using `--force` for that
+    Git guard.
 
 Branch type should follow Conventional Commits prefixes.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,13 @@ Rule: Use a dedicated worktree and PR for changes. Do not commit directly to `ma
   - Command: `cd $HOME/trees/nixos/<type>-<name>` then commit changes
 - PR
   - Command: `gh pr create --title "<type>(scope): summary" --body "..."` (Assign labels)
+- Cleanup after merge
+  - Command: `scripts/git-worktree-remove-safe.sh $HOME/trees/nixos/<type>-<name>`
+  - Follow-up: `git branch -d <type>/<name> && git worktree prune`
+  - Why: the repository has the initialized `secrets/` submodule. Plain
+    `git worktree remove` can fail on clean worktrees with
+    `working trees containing submodules cannot be moved or removed`; the helper
+    refuses dirty or locked worktrees before using `--force` for that Git guard.
 
 Branch type should follow Conventional Commits prefixes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,20 @@ Work in that tree, then create a PR:
 gh pr create --title "<type>(scope): summary" --body "..."
 ```
 
+After the PR merges, remove the finished worktree through the safe helper:
+
+```sh
+scripts/git-worktree-remove-safe.sh "$HOME/trees/nixos/<type>-<name>"
+git branch -d "<type>/<name>"
+git worktree prune
+```
+
+This repo has an initialized `secrets/` submodule, so plain
+`git worktree remove` can fail on clean worktrees with
+`working trees containing submodules cannot be moved or removed`. The helper
+checks for dirty and locked worktrees first, then uses `--force` only for that
+Git submodule guard.
+
 Branch type should follow Conventional Commits prefixes. PR bodies should
 include:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,8 +145,8 @@ git worktree prune
 This repo has an initialized `secrets/` submodule, so plain
 `git worktree remove` can fail on clean worktrees with
 `working trees containing submodules cannot be moved or removed`. The helper
-checks for dirty and locked worktrees first, then uses `--force` only for that
-Git submodule guard.
+checks for dirty, ignored, and locked worktrees first, then uses `--force` only
+for that Git submodule guard.
 
 Branch type should follow Conventional Commits prefixes. PR bodies should
 include:

--- a/scripts/git-worktree-remove-safe.sh
+++ b/scripts/git-worktree-remove-safe.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+prog_name="${0##*/}"
+
+usage() {
+  printf 'usage: %s <worktree-path>\n' "${prog_name}" >&2
+}
+
+error_msg() {
+  printf '%s: %s\n' "${prog_name}" "$1" >&2
+}
+
+git_common_dir() {
+  local repo_root common_dir
+  repo_root="$1"
+  common_dir="$(git -C "${repo_root}" rev-parse --git-common-dir)"
+  if [[ ${common_dir} != /* ]]; then
+    common_dir="${repo_root}/${common_dir}"
+  fi
+  readlink -f "${common_dir}"
+}
+
+resolve_worktree_root() {
+  local target_path
+  target_path="$1"
+  if [[ ! -d ${target_path} ]]; then
+    error_msg "worktree path does not exist: ${target_path}"
+    exit 1
+  fi
+  if ! git -C "${target_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    error_msg "path is not inside a git worktree: ${target_path}"
+    exit 1
+  fi
+  readlink -f "$(git -C "${target_path}" rev-parse --show-toplevel)"
+}
+
+require_registered_unlocked_worktree() {
+  local repo_root worktree_path current_path in_target found locked entry
+  repo_root="$1"
+  worktree_path="$2"
+  current_path=""
+  in_target=false
+  found=false
+  locked=false
+
+  while IFS= read -r -d '' entry; do
+    case "${entry}" in
+    worktree\ *)
+      current_path="$(readlink -f "${entry#worktree }")"
+      if [[ ${current_path} == "${worktree_path}" ]]; then
+        in_target=true
+        found=true
+      else
+        in_target=false
+      fi
+      ;;
+    locked*)
+      if [[ ${in_target} == true ]]; then
+        locked=true
+      fi
+      ;;
+    esac
+  done < <(git -C "${repo_root}" worktree list --porcelain -z)
+
+  if [[ ${found} != true ]]; then
+    error_msg "path is not a registered worktree for this repository: ${worktree_path}"
+    exit 1
+  fi
+  if [[ ${locked} == true ]]; then
+    error_msg "refusing to remove locked worktree: ${worktree_path}"
+    exit 1
+  fi
+}
+
+require_clean_worktree() {
+  local worktree_path status submodule_status
+  worktree_path="$1"
+
+  status="$(git -C "${worktree_path}" status --porcelain=v1 --untracked-files=all)"
+  if [[ -n ${status} ]]; then
+    error_msg "refusing to remove dirty worktree: ${worktree_path}"
+    printf '%s\n' "${status}" >&2
+    exit 1
+  fi
+
+  # shellcheck disable=SC2016 # This body runs inside git-submodule foreach.
+  if ! submodule_status="$(
+    git -C "${worktree_path}" submodule foreach --quiet --recursive '
+      status="$(git status --porcelain=v1 --untracked-files=all)"
+      if test -n "${status}"; then
+        printf "%s\n%s\n" "${displaypath}" "${status}"
+        exit 1
+      fi
+    ' 2>&1
+  )"; then
+    error_msg "refusing to remove worktree with dirty submodule state: ${worktree_path}"
+    printf '%s\n' "${submodule_status}" >&2
+    exit 1
+  fi
+}
+
+main() {
+  local repo_root target_arg worktree_path repo_common_dir worktree_common_dir remove_output remove_status
+
+  if [[ $# -ne 1 ]]; then
+    usage
+    exit 64
+  fi
+
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    error_msg "must be run from within the repository that owns the worktree"
+    exit 1
+  fi
+
+  repo_root="$(git rev-parse --show-toplevel)"
+  target_arg="$1"
+  worktree_path="$(resolve_worktree_root "${target_arg}")"
+  repo_root="$(readlink -f "${repo_root}")"
+  repo_common_dir="$(git_common_dir "${repo_root}")"
+  worktree_common_dir="$(git_common_dir "${worktree_path}")"
+
+  if [[ ${repo_common_dir} != "${worktree_common_dir}" ]]; then
+    error_msg "target belongs to a different repository: ${worktree_path}"
+    exit 1
+  fi
+  if [[ ${worktree_path} == "${repo_root}" ]]; then
+    error_msg "refusing to remove the worktree running this helper: ${worktree_path}"
+    exit 1
+  fi
+
+  require_registered_unlocked_worktree "${repo_root}" "${worktree_path}"
+  require_clean_worktree "${worktree_path}"
+
+  if remove_output="$(git -C "${repo_root}" worktree remove "${worktree_path}" 2>&1)"; then
+    if [[ -n ${remove_output} ]]; then
+      printf '%s\n' "${remove_output}" >&2
+    fi
+    exit 0
+  fi
+  remove_status="$?"
+
+  if [[ ${remove_output} == *"working trees containing submodules cannot be moved or removed"* ]]; then
+    error_msg "worktree contains submodules; retrying with --force after clean checks: ${worktree_path}"
+    git -C "${repo_root}" worktree remove --force "${worktree_path}"
+    exit 0
+  fi
+
+  printf '%s\n' "${remove_output}" >&2
+  exit "${remove_status}"
+}
+
+main "$@"

--- a/scripts/git-worktree-remove-safe.sh
+++ b/scripts/git-worktree-remove-safe.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
+export LC_ALL=C
 
 prog_name="${0##*/}"
 
@@ -77,9 +78,9 @@ require_clean_worktree() {
   local worktree_path status submodule_status
   worktree_path="$1"
 
-  status="$(git -C "${worktree_path}" status --porcelain=v1 --untracked-files=all)"
+  status="$(git -C "${worktree_path}" status --porcelain=v1 --untracked-files=all --ignored=matching)"
   if [[ -n ${status} ]]; then
-    error_msg "refusing to remove dirty worktree: ${worktree_path}"
+    error_msg "refusing to remove worktree with dirty, untracked, or ignored local state: ${worktree_path}"
     printf '%s\n' "${status}" >&2
     exit 1
   fi
@@ -87,7 +88,7 @@ require_clean_worktree() {
   # shellcheck disable=SC2016 # This body runs inside git-submodule foreach.
   if ! submodule_status="$(
     git -C "${worktree_path}" submodule foreach --quiet --recursive '
-      status="$(git status --porcelain=v1 --untracked-files=all)"
+      status="$(git status --porcelain=v1 --untracked-files=all --ignored=matching)"
       if test -n "${status}"; then
         printf "%s\n%s\n" "${displaypath}" "${status}"
         exit 1
@@ -137,8 +138,9 @@ main() {
       printf '%s\n' "${remove_output}" >&2
     fi
     exit 0
+  else
+    remove_status="$?"
   fi
-  remove_status="$?"
 
   if [[ ${remove_output} == *"working trees containing submodules cannot be moved or removed"* ]]; then
     error_msg "worktree contains submodules; retrying with --force after clean checks: ${worktree_path}"


### PR DESCRIPTION
## Summary

- add `scripts/git-worktree-remove-safe.sh` for merged PR worktree cleanup
- reject dirty, locked, foreign, or current worktree targets before removal
- retry `git worktree remove --force` only after Git hits the initialized submodule guard
- document the cleanup command in `AGENTS.md` and `CLAUDE.md`

## Why

This repository initializes the `secrets/` submodule in feature worktrees. Git 2.53 refuses plain `git worktree remove` for a clean worktree that contains an initialized submodule with:

```text
fatal: working trees containing submodules cannot be moved or removed
```

The helper keeps the cleanup path recoverable by validating worktree and submodule cleanliness before using `--force` for that specific Git guard.

## Test plan

- `bash -n scripts/git-worktree-remove-safe.sh`
- `shellcheck scripts/git-worktree-remove-safe.sh`
- `nix fmt -- --fail-on-change`
- `git diff --check`
- commit hooks: shellcheck, treefmt, typos
- smoke test: created `tmp/worktree-remove-safe-smoke-r2`, initialized `secrets`, confirmed plain `git worktree remove` failed with the submodule guard, then removed it with `scripts/git-worktree-remove-safe.sh`
