### PR TITLE
feat(pager): export bat pager defaults

### DIFF
--- a/modules/apps/bat.nix
+++ b/modules/apps/bat.nix
@@ -36,9 +36,9 @@ let
 
       config = lib.mkIf cfg.enable {
         host.defaults.pager = {
-          command = lib.mkOverride 900 "bat --plain --paging=always";
+          command = lib.mkOverride 900 "${lib.getExe pkgs.bat} --plain --paging=always";
           man = {
-            pager = lib.mkOverride 900 "env BATMAN_IS_BEING_MANPAGER=yes ${lib.getExe pkgs.bash} ${lib.getExe batman}";
+            pager = lib.mkOverride 900 "env BATMAN_IS_BEING_MANPAGER=yes ${lib.getExe batman}";
             roffopt = lib.mkOverride 900 "-c";
             width = lib.mkOverride 900 "120";
           };

--- a/modules/apps/bat.nix
+++ b/modules/apps/bat.nix
@@ -15,13 +15,33 @@
 _:
 let
   BatModule =
-    { lib, ... }:
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.bat.extended;
+      batman = pkgs.bat-extras.batman;
+    in
     {
       options.programs.bat.extended = {
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
           description = "Whether to enable bat.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        host.defaults.pager = {
+          command = lib.mkOverride 900 "bat --plain --paging=always";
+          man = {
+            pager = lib.mkOverride 900 "env BATMAN_IS_BEING_MANPAGER=yes ${lib.getExe pkgs.bash} ${lib.getExe batman}";
+            roffopt = lib.mkOverride 900 "-c";
+            width = lib.mkOverride 900 "120";
+          };
         };
       };
     };

--- a/modules/hm-apps/bat.nix
+++ b/modules/hm-apps/bat.nix
@@ -32,7 +32,12 @@
 
 _: {
   flake.homeManagerModules.apps.bat =
-    { osConfig, lib, ... }:
+    {
+      osConfig,
+      lib,
+      pkgs,
+      ...
+    }:
     let
       enabled = lib.attrByPath [ "programs" "bat" "extended" "enable" ] false osConfig;
     in
@@ -54,6 +59,9 @@ _: {
             # never: always print to stdout
             # always: always use pager
             paging = "auto";
+
+            # Keep bat from recursively consulting PAGER when PAGER points at bat.
+            pager = "less --RAW-CONTROL-CHARS --quit-if-one-screen";
 
             # Wrap long lines
             # auto: wrap if terminal is narrow
@@ -97,13 +105,12 @@ _: {
           #   };
           # };
 
-          # Extra packages that provide syntax highlighting
-          # extraPackages = with pkgs.bat-extras; [
-          #   batdiff  # diff with bat
-          #   batman   # man pages with bat
-          #   batgrep  # grep with bat
-          #   batwatch # watch with bat
-          # ];
+          extraPackages = with pkgs.bat-extras; [
+            batdiff
+            batman
+            batgrep
+            batwatch
+          ];
         };
       };
     };

--- a/modules/hosts/common/default-apps.nix
+++ b/modules/hosts/common/default-apps.nix
@@ -16,13 +16,16 @@
     host.defaults.audioPlayer = "mpv";
     host.defaults.videoPlayer = "mpv";
     host.defaults.editor = "nvim";
-    host.defaults.pager = "less";
-    host.defaults.diffProgram = "nvim -d";
+    host.defaults.pager.command = "bat --plain --paging=always";
+    host.defaults.pager.man.pager = "batman";
+    host.defaults.pager.man.roffopt = "-c";
+    host.defaults.pager.man.width = "120";
     host.defaults.opener = "xdg-open";
+    host.defaults.diffProgram = "nvim -d";
 
   IMPORTANT: The corresponding app module must be enabled in apps-enable.nix.
   An assertion will fail if a default is set but the app module is disabled.
-  (Env-only categories like pager and diffProgram are exempt.)
+  (Env-only categories like editor, pager, and diffProgram are exempt.)
 */
 { config, lib, ... }:
 let
@@ -57,9 +60,13 @@ let
 
       mkEnvOnlyOption =
         _name: cat:
+        let
+          valueType = cat.type or lib.types.str;
+          nullable = cat.nullable or true;
+        in
         lib.mkOption {
-          type = lib.types.nullOr lib.types.str;
-          default = null;
+          type = if nullable then lib.types.nullOr valueType else valueType;
+          default = if nullable then null else cat.defaultValue;
           inherit (cat) example description;
         };
 

--- a/modules/xdg/mime.nix
+++ b/modules/xdg/mime.nix
@@ -543,28 +543,76 @@ let
     };
 
     pager = {
-      defaultValue = "less";
-      example = "bat";
-      description = ''
-        Default pager for this host.
-        Sets PAGER, MANPAGER, and MANWIDTH environment variables.
-      '';
-      extraConfig = value: {
-        environment.variables = {
-          PAGER = value;
-          MANPAGER = value;
-          MANWIDTH = "120";
-        };
-        home-manager.sharedModules = [
-          {
-            home.sessionVariables = {
-              PAGER = value;
-              MANPAGER = value;
-              MANWIDTH = "120";
+      nullable = false;
+      type = lib.types.submodule {
+        options = {
+          command = lib.mkOption {
+            type = lib.types.str;
+            default = "less";
+            example = "bat --plain --paging=always";
+            description = "Command exported as PAGER.";
+          };
+
+          man = {
+            pager = lib.mkOption {
+              type = lib.types.str;
+              default = "less";
+              example = "batman";
+              description = "Command exported as MANPAGER.";
             };
-          }
-        ];
+
+            roffopt = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              example = "-c";
+              description = "Optional value exported as MANROFFOPT.";
+            };
+
+            width = lib.mkOption {
+              type = lib.types.str;
+              default = "120";
+              example = "120";
+              description = "Value exported as MANWIDTH.";
+            };
+          };
+        };
       };
+      defaultValue = {
+        command = "less";
+        man = {
+          pager = "less";
+          roffopt = null;
+          width = "120";
+        };
+      };
+      example = {
+        command = "bat --plain --paging=always";
+        man = {
+          pager = "batman";
+          roffopt = "-c";
+          width = "120";
+        };
+      };
+      description = ''
+        Default terminal pagers for this host.
+        Sets PAGER, MANPAGER, MANROFFOPT, and MANWIDTH environment variables.
+      '';
+      extraConfig =
+        value:
+        let
+          env = {
+            PAGER = value.command;
+            MANPAGER = value.man.pager;
+            MANWIDTH = value.man.width;
+          }
+          // lib.optionalAttrs (value.man.roffopt != null) {
+            MANROFFOPT = value.man.roffopt;
+          };
+        in
+        {
+          environment.variables = env;
+          home-manager.sharedModules = [ { home.sessionVariables = env; } ];
+        };
     };
 
     diffProgram = {


### PR DESCRIPTION
## Summary

- Model host pager defaults as separate PAGER and manpager settings.
- Let the bat module own bat and batman pager defaults when bat is enabled.
- Keep Home Manager bat from recursing through PAGER by pinning its internal pager to less.

## Test plan

- nix fmt --accept-flake-config --no-write-lock-file -- modules/apps/bat.nix modules/hm-apps/bat.nix modules/hosts/common/default-apps.nix modules/xdg/mime.nix
- nix-instantiate --parse modules/apps/bat.nix modules/hm-apps/bat.nix modules/hosts/common/default-apps.nix modules/xdg/mime.nix
- nix eval --accept-flake-config --no-write-lock-file --raw .#nixosConfigurations.tpnix.config.environment.variables.PAGER
- nix eval --accept-flake-config --no-write-lock-file --raw .#nixosConfigurations.system76.config.environment.variables.PAGER
- nix flake check --accept-flake-config --no-build --offline --no-write-lock-file
- git push pre-push hooks