### PR TITLE
refactor(hardware): use nixos-hardware CPU modules

### DIFF
--- a/modules/base/hardware-scan.nix
+++ b/modules/base/hardware-scan.nix
@@ -29,7 +29,7 @@
       enableAllFirmware = false;
     };
 
-    # CPU microcode is set per-host in hardware-config.nix
+    # CPU microcode is provided by explicit CPU-family hardware modules.
 
     # Permit insecure packages that are required but marked as insecure
     nixpkgs.config.permittedInsecurePackages = [

--- a/modules/system76/hardware-config.nix
+++ b/modules/system76/hardware-config.nix
@@ -19,9 +19,6 @@ _: {
 
       # Hardware configuration
       hardware = {
-        # CPU microcode updates
-        cpu.intel.updateMicrocode = lib.mkDefault true;
-
         # Enable Bluetooth
         bluetooth = {
           enable = true;

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -50,6 +50,7 @@ in
       config.flake.nixosModules.zshKeybindings
 
       # External hardware modules
+      inputs.nixos-hardware.nixosModules.common-cpu-intel-cpu-only
       inputs.nixos-hardware.nixosModules.system76
     ]
     # Optional modules (graceful degradation)

--- a/modules/tpnix/hardware-config.nix
+++ b/modules/tpnix/hardware-config.nix
@@ -1,65 +1,61 @@
 { lib, ... }:
 {
-  configurations.nixos.tpnix.module =
-    { config, ... }:
-    {
-      hardware.enableRedistributableFirmware = lib.mkForce true;
-      nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
-      hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
+  configurations.nixos.tpnix.module = _: {
+    nixpkgs.hostPlatform = lib.mkDefault "x86_64-linux";
 
-      boot = {
-        initrd = {
-          availableKernelModules = [
-            "xhci_pci"
-            "thunderbolt"
-            "nvme"
-            "usbhid"
-            "usb_storage"
-            "sd_mod"
-            "sdhci_pci"
-          ];
-          kernelModules = [ ];
-          luks = {
-            devices = {
-              "luks-dc8e394e-d685-429e-b256-3b803635b47d".device =
-                "/dev/disk/by-uuid/dc8e394e-d685-429e-b256-3b803635b47d";
-              "luks-df7db70f-8965-4516-976d-8fdac91ae660".device =
-                "/dev/disk/by-uuid/df7db70f-8965-4516-976d-8fdac91ae660";
-            };
+    boot = {
+      initrd = {
+        availableKernelModules = [
+          "xhci_pci"
+          "thunderbolt"
+          "nvme"
+          "usbhid"
+          "usb_storage"
+          "sd_mod"
+          "sdhci_pci"
+        ];
+        kernelModules = [ ];
+        luks = {
+          devices = {
+            "luks-dc8e394e-d685-429e-b256-3b803635b47d".device =
+              "/dev/disk/by-uuid/dc8e394e-d685-429e-b256-3b803635b47d";
+            "luks-df7db70f-8965-4516-976d-8fdac91ae660".device =
+              "/dev/disk/by-uuid/df7db70f-8965-4516-976d-8fdac91ae660";
           };
         };
-        kernelModules = [ "kvm-intel" ];
-        extraModulePackages = [ ];
       };
+      kernelModules = [ "kvm-intel" ];
+      extraModulePackages = [ ];
+    };
 
-      fileSystems = {
-        "/" = {
-          device = "/dev/mapper/luks-dc8e394e-d685-429e-b256-3b803635b47d";
-          fsType = "ext4";
-        };
-        "/boot" = {
-          device = "/dev/disk/by-uuid/1F94-C5D7";
-          fsType = "vfat";
-          options = [
-            "fmask=0077"
-            "dmask=0077"
-          ];
-        };
+    fileSystems = {
+      "/" = {
+        device = "/dev/mapper/luks-dc8e394e-d685-429e-b256-3b803635b47d";
+        fsType = "ext4";
       };
-
-      swapDevices = [
-        {
-          device = "/dev/mapper/luks-df7db70f-8965-4516-976d-8fdac91ae660";
-        }
-      ];
-
-      services.libinput = {
-        enable = true;
-        touchpad = {
-          tapping = true;
-          middleEmulation = true;
-          naturalScrolling = true;
-        };
+      "/boot" = {
+        device = "/dev/disk/by-uuid/1F94-C5D7";
+        fsType = "vfat";
+        options = [
+          "fmask=0077"
+          "dmask=0077"
+        ];
       };
     };
+
+    swapDevices = [
+      {
+        device = "/dev/mapper/luks-df7db70f-8965-4516-976d-8fdac91ae660";
+      }
+    ];
+
+    services.libinput = {
+      enable = true;
+      touchpad = {
+        tapping = true;
+        middleEmulation = true;
+        naturalScrolling = true;
+      };
+    };
+  };
 }

--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -38,6 +38,9 @@ in
       config.flake.nixosModules.ssh
       config.flake.nixosModules.bluetooth
       config.flake.nixosModules.zshKeybindings
+
+      # External hardware modules
+      inputs.nixos-hardware.nixosModules.common-cpu-intel-cpu-only
     ]
     ++ lib.optionals duplicatiModuleExists [ config.flake.nixosModules."duplicati-r2" ]
     ++ lib.optionals mirrorRootModuleExists [ config.flake.nixosModules.mirror-root ]


### PR DESCRIPTION
## Summary
- import the nixos-hardware Intel CPU-only module for the Intel hosts
- remove host-local Intel microcode ownership from hardware configs
- keep the tpnix hardware module formatted according to hooks

## Test plan
- Not run per request; relied on git commit and push hooks only.