### PR TITLE
feat(packages): add JavaScript package updaters

### DIFF
--- a/modules/packages/restringer.nix
+++ b/modules/packages/restringer.nix
@@ -1,0 +1,7 @@
+_: {
+  perSystem =
+    { pkgs, ... }:
+    {
+      packages.restringer = pkgs.callPackage ../../packages/restringer { };
+    };
+}

--- a/packages/age-plugin-fido2prf/update.py
+++ b/packages/age-plugin-fido2prf/update.py
@@ -15,16 +15,12 @@ OWNER = "FiloSottile"
 REPO = "typage"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/age-plugin-fido2prf/update.py
+++ b/packages/age-plugin-fido2prf/update.py
@@ -14,11 +14,17 @@ PACKAGE_NAME = "age-plugin-fido2prf"
 OWNER = "FiloSottile"
 REPO = "typage"
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/azd/update.py
+++ b/packages/azd/update.py
@@ -30,16 +30,12 @@ BINARY_NAMES = {
 }
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/azd/update.py
+++ b/packages/azd/update.py
@@ -30,39 +30,17 @@ BINARY_NAMES = {
 }
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
-    for parent in [start, *start.parents]:
-        if (
-            (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return parent
-    return None
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
+from updater_bootstrap import bootstrap  # noqa: E402
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
-
-    msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
-        f"packages/{PACKAGE_NAME}/."
-    )
-    raise RuntimeError(msg)
-
-
-FLAKE_ROOT = _checkout_root()
-PACKAGE_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "default.nix"
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import calculate_platform_hashes, fetch_json  # noqa: E402

--- a/packages/brave-origin/update.py
+++ b/packages/brave-origin/update.py
@@ -29,39 +29,17 @@ ASSET_TEMPLATES = {
 }
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
-    for parent in [start, *start.parents]:
-        if (
-            (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return parent
-    return None
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
+from updater_bootstrap import bootstrap  # noqa: E402
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
-
-    msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
-        f"packages/{PACKAGE_NAME}/."
-    )
-    raise RuntimeError(msg)
-
-
-FLAKE_ROOT = _checkout_root()
-PACKAGE_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "default.nix"
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import calculate_platform_hashes, fetch_json  # noqa: E402

--- a/packages/brave-origin/update.py
+++ b/packages/brave-origin/update.py
@@ -29,16 +29,12 @@ ASSET_TEMPLATES = {
 }
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/charles/update.py
+++ b/packages/charles/update.py
@@ -15,11 +15,17 @@ PACKAGE_NAME = "charles"
 VERSION_HISTORY_URL = "https://www.charlesproxy.com/documentation/version-history/"
 USER_AGENT = "Mozilla/5.0"
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/charles/update.py
+++ b/packages/charles/update.py
@@ -16,16 +16,12 @@ VERSION_HISTORY_URL = "https://www.charlesproxy.com/documentation/version-histor
 USER_AGENT = "Mozilla/5.0"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/codeburn/update.py
+++ b/packages/codeburn/update.py
@@ -15,16 +15,12 @@ OWNER = "getagentseal"
 REPO = "codeburn"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/codeburn/update.py
+++ b/packages/codeburn/update.py
@@ -14,11 +14,17 @@ PACKAGE_NAME = "codeburn"
 OWNER = "getagentseal"
 REPO = "codeburn"
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/electron-mail/update.py
+++ b/packages/electron-mail/update.py
@@ -24,39 +24,17 @@ URL_TEMPLATE = (
 )
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
-    for parent in [start, *start.parents]:
-        if (
-            (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return parent
-    return None
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
+from updater_bootstrap import bootstrap  # noqa: E402
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
-
-    msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
-        "packages/electron-mail/."
-    )
-    raise RuntimeError(msg)
-
-
-FLAKE_ROOT = _checkout_root()
-PACKAGE_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "default.nix"
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import calculate_platform_hashes, fetch_json  # noqa: E402

--- a/packages/electron-mail/update.py
+++ b/packages/electron-mail/update.py
@@ -24,16 +24,12 @@ URL_TEMPLATE = (
 )
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/gitlawb/update.py
+++ b/packages/gitlawb/update.py
@@ -24,16 +24,12 @@ ASSET_TEMPLATES = {
 }
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/gitlawb/update.py
+++ b/packages/gitlawb/update.py
@@ -24,39 +24,17 @@ ASSET_TEMPLATES = {
 }
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
-    for parent in [start, *start.parents]:
-        if (
-            (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return parent
-    return None
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
+from updater_bootstrap import bootstrap  # noqa: E402
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
-
-    msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
-        f"packages/{PACKAGE_NAME}/."
-    )
-    raise RuntimeError(msg)
-
-
-FLAKE_ROOT = _checkout_root()
-PACKAGE_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "default.nix"
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import calculate_platform_hashes, fetch_json  # noqa: E402

--- a/packages/malimite/update.py
+++ b/packages/malimite/update.py
@@ -22,16 +22,12 @@ TAG_PATTERN = re.compile(r"^(?P<version>[0-9][0-9A-Za-z.+_-]*)$")
 ARCHIVE_KEY = "linux"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/malimite/update.py
+++ b/packages/malimite/update.py
@@ -22,39 +22,17 @@ TAG_PATTERN = re.compile(r"^(?P<version>[0-9][0-9A-Za-z.+_-]*)$")
 ARCHIVE_KEY = "linux"
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
-    for parent in [start, *start.parents]:
-        if (
-            (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return parent
-    return None
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
+from updater_bootstrap import bootstrap  # noqa: E402
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
-
-    msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
-        f"packages/{PACKAGE_NAME}/."
-    )
-    raise RuntimeError(msg)
-
-
-FLAKE_ROOT = _checkout_root()
-PACKAGE_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "default.nix"
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import calculate_platform_hashes, fetch_json  # noqa: E402

--- a/packages/opendirectorydownloader/update.py
+++ b/packages/opendirectorydownloader/update.py
@@ -25,16 +25,12 @@ ASSET_TEMPLATES = {
 }
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/opendirectorydownloader/update.py
+++ b/packages/opendirectorydownloader/update.py
@@ -25,39 +25,17 @@ ASSET_TEMPLATES = {
 }
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
-    for parent in [start, *start.parents]:
-        if (
-            (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return parent
-    return None
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
+from updater_bootstrap import bootstrap  # noqa: E402
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
-
-    msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
-        f"packages/{PACKAGE_NAME}/."
-    )
-    raise RuntimeError(msg)
-
-
-FLAKE_ROOT = _checkout_root()
-PACKAGE_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "default.nix"
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import calculate_platform_hashes, fetch_json  # noqa: E402

--- a/packages/restringer/default.nix
+++ b/packages/restringer/default.nix
@@ -10,21 +10,23 @@
 }:
 
 let
+  pin = lib.importJSON ./hashes.json;
+
   # Fetch prebuilt isolated-vm binary for Node 22 (ABI v127)
   isolatedVmPrebuild = fetchurl {
-    url = "https://github.com/laverdet/isolated-vm/releases/download/v5.0.4/isolated-vm-v5.0.4-node-v127-linux-x64.tar.gz";
-    hash = "sha256-1HrBJ9xGroKS7Jttx4F+dE+JMsS1t8cU4cUO9yAOvbI=";
+    url = "https://github.com/laverdet/isolated-vm/releases/download/v${pin.isolatedVmVersion}/isolated-vm-v${pin.isolatedVmVersion}-${pin.isolatedVmNodeAbi}-${pin.isolatedVmPlatform}.tar.gz";
+    hash = pin.isolatedVmPrebuildHash;
   };
 in
 buildNpmPackage rec {
   pname = "restringer";
-  version = "2.1.0";
+  inherit (pin) version;
 
   src = fetchFromGitHub {
     owner = "HumanSecurity";
     repo = "restringer";
     rev = "v${version}";
-    hash = "sha256-wUiYrQJVETMnwZ0gPcrcmGTSV/g6S2ZqP8RMJ+QPCDQ=";
+    hash = pin.srcHash;
   };
 
   nodejs = nodejs_22;
@@ -32,7 +34,7 @@ buildNpmPackage rec {
   # python3 needed for node-gyp (isolated-vm native module)
   nativeBuildInputs = [ python3 ];
 
-  npmDepsHash = "sha256-mr+S9odeC59BlHprCWOchlAKjbvg0g/IR7Ec9u1A8iE=";
+  inherit (pin) npmDepsHash;
 
   # Provide Node headers for node-gyp
   env.npm_config_nodedir = nodejs_22;
@@ -48,6 +50,8 @@ buildNpmPackage rec {
 
   # No build step needed - restringer is plain JS with native deps
   dontNpmBuild = true;
+
+  passthru.updateScript = ./update.py;
 
   meta = {
     description = "Deobfuscate Javascript with emphasis on reconstructing strings";

--- a/packages/restringer/hashes.json
+++ b/packages/restringer/hashes.json
@@ -1,0 +1,9 @@
+{
+	"version": "2.1.0",
+	"srcHash": "sha256-wUiYrQJVETMnwZ0gPcrcmGTSV/g6S2ZqP8RMJ+QPCDQ=",
+	"npmDepsHash": "sha256-mr+S9odeC59BlHprCWOchlAKjbvg0g/IR7Ec9u1A8iE=",
+	"isolatedVmVersion": "5.0.4",
+	"isolatedVmNodeAbi": "node-v127",
+	"isolatedVmPlatform": "linux-x64",
+	"isolatedVmPrebuildHash": "sha256-1HrBJ9xGroKS7Jttx4F+dE+JMsS1t8cU4cUO9yAOvbI="
+}

--- a/packages/restringer/update.py
+++ b/packages/restringer/update.py
@@ -18,39 +18,45 @@ DEFAULT_NODE_ABI = "node-v127"
 DEFAULT_PLATFORM = "linux-x64"
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
+def _find_scripts_dir(start: Path) -> Path | None:
+    """Walk up from ``start`` until this checkout's scripts dir is found."""
     for parent in [start, *start.parents]:
+        scripts_dir = parent / "scripts"
         if (
             (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
+            and (scripts_dir / "updater_bootstrap.py").is_file()
             and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
         ):
-            return parent
+            return scripts_dir
     return None
 
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
+def _add_bootstrap_import_path() -> None:
+    """Make updater_bootstrap importable from cwd or the checkout script path."""
     starts = [
         Path.cwd().resolve(),
         Path(__file__).resolve().parent,
     ]
     for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
+        scripts_dir = _find_scripts_dir(start)
+        if scripts_dir is not None:
+            sys.path.insert(0, str(scripts_dir))
+            return
 
     msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
+        "Could not find the nixos checkout scripts directory. Run this updater "
+        "from the repository checkout, or execute the checkout copy under "
         f"packages/{PACKAGE_NAME}/."
     )
     raise RuntimeError(msg)
 
 
-FLAKE_ROOT = _checkout_root()
-HASHES_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "hashes.json"
+_add_bootstrap_import_path()
+
+from updater_bootstrap import bootstrap  # noqa: E402
+
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = f"{FLAKE_ROOT}#restringer"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/restringer/update.py
+++ b/packages/restringer/update.py
@@ -18,44 +18,16 @@ DEFAULT_NODE_ABI = "node-v127"
 DEFAULT_PLATFORM = "linux-x64"
 
 
-def _find_scripts_dir(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's scripts dir is found."""
-    for parent in [start, *start.parents]:
-        scripts_dir = parent / "scripts"
-        if (
-            (parent / "flake.nix").is_file()
-            and (scripts_dir / "updater_bootstrap.py").is_file()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return scripts_dir
-    return None
-
-
-def _add_bootstrap_import_path() -> None:
-    """Make updater_bootstrap importable from cwd or the checkout script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        scripts_dir = _find_scripts_dir(start)
-        if scripts_dir is not None:
-            sys.path.insert(0, str(scripts_dir))
-            return
-
-    msg = (
-        "Could not find the nixos checkout scripts directory. Run this updater "
-        "from the repository checkout, or execute the checkout copy under "
-        f"packages/{PACKAGE_NAME}/."
-    )
-    raise RuntimeError(msg)
-
-
-_add_bootstrap_import_path()
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = f"{FLAKE_ROOT}#restringer"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/restringer/update.py
+++ b/packages/restringer/update.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import sys
+import urllib.error
 from pathlib import Path
 from typing import Any, cast
 
@@ -63,7 +64,7 @@ def package_json_isolated_vm_version(version: str) -> str:
     if not isinstance(isolated_vm, str):
         msg = "Could not find isolated-vm in package.json"
         raise RuntimeError(msg)
-    if not isolated_vm[0].isdigit():
+    if not isolated_vm or not isolated_vm[0].isdigit():
         msg = f"package.json isolated-vm dependency is not exact: {isolated_vm}"
         raise RuntimeError(msg)
     return isolated_vm
@@ -71,7 +72,12 @@ def package_json_isolated_vm_version(version: str) -> str:
 
 def lockfile_isolated_vm_version(version: str) -> str | None:
     """Read the exact isolated-vm dependency from package-lock.json."""
-    data = fetch_json(upstream_url(version, "package-lock.json"))
+    try:
+        data = fetch_json(upstream_url(version, "package-lock.json"))
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return None
+        raise
     if not isinstance(data, dict):
         msg = f"Expected package-lock.json dict, got {type(data)}"
         raise TypeError(msg)

--- a/packages/restringer/update.py
+++ b/packages/restringer/update.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env nix
+#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+"""Update script for restringer."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+
+PACKAGE_NAME = "restringer"
+OWNER = "HumanSecurity"
+REPO = "restringer"
+TAG_PATTERN = r"^v(?P<version>\d+\.\d+\.\d+)$"
+DEFAULT_NODE_ABI = "node-v127"
+DEFAULT_PLATFORM = "linux-x64"
+
+
+def _flake_root(start: Path) -> Path | None:
+    """Walk up from ``start`` until this checkout's flake root is found."""
+    for parent in [start, *start.parents]:
+        if (
+            (parent / "flake.nix").is_file()
+            and (parent / "scripts" / "updater").is_dir()
+            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
+        ):
+            return parent
+    return None
+
+
+def _checkout_root() -> Path:
+    """Find the editable checkout from either cwd or the script path."""
+    starts = [
+        Path.cwd().resolve(),
+        Path(__file__).resolve().parent,
+    ]
+    for start in starts:
+        root = _flake_root(start)
+        if root is not None:
+            return root
+
+    msg = (
+        "Could not find the nixos checkout root. Run this updater from the "
+        "repository checkout, or execute the checkout copy under "
+        f"packages/{PACKAGE_NAME}/."
+    )
+    raise RuntimeError(msg)
+
+
+FLAKE_ROOT = _checkout_root()
+HASHES_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "hashes.json"
+PACKAGE_ATTR = f"{FLAKE_ROOT}#restringer"
+sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
+
+from updater import (  # noqa: E402
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_github_latest_tag,
+    fetch_json,
+    load_hashes,
+    save_hashes,
+)
+
+
+def latest_version() -> str:
+    """Fetch the highest stable restringer tag."""
+    return fetch_github_latest_tag(OWNER, REPO, TAG_PATTERN)
+
+
+def upstream_url(version: str, path: str) -> str:
+    """Return a raw GitHub URL for the tagged restringer source."""
+    return f"https://raw.githubusercontent.com/{OWNER}/{REPO}/v{version}/{path}"
+
+
+def package_json_isolated_vm_version(version: str) -> str:
+    """Read an exact isolated-vm dependency from package.json."""
+    data = fetch_json(upstream_url(version, "package.json"))
+    if not isinstance(data, dict):
+        msg = f"Expected package.json dict, got {type(data)}"
+        raise TypeError(msg)
+
+    dependencies = data.get("dependencies")
+    if not isinstance(dependencies, dict):
+        msg = f"Expected dependencies dict, got {type(dependencies)}"
+        raise TypeError(msg)
+    isolated_vm = dependencies.get("isolated-vm")
+    if not isinstance(isolated_vm, str):
+        msg = "Could not find isolated-vm in package.json"
+        raise RuntimeError(msg)
+    if not isolated_vm[0].isdigit():
+        msg = f"package.json isolated-vm dependency is not exact: {isolated_vm}"
+        raise RuntimeError(msg)
+    return isolated_vm
+
+
+def lockfile_isolated_vm_version(version: str) -> str | None:
+    """Read the exact isolated-vm dependency from package-lock.json."""
+    data = fetch_json(upstream_url(version, "package-lock.json"))
+    if not isinstance(data, dict):
+        msg = f"Expected package-lock.json dict, got {type(data)}"
+        raise TypeError(msg)
+
+    packages = data.get("packages")
+    if isinstance(packages, dict):
+        package_entry = packages.get("node_modules/isolated-vm")
+        if isinstance(package_entry, dict):
+            lock_version = package_entry.get("version")
+            if isinstance(lock_version, str):
+                return lock_version
+
+    dependencies = data.get("dependencies")
+    if isinstance(dependencies, dict):
+        dependency_entry = dependencies.get("isolated-vm")
+        if isinstance(dependency_entry, dict):
+            lock_version = dependency_entry.get("version")
+            if isinstance(lock_version, str):
+                return lock_version
+
+    return None
+
+
+def upstream_isolated_vm_version(version: str) -> str:
+    """Find the exact isolated-vm version used by upstream."""
+    lock_version = lockfile_isolated_vm_version(version)
+    if lock_version is not None:
+        return lock_version
+    return package_json_isolated_vm_version(version)
+
+
+def isolated_vm_prebuild_url(
+    isolated_vm_version: str,
+    node_abi: str,
+    platform: str,
+) -> str:
+    """Return the isolated-vm prebuild URL for the supported platform."""
+    archive = f"isolated-vm-v{isolated_vm_version}-{node_abi}-{platform}.tar.gz"
+    return (
+        "https://github.com/laverdet/isolated-vm/releases/download/"
+        f"v{isolated_vm_version}/{archive}"
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check-release",
+        action="store_true",
+        help="validate release metadata without fetching hashes",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="recalculate hashes even when the version is unchanged",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Update restringer to the latest stable tag."""
+    args = parse_args()
+    data = load_hashes(HASHES_FILE)
+    current = cast("str", data["version"])
+    latest = latest_version()
+    isolated_vm_version = upstream_isolated_vm_version(latest)
+    node_abi = cast("str", data.get("isolatedVmNodeAbi", DEFAULT_NODE_ABI))
+    platform = cast("str", data.get("isolatedVmPlatform", DEFAULT_PLATFORM))
+
+    print(f"Current:     {current}")
+    print(f"Latest:      {latest}")
+    print(f"isolated-vm: {isolated_vm_version}")
+    print(f"Prebuild:    {node_abi}-{platform}")
+
+    if args.check_release:
+        print("Release metadata is valid")
+        return
+
+    native_pin_changed = (
+        data.get("isolatedVmVersion") != isolated_vm_version
+        or data.get("isolatedVmNodeAbi") != node_abi
+        or data.get("isolatedVmPlatform") != platform
+    )
+    if current == latest and not native_pin_changed and not args.force:
+        print("Already up to date")
+        return
+
+    print("Calculating source hash...")
+    src_hash = calculate_url_hash(
+        f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz",
+        unpack=True,
+    )
+
+    if native_pin_changed:
+        print("Calculating isolated-vm prebuild hash...")
+        prebuild_hash = calculate_url_hash(
+            isolated_vm_prebuild_url(isolated_vm_version, node_abi, platform),
+        )
+    else:
+        prebuild_hash = cast("str", data["isolatedVmPrebuildHash"])
+
+    new_data: dict[str, Any] = {
+        "version": latest,
+        "srcHash": src_hash,
+        "npmDepsHash": data.get("npmDepsHash", ""),
+        "isolatedVmVersion": isolated_vm_version,
+        "isolatedVmNodeAbi": node_abi,
+        "isolatedVmPlatform": platform,
+        "isolatedVmPrebuildHash": prebuild_hash,
+    }
+    new_data["npmDepsHash"] = calculate_dependency_hash(
+        PACKAGE_ATTR,
+        "npmDepsHash",
+        HASHES_FILE,
+        new_data,
+    )
+    save_hashes(HASHES_FILE, new_data)
+    print(f"Updated {HASHES_FILE.relative_to(FLAKE_ROOT)} to {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/restringer/update.py
+++ b/packages/restringer/update.py
@@ -18,16 +18,12 @@ DEFAULT_NODE_ABI = "node-v127"
 DEFAULT_PLATFORM = "linux-x64"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = f"{FLAKE_ROOT}#restringer"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/searchfox-cli/update.py
+++ b/packages/searchfox-cli/update.py
@@ -14,16 +14,12 @@ PACKAGE_NAME = "searchfox-cli"
 REPO = "padenot/searchfox-cli"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = f"{FLAKE_ROOT}#nixosConfigurations.system76.pkgs.{PACKAGE_NAME}"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/searchfox-cli/update.py
+++ b/packages/searchfox-cli/update.py
@@ -14,39 +14,17 @@ PACKAGE_NAME = "searchfox-cli"
 REPO = "padenot/searchfox-cli"
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
-    for parent in [start, *start.parents]:
-        if (
-            (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return parent
-    return None
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
+from updater_bootstrap import bootstrap  # noqa: E402
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
-
-    msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
-        f"packages/{PACKAGE_NAME}/."
-    )
-    raise RuntimeError(msg)
-
-
-FLAKE_ROOT = _checkout_root()
-HASHES_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "hashes.json"
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = f"{FLAKE_ROOT}#nixosConfigurations.system76.pkgs.{PACKAGE_NAME}"
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 

--- a/packages/source-map-explorer/update.py
+++ b/packages/source-map-explorer/update.py
@@ -15,16 +15,12 @@ OWNER = "danvk"
 REPO = "source-map-explorer"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/source-map-explorer/update.py
+++ b/packages/source-map-explorer/update.py
@@ -14,11 +14,17 @@ PACKAGE_NAME = "source-map-explorer"
 OWNER = "danvk"
 REPO = "source-map-explorer"
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/tweakcc/update.py
+++ b/packages/tweakcc/update.py
@@ -19,16 +19,12 @@ REPO = "Piebald-AI/tweakcc"
 BRANCH = "main"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import (  # noqa: E402

--- a/packages/tweakcc/update.py
+++ b/packages/tweakcc/update.py
@@ -14,16 +14,21 @@ from pathlib import Path
 from typing import Any, cast
 
 
-def _flake_root(start: Path) -> Path:
-    """Walk up from directory ``start`` until ``flake.nix`` is found."""
-    for parent in [start, *start.parents]:
-        if (parent / "flake.nix").is_file():
-            return parent
-    msg = f"Could not find flake.nix above {start}"
-    raise RuntimeError(msg)
+PACKAGE_NAME = "tweakcc"
+REPO = "Piebald-AI/tweakcc"
+BRANCH = "main"
 
 
-FLAKE_ROOT = _flake_root(Path(__file__).resolve().parent)
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
+
+from updater_bootstrap import bootstrap  # noqa: E402
+
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import (  # noqa: E402
@@ -34,9 +39,7 @@ from updater import (  # noqa: E402
     save_hashes,
 )
 
-REPO = "Piebald-AI/tweakcc"
-BRANCH = "main"
-HASHES_FILE = Path(__file__).parent / "hashes.json"
+HASHES_FILE = PACKAGE_DIR / "hashes.json"
 
 
 def latest_main_commit() -> dict[str, Any]:

--- a/packages/wakaru/default.nix
+++ b/packages/wakaru/default.nix
@@ -10,17 +10,17 @@
 }:
 
 let
-  version = "0.0.10";
+  pin = lib.importJSON ./hashes.json;
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "wakaru";
-  inherit version;
+  inherit (pin) version;
 
   src = fetchFromGitHub {
     owner = "pionxzh";
     repo = "wakaru";
-    rev = "cli-v${version}";
-    hash = "sha256-bWApVN11HZy88xHbB2fQdk4quiyKsn6oyHa91Unxjds=";
+    rev = "cli-v${pin.version}";
+    hash = pin.srcHash;
   };
 
   nativeBuildInputs = [
@@ -42,7 +42,7 @@ stdenv.mkDerivation (finalAttrs: {
       ;
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-y8I+nudfmsecpou9f6C23x6DVre9YXgybhMchILcBmo=";
+    hash = pin.pnpmDepsHash;
   };
 
   buildPhase = ''
@@ -70,6 +70,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = ./update.py;
 
   meta = {
     description = "Javascript decompiler for modern frontend";

--- a/packages/wakaru/hashes.json
+++ b/packages/wakaru/hashes.json
@@ -1,0 +1,5 @@
+{
+	"version": "0.0.10",
+	"srcHash": "sha256-bWApVN11HZy88xHbB2fQdk4quiyKsn6oyHa91Unxjds=",
+	"pnpmDepsHash": "sha256-y8I+nudfmsecpou9f6C23x6DVre9YXgybhMchILcBmo="
+}

--- a/packages/wakaru/update.py
+++ b/packages/wakaru/update.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env nix
+#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+"""Update script for wakaru."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+
+PACKAGE_NAME = "wakaru"
+OWNER = "pionxzh"
+REPO = "wakaru"
+TAG_PATTERN = r"^cli-v(?P<version>\d+\.\d+\.\d+)$"
+
+
+def _flake_root(start: Path) -> Path | None:
+    """Walk up from ``start`` until this checkout's flake root is found."""
+    for parent in [start, *start.parents]:
+        if (
+            (parent / "flake.nix").is_file()
+            and (parent / "scripts" / "updater").is_dir()
+            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
+        ):
+            return parent
+    return None
+
+
+def _checkout_root() -> Path:
+    """Find the editable checkout from either cwd or the script path."""
+    starts = [
+        Path.cwd().resolve(),
+        Path(__file__).resolve().parent,
+    ]
+    for start in starts:
+        root = _flake_root(start)
+        if root is not None:
+            return root
+
+    msg = (
+        "Could not find the nixos checkout root. Run this updater from the "
+        "repository checkout, or execute the checkout copy under "
+        f"packages/{PACKAGE_NAME}/."
+    )
+    raise RuntimeError(msg)
+
+
+FLAKE_ROOT = _checkout_root()
+HASHES_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "hashes.json"
+PACKAGE_ATTR = f"{FLAKE_ROOT}#nixosConfigurations.system76.pkgs.{PACKAGE_NAME}"
+sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
+
+from updater import (  # noqa: E402
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_github_latest_tag,
+    load_hashes,
+    save_hashes,
+)
+
+
+def latest_version() -> str:
+    """Fetch the highest stable wakaru CLI tag."""
+    return fetch_github_latest_tag(OWNER, REPO, TAG_PATTERN)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check-release",
+        action="store_true",
+        help="validate release metadata without fetching hashes",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="recalculate hashes even when the version is unchanged",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Update wakaru to the latest CLI tag."""
+    args = parse_args()
+    data = load_hashes(HASHES_FILE)
+    current = cast("str", data["version"])
+    latest = latest_version()
+
+    print(f"Current: {current}")
+    print(f"Latest:  {latest}")
+    print(f"Tag:     cli-v{latest}")
+
+    if args.check_release:
+        print("Release metadata is valid")
+        return
+
+    if current == latest and not args.force:
+        print("Already up to date")
+        return
+
+    print("Calculating source hash...")
+    src_hash = calculate_url_hash(
+        f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/cli-v{latest}.tar.gz",
+        unpack=True,
+    )
+
+    new_data: dict[str, Any] = {
+        "version": latest,
+        "srcHash": src_hash,
+        "pnpmDepsHash": data.get("pnpmDepsHash", ""),
+    }
+    new_data["pnpmDepsHash"] = calculate_dependency_hash(
+        PACKAGE_ATTR,
+        "pnpmDepsHash",
+        HASHES_FILE,
+        new_data,
+    )
+    save_hashes(HASHES_FILE, new_data)
+    print(f"Updated {HASHES_FILE.relative_to(FLAKE_ROOT)} to {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/wakaru/update.py
+++ b/packages/wakaru/update.py
@@ -16,16 +16,12 @@ REPO = "wakaru"
 TAG_PATTERN = r"^cli-v(?P<version>\d+\.\d+\.\d+)$"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/wakaru/update.py
+++ b/packages/wakaru/update.py
@@ -16,40 +16,46 @@ REPO = "wakaru"
 TAG_PATTERN = r"^cli-v(?P<version>\d+\.\d+\.\d+)$"
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
+def _find_scripts_dir(start: Path) -> Path | None:
+    """Walk up from ``start`` until this checkout's scripts dir is found."""
     for parent in [start, *start.parents]:
+        scripts_dir = parent / "scripts"
         if (
             (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
+            and (scripts_dir / "updater_bootstrap.py").is_file()
             and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
         ):
-            return parent
+            return scripts_dir
     return None
 
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
+def _add_bootstrap_import_path() -> None:
+    """Make updater_bootstrap importable from cwd or the checkout script path."""
     starts = [
         Path.cwd().resolve(),
         Path(__file__).resolve().parent,
     ]
     for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
+        scripts_dir = _find_scripts_dir(start)
+        if scripts_dir is not None:
+            sys.path.insert(0, str(scripts_dir))
+            return
 
     msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
+        "Could not find the nixos checkout scripts directory. Run this updater "
+        "from the repository checkout, or execute the checkout copy under "
         f"packages/{PACKAGE_NAME}/."
     )
     raise RuntimeError(msg)
 
 
-FLAKE_ROOT = _checkout_root()
-HASHES_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "hashes.json"
-PACKAGE_ATTR = f"{FLAKE_ROOT}#nixosConfigurations.system76.pkgs.{PACKAGE_NAME}"
+_add_bootstrap_import_path()
+
+from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
+
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+HASHES_FILE = PACKAGE_DIR / "hashes.json"
+PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import (  # noqa: E402

--- a/packages/wakaru/update.py
+++ b/packages/wakaru/update.py
@@ -16,44 +16,16 @@ REPO = "wakaru"
 TAG_PATTERN = r"^cli-v(?P<version>\d+\.\d+\.\d+)$"
 
 
-def _find_scripts_dir(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's scripts dir is found."""
-    for parent in [start, *start.parents]:
-        scripts_dir = parent / "scripts"
-        if (
-            (parent / "flake.nix").is_file()
-            and (scripts_dir / "updater_bootstrap.py").is_file()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return scripts_dir
-    return None
-
-
-def _add_bootstrap_import_path() -> None:
-    """Make updater_bootstrap importable from cwd or the checkout script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        scripts_dir = _find_scripts_dir(start)
-        if scripts_dir is not None:
-            sys.path.insert(0, str(scripts_dir))
-            return
-
-    msg = (
-        "Could not find the nixos checkout scripts directory. Run this updater "
-        "from the repository checkout, or execute the checkout copy under "
-        f"packages/{PACKAGE_NAME}/."
-    )
-    raise RuntimeError(msg)
-
-
-_add_bootstrap_import_path()
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/wappalyzer-next/update.py
+++ b/packages/wappalyzer-next/update.py
@@ -15,16 +15,12 @@ OWNER = "s0md3v"
 REPO = "wappalyzer-next"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/wappalyzer-next/update.py
+++ b/packages/wappalyzer-next/update.py
@@ -14,11 +14,17 @@ PACKAGE_NAME = "wappalyzer-next"
 OWNER = "s0md3v"
 REPO = "wappalyzer-next"
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/webcrack/default.nix
+++ b/packages/webcrack/default.nix
@@ -32,14 +32,14 @@
 }:
 
 let
-  version = "2.15.1";
+  pin = lib.importJSON ./hashes.json;
   simdutf_6 = simdutf.overrideAttrs {
-    version = "6.5.0";
+    version = pin.simdutfVersion;
     src = fetchFromGitHub {
       owner = "simdutf";
       repo = "simdutf";
-      rev = "v6.5.0";
-      hash = "sha256-bZ4r62GMz2Dkd3fKTJhelitaA8jUBaDjG6jOysEg8Nk=";
+      rev = "v${pin.simdutfVersion}";
+      hash = pin.simdutfHash;
     };
   };
 
@@ -50,8 +50,8 @@ let
     src = fetchFromGitHub {
       owner = "j4k0xb";
       repo = "webcrack";
-      rev = "v${version}";
-      hash = "sha256-9xCndYtGXnVGV6gXdqjLM4ruSIHi7JRXPHRBom7K7Ds=";
+      rev = "v${pin.version}";
+      hash = pin.srcHash;
     };
 
     nativeBuildInputs = [
@@ -68,26 +68,23 @@ let
       mv $out/package.json.tmp $out/package.json
       ${lib.getExe yq-go} -i 'del(.patchedDependencies)' $out/pnpm-lock.yaml
 
-      # Upgrade isolated-vm 5.0.1 -> 6.0.2 (5.0.1 fails to compile with current GCC)
-      # Update packages/webcrack/package.json dependency
-      ${lib.getExe jq} '.dependencies["isolated-vm"] = "^6.0.2"' \
+      # Keep isolated-vm pinned to the updater-owned lock metadata.
+      ${lib.getExe jq} '.dependencies["isolated-vm"] = "^${pin.isolatedVmVersion}"' \
         $out/packages/webcrack/package.json > $out/packages/webcrack/package.json.tmp
       mv $out/packages/webcrack/package.json.tmp $out/packages/webcrack/package.json
 
-      # Update pnpm-lock.yaml for isolated-vm 5.0.1 -> 6.0.2
       ${lib.getExe yq-go} -i '
-        .importers."packages/webcrack".dependencies."isolated-vm".specifier = "^6.0.2" |
-        .importers."packages/webcrack".dependencies."isolated-vm".version = "6.0.2" |
-        .packages."isolated-vm@6.0.2".resolution.integrity = "sha512-Qw6AJuagG/VJuh2AIcSWmQPsAArti/L+lKhjXU+lyhYkbt3J57XZr+ZjgfTnOr4NJcY1r3f8f0eePS7MRGp+pg==" |
-        .packages."isolated-vm@6.0.2".engines.node = ">=22.0.0" |
-        .snapshots."isolated-vm@6.0.2".dependencies."prebuild-install" = "7.1.2"
+        .importers."packages/webcrack".dependencies."isolated-vm".specifier = "^${pin.isolatedVmVersion}" |
+        .importers."packages/webcrack".dependencies."isolated-vm".version = "${pin.isolatedVmVersion}" |
+        .packages."isolated-vm@${pin.isolatedVmVersion}".resolution.integrity = "${pin.isolatedVmIntegrity}" |
+        .packages."isolated-vm@${pin.isolatedVmVersion}".engines.node = ">=22.0.0"
       ' $out/pnpm-lock.yaml
     '';
   };
 in
 stdenv.mkDerivation (finalAttrs: {
   pname = "webcrack";
-  inherit version;
+  inherit (pin) version;
   src = patchedSrc;
 
   nativeBuildInputs = [
@@ -127,14 +124,14 @@ stdenv.mkDerivation (finalAttrs: {
     inherit (finalAttrs) pname version src;
     pnpm = pnpm_9;
     fetcherVersion = 3;
-    hash = "sha256-WuLdIcbN9MI3baerKZtHcY5KbG/AFImhafufiX8mHHI=";
+    hash = pin.pnpmDepsHash;
   };
 
   buildPhase = ''
     runHook preBuild
 
     # Build isolated-vm native module (pnpmConfigHook skips install scripts)
-    cd node_modules/.pnpm/isolated-vm@6.0.2/node_modules/isolated-vm
+    cd node_modules/.pnpm/isolated-vm@${pin.isolatedVmVersion}/node_modules/isolated-vm
     npm run rebuild
     cd -
 
@@ -149,7 +146,7 @@ stdenv.mkDerivation (finalAttrs: {
   '';
 
   # NOTE: Copies pnpm workspace to preserve symlink structure for runtime.
-  # Uses isolated-vm 6.0.2 (patched from 5.0.1) for VM-based deobfuscation.
+  # Uses the updater-pinned isolated-vm for VM-based deobfuscation.
   installPhase = ''
     runHook preInstall
 
@@ -177,6 +174,8 @@ stdenv.mkDerivation (finalAttrs: {
 
     runHook postInstall
   '';
+
+  passthru.updateScript = ./update.py;
 
   meta = {
     description = "Deobfuscate obfuscator.io, unminify and unpack bundled javascript";

--- a/packages/webcrack/hashes.json
+++ b/packages/webcrack/hashes.json
@@ -1,0 +1,9 @@
+{
+	"version": "2.16.0",
+	"srcHash": "sha256-IalU/wio1cNCr6K7Pa1neHVpnO2md4Ey6YmtReE3r+8=",
+	"pnpmDepsHash": "sha256-Uo9LR49yhPan88WpSm0t7BVO4qW4nGlZ14cX6ImLMQ8=",
+	"isolatedVmVersion": "6.1.2",
+	"isolatedVmIntegrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
+	"simdutfVersion": "6.5.0",
+	"simdutfHash": "sha256-bZ4r62GMz2Dkd3fKTJhelitaA8jUBaDjG6jOysEg8Nk="
+}

--- a/packages/webcrack/update.py
+++ b/packages/webcrack/update.py
@@ -19,44 +19,16 @@ REPO = "webcrack"
 TAG_PATTERN = r"^v(?P<version>\d+\.\d+\.\d+)$"
 
 
-def _find_scripts_dir(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's scripts dir is found."""
-    for parent in [start, *start.parents]:
-        scripts_dir = parent / "scripts"
-        if (
-            (parent / "flake.nix").is_file()
-            and (scripts_dir / "updater_bootstrap.py").is_file()
-            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
-        ):
-            return scripts_dir
-    return None
-
-
-def _add_bootstrap_import_path() -> None:
-    """Make updater_bootstrap importable from cwd or the checkout script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(__file__).resolve().parent,
-    ]
-    for start in starts:
-        scripts_dir = _find_scripts_dir(start)
-        if scripts_dir is not None:
-            sys.path.insert(0, str(scripts_dir))
-            return
-
-    msg = (
-        "Could not find the nixos checkout scripts directory. Run this updater "
-        "from the repository checkout, or execute the checkout copy under "
-        f"packages/{PACKAGE_NAME}/."
-    )
-    raise RuntimeError(msg)
-
-
-_add_bootstrap_import_path()
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/webcrack/update.py
+++ b/packages/webcrack/update.py
@@ -19,40 +19,46 @@ REPO = "webcrack"
 TAG_PATTERN = r"^v(?P<version>\d+\.\d+\.\d+)$"
 
 
-def _flake_root(start: Path) -> Path | None:
-    """Walk up from ``start`` until this checkout's flake root is found."""
+def _find_scripts_dir(start: Path) -> Path | None:
+    """Walk up from ``start`` until this checkout's scripts dir is found."""
     for parent in [start, *start.parents]:
+        scripts_dir = parent / "scripts"
         if (
             (parent / "flake.nix").is_file()
-            and (parent / "scripts" / "updater").is_dir()
+            and (scripts_dir / "updater_bootstrap.py").is_file()
             and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
         ):
-            return parent
+            return scripts_dir
     return None
 
 
-def _checkout_root() -> Path:
-    """Find the editable checkout from either cwd or the script path."""
+def _add_bootstrap_import_path() -> None:
+    """Make updater_bootstrap importable from cwd or the checkout script path."""
     starts = [
         Path.cwd().resolve(),
         Path(__file__).resolve().parent,
     ]
     for start in starts:
-        root = _flake_root(start)
-        if root is not None:
-            return root
+        scripts_dir = _find_scripts_dir(start)
+        if scripts_dir is not None:
+            sys.path.insert(0, str(scripts_dir))
+            return
 
     msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
+        "Could not find the nixos checkout scripts directory. Run this updater "
+        "from the repository checkout, or execute the checkout copy under "
         f"packages/{PACKAGE_NAME}/."
     )
     raise RuntimeError(msg)
 
 
-FLAKE_ROOT = _checkout_root()
-HASHES_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "hashes.json"
-PACKAGE_ATTR = f"{FLAKE_ROOT}#nixosConfigurations.system76.pkgs.{PACKAGE_NAME}"
+_add_bootstrap_import_path()
+
+from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
+
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+HASHES_FILE = PACKAGE_DIR / "hashes.json"
+PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import (  # noqa: E402

--- a/packages/webcrack/update.py
+++ b/packages/webcrack/update.py
@@ -8,7 +8,6 @@ import argparse
 import json
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from typing import Any, cast
 
@@ -52,15 +51,13 @@ def upstream_url(version: str, path: str) -> str:
 
 def parse_pnpm_lock(lock_text: str) -> dict[str, Any]:
     """Parse pnpm-lock.yaml with yq."""
-    with tempfile.NamedTemporaryFile("w", suffix=".yaml") as lock_file:
-        lock_file.write(lock_text)
-        lock_file.flush()
-        result = subprocess.run(
-            ["yq", "-o=json", ".", lock_file.name],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+    result = subprocess.run(
+        ["yq", "-o=json", "."],
+        check=True,
+        capture_output=True,
+        text=True,
+        input=lock_text,
+    )
     data = json.loads(result.stdout)
     if not isinstance(data, dict):
         msg = f"Expected dict from pnpm lock, got {type(data)}"
@@ -121,10 +118,17 @@ def upstream_isolated_vm_pin(version: str) -> tuple[str, str]:
     if not isinstance(packages, dict):
         msg = f"Expected packages dict, got {type(packages)}"
         raise TypeError(msg)
-    package_entry = packages.get(f"isolated-vm@{lock_version}")
-    if not isinstance(package_entry, dict):
+    package_key_suffix = f"isolated-vm@{lock_version}"
+    package_entry = next(
+        (entry for key, entry in packages.items() if key.endswith(package_key_suffix)),
+        None,
+    )
+    if package_entry is None:
         msg = f"Could not find isolated-vm@{lock_version} in pnpm-lock.yaml"
         raise RuntimeError(msg)
+    if not isinstance(package_entry, dict):
+        msg = f"Expected isolated-vm package entry dict, got {type(package_entry)}"
+        raise TypeError(msg)
     resolution = package_entry.get("resolution")
     if not isinstance(resolution, dict):
         msg = f"Expected isolated-vm resolution dict, got {type(resolution)}"

--- a/packages/webcrack/update.py
+++ b/packages/webcrack/update.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env nix
+#! nix shell nixpkgs#python3 nixpkgs#nix nixpkgs#yq-go --command python3
+"""Update script for webcrack."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, cast
+
+
+PACKAGE_NAME = "webcrack"
+OWNER = "j4k0xb"
+REPO = "webcrack"
+TAG_PATTERN = r"^v(?P<version>\d+\.\d+\.\d+)$"
+
+
+def _flake_root(start: Path) -> Path | None:
+    """Walk up from ``start`` until this checkout's flake root is found."""
+    for parent in [start, *start.parents]:
+        if (
+            (parent / "flake.nix").is_file()
+            and (parent / "scripts" / "updater").is_dir()
+            and (parent / "packages" / PACKAGE_NAME / "default.nix").is_file()
+        ):
+            return parent
+    return None
+
+
+def _checkout_root() -> Path:
+    """Find the editable checkout from either cwd or the script path."""
+    starts = [
+        Path.cwd().resolve(),
+        Path(__file__).resolve().parent,
+    ]
+    for start in starts:
+        root = _flake_root(start)
+        if root is not None:
+            return root
+
+    msg = (
+        "Could not find the nixos checkout root. Run this updater from the "
+        "repository checkout, or execute the checkout copy under "
+        f"packages/{PACKAGE_NAME}/."
+    )
+    raise RuntimeError(msg)
+
+
+FLAKE_ROOT = _checkout_root()
+HASHES_FILE = FLAKE_ROOT / "packages" / PACKAGE_NAME / "hashes.json"
+PACKAGE_ATTR = f"{FLAKE_ROOT}#nixosConfigurations.system76.pkgs.{PACKAGE_NAME}"
+sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
+
+from updater import (  # noqa: E402
+    calculate_dependency_hash,
+    calculate_url_hash,
+    fetch_github_latest_tag,
+    fetch_json,
+    fetch_text,
+    load_hashes,
+    save_hashes,
+)
+
+
+def latest_version() -> str:
+    """Fetch the highest stable webcrack tag."""
+    return fetch_github_latest_tag(OWNER, REPO, TAG_PATTERN)
+
+
+def upstream_url(version: str, path: str) -> str:
+    """Return a raw GitHub URL for the tagged webcrack source."""
+    return f"https://raw.githubusercontent.com/{OWNER}/{REPO}/v{version}/{path}"
+
+
+def parse_pnpm_lock(lock_text: str) -> dict[str, Any]:
+    """Parse pnpm-lock.yaml with yq."""
+    with tempfile.NamedTemporaryFile("w", suffix=".yaml") as lock_file:
+        lock_file.write(lock_text)
+        lock_file.flush()
+        result = subprocess.run(
+            ["yq", "-o=json", ".", lock_file.name],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    data = json.loads(result.stdout)
+    if not isinstance(data, dict):
+        msg = f"Expected dict from pnpm lock, got {type(data)}"
+        raise TypeError(msg)
+    return cast("dict[str, Any]", data)
+
+
+def upstream_isolated_vm_pin(version: str) -> tuple[str, str]:
+    """Read the exact isolated-vm version and integrity from upstream."""
+    package_json = fetch_json(upstream_url(version, "packages/webcrack/package.json"))
+    if not isinstance(package_json, dict):
+        msg = f"Expected package.json dict, got {type(package_json)}"
+        raise TypeError(msg)
+
+    dependencies = package_json.get("dependencies")
+    if not isinstance(dependencies, dict):
+        msg = f"Expected dependencies dict, got {type(dependencies)}"
+        raise TypeError(msg)
+    package_specifier = dependencies.get("isolated-vm")
+    if not isinstance(package_specifier, str):
+        msg = "Could not find isolated-vm in packages/webcrack/package.json"
+        raise RuntimeError(msg)
+
+    lock_text = fetch_text(upstream_url(version, "pnpm-lock.yaml"))
+    lock_data = parse_pnpm_lock(lock_text)
+    importers = lock_data.get("importers")
+    if not isinstance(importers, dict):
+        msg = f"Expected importers dict, got {type(importers)}"
+        raise TypeError(msg)
+
+    webcrack_importer = importers.get("packages/webcrack")
+    if not isinstance(webcrack_importer, dict):
+        msg = "Could not find packages/webcrack importer in pnpm-lock.yaml"
+        raise RuntimeError(msg)
+    importer_deps = webcrack_importer.get("dependencies")
+    if not isinstance(importer_deps, dict):
+        msg = f"Expected importer dependencies dict, got {type(importer_deps)}"
+        raise TypeError(msg)
+
+    isolated_vm = importer_deps.get("isolated-vm")
+    if not isinstance(isolated_vm, dict):
+        msg = "Could not find isolated-vm importer entry in pnpm-lock.yaml"
+        raise RuntimeError(msg)
+
+    lock_specifier = isolated_vm.get("specifier")
+    lock_version = isolated_vm.get("version")
+    if lock_specifier != package_specifier:
+        msg = (
+            "isolated-vm package.json specifier does not match pnpm lock: "
+            f"{package_specifier} != {lock_specifier}"
+        )
+        raise RuntimeError(msg)
+    if not isinstance(lock_version, str):
+        msg = f"Expected isolated-vm version string, got {type(lock_version)}"
+        raise TypeError(msg)
+
+    packages = lock_data.get("packages")
+    if not isinstance(packages, dict):
+        msg = f"Expected packages dict, got {type(packages)}"
+        raise TypeError(msg)
+    package_entry = packages.get(f"isolated-vm@{lock_version}")
+    if not isinstance(package_entry, dict):
+        msg = f"Could not find isolated-vm@{lock_version} in pnpm-lock.yaml"
+        raise RuntimeError(msg)
+    resolution = package_entry.get("resolution")
+    if not isinstance(resolution, dict):
+        msg = f"Expected isolated-vm resolution dict, got {type(resolution)}"
+        raise TypeError(msg)
+    integrity = resolution.get("integrity")
+    if not isinstance(integrity, str):
+        msg = f"Expected isolated-vm integrity string, got {type(integrity)}"
+        raise TypeError(msg)
+
+    return lock_version, integrity
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--check-release",
+        action="store_true",
+        help="validate release metadata without fetching hashes",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="recalculate hashes even when the version is unchanged",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """Update webcrack to the latest stable tag."""
+    args = parse_args()
+    data = load_hashes(HASHES_FILE)
+    current = cast("str", data["version"])
+    latest = latest_version()
+    isolated_vm_version, isolated_vm_integrity = upstream_isolated_vm_pin(latest)
+
+    print(f"Current:     {current}")
+    print(f"Latest:      {latest}")
+    print(f"isolated-vm: {isolated_vm_version}")
+
+    if args.check_release:
+        print("Release metadata is valid")
+        return
+
+    needs_pin_update = (
+        data.get("isolatedVmVersion") != isolated_vm_version
+        or data.get("isolatedVmIntegrity") != isolated_vm_integrity
+    )
+    if current == latest and not needs_pin_update and not args.force:
+        print("Already up to date")
+        return
+
+    print("Calculating source hash...")
+    src_hash = calculate_url_hash(
+        f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz",
+        unpack=True,
+    )
+
+    new_data: dict[str, Any] = {
+        "version": latest,
+        "srcHash": src_hash,
+        "pnpmDepsHash": data.get("pnpmDepsHash", ""),
+        "isolatedVmVersion": isolated_vm_version,
+        "isolatedVmIntegrity": isolated_vm_integrity,
+        "simdutfVersion": data["simdutfVersion"],
+        "simdutfHash": data["simdutfHash"],
+    }
+    new_data["pnpmDepsHash"] = calculate_dependency_hash(
+        PACKAGE_ATTR,
+        "pnpmDepsHash",
+        HASHES_FILE,
+        new_data,
+    )
+    save_hashes(HASHES_FILE, new_data)
+    print(f"Updated {HASHES_FILE.relative_to(FLAKE_ROOT)} to {latest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/webcrack/update.py
+++ b/packages/webcrack/update.py
@@ -19,16 +19,12 @@ REPO = "webcrack"
 TAG_PATTERN = r"^v(?P<version>\d+\.\d+\.\d+)$"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/wfuzz/update.py
+++ b/packages/wfuzz/update.py
@@ -14,11 +14,17 @@ PACKAGE_NAME = "wfuzz"
 OWNER = "xmendez"
 REPO = "wfuzz"
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+
+_CWD = Path.cwd().resolve()
+sys.path[:0] = [
+    str(root / "scripts")
+    for root in [_CWD, *_CWD.parents]
+    if (root / "scripts" / "updater_bootstrap.py").is_file()
+]
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/packages/wfuzz/update.py
+++ b/packages/wfuzz/update.py
@@ -15,16 +15,12 @@ OWNER = "xmendez"
 REPO = "wfuzz"
 
 
-_CWD = Path.cwd().resolve()
-sys.path[:0] = [
-    str(root / "scripts")
-    for root in [_CWD, *_CWD.parents]
-    if (root / "scripts" / "updater_bootstrap.py").is_file()
-]
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
 
 from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
-FLAKE_ROOT, PACKAGE_DIR = bootstrap(PACKAGE_NAME)
+FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 PACKAGE_FILE = PACKAGE_DIR / "default.nix"
 PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))

--- a/scripts/updater/__init__.py
+++ b/scripts/updater/__init__.py
@@ -39,6 +39,7 @@ from .platforms import calculate_platform_hashes
 
 # Version fetching
 from .version import (
+    fetch_github_latest_tag,
     fetch_github_latest_release,
     fetch_github_latest_tag_version,
     fetch_npm_version,
@@ -54,6 +55,7 @@ __all__ = [
     "clone_and_generate_bun_nix",
     "extract_or_generate_lockfile",
     "fetch_github_latest_release",
+    "fetch_github_latest_tag",
     "fetch_github_latest_tag_version",
     "fetch_json",
     "fetch_npm_version",

--- a/scripts/updater/nix.py
+++ b/scripts/updater/nix.py
@@ -76,8 +76,10 @@ def nix_command(
         "--experimental-features",
         "nix-command flakes",
     ]
-    if args and args[0] in {"build", "eval"}:
-        cmd.extend([args[0], "--no-write-lock-file", *args[1:]])
+    flake_aware = {"build", "eval", "run", "develop", "shell", "flake"}
+    if args and args[0] in flake_aware and "--no-write-lock-file" not in args:
+        insert_at = 2 if args[0] == "flake" and len(args) > 1 else 1
+        cmd.extend([*args[:insert_at], "--no-write-lock-file", *args[insert_at:]])
     else:
         cmd.extend(args)
     return run_command(cmd, check=check, capture_output=capture_output, cwd=cwd)

--- a/scripts/updater/nix.py
+++ b/scripts/updater/nix.py
@@ -77,7 +77,18 @@ def nix_command(
         "nix-command flakes",
     ]
     flake_aware = {"build", "eval", "run", "develop", "shell", "flake"}
-    if args and args[0] in flake_aware and "--no-write-lock-file" not in args:
+    flake_mutating = (
+        bool(args)
+        and args[0] == "flake"
+        and len(args) > 1
+        and args[1] in {"update", "lock"}
+    )
+    if (
+        args
+        and args[0] in flake_aware
+        and "--no-write-lock-file" not in args
+        and not flake_mutating
+    ):
         insert_at = 2 if args[0] == "flake" and len(args) > 1 else 1
         cmd.extend([*args[:insert_at], "--no-write-lock-file", *args[insert_at:]])
     else:

--- a/scripts/updater/nix.py
+++ b/scripts/updater/nix.py
@@ -71,7 +71,15 @@ def nix_command(
         CompletedProcess with command results
 
     """
-    cmd = ["nix", "--experimental-features", "nix-command flakes", *args]
+    cmd = [
+        "nix",
+        "--experimental-features",
+        "nix-command flakes",
+    ]
+    if args and args[0] in {"build", "eval"}:
+        cmd.extend([args[0], "--no-write-lock-file", *args[1:]])
+    else:
+        cmd.extend(args)
     return run_command(cmd, check=check, capture_output=capture_output, cwd=cwd)
 
 

--- a/scripts/updater/version.py
+++ b/scripts/updater/version.py
@@ -102,6 +102,7 @@ def _version_group_pattern(pattern: str, version_group: str) -> str | None:
     index = start + len(marker)
     depth = 1
     escaped = False
+    in_char_class = False
     group_chars: list[str] = []
     while index < len(pattern):
         char = pattern[index]
@@ -111,10 +112,16 @@ def _version_group_pattern(pattern: str, version_group: str) -> str | None:
         elif char == "\\":
             group_chars.append(char)
             escaped = True
-        elif char == "(":
+        elif char == "[" and not in_char_class:
+            in_char_class = True
+            group_chars.append(char)
+        elif char == "]" and in_char_class:
+            in_char_class = False
+            group_chars.append(char)
+        elif char == "(" and not in_char_class:
             group_chars.append(char)
             depth += 1
-        elif char == ")":
+        elif char == ")" and not in_char_class:
             depth -= 1
             if depth == 0:
                 return "".join(group_chars)

--- a/scripts/updater/version.py
+++ b/scripts/updater/version.py
@@ -92,6 +92,135 @@ def fetch_github_latest_tag_version(
     return max(versions, key=cmp_to_key(compare_versions))
 
 
+def _version_group_pattern(pattern: str, version_group: str) -> str | None:
+    """Extract the source pattern for a named regex group."""
+    marker = f"(?P<{version_group}>"
+    start = pattern.find(marker)
+    if start == -1:
+        return None
+
+    index = start + len(marker)
+    depth = 1
+    escaped = False
+    group_chars: list[str] = []
+    while index < len(pattern):
+        char = pattern[index]
+        if escaped:
+            group_chars.append(char)
+            escaped = False
+        elif char == "\\":
+            group_chars.append(char)
+            escaped = True
+        elif char == "(":
+            group_chars.append(char)
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return "".join(group_chars)
+            group_chars.append(char)
+        else:
+            group_chars.append(char)
+        index += 1
+
+    return None
+
+
+def _pattern_explicitly_accepts_prerelease(
+    pattern: str,
+    version_group: str,
+) -> bool:
+    """Return true when the version capture visibly allows prerelease suffixes."""
+    group_pattern = _version_group_pattern(pattern, version_group)
+    if group_pattern is None:
+        return False
+
+    prerelease_markers = [
+        "-",
+        "alpha",
+        "beta",
+        "canary",
+        "dev",
+        "next",
+        "pre",
+        "preview",
+        "rc",
+    ]
+    return any(marker in group_pattern.lower() for marker in prerelease_markers)
+
+
+def _looks_like_prerelease(version: str) -> bool:
+    """Return true when a captured version has a prerelease-looking suffix."""
+    _numeric, suffix = parse_version(version)
+    return bool(suffix)
+
+
+def fetch_github_latest_tag(
+    owner: str,
+    repo: str,
+    pattern: str,
+    version_group: str = "version",
+) -> str:
+    """Fetch the highest matching stable tag version from GitHub.
+
+    Args:
+        owner: Repository owner
+        repo: Repository name
+        pattern: Full tag regex with a named version capture group
+        version_group: Named regex group containing the comparable version
+
+    Returns:
+        Highest matching version captured from the tag
+
+    Raises:
+        ValueError: If no matching tag is found
+
+    """
+    tag_pattern = re.compile(pattern)
+    allow_prerelease = _pattern_explicitly_accepts_prerelease(pattern, version_group)
+    latest: str | None = None
+    page = 1
+
+    while True:
+        url = (
+            f"https://api.github.com/repos/{owner}/{repo}/tags?per_page=100&page={page}"
+        )
+        data = fetch_json(url)
+        if not isinstance(data, list):
+            msg = f"Expected list from GitHub tags API, got {type(data)}"
+            raise TypeError(msg)
+        if not data:
+            break
+
+        for tag in data:
+            if not isinstance(tag, dict):
+                msg = f"Expected tag dict from GitHub API, got {type(tag)}"
+                raise TypeError(msg)
+            name = tag.get("name")
+            if not isinstance(name, str):
+                msg = f"Expected tag name string, got {type(name)}"
+                raise TypeError(msg)
+
+            match = tag_pattern.fullmatch(name)
+            if match is None:
+                continue
+
+            version = match.group(version_group)
+            if not allow_prerelease and _looks_like_prerelease(version):
+                continue
+            if latest is None or compare_versions(latest, version) < 0:
+                latest = version
+
+        if len(data) < 100:
+            break
+        page += 1
+
+    if latest is None:
+        msg = f"Could not find a matching stable tag for {owner}/{repo}"
+        raise ValueError(msg)
+    return latest
+
+
 def fetch_npm_version(package: str) -> str:
     """Fetch the latest version from npm registry.
 

--- a/scripts/updater_bootstrap.py
+++ b/scripts/updater_bootstrap.py
@@ -18,22 +18,22 @@ def _flake_root(start: Path, package_name: str) -> Path | None:
     return None
 
 
-def checkout_root(package_name: str) -> Path:
-    """Find the editable checkout from the current working directory."""
-    root = _flake_root(Path.cwd().resolve(), package_name)
+def checkout_root(script_file: str | Path, package_name: str) -> Path:
+    """Find the checkout root from an updater file path."""
+    root = _flake_root(Path(script_file).resolve().parent, package_name)
     if root is not None:
         return root
 
     msg = (
-        "Could not find the nixos checkout root from the current working "
-        f"directory. Run this updater from the repository checkout for {package_name}."
+        "Could not find the nixos checkout root from update script path for "
+        f"{package_name}."
     )
     raise RuntimeError(msg)
 
 
-def bootstrap(package_name: str) -> tuple[Path, Path]:
+def bootstrap(script_file: str | Path, package_name: str) -> tuple[Path, Path]:
     """Return the checkout root and package directory for an update script."""
-    flake_root = checkout_root(package_name)
+    flake_root = checkout_root(script_file, package_name)
     return flake_root, flake_root / "packages" / package_name
 
 

--- a/scripts/updater_bootstrap.py
+++ b/scripts/updater_bootstrap.py
@@ -18,28 +18,22 @@ def _flake_root(start: Path, package_name: str) -> Path | None:
     return None
 
 
-def checkout_root(script_file: str | Path, package_name: str) -> Path:
-    """Find the editable checkout from either cwd or the script path."""
-    starts = [
-        Path.cwd().resolve(),
-        Path(script_file).resolve().parent,
-    ]
-    for start in starts:
-        root = _flake_root(start, package_name)
-        if root is not None:
-            return root
+def checkout_root(package_name: str) -> Path:
+    """Find the editable checkout from the current working directory."""
+    root = _flake_root(Path.cwd().resolve(), package_name)
+    if root is not None:
+        return root
 
     msg = (
-        "Could not find the nixos checkout root. Run this updater from the "
-        "repository checkout, or execute the checkout copy under "
-        f"packages/{package_name}/."
+        "Could not find the nixos checkout root from the current working "
+        f"directory. Run this updater from the repository checkout for {package_name}."
     )
     raise RuntimeError(msg)
 
 
-def bootstrap(script_file: str | Path, package_name: str) -> tuple[Path, Path]:
+def bootstrap(package_name: str) -> tuple[Path, Path]:
     """Return the checkout root and package directory for an update script."""
-    flake_root = checkout_root(script_file, package_name)
+    flake_root = checkout_root(package_name)
     return flake_root, flake_root / "packages" / package_name
 
 


### PR DESCRIPTION
## Summary

- add a paginated GitHub tag helper for package-specific stable tag schemes
- add hashes.json backed update.py scripts for wakaru, webcrack, and restringer
- update webcrack to 2.16.0 and its upstream isolated-vm 6.1.2 lock metadata
- expose .#restringer for updater and build validation while keeping the app disabled by default

## Test plan

- nix fmt
- nix fmt --no-write-lock-file -- --fail-on-change <touched paths>
- nix run nixpkgs#ruff -- check scripts/updater packages/wakaru/update.py packages/webcrack/update.py packages/restringer/update.py
- nix run nixpkgs#ruff -- format --check scripts/updater packages/wakaru/update.py packages/webcrack/update.py packages/restringer/update.py
- PYTHONPATH="$PWD/scripts" nix run nixpkgs#pyright -- scripts/updater packages/wakaru/update.py packages/webcrack/update.py packages/restringer/update.py
- ./packages/wakaru/update.py --check-release
- ./packages/webcrack/update.py --check-release
- ./packages/restringer/update.py --check-release
- evaluated passthru updateScript --check-release for wakaru, webcrack, and restringer
- ./packages/wakaru/update.py --force
- ./packages/webcrack/update.py --force
- ./packages/restringer/update.py --force
- nix build --accept-flake-config --no-write-lock-file --no-link .#nixosConfigurations.system76.pkgs.wakaru
- nix build --accept-flake-config --no-write-lock-file --no-link .#nixosConfigurations.system76.pkgs.webcrack
- nix build --accept-flake-config --no-write-lock-file --no-link .#restringer
- nix flake check --accept-flake-config --no-write-lock-file --no-build --offline

Note: full tree nix fmt --no-write-lock-file -- --fail-on-change was also attempted and failed on unrelated existing formatter drift outside this change set.