### PR TITLE
chore(docs): normalize README command table

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,11 @@ It refuses to run on a dirty worktree by default; use `--allow-dirty` to overrid
 
 **Development commands:**
 
-| Command | Description |
-|---------|-------------|
-| `nix develop` | Enter dev shell |
-| `nix fmt` | Format files |
-| `pre-commit run --all-files --hook-stage manual` | Run all hooks |
+| Command                                                         | Description     |
+| --------------------------------------------------------------- | --------------- |
+| `nix develop`                                                   | Enter dev shell |
+| `nix fmt`                                                       | Format files    |
+| `nix develop -c pre-commit run --all-files --hook-stage manual` | Run all hooks   |
 
 ## Home Manager Package Pattern
 

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -67,11 +67,11 @@
 
           **Development commands:**
 
-          | Command | Description |
-          |---------|-------------|
-          | `nix develop` | Enter dev shell |
-          | `nix fmt` | Format files |
-          | `pre-commit run --all-files --hook-stage manual` | Run all hooks |
+          | Command                                                         | Description     |
+          | --------------------------------------------------------------- | --------------- |
+          | `nix develop`                                                   | Enter dev shell |
+          | `nix fmt`                                                       | Format files    |
+          | `nix develop -c pre-commit run --all-files --hook-stage manual` | Run all hooks   |
 
         '';
 


### PR DESCRIPTION
## Summary
- normalize the generated README development-command table from modules/readme.nix
- use the dev-shell pre-commit invocation in the generated command list
- keep this PR limited to the residual style/docs surface split out of PR #255

## Test plan
- nix develop --accept-flake-config --no-write-lock-file -c write-files --offline
- git diff --check
- nix fmt --no-write-lock-file -- --fail-on-change modules/readme.nix README.md
- nix develop --accept-flake-config --no-write-lock-file -c hook-managed-files-drift
- commit hook suite during git commit
- push hook suite during git push