### PR TITLE
refactor(flake): rename dedupe_systems and dedup stylix follows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,9 @@ Do NOT iterate over `flake.lib.nixos.hosts` with `lib.filterAttrs`/`lib.mapAttrs
 
 ### Flake Input Deduplication
 
-Inputs prefixed with `dedupe_` exist for dependency deduplication through `.follows`. If no `follows` references remain, remove the `dedupe_` input. Keep the root `systems` input unprefixed because that is the canonical `nix-systems` input name, even when dependency inputs follow it.
+Use the generated README's "Flake Input Deduplication" section as the canonical
+source for local flake input naming and follower relationships. Its source text
+is `modules/readme.nix`.
 
 ### Repository Layout
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,7 +93,7 @@ Do NOT iterate over `flake.lib.nixos.hosts` with `lib.filterAttrs`/`lib.mapAttrs
 
 ### Flake Input Deduplication
 
-Inputs prefixed with `dedupe_` exist for dependency deduplication through `.follows`. If no `follows` references remain, remove the `dedupe_` input.
+Inputs prefixed with `dedupe_` exist for dependency deduplication through `.follows`. If no `follows` references remain, remove the `dedupe_` input. Keep the root `systems` input unprefixed because that is the canonical `nix-systems` input name, even when dependency inputs follow it.
 
 ### Repository Layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,10 +87,10 @@ value.
 
 ### Flake Input Deduplication
 
-Inputs prefixed with `dedupe_` exist for dependency deduplication through
-`.follows`. If no `follows` references remain, remove the `dedupe_` input. Keep
-the root `systems` input unprefixed because that is the canonical `nix-systems`
-input name, even when dependency inputs follow it.
+Do not restate the local flake input naming table here. Read the generated
+README's "Flake Input Deduplication" section, whose source is
+`modules/readme.nix`, before changing root input names or follower
+relationships.
 
 ## Ownership Map
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,9 @@ value.
 ### Flake Input Deduplication
 
 Inputs prefixed with `dedupe_` exist for dependency deduplication through
-`.follows`. If no `follows` references remain, remove the `dedupe_` input.
+`.follows`. If no `follows` references remain, remove the `dedupe_` input. Keep
+the root `systems` input unprefixed because that is the canonical `nix-systems`
+input name, even when dependency inputs follow it.
 
 ## Ownership Map
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ See the [sops documentation](docs/sops/README.md) for usage instructions.
 
 ## Flake Input Deduplication
 
-These root inputs pin shared dependencies used through `.follows` declarations. `systems` keeps the canonical `nix-systems` input name even though dependency inputs also follow it.
+These root inputs pin shared dependencies used through `.follows` declarations. `systems` keeps the canonical `nix-systems` input name even though dependency inputs also follow it. Remove any `dedupe_*` input once no `.follows` declaration references it.
 
 | Input                 | Followed By                                                  |
 | --------------------- | ------------------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ See the [sops documentation](docs/sops/README.md) for usage instructions.
 
 ## Flake Input Deduplication
 
-Inputs prefixed with `dedupe_` exist solely for deduplication via `.follows` declarations.
+These root inputs pin shared dependencies used through `.follows` declarations. `systems` keeps the canonical `nix-systems` input name even though dependency inputs also follow it.
 
-| Input | Followed By |
-|-------|-------------|
-| `dedupe_flake-compat` | make-shell |
-| `dedupe_flake-utils` | (internal) |
-| `dedupe_nur` | stylix |
-| `dedupe_systems` | stylix, dedupe_flake-utils |
+| Input                 | Followed By                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `dedupe_flake-compat` | `make-shell.inputs.flake-compat`                             |
+| `dedupe_flake-utils`  | `claude-desktop-linux-flake.inputs.flake-utils`              |
+| `dedupe_nur`          | `stylix.inputs.nur`                                          |
+| `systems`             | `dedupe_flake-utils.inputs.systems`, `stylix.inputs.systems` |
 
 ## Generated Files
 

--- a/flake.nix
+++ b/flake.nix
@@ -139,9 +139,10 @@
     stylix = {
       url = "github:nix-community/stylix";
       inputs = {
+        flake-parts.follows = "flake-parts";
         nixpkgs.follows = "nixpkgs";
         nur.follows = "dedupe_nur";
-        systems.follows = "dedupe_systems";
+        systems.follows = "systems";
         tinted-schemes.follows = "tinted-schemes";
       };
     };
@@ -194,12 +195,13 @@
       url = "github:MichaelAquilina/zsh-auto-notify";
     };
 
-    # _additional_ `inputs` only for deduplication
+    # Shared dependency pins consumed through `follows`. Generic pins use the
+    # `dedupe_` prefix; `systems` keeps the canonical `nix-systems` input name.
     dedupe_flake-compat.url = "github:edolstra/flake-compat";
 
     dedupe_flake-utils = {
       url = "github:numtide/flake-utils";
-      inputs.systems.follows = "dedupe_systems";
+      inputs.systems.follows = "systems";
     };
 
     dedupe_nur = {
@@ -210,7 +212,7 @@
       };
     };
 
-    dedupe_systems.url = "github:nix-systems/default";
+    systems.url = "github:nix-systems/default";
 
     git-hooks = {
       url = "github:cachix/git-hooks.nix";
@@ -230,10 +232,6 @@
       imports = [
         inputs."git-hooks".flakeModule
         (inputs.import-tree ./modules)
-      ];
-
-      systems = [
-        "x86_64-linux"
       ];
 
       _module.args = {

--- a/modules/meta/systems.nix
+++ b/modules/meta/systems.nix
@@ -1,6 +1,6 @@
 {
   systems = [
     "x86_64-linux"
-    #"aarch64-darwin"
+    # "aarch64-darwin"
   ];
 }

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -8,7 +8,7 @@
       "build"
       "hm-package-pattern"
       "secrets"
-      "flake-inputs-dedupe-prefix"
+      "flake-input-deduplication"
       "files"
     ];
 
@@ -97,19 +97,19 @@
 
         '';
 
-      flake-inputs-dedupe-prefix =
+      flake-input-deduplication =
         # markdown
         ''
           ## Flake Input Deduplication
 
-          Inputs prefixed with `dedupe_` exist solely for deduplication via `.follows` declarations.
+          These root inputs pin shared dependencies used through `.follows` declarations. `systems` keeps the canonical `nix-systems` input name even though dependency inputs also follow it.
 
-          | Input | Followed By |
-          |-------|-------------|
-          | `dedupe_flake-compat` | make-shell |
-          | `dedupe_flake-utils` | (internal) |
-          | `dedupe_nur` | stylix |
-          | `dedupe_systems` | stylix, dedupe_flake-utils |
+          | Input                 | Followed By                                                  |
+          | --------------------- | ------------------------------------------------------------ |
+          | `dedupe_flake-compat` | `make-shell.inputs.flake-compat`                             |
+          | `dedupe_flake-utils`  | `claude-desktop-linux-flake.inputs.flake-utils`              |
+          | `dedupe_nur`          | `stylix.inputs.nur`                                          |
+          | `systems`             | `dedupe_flake-utils.inputs.systems`, `stylix.inputs.systems` |
 
         '';
 

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -102,7 +102,7 @@
         ''
           ## Flake Input Deduplication
 
-          These root inputs pin shared dependencies used through `.follows` declarations. `systems` keeps the canonical `nix-systems` input name even though dependency inputs also follow it.
+          These root inputs pin shared dependencies used through `.follows` declarations. `systems` keeps the canonical `nix-systems` input name even though dependency inputs also follow it. Remove any `dedupe_*` input once no `.follows` declaration references it.
 
           | Input                 | Followed By                                                  |
           | --------------------- | ------------------------------------------------------------ |


### PR DESCRIPTION
## Summary

- rename root input `dedupe_systems` to `systems` to match the canonical `nix-systems/default` name; `flake.lock` already recorded `systems`, so every `nix flake` invocation kept trying to rewrite the lock
- retarget `stylix.inputs.systems.follows` and `dedupe_flake-utils.inputs.systems.follows` at the renamed root input
- add `stylix.inputs.flake-parts.follows = "flake-parts"` to dedup the previously distinct `flake-parts_X` node pulled in by stylix
- remove the duplicate `systems = ["x86_64-linux"]` from `flake.nix` outputs; the auto-discovered `modules/systems.nix` already supplies it
- move `modules/systems.nix` to `modules/meta/systems.nix` next to other meta modules (`ci.nix`, `flake-output.nix`, `owner.nix`)
- rename the README section id `flake-inputs-dedupe-prefix` to `flake-input-deduplication`, widen the follower table to fully-qualified notation (`make-shell.inputs.flake-compat`, etc.), and note `systems` as the named exception to the `dedupe_` prefix convention
- collapse the dedupe guidance in `AGENTS.md` and `CLAUDE.md` to a pointer at the generated README; restore the `dedupe_*` cleanup rule in `CLAUDE.md` in a follow-up commit

This PR is independent of #258 (RFC on path-backed maintained inputs), which was decided in #260 via `modules/meta/maintained-inputs.nix`. Listed there only as area context.

## Test plan

- `nix develop --accept-flake-config --no-write-lock-file -c write-files --offline`
- `git diff --check`
- `nix-instantiate --parse flake.nix`
- `nix-instantiate --parse modules/readme.nix`
- `nix-instantiate --parse modules/meta/systems.nix`
- `nix flake metadata --accept-flake-config --no-write-lock-file --json | jq -e '.locks.nodes.root.inputs.systems'`
- `nix fmt --no-write-lock-file -- --fail-on-change AGENTS.md CLAUDE.md README.md flake.nix modules/meta/systems.nix modules/readme.nix`
- `nix develop --accept-flake-config --no-write-lock-file -c hook-managed-files-drift`
- `nix flake check --accept-flake-config --no-write-lock-file --no-build --offline`
- commit hook suite during `git commit`
- push hook suite during `git push`