### PR TITLE
fix(home-manager): skip sops service when secrets are disabled

### DIFF
--- a/modules/home-manager/sops-runtime.nix
+++ b/modules/home-manager/sops-runtime.nix
@@ -1,6 +1,7 @@
 _: {
   flake.homeManagerModules.sopsRuntime =
     {
+      config,
       inputs,
       lib,
       metaOwner,
@@ -9,19 +10,26 @@ _: {
     let
       homeDirectory = "/home/${metaOwner.username}";
       sopsServiceHome = "${homeDirectory}/.local/share/sops-nix";
+      hasSopsMaterial = (config.sops.secrets or { }) != { } || (config.sops.templates or { }) != { };
     in
     {
       imports = [ inputs.sops-nix.homeManagerModules.sops ];
 
-      sops.age.keyFile = lib.mkDefault "${homeDirectory}/.config/sops/age/keys.txt";
+      config = lib.mkMerge [
+        {
+          sops.age.keyFile = lib.mkDefault "${homeDirectory}/.config/sops/age/keys.txt";
+        }
 
-      home.activation.ensureSopsServiceHome = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
-        mkdir -p '${sopsServiceHome}'
-        chmod 700 '${sopsServiceHome}'
-      '';
+        (lib.mkIf hasSopsMaterial {
+          home.activation.ensureSopsServiceHome = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+            mkdir -p '${sopsServiceHome}'
+            chmod 700 '${sopsServiceHome}'
+          '';
 
-      systemd.user.services.sops-nix.Service.Environment = lib.mkForce [
-        "HOME=${sopsServiceHome}"
+          systemd.user.services.sops-nix.Service.Environment = lib.mkForce [
+            "HOME=${sopsServiceHome}"
+          ];
+        })
       ];
     };
 }

--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -91,6 +91,7 @@ in
     home-manager.users.${metaOwner.username} = {
       home = {
         context7Secrets.enable = lib.mkForce false;
+        geckoSecrets.enable = lib.mkForce false;
         greptileSecrets.enable = lib.mkForce false;
         r2Secrets.enable = lib.mkForce false;
         virustotalSecrets.enable = lib.mkForce false;


### PR DESCRIPTION
## Summary
- disable the remaining Home Manager Gecko SOPS secret module on `tpnix`
- only customize the Home Manager `sops-nix` user service when HM secrets or templates are declared
- keep the SOPS option namespace imported so secret modules still evaluate cleanly when disabled

## Test plan
- `nix eval --accept-flake-config --json '.#nixosConfigurations.tpnix.config.home-manager.users.vx.home.geckoSecrets.enable'`
- `nix eval --accept-flake-config --json '.#nixosConfigurations.tpnix.config.home-manager.users.vx.sops.secrets' --apply builtins.attrNames`
- `nix eval --accept-flake-config --json '.#nixosConfigurations.tpnix.config.home-manager.users.vx.systemd.user.services' --apply builtins.attrNames`
- `nix eval --accept-flake-config --json '.#nixosConfigurations.system76.config.home-manager.users.vx.systemd.user.services.sops-nix.Service.Environment'`