### PR TITLE
fix(gecko): align declared toolbar state

### DIFF
--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -13,11 +13,19 @@ let
   # ExtensionSettings policy key.
   amoLatestBaseUrl = "https://addons.mozilla.org/firefox/downloads/latest/";
   mkAmoInstallUrl =
-    extensionId:
-    "${amoLatestBaseUrl}${lib.replaceStrings [ "{" "}" ] [ "%7B" "%7D" ] extensionId}/latest.xpi";
+    extension:
+    "${amoLatestBaseUrl}${lib.replaceStrings [ "{" "}" ] [ "%7B" "%7D" ] extension}/latest.xpi";
+  toWidgetId =
+    extension:
+    let
+      allowed = lib.stringToCharacters "abcdefghijklmnopqrstuvwxyz0123456789_-";
+      sanitizeChar = char: if builtins.elem char allowed then char else "_";
+      sanitized = lib.concatMapStrings sanitizeChar (lib.stringToCharacters (lib.toLower extension));
+    in
+    "${sanitized}-browser-action";
 
-  ublockOriginId = "uBlock0@raymondhill.net";
-  ublockOriginInstallUrl = mkAmoInstallUrl ublockOriginId;
+  ublockOrigin = "uBlock0@raymondhill.net";
+  ublockOriginInstallUrl = mkAmoInstallUrl ublockOrigin;
   stylixEnabled = config.stylix.enable or false;
   stylixPolarity = config.stylix.polarity or "auto";
   stylixColors = lib.attrByPath [ "lib" "stylix" "colors" ] { } config;
@@ -44,7 +52,7 @@ let
       "auto";
   ublockOriginAccentColor = getStylixColor "base0D" "#aca0f7";
 
-  onePasswordId = "{d634138d-c276-4fc8-924b-40a0ea21d284}";
+  onePassword = "{d634138d-c276-4fc8-924b-40a0ea21d284}";
   # Browser-side trust manifest for the managed 1Password extension. The
   # 1Password GUI module owns the /run/wrappers/bin target.
   onePasswordNativeMessagingHost =
@@ -55,92 +63,76 @@ let
           description = "1Password BrowserSupport";
           path = "/run/wrappers/bin/1Password-BrowserSupport";
           type = "stdio";
-          allowed_extensions = [ onePasswordId ];
+          allowed_extensions = [ onePassword ];
         }
       );
 
-  arabicDictionaryId = "ar@dictionaries.addons.mozilla.org";
-  cookieAutoDeleteId = "CookieAutoDelete@kennydo.com";
-  darkreaderId = "addon@darkreader.org";
-  foxyproxyId = "foxyproxy@eric.h.jung";
-  languageToolId = "languagetool-webextension@languagetool.org";
-  printEditId = "printedit-we@DW-dev";
-  raindropId = "jid0-adyhmvsP91nUO8pRv0Mn2VKeB84@jetpack";
-  savePageId = "savepage-we@DW-dev";
-  simpleLoginId = "addon@simplelogin";
-  stylusId = "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}";
-  svgGobblerId = "{7962ff4a-5985-4cf2-9777-4bb642ad05b8}";
-  tabStashId = "tab-stash@condordes.net";
-  tridactylId = "tridactyl.vim@cmcaine.co.uk";
-  violentmonkeyId = "{aecec67f-0d10-4fa7-b7c7-609a2db280cf}";
-  wappalyzerId = "wappalyzer@crunchlabz.com";
-  webArchivesId = "{d07ccf11-c0cd-4938-a265-2a4d6ad01189}";
+  arabicDictionary = "ar@dictionaries.addons.mozilla.org";
+  cookieAutoDelete = "CookieAutoDelete@kennydo.com";
+  darkreader = "addon@darkreader.org";
+  firefoxColor = "FirefoxColor@mozilla.com";
+  foxyproxy = "foxyproxy@eric.h.jung";
+  languageTool = "languagetool-webextension@languagetool.org";
+  printEdit = "printedit-we@DW-dev";
+  raindrop = "jid0-adyhmvsP91nUO8pRv0Mn2VKeB84@jetpack";
+  savePage = "savepage-we@DW-dev";
+  simpleLogin = "addon@simplelogin";
+  stylus = "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}";
+  svgGobbler = "{7962ff4a-5985-4cf2-9777-4bb642ad05b8}";
+  tabStash = "tab-stash@condordes.net";
+  tridactyl = "tridactyl.vim@cmcaine.co.uk";
+  violentmonkey = "{aecec67f-0d10-4fa7-b7c7-609a2db280cf}";
+  wappalyzer = "wappalyzer@crunchlabz.com";
+  webArchives = "{d07ccf11-c0cd-4938-a265-2a4d6ad01189}";
 
   policyExtensionIds = [
-    arabicDictionaryId
-    cookieAutoDeleteId
-    darkreaderId
-    foxyproxyId
-    languageToolId
-    onePasswordId
-    printEditId
-    raindropId
-    savePageId
-    simpleLoginId
-    stylusId
-    svgGobblerId
-    tabStashId
-    tridactylId
-    violentmonkeyId
-    wappalyzerId
-    webArchivesId
-  ];
-
-  mkNormalInstalledPolicy = extensionId: {
-    installation_mode = "normal_installed";
-    install_url = mkAmoInstallUrl extensionId;
-  };
-
-  widgetIds = {
-    cookieAutoDelete = "cookieautodelete_kennydo_com-browser-action";
-    darkreader = "addon_darkreader_org-browser-action";
-    firefoxColor = "firefoxcolor_mozilla_com-browser-action";
-    languageTool = "languagetool-webextension_languagetool_org-browser-action";
-    onePassword = "_d634138d-c276-4fc8-924b-40a0ea21d284_-browser-action";
-    raindrop = "jid0-adyhmvsp91nuo8prv0mn2vkeb84_jetpack-browser-action";
-    simpleLogin = "addon_simplelogin-browser-action";
-    stylus = "_7a7a4a92-a2a0-41d1-9fd7-1e92480d612d_-browser-action";
-    svgGobbler = "_7962ff4a-5985-4cf2-9777-4bb642ad05b8_-browser-action";
-    tabStash = "tab-stash_condordes_net-browser-action";
-    tridactyl = "tridactyl_vim_cmcaine_co_uk-browser-action";
-    ublockOrigin = "ublock0_raymondhill_net-browser-action";
-    violentmonkey = "_aecec67f-0d10-4fa7-b7c7-609a2db280cf_-browser-action";
-    webArchives = "_d07ccf11-c0cd-4938-a265-2a4d6ad01189_-browser-action";
-  };
-
-  unifiedExtensionsArea = with widgetIds; [
-    raindrop
-    firefoxColor
-    tabStash
-    simpleLogin
+    arabicDictionary
     cookieAutoDelete
     darkreader
-    webArchives
+    foxyproxy
     languageTool
+    onePassword
+    printEdit
+    raindrop
+    savePage
+    simpleLogin
     stylus
-    violentmonkey
     svgGobbler
+    tabStash
+    tridactyl
+    violentmonkey
+    wappalyzer
+    webArchives
   ];
 
-  navBarWidgets = with widgetIds; [
+  mkNormalInstalledPolicy = extension: {
+    installation_mode = "normal_installed";
+    install_url = mkAmoInstallUrl extension;
+  };
+
+  unifiedExtensionsArea = [
+    (toWidgetId raindrop)
+    (toWidgetId firefoxColor)
+    (toWidgetId tabStash)
+    (toWidgetId simpleLogin)
+    (toWidgetId cookieAutoDelete)
+    (toWidgetId darkreader)
+    (toWidgetId webArchives)
+    (toWidgetId languageTool)
+    (toWidgetId stylus)
+    (toWidgetId violentmonkey)
+    (toWidgetId svgGobbler)
+  ];
+
+  navBarWidgets = [
     "firefox-view-button"
     "back-button"
     "stop-reload-button"
     "forward-button"
     "urlbar-container"
     "vertical-spacer"
-    onePassword
-    ublockOrigin
+    (toWidgetId onePassword)
+    (toWidgetId ublockOrigin)
     "unified-extensions-button"
   ];
 
@@ -154,14 +146,12 @@ let
     PersonalToolbar = [ "personal-bookmarks" ];
   };
 
-  toolbarSeen =
-    unifiedExtensionsArea
-    ++ (with widgetIds; [
-      onePassword
-      ublockOrigin
-      "developer-button"
-      "screenshot-button"
-    ]);
+  toolbarSeen = unifiedExtensionsArea ++ [
+    (toWidgetId onePassword)
+    (toWidgetId ublockOrigin)
+    "developer-button"
+    "screenshot-button"
+  ];
 
   toolbarState = {
     placements = toolbarPlacements;
@@ -180,8 +170,8 @@ let
 
   onePasswordToolbarIcon = ../stylix/icons/1password-outline.svg;
   userChrome = ''
-    #${widgetIds.onePassword} > .toolbarbutton-icon,
-    #${widgetIds.onePassword} > .toolbarbutton-badge-stack > .toolbarbutton-icon {
+    #${toWidgetId onePassword} > .toolbarbutton-icon,
+    #${toWidgetId onePassword} > .toolbarbutton-badge-stack > .toolbarbutton-icon {
       list-style-image: url("file://${onePasswordToolbarIcon}") !important;
     }
   '';
@@ -360,7 +350,7 @@ let
   ];
 
   extensionSettings = (lib.genAttrs policyExtensionIds mkNormalInstalledPolicy) // {
-    "${ublockOriginId}" = {
+    "${ublockOrigin}" = {
       installation_mode = "force_installed";
       install_url = ublockOriginInstallUrl;
       private_browsing = true;
@@ -377,7 +367,7 @@ in
   extensionPolicies = {
     ExtensionSettings = extensionSettings;
 
-    "3rdparty".Extensions."${ublockOriginId}" = {
+    "3rdparty".Extensions."${ublockOrigin}" = {
       adminSettings = builtins.toJSON {
         assetsBootstrapLocation = librewolfUblockOriginListData.source;
       };
@@ -391,14 +381,14 @@ in
   sidebarSettings =
     let
       sidebarExtensionIds = [
-        raindropId
-        tabStashId
-        stylusId
-        tridactylId
+        raindrop
+        tabStash
+        stylus
+        tridactyl
       ];
       sidebarTools = [
-        raindropId
-        tabStashId
+        raindrop
+        tabStash
         "history"
       ];
     in
@@ -416,7 +406,7 @@ in
 
   inherit userChrome;
 
-  extensionStorage."${ublockOriginId}".settings = {
+  extensionStorage."${ublockOrigin}".settings = {
     advancedUserEnabled = true;
     cloudStorageEnabled = true;
     colorBlindFriendly = false;
@@ -462,7 +452,7 @@ in
     ];
   };
 
-  extensionStorage."${violentmonkeyId}".settings = {
+  extensionStorage."${violentmonkey}".settings = {
     "code:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaCode;
     "scr:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaRecord;
   };

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -208,7 +208,6 @@ let
   disabledLibrewolfLists = [
     "adguard-spyware-url"
     "ublock-badware"
-    "easylist"
     "urlhaus-1"
     "curben-phishing"
   ];
@@ -405,19 +404,31 @@ in
 
   inherit userChrome;
 
+  # uBO
   extensionStorage."${ublockOrigin}".settings = {
     advancedUserEnabled = true;
-    cloudStorageEnabled = true;
-    colorBlindFriendly = false;
+    cloudStorageEnabled = false;
+
+    hiddenSettings = { };
+    importedLists = [ ];
+
     showIconBadge = false;
     uiAccentCustom = stylixEnabled;
     uiAccentCustom0 = ublockOriginAccentColor;
     uiTheme = ublockOriginUiTheme;
+
     hostnameSwitchesString = builtins.concatStringsSep "\n" [
       "no-csp-reports: * true"
       "no-large-media: behind-the-scene false"
     ];
+
     dynamicFilteringString = builtins.concatStringsSep "\n" ublockOriginMediumModeRules;
+
+    netWhitelist = [
+      "chrome-extension-scheme"
+      "moz-extension-scheme"
+    ];
+    urlFilteringString = "";
     userFilters = ''
       ! https://octobox.io
       octobox.io##.btn-outline-light.btn-sm.btn
@@ -425,32 +436,46 @@ in
       ! https://web.webex.com
       web.webex.com##.cookie-banner-body
     '';
+
     selectedFilterLists = librewolfUblockOriginLists ++ [
       # Keep "My filters" enabled; uBO hides the element picker without it.
       "user-filters"
 
-      # Additional regional lists
-      "ara-0"
+      # uBO Lists
+      "ublock-filters"
+      "ublock-privacy"
+      "ublock-quick-fixes"
+      "ublock-unbreak"
 
-      # Additional generic ad blocking
+      # Ads Lists
+      "easylist"
       "adguard-generic"
 
-      # Network / LAN protection
+      # Privacy Lists
+      "easyprivacy"
+      "LegitimateURLShortener"
+      "adguard-spyware-url" # AdGuard/uBO - URL Tracking Protection
       "block-lan"
 
-      # Additional lists to suppress cookie banners/annoyances
-      "ublock-annoyances"
+      # Multipurpose
+      "plowe-0"
+
+      # Cookie notices
       "adguard-cookies"
-      "ublock-cookies-adguard"
-      # "fanboy-cookiemonster"
-      # "ublock-cookies-easylist"
-      "fanboy-thirdparty_social"
+      "ublock-cookies-adguard" # Fanboy - Anti-Facebook
+
+      # Annoyances
       "adguard-other-annoyances"
       "adguard-popup-overlays"
       "adguard-widgets"
+      "ublock-annoyances"
+
+      # Additional regional lists
+      "ara-0"
     ];
   };
 
+  # ViolentMonkey
   extensionStorage."${violentmonkey}".settings = {
     "code:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaCode;
     "scr:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaRecord;

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -70,14 +70,11 @@ let
   arabicDictionary = "ar@dictionaries.addons.mozilla.org";
   cookieAutoDelete = "CookieAutoDelete@kennydo.com";
   darkreader = "addon@darkreader.org";
-  firefoxColor = "FirefoxColor@mozilla.com";
   foxyproxy = "foxyproxy@eric.h.jung";
   languageTool = "languagetool-webextension@languagetool.org";
   printEdit = "printedit-we@DW-dev";
   raindrop = "jid0-adyhmvsP91nUO8pRv0Mn2VKeB84@jetpack";
   savePage = "savepage-we@DW-dev";
-  simpleLogin = "addon@simplelogin";
-  stylus = "{7a7a4a92-a2a0-41d1-9fd7-1e92480d612d}";
   svgGobbler = "{7962ff4a-5985-4cf2-9777-4bb642ad05b8}";
   tabStash = "tab-stash@condordes.net";
   tridactyl = "tridactyl.vim@cmcaine.co.uk";
@@ -95,8 +92,6 @@ let
     printEdit
     raindrop
     savePage
-    simpleLogin
-    stylus
     svgGobbler
     tabStash
     tridactyl
@@ -111,29 +106,33 @@ let
   };
 
   unifiedExtensionsArea = [
-    (toWidgetId raindrop)
-    (toWidgetId firefoxColor)
-    (toWidgetId tabStash)
-    (toWidgetId simpleLogin)
     (toWidgetId cookieAutoDelete)
     (toWidgetId darkreader)
     (toWidgetId webArchives)
     (toWidgetId languageTool)
-    (toWidgetId stylus)
     (toWidgetId violentmonkey)
     (toWidgetId svgGobbler)
+    (toWidgetId printEdit)
+    (toWidgetId savePage)
+    (toWidgetId foxyproxy)
   ];
 
   navBarWidgets = [
-    "firefox-view-button"
     "back-button"
     "stop-reload-button"
     "forward-button"
-    "urlbar-container"
-    "vertical-spacer"
-    (toWidgetId onePassword)
+    "customizableui-special-spring1"
+    "customizableui-special-spring2"
+    "firefox-view-button"
+    "developer-button"
     (toWidgetId ublockOrigin)
+    "urlbar-container"
+    (toWidgetId raindrop)
+    (toWidgetId onePassword)
     "unified-extensions-button"
+    "customizableui-special-spring3"
+    "customizableui-special-spring4"
+    "vertical-spacer"
   ];
 
   toolbarPlacements = {
@@ -148,6 +147,7 @@ let
 
   toolbarSeen = unifiedExtensionsArea ++ [
     (toWidgetId onePassword)
+    (toWidgetId raindrop)
     (toWidgetId ublockOrigin)
     "developer-button"
     "screenshot-button"
@@ -383,7 +383,6 @@ in
       sidebarExtensionIds = [
         raindrop
         tabStash
-        stylus
         tridactyl
       ];
       sidebarTools = [

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -427,7 +427,9 @@ in
       "chrome-extension-scheme"
       "moz-extension-scheme"
     ];
+
     urlFilteringString = "";
+
     userFilters = ''
       ! https://octobox.io
       octobox.io##.btn-outline-light.btn-sm.btn
@@ -436,42 +438,45 @@ in
       web.webex.com##.cookie-banner-body
     '';
 
-    selectedFilterLists = librewolfUblockOriginLists ++ [
-      # Keep "My filters" enabled; uBO hides the element picker without it.
-      "user-filters"
+    selectedFilterLists = lib.unique (
+      librewolfUblockOriginLists
+      ++ [
+        # Keep "My filters" enabled; uBO hides the element picker without it.
+        "user-filters"
 
-      # uBO Lists
-      "ublock-filters"
-      "ublock-privacy"
-      "ublock-quick-fixes"
-      "ublock-unbreak"
+        # uBO Lists
+        "ublock-filters"
+        "ublock-privacy"
+        "ublock-quick-fixes"
+        "ublock-unbreak"
 
-      # Ads Lists
-      "easylist"
-      "adguard-generic"
+        # Ads Lists
+        "easylist"
+        "adguard-generic"
 
-      # Privacy Lists
-      "easyprivacy"
-      "LegitimateURLShortener"
-      "adguard-spyware-url" # AdGuard/uBO - URL Tracking Protection
-      "block-lan"
+        # Privacy Lists
+        "easyprivacy"
+        "LegitimateURLShortener"
+        "adguard-spyware-url" # AdGuard/uBO - URL Tracking Protection
+        "block-lan"
 
-      # Multipurpose
-      "plowe-0"
+        # Multipurpose
+        "plowe-0"
 
-      # Cookie notices
-      "adguard-cookies"
-      "ublock-cookies-adguard" # Fanboy - Anti-Facebook
+        # Cookie notices
+        "adguard-cookies"
+        "ublock-cookies-adguard" # Fanboy - Anti-Facebook
 
-      # Annoyances
-      "adguard-other-annoyances"
-      "adguard-popup-overlays"
-      "adguard-widgets"
-      "ublock-annoyances"
+        # Annoyances
+        "adguard-other-annoyances"
+        "adguard-popup-overlays"
+        "adguard-widgets"
+        "ublock-annoyances"
 
-      # Additional regional lists
-      "ara-0"
-    ];
+        # Additional regional lists
+        "ara-0"
+      ]
+    );
   };
 
   # ViolentMonkey

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -15,14 +15,13 @@ let
   mkAmoInstallUrl =
     extension:
     "${amoLatestBaseUrl}${lib.replaceStrings [ "{" "}" ] [ "%7B" "%7D" ] extension}/latest.xpi";
+  allowedWidgetChars = lib.stringToCharacters "abcdefghijklmnopqrstuvwxyz0123456789_-";
   toWidgetId =
     extension:
     let
-      allowed = lib.stringToCharacters "abcdefghijklmnopqrstuvwxyz0123456789_-";
-      sanitizeChar = char: if builtins.elem char allowed then char else "_";
-      sanitized = lib.concatMapStrings sanitizeChar (lib.stringToCharacters (lib.toLower extension));
+      sanitizeChar = char: if builtins.elem char allowedWidgetChars then char else "_";
     in
-    "${sanitized}-browser-action";
+    "${lib.stringAsChars sanitizeChar (lib.toLower extension)}-browser-action";
 
   ublockOrigin = "uBlock0@raymondhill.net";
   ublockOriginInstallUrl = mkAmoInstallUrl ublockOrigin;

--- a/modules/hm-apps/_gecko-prefs.nix
+++ b/modules/hm-apps/_gecko-prefs.nix
@@ -121,8 +121,8 @@ in
       "sidebar.command" = "viewTabsSidebar";
       "sidebar.verticalTabs.dragToPinPromo.dismissed" = true;
 
-      # Show the bookmarks toolbar only on the new-tab page.
-      "browser.toolbars.bookmarks.visibility" = "newtab";
+      # Keep the bookmarks toolbar hidden.
+      "browser.toolbars.bookmarks.visibility" = "never";
 
       "reader.font_type" = "monospace";
 


### PR DESCRIPTION
## Summary

- derive Gecko toolbar widget IDs from extension IDs instead of hardcoding browser-action names
- remove Stylus and SimpleLogin from managed extension policy, toolbar, and sidebar state
- hide the bookmarks toolbar and align the shared nav-bar and unified extensions placement

## Test plan

- nix fmt -- modules/hm-apps/_gecko-extensions.nix modules/hm-apps/_gecko-prefs.nix
- nix-instantiate --parse modules/hm-apps/_gecko-extensions.nix
- nix-instantiate --parse modules/hm-apps/_gecko-prefs.nix
- git diff --check -- modules/hm-apps/_gecko-extensions.nix modules/hm-apps/_gecko-prefs.nix
- nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.home-manager.users.vx.programs.librewolf.profiles.primary.settings.\"browser.uiCustomization.state\"
- nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.home-manager.users.vx.programs.librewolf.policies.ExtensionSettings
- nix flake check --accept-flake-config --no-build --offline

## uBO changes

- Declares uBO profile storage for disabled cloud sync, empty imported lists, extension-scheme whitelisting, URL filtering state, and curated filter-list groups.
