### PR TITLE
feat(apps): add helix editor

### DIFF
--- a/modules/apps/helix.nix
+++ b/modules/apps/helix.nix
@@ -1,0 +1,46 @@
+/*
+  Package: helix
+  Description: Post-modern modal text editor.
+  Homepage: https://helix-editor.com
+  Documentation: https://docs.helix-editor.com
+  Repository: https://github.com/helix-editor/helix
+
+  Summary:
+    * Modal editing with multiple selections as a core feature.
+    * Built-in language server support.
+
+  Options:
+    -h: Print help.
+    -c: Specify a config file.
+*/
+_:
+let
+  HelixModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.helix.extended;
+    in
+    {
+      options.programs.helix.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable helix.";
+        };
+
+        package = lib.mkPackageOption pkgs "helix" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.helix = HelixModule;
+}

--- a/modules/hm-apps/helix.nix
+++ b/modules/hm-apps/helix.nix
@@ -1,0 +1,295 @@
+/*
+  Package: helix
+  Description: Post-modern modal text editor.
+  Homepage: https://helix-editor.com
+  Documentation: https://docs.helix-editor.com
+  Repository: https://github.com/helix-editor/helix
+
+  Summary:
+    * Modal editing with multiple selections as a core feature.
+    * Built-in language server support.
+
+  Options:
+    -h: Print help.
+    -c: Specify a config file.
+*/
+_: {
+  flake.homeManagerModules.apps.helix =
+    {
+      osConfig,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      nixosEnabled = lib.attrByPath [ "programs" "helix" "extended" "enable" ] false osConfig;
+      hostname = osConfig.networking.hostName;
+
+      # Helix pipes the buffer over stdin and reads the result from stdout.
+      # Biome selects its parser from the (dummy) file extension. Matches the
+      # `biome` formatter used by treefmt (modules/meta/treefmt.nix).
+      biomeFormatter = ext: {
+        command = "biome";
+        args = [
+          "format"
+          "--stdin-file-path=stdin.${ext}"
+        ];
+      };
+    in
+    {
+      config = lib.mkIf nixosEnabled {
+        programs.helix = {
+          enable = true;
+          defaultEditor = false;
+
+          # Language servers and formatters are placed on hx's PATH only: the HM
+          # module wraps hx with `--suffix PATH`, so these are not installed into
+          # the global environment.
+          extraPackages = with pkgs; [
+            # Nix
+            nixd
+            nixfmt
+            # Rust
+            rust-analyzer
+            # Python
+            pyright
+            ruff
+            # Go
+            gopls
+            # JavaScript / TypeScript / web
+            typescript-language-server
+            typescript
+            vscode-langservers-extracted
+            biome
+            # Bash
+            bash-language-server
+            shfmt
+            shellcheck
+            # Markdown
+            marksman
+            (mdformat.withPlugins (ps: [ ps.mdformat-gfm ]))
+            # YAML
+            yaml-language-server
+            yamlfmt
+            # TOML
+            taplo
+            # Lua
+            lua-language-server
+            stylua
+          ];
+
+          settings = {
+            # Built-in OneDark theme. Stylix theming for Helix is disabled in
+            # modules/stylix/stylix.nix so this does not collide with a generated
+            # `stylix` theme.
+            theme = "onedark";
+
+            editor = {
+              line-number = "relative";
+              cursorline = true;
+              scrolloff = 8;
+              color-modes = true;
+              bufferline = "multiple";
+              # Override truecolor autodetection false-negatives (e.g. under tmux).
+              true-color = true;
+              cursor-shape = {
+                normal = "block";
+                insert = "bar";
+                select = "underline";
+              };
+              indent-guides.render = true;
+              # Show dotfiles in the picker; useful in a dotfiles/Nix config repo.
+              file-picker.hidden = false;
+              lsp.display-messages = true;
+              statusline.left = [
+                "mode"
+                "spinner"
+                "version-control"
+                "file-name"
+                "read-only-indicator"
+                "file-modification-indicator"
+              ];
+            };
+          };
+
+          # Merged over Helix's built-in languages.toml, so only overrides are set.
+          languages = {
+            language-server = {
+              # Deep nixd integration: completion and docs for nixpkgs plus this
+              # flake's NixOS / home-manager / flake-parts option sets.
+              nixd = {
+                command = "nixd";
+                config = {
+                  nixpkgs.expr = "import <nixpkgs> {}";
+                  options = {
+                    nixos.expr = ''
+                      let
+                        flake = builtins.getFlake (toString ./.);
+                        hosts = flake.nixosConfigurations or {};
+                        host = hosts.${hostname} or (builtins.head (builtins.attrValues hosts)) or null;
+                      in
+                        if host != null then host.options else {}
+                    '';
+                    home-manager.expr = ''
+                      let
+                        flake = builtins.getFlake (toString ./.);
+                        configs = flake.homeConfigurations or {};
+                        first = if configs != {} then builtins.head (builtins.attrValues configs) else null;
+                      in
+                        if first != null then first.options else {}
+                    '';
+                    flake-parts.expr = ''
+                      let
+                        flake = builtins.getFlake (toString ./.);
+                      in
+                        flake.debug.options or flake.currentSystem.options or {}
+                    '';
+                  };
+                };
+              };
+
+              rust-analyzer.config.check.command = "clippy";
+
+              pyright.config.python.analysis = {
+                typeCheckingMode = "basic";
+                autoImportCompletions = true;
+              };
+            };
+
+            language = [
+              {
+                name = "nix";
+                auto-format = true;
+                language-servers = [ "nixd" ];
+                formatter.command = "nixfmt";
+              }
+              {
+                name = "python";
+                auto-format = true;
+                # Override Helix defaults (ty/jedi/pylsp); ruff also formats.
+                language-servers = [
+                  "pyright"
+                  "ruff"
+                ];
+              }
+              {
+                name = "rust";
+                auto-format = true;
+              }
+              {
+                name = "go";
+                auto-format = true;
+              }
+              {
+                name = "bash";
+                auto-format = true;
+                formatter = {
+                  command = "shfmt";
+                  args = [
+                    "-i"
+                    "2"
+                    "-s"
+                    "-"
+                  ];
+                };
+              }
+              {
+                name = "lua";
+                auto-format = true;
+                formatter = {
+                  command = "stylua";
+                  args = [
+                    "--indent-type"
+                    "Spaces"
+                    "--indent-width"
+                    "2"
+                    "--column-width"
+                    "120"
+                    "-"
+                  ];
+                };
+              }
+              {
+                name = "toml";
+                auto-format = true;
+                formatter = {
+                  command = "taplo";
+                  args = [
+                    "fmt"
+                    "--option"
+                    "column_width=120"
+                    "--option"
+                    "reorder_keys=false"
+                    "--option"
+                    "indent_string=  "
+                    "-"
+                  ];
+                };
+              }
+              {
+                name = "yaml";
+                auto-format = true;
+                formatter = {
+                  command = "yamlfmt";
+                  args = [ "-" ];
+                };
+              }
+              {
+                name = "markdown";
+                auto-format = true;
+                formatter = {
+                  command = "mdformat";
+                  args = [
+                    "--wrap"
+                    "keep"
+                    "--number"
+                    "-"
+                  ];
+                };
+              }
+              {
+                name = "json";
+                auto-format = true;
+                formatter = biomeFormatter "json";
+              }
+              {
+                name = "jsonc";
+                auto-format = true;
+                formatter = biomeFormatter "jsonc";
+              }
+              {
+                name = "css";
+                auto-format = true;
+                formatter = biomeFormatter "css";
+              }
+              {
+                name = "html";
+                auto-format = true;
+                formatter = biomeFormatter "html";
+              }
+              {
+                name = "javascript";
+                auto-format = true;
+                formatter = biomeFormatter "js";
+              }
+              {
+                name = "jsx";
+                auto-format = true;
+                formatter = biomeFormatter "jsx";
+              }
+              {
+                name = "typescript";
+                auto-format = true;
+                formatter = biomeFormatter "ts";
+              }
+              {
+                name = "tsx";
+                auto-format = true;
+                formatter = biomeFormatter "tsx";
+              }
+            ];
+          };
+        };
+      };
+    };
+}

--- a/modules/hm-apps/helix.nix
+++ b/modules/hm-apps/helix.nix
@@ -40,6 +40,7 @@ _: {
       config = lib.mkIf nixosEnabled {
         programs.helix = {
           enable = true;
+          package = osConfig.programs.helix.extended.package;
           defaultEditor = false;
 
           # Language servers and formatters are placed on hx's PATH only: the HM

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -189,6 +189,7 @@ let
       gzip.extended.enable = lib.mkOverride 1100 true;
       hashcat.extended.enable = lib.mkOverride 1100 true;
       hdparm.extended.enable = lib.mkOverride 1100 true;
+      helix.extended.enable = lib.mkOverride 1100 true;
       hopper.extended.enable = lib.mkOverride 1100 false;
       hsetroot.extended.enable = lib.mkOverride 1100 true;
       htmlq.extended.enable = lib.mkOverride 1100 true;

--- a/modules/hosts/common/home-manager-apps.nix
+++ b/modules/hosts/common/home-manager-apps.nix
@@ -29,6 +29,7 @@ let
     "greenclip"
     "google-chrome"
     "gptfdisk"
+    "helix"
     "htop"
     "i3-config"
     "jq"

--- a/modules/stylix/stylix.nix
+++ b/modules/stylix/stylix.nix
@@ -303,6 +303,11 @@ in
 
               # Nushell theming (only if enabled)
               nushell.enable = nushellEnabled;
+
+              # Helix uses its built-in OneDark theme (set in the Helix HM module),
+              # not Stylix's generated base16 theme. Disable explicitly so Stylix
+              # autoEnable cannot set `settings.theme = "stylix"` and collide.
+              helix.enable = false;
             };
           };
 


### PR DESCRIPTION
## Summary

- Add helix as an opt-in modal editor: `nixosModules.apps.helix` (exposing `programs.helix.extended`) plus Home Manager configuration, enabled in the common host baseline.
- Mirror the existing nixvim language set: 17 languages with language servers and format-on-save aligned to the `treefmt` formatters (nixfmt, ruff, shfmt, stylua, taplo, yamlfmt, mdformat, biome).
- Wire `nixd` to the nixos, home-manager, and flake-parts option sets for completion, matching the nixvim setup.
- Use the built-in OneDark theme by disabling the Stylix helix target (avoids the generated base16 theme).
- Language servers and formatters are placed on the wrapped `hx` PATH via `extraPackages`, not installed globally.

Note: `flake.lock` is intentionally excluded from this PR.

## Test plan

- `nix fmt`: clean (0 changed).
- Eval both hosts (system76, tpnix): `programs.helix.settings.theme` resolves to `onedark` (no Stylix conflict); all `extraPackages` resolve; `nixd` interpolates the correct per-host name.
- Built and inspected the generated `helix/config.toml` and `helix/languages.toml`.