### PR TITLE
feat(tmpfs): enable useTmpfs for system76 and tpnix

### DIFF
--- a/modules/system76/boot.nix
+++ b/modules/system76/boot.nix
@@ -7,6 +7,9 @@ _: {
       #boot.kernelPackages = pkgs.linuxPackages;
 
       boot = {
+        tmp.useTmpfs = true;
+        tmp.tmpfsSize = "90%";
+
         # Base kernel modules for System76 hardware
         initrd.availableKernelModules = [
           "xhci_pci"

--- a/modules/tpnix/boot.nix
+++ b/modules/tpnix/boot.nix
@@ -6,6 +6,9 @@
       boot.kernelPackages = lib.mkDefault pkgs.cachyosKernels.linuxPackages-cachyos-latest;
 
       boot = {
+        tmp.useTmpfs = true;
+        tmp.tmpfsSize = "90%";
+
         initrd.availableKernelModules = [
           "xhci_pci"
           "ahci"


### PR DESCRIPTION
## Summary
Enable /tmp on tmpfs to reduce disk writes and save disk space on root partitions for system76 and tpnix.

## Test plan
Configuration passes evaluation.