### PR TITLE
fix(flake): suppress release mismatch warnings

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     };
 
     home-manager = {
-      url = "github:Bad3r/home-manager";
+      url = "github:Bad3r/home-manager/master";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -136,7 +136,7 @@
     };
 
     stylix = {
-      url = "github:Bad3r/stylix";
+      url = "github:Bad3r/stylix/master";
       inputs = {
         flake-parts.follows = "flake-parts";
         nixpkgs.follows = "nixpkgs";

--- a/modules/hm-apps/nixvim.nix
+++ b/modules/hm-apps/nixvim.nix
@@ -74,7 +74,12 @@ _: {
               # Nixvim builds its own pkgs instance, so the system-level
               # allowUnfreePredicate doesn't apply. Forward it so unfree
               # plugins listed in `nixpkgs.allowedUnfreePackages` are honored.
-              nixpkgs.config.allowUnfreePredicate = pkgs.config.allowUnfreePredicate;
+              version.enableNixpkgsReleaseCheck = false;
+              nixpkgs = {
+                useGlobalPackages = false;
+                source = inputs.nixpkgs;
+                config.allowUnfreePredicate = pkgs.config.allowUnfreePredicate;
+              };
 
               # Leader keys.
               globals = {

--- a/modules/home-manager/checks.nix
+++ b/modules/home-manager/checks.nix
@@ -2,30 +2,22 @@
 {
   perSystem =
     { pkgs, ... }:
-    let
-      smokeOsConfig.system.stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
-
-      stateVersionModule =
-        { osConfig, ... }:
-        {
-          home.stateVersion = osConfig.system.stateVersion;
-          home.enableNixpkgsReleaseCheck = false;
-        };
-    in
     {
       checks = {
         "home-manager/base" =
           let
             hm = inputs.home-manager.lib.homeManagerConfiguration {
               inherit pkgs;
-              extraSpecialArgs.osConfig = smokeOsConfig;
               modules = [
                 {
-                  home.username = "hm-smoke";
-                  home.homeDirectory = "/tmp/hm-smoke";
+                  home = {
+                    username = "hm-smoke";
+                    homeDirectory = "/tmp/hm-smoke";
+                    stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
+                    enableNixpkgsReleaseCheck = false;
+                  };
                   programs.home-manager.enable = true;
                 }
-                stateVersionModule
               ];
             };
           in
@@ -35,15 +27,17 @@
           let
             hm = inputs.home-manager.lib.homeManagerConfiguration {
               inherit pkgs;
-              extraSpecialArgs.osConfig = smokeOsConfig;
               modules = [
                 {
-                  home.username = "hm-smoke";
-                  home.homeDirectory = "/tmp/hm-smoke";
+                  home = {
+                    username = "hm-smoke";
+                    homeDirectory = "/tmp/hm-smoke";
+                    stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
+                    enableNixpkgsReleaseCheck = false;
+                  };
                   programs.home-manager.enable = true;
                   programs.alacritty.enable = true;
                 }
-                stateVersionModule
               ];
             };
           in

--- a/modules/home-manager/checks.nix
+++ b/modules/home-manager/checks.nix
@@ -2,19 +2,30 @@
 {
   perSystem =
     { pkgs, ... }:
+    let
+      smokeOsConfig.system.stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
+
+      stateVersionModule =
+        { osConfig, ... }:
+        {
+          home.stateVersion = osConfig.system.stateVersion;
+          home.enableNixpkgsReleaseCheck = false;
+        };
+    in
     {
       checks = {
         "home-manager/base" =
           let
             hm = inputs.home-manager.lib.homeManagerConfiguration {
               inherit pkgs;
+              extraSpecialArgs.osConfig = smokeOsConfig;
               modules = [
                 {
                   home.username = "hm-smoke";
                   home.homeDirectory = "/tmp/hm-smoke";
                   programs.home-manager.enable = true;
                 }
-                { home.stateVersion = "26.05"; }
+                stateVersionModule
               ];
             };
           in
@@ -24,6 +35,7 @@
           let
             hm = inputs.home-manager.lib.homeManagerConfiguration {
               inherit pkgs;
+              extraSpecialArgs.osConfig = smokeOsConfig;
               modules = [
                 {
                   home.username = "hm-smoke";
@@ -31,7 +43,7 @@
                   programs.home-manager.enable = true;
                   programs.alacritty.enable = true;
                 }
-                { home.stateVersion = "26.05"; }
+                stateVersionModule
               ];
             };
           in

--- a/modules/home-manager/nixos.nix
+++ b/modules/home-manager/nixos.nix
@@ -121,6 +121,7 @@ let
     { osConfig, ... }:
     {
       home.stateVersion = osConfig.system.stateVersion;
+      home.enableNixpkgsReleaseCheck = false;
     };
   baseModule = loadHomeModule ../home-manager/base.nix [
     "flake"

--- a/modules/stylix/stylix.nix
+++ b/modules/stylix/stylix.nix
@@ -6,6 +6,7 @@
 let
   baseTheme = {
     enable = true;
+    enableReleaseChecks = false;
     base16Scheme = lib.mkDefault "${inputs.tinted-schemes}/base16/onedark.yaml";
     polarity = lib.mkDefault "dark";
   };
@@ -81,6 +82,7 @@ in
         # cycle without losing functionality.
         disabledModules = [ "${inputs.stylix}/modules/neovim/hm.nix" ];
         stylix = baseTheme // {
+          overlays.enable = false;
           targets = {
             kde.enable = false;
             gnome.enable = false;


### PR DESCRIPTION
## Summary

- Pin the Home Manager and Stylix fork inputs to their `master` refs to match the lock metadata.
- Disable Home Manager, NixVim, and Stylix release mismatch checks where this flake intentionally follows current nixpkgs.
- Set NixVim's nixpkgs source explicitly so the follows warning stops firing.

## Test plan

- `nix fmt -- flake.nix modules/hm-apps/nixvim.nix modules/home-manager/checks.nix modules/home-manager/nixos.nix modules/stylix/stylix.nix`
- `git diff --check`
- `nix flake check --accept-flake-config --no-build --offline`

Base branch is `refactor/files-module-attrs` because current flake evaluation needs the `files.file` migration from https://github.com/Bad3r/nixos/pull/277.