### PR TITLE
fix(apps): avoid system path collisions

### DIFF
--- a/modules/apps/httpx.nix
+++ b/modules/apps/httpx.nix
@@ -45,7 +45,9 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
+        # hiPrio so the projectdiscovery httpx CLI wins over jupyter-all's
+        # bundled bin/httpx in system-path (avoids a buildEnv subpath collision).
+        environment.systemPackages = [ (lib.hiPrio cfg.package) ];
       };
     };
 in

--- a/modules/apps/i3lock-color.nix
+++ b/modules/apps/i3lock-color.nix
@@ -47,10 +47,20 @@ let
       config = lib.mkIf cfg.enable {
         environment.systemPackages = [ cfg.package ];
 
-        # Enable PAM service for i3lock-color authentication.
-        # NixOS 25.05+ disables PAM services for i3lock by default.
+        # Enable the nixpkgs programs.i3lock module so its PAM services
+        # (/etc/pam.d/i3lock and /etc/pam.d/i3lock-color, gated on
+        # programs.i3lock.enable in nixpkgs security/pam.nix) stay intact.
+        # NixOS 25.05+ disables those PAM services by default.
         # See: https://github.com/NixOS/nixpkgs/blob/master/nixos/doc/manual/release-notes/rl-2505.section.md
+        #
+        # Point programs.i3lock.package at cfg.package so the nixpkgs module
+        # installs i3lock-color as the i3lock binary instead of plain
+        # pkgs.i3lock. Without this override, both packages land in
+        # system-path and collide. Disabling programs.i3lock instead would
+        # drop the PAM service and lock the user out on hosts without a
+        # fingerprint module.
         programs.i3lock.enable = true;
+        programs.i3lock.package = cfg.package;
       };
     };
 in

--- a/modules/apps/i3wm/nixos.nix
+++ b/modules/apps/i3wm/nixos.nix
@@ -62,6 +62,12 @@ let
         # a host can still disable a specific helper with a higher-priority
         # override (`= false` or `lib.mkForce false`).
         programs = {
+          # Run i3lock-color as the i3lock binary so the nixpkgs i3 module's
+          # programs.i3lock PAM service (/etc/pam.d/i3lock) stays intact while
+          # removing the duplicate plain-i3lock that collides with i3lock-color
+          # in system-path. Disabling programs.i3lock instead would drop that
+          # PAM service on hosts without a fingerprint module and lock the user out.
+          i3lock.package = pkgs.i3lock-color;
           "i3-focus-or-launch".extended.enable = lib.mkDefault true;
           "i3-scratchpad-show-or-create".extended.enable = lib.mkDefault true;
           "monitor-query".extended.enable = lib.mkDefault true;

--- a/modules/apps/i3wm/nixos.nix
+++ b/modules/apps/i3wm/nixos.nix
@@ -62,12 +62,6 @@ let
         # a host can still disable a specific helper with a higher-priority
         # override (`= false` or `lib.mkForce false`).
         programs = {
-          # Run i3lock-color as the i3lock binary so the nixpkgs i3 module's
-          # programs.i3lock PAM service (/etc/pam.d/i3lock) stays intact while
-          # removing the duplicate plain-i3lock that collides with i3lock-color
-          # in system-path. Disabling programs.i3lock instead would drop that
-          # PAM service on hosts without a fingerprint module and lock the user out.
-          i3lock.package = pkgs.i3lock-color;
           "i3-focus-or-launch".extended.enable = lib.mkDefault true;
           "i3-scratchpad-show-or-create".extended.enable = lib.mkDefault true;
           "monitor-query".extended.enable = lib.mkDefault true;

--- a/modules/apps/python.nix
+++ b/modules/apps/python.nix
@@ -44,7 +44,9 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
+        # hiPrio so the clean python3 interpreter wins over jupyter-all's
+        # bundled python3 in system-path (avoids buildEnv subpath collisions).
+        environment.systemPackages = [ (lib.hiPrio cfg.package) ];
       };
     };
 in

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -249,7 +249,7 @@ let
       lxsession.extended.enable = lib.mkOverride 1100 true;
       lychee.extended.enable = lib.mkOverride 1100 true;
       lynis.extended.enable = lib.mkOverride 1100 true;
-      maestral.extended.enable = lib.mkOverride 1100 true;
+      maestral.extended.enable = lib.mkOverride 1100 false;
       "maestral-gui".extended.enable = lib.mkOverride 1100 true;
       maim.extended.enable = lib.mkOverride 1100 true;
       malimite.extended.enable = lib.mkOverride 1100 false;
@@ -287,7 +287,7 @@ let
       "nix-diff".extended.enable = lib.mkOverride 1100 true;
       "nix-direnv".extended.enable = lib.mkOverride 1100 true;
       "nix-eval-jobs".extended.enable = lib.mkOverride 1100 true;
-      "nix-index".extended.enable = lib.mkOverride 1100 true;
+      "nix-index".extended.enable = lib.mkOverride 1100 false;
       "nix-output-monitor".extended.enable = lib.mkOverride 1100 true;
       "nix-prefetch-git".extended.enable = lib.mkOverride 1100 true;
       "nix-prefetch-github".extended.enable = lib.mkOverride 1100 true;
@@ -296,7 +296,7 @@ let
       "nixpkgs-review".extended.enable = lib.mkOverride 1100 true;
       nmap.extended.enable = lib.mkOverride 1100 true;
       "node-cloudflare-sdk".extended.enable = lib.mkOverride 1100 false;
-      nodejs_22.extended.enable = lib.mkOverride 1100 true;
+      nodejs_22.extended.enable = lib.mkOverride 1100 false;
       nodejs_24.extended.enable = lib.mkOverride 1100 true;
       "nomachine-client".extended.enable = lib.mkOverride 1100 true;
       normcap.extended.enable = lib.mkOverride 1100 true;
@@ -320,7 +320,7 @@ let
       openssl.extended.enable = lib.mkOverride 1100 true;
       openvpn.extended.enable = lib.mkOverride 1100 true;
       overskride.extended.enable = lib.mkOverride 1100 true;
-      p7zip.extended.enable = lib.mkOverride 1100 true;
+      p7zip.extended.enable = lib.mkOverride 1100 false;
       "p7zip-rar".extended.enable = lib.mkOverride 1100 true;
       pamixer.extended.enable = lib.mkOverride 1100 true;
       pandoc.extended.enable = lib.mkOverride 1100 true;
@@ -430,7 +430,7 @@ let
       "typescript-language-server".extended.enable = lib.mkOverride 1100 false;
       udiskie.extended.enable = lib.mkOverride 1100 true;
       "ungoogled-chromium".extended.enable = lib.mkOverride 1100 true;
-      unrar.extended.enable = lib.mkOverride 1100 true;
+      unrar.extended.enable = lib.mkOverride 1100 false;
       unzip.extended.enable = lib.mkOverride 1100 true;
       upscayl.extended.enable = lib.mkOverride 1100 true;
       usbutils.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -40,13 +40,11 @@ let
     kdiskmark = false;
     "kiro-fhs" = false;
     lxsession = false;
-    maestral = false;
     "maestral-gui" = false;
     "minio-client" = false;
     mpv = false;
     "msgraph-cli" = false;
     "mullvad-browser" = false;
-    nodejs_22 = false;
     "oh-my-opencode" = false;
     onlyoffice-desktopeditors = false;
     opendirectorydownloader = false;


### PR DESCRIPTION
## Summary

- Give the intended `httpx` and clean `python3` packages priority over Jupyter-provided binaries.
- Use `i3lock-color` as the package for the nixpkgs i3lock module so the PAM service remains present without installing duplicate i3lock binaries.
- Disable duplicate common app baseline entries and remove redundant tpnix overrides.

## Test plan

- `nix fmt -- modules/apps/httpx.nix modules/apps/i3wm/nixos.nix modules/apps/python.nix modules/hosts/common/apps-enable.nix modules/tpnix/apps-enable.nix`
- `git diff --check`
- `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel --no-link --print-out-paths`

Base branch is `refactor/files-module-attrs` because current flake evaluation needs the `files.file` migration from https://github.com/Bad3r/nixos/pull/277.