### PR TITLE
fix(tpnix): enable repo secrets

### DIFF
--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -82,7 +82,7 @@ in
     security = {
       polkit.wheelPowerManagement.enable = true;
       polkit.wheelSystemdManagement.enable = false;
-      repoSecrets.enable = lib.mkForce false;
+      repoSecrets.enable = true;
       r2CloudSecrets.enable = lib.mkForce false;
     };
 


### PR DESCRIPTION
## Summary

- Enable `security.repoSecrets` on tpnix instead of forcing it off.
- Keep the existing R2 cloud secrets override disabled.
- Allow repo-managed secret consumers on tpnix to use the declared repo secret path.

## Test plan

- `nix fmt -- modules/tpnix/imports.nix`
- `git diff --check`
- `nix eval --accept-flake-config --offline .#nixosConfigurations.tpnix.config.security.repoSecrets.enable --json`

Base branch is `refactor/files-module-attrs` because current flake evaluation needs the `files.file` migration from https://github.com/Bad3r/nixos/pull/277.