### PR TITLE
fix(browsers): allow Google reCAPTCHA challenge pages

### DIFF
--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -301,9 +301,6 @@ let
     "accounts.google.com * 3p-frame noop"
     "myaccount.google.com * 3p-script noop"
     "myaccount.google.com * 3p-frame noop"
-    # Google ReCaptcha
-    "www.google.com/sorry * 3p-script noop"
-    "www.google.com/sorry * 3p-frame noop"
 
     # Microsoft 365
     "teams.cloud.microsoft * 3p-script noop"
@@ -439,6 +436,9 @@ in
 
       ! https://web.webex.com
       web.webex.com##.cookie-banner-body
+
+      ! https://www.google.com/sorry
+      @@||www.google.com/sorry^$document
     '';
 
     selectedFilterLists = lib.unique (

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -436,6 +436,9 @@ in
 
       ! https://web.webex.com
       web.webex.com##.cookie-banner-body
+
+      ! https://www.google.com/sorry
+      @@||www.google.com/sorry^$document
     '';
 
     selectedFilterLists = lib.unique (

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -301,6 +301,9 @@ let
     "accounts.google.com * 3p-frame noop"
     "myaccount.google.com * 3p-script noop"
     "myaccount.google.com * 3p-frame noop"
+    # Google ReCaptcha
+    "www.google.com/sorry * 3p-script noop"
+    "www.google.com/sorry * 3p-frame noop"
 
     # Microsoft 365
     "teams.cloud.microsoft * 3p-script noop"
@@ -436,9 +439,6 @@ in
 
       ! https://web.webex.com
       web.webex.com##.cookie-banner-body
-
-      ! https://www.google.com/sorry
-      @@||www.google.com/sorry^$document
     '';
 
     selectedFilterLists = lib.unique (


### PR DESCRIPTION
## Summary

- Add a uBO document exception for `www.google.com/sorry` so Google reCAPTCHA challenge pages can load.
- Keep the exception in My filters instead of medium-mode dynamic rules because the page document is the blocked resource.

## Test plan

- `nix fmt -- modules/hm-apps/_gecko-extensions.nix`
- `git diff --check`
- `git diff --cached --check`
- `nix-instantiate --parse modules/hm-apps/_gecko-extensions.nix`

Base branch is `refactor/files-module-attrs` because current flake evaluation needs the `files.file` migration from https://github.com/Bad3r/nixos/pull/277.
