### PR TITLE
fix(codex): migrate to profile-v2 config layout

### DIFF
--- a/modules/agents/codex/_default-settings.nix
+++ b/modules/agents/codex/_default-settings.nix
@@ -96,8 +96,6 @@
   # permissions = null;
   # personality = null;
   # plan_mode_reasoning_effort = null;
-  # profile = null;
-  profiles = { };
   # project_doc_fallback_filenames = null;
   # project_doc_max_bytes = null;
   project_root_markers = [ ".git" ];

--- a/modules/agents/codex/_settings.nix
+++ b/modules/agents/codex/_settings.nix
@@ -43,7 +43,6 @@ let
     # Core settings
     model = "gpt-5.5";
     review_model = "gpt-5.5";
-    profile = "default";
     commit_attribution = "";
     approval_policy = "on-request";
     default_permissions = "workspace";
@@ -74,7 +73,7 @@ let
     # model_supports_reasoning_summaries = true; # Avoid sending reasoning.summary.
     model_reasoning_effort = "xhigh";
     plan_mode_reasoning_effort = "xhigh"; # none|minimal|low|medium|high|xhigh
-    model_verbosity = "medium";
+    model_verbosity = "high";
 
     # Reasoning visibility
     hide_agent_reasoning = false;
@@ -190,17 +189,6 @@ let
 
     # MCP servers
     mcp_servers = codexMcpServers;
-
-    # Profiles
-    profiles = {
-      default = {
-        model = "gpt-5.5";
-        approval_policy = "on-request";
-        # model_supports_reasoning_summaries = true; # Avoid sending reasoning.summary.
-        model_reasoning_effort = "xhigh";
-        model_verbosity = "medium";
-      };
-    };
   };
 
   # Base settings (everything except projects - those are merged at runtime)

--- a/modules/agents/codex/home-manager.nix
+++ b/modules/agents/codex/home-manager.nix
@@ -11,7 +11,7 @@
 
   Options:
     --cd <path>: Set the working directory Codex should operate in before executing tasks.
-    --profile <name>: Select a saved profile configuration for the current session.
+    --profile <name>: Layer `$CODEX_HOME/<name>.config.toml` on top of the base user config for the session.
     --approval-policy <mode>: Override the approval policy (for example `never`, `always`, `manual`).
     --sandbox-mode <mode>: Adjust the sandbox level for commands launched by Codex.
 


### PR DESCRIPTION
## Summary

- Codex now rejects `profile = "default"` at config load (`codex-rs/core/src/config/mod.rs:2541`) since upstream PR #24051 (`fd72e99384`) removed the legacy v1 profile selector path. Running `codex --yolo` produced: `Error loading configuration: legacy `profile = "default"` config is no longer supported; use --profile default with default.config.toml instead`.
- Drop the deprecated top-level `profile` key and the matching `[profiles.default]` table. The profile block only mirrored values that were already present in the base settings, so removal is behavior-preserving for the base flow.
- Codex v2 layers `$CODEX_HOME/<name>.config.toml` on top of the base user config only when `--profile <name>` is passed (`codex-rs/config/src/loader/mod.rs` "user/profile layering"). The base config now carries the previously-duplicated overrides directly.
- Bump `model_verbosity` to `"high"` so high-verbosity output applies to every invocation; previously it was duplicated in the redundant default profile at `"medium"`.
- Update the `--profile <name>` docstring in `home-manager.nix` to describe the v2 layered-file semantics. Prune the dead `profile`/`profiles` entries from the `_default-settings.nix` schema mirror.

## Test plan

- [x] `nix fmt`
- [x] `nix flake check --accept-flake-config --no-build --offline`
- [x] `nix build .#nixosConfigurations.system76.config.home-manager.users.vx.xdg.configFile."codex/config.base.toml".source`
- [x] `grep -nE '^profile\s*=|^\[profiles' $(nix path-info ...)` confirmed no legacy keys in the emitted TOML
- [x] `CODEX_HOME=<tempdir-with-new-config> codex exec ...` loads without the legacy-profile error
- [ ] Rebuild a host (e.g. `nixos-rebuild switch`) and confirm `codex --yolo` no longer errors during config load