### PR TITLE
fix(codex): bundle zsh wrapper as packaged-zsh layout

### DIFF
--- a/modules/agents/codex/_default-settings.nix
+++ b/modules/agents/codex/_default-settings.nix
@@ -131,5 +131,4 @@
     # status_line = null;
   };
   web_search = "cached";
-  # zsh_path = null;
 }

--- a/modules/agents/codex/_packaged-codex.nix
+++ b/modules/agents/codex/_packaged-codex.nix
@@ -1,0 +1,52 @@
+{
+  pkgs,
+  codexPkg,
+  codexZshWrapper,
+}:
+let
+  version = codexPkg.version or "unknown";
+  pname = codexPkg.pname or "codex";
+in
+# Rewrap upstream codex so InstallContext::from_exe finds the layout expected
+# by `shell_zsh_fork = true;` and other bundled-resource consumers.
+# Invariants required by codex-rs/install-context/src/lib.rs:
+#   * $out/bin must be the parent of the resolved exe (canonicalised).
+#   * $out/codex-package.json must be a regular file (contents not parsed).
+#   * $out/codex-resources/zsh/bin/zsh must satisfy is_file() (symlink ok).
+# `codex-path/` is intentionally omitted so codex falls back to the system rg
+# from PATH; the same applies to every other bundled_resource() consumer.
+pkgs.runCommandLocal "${pname}-packaged-${version}"
+  {
+    passthru = {
+      unwrapped = codexPkg;
+    };
+    meta = (codexPkg.meta or { }) // {
+      mainProgram = "codex";
+    };
+  }
+  ''
+    mkdir -p $out/bin $out/codex-resources/zsh/bin
+
+    # Copy the real ELF, not the upstream bash trampoline. current_exe() after
+    # execve must canonicalise inside $out so CodexPackageLayout::from_exe
+    # locates $out/codex-package.json (the trampoline would leave it pointing
+    # at upstream's store path, which has no metadata file).
+    cp -L ${codexPkg}/bin/.codex-wrapped $out/bin/.codex-wrapped
+    chmod +w $out/bin/.codex-wrapped
+
+    # New trampoline preserves the bubblewrap PATH prepend that upstream's
+    # wrapProgram adds, so use_linux_sandbox_bwrap keeps finding bwrap.
+    cat > $out/bin/codex << EOF
+    #!${pkgs.bash}/bin/bash -e
+    PATH='${pkgs.bubblewrap}/bin'\''${PATH:+:\$PATH}
+    export PATH
+    exec -a "\$0" "$out/bin/.codex-wrapped" "\$@"
+    EOF
+    chmod +x $out/bin/codex
+
+    # InstallContext::from_exe only checks is_file(); upstream's own tests
+    # write literal `{}` here.
+    printf '{}' > $out/codex-package.json
+
+    ln -s ${codexZshWrapper}/bin/zsh $out/codex-resources/zsh/bin/zsh
+  ''

--- a/modules/agents/codex/_settings.nix
+++ b/modules/agents/codex/_settings.nix
@@ -3,7 +3,6 @@
   homeDir,
   lib,
   pkgs,
-  codexZshWrapper,
 }:
 let
   # MCP servers via compiled agents.mcp client profile
@@ -48,7 +47,6 @@ let
     default_permissions = "workspace";
     personality = "pragmatic";
     web_search = "live";
-    zsh_path = lib.getExe codexZshWrapper;
 
     # Developer instructions for security research context
     developer_instructions = ''
@@ -108,6 +106,8 @@ let
       memories = true;
       realtime_conversation = true;
       exec_permission_approvals = true;
+      # Patched zsh layout provided by ./_packaged-codex.nix; upstream removed
+      # the `zsh_path` key in v0.135.0 and now resolves via InstallContext.
       shell_zsh_fork = true;
       shell_snapshot = true;
       skill_env_var_dependency_prompt = true;

--- a/modules/agents/codex/_wrapper.nix
+++ b/modules/agents/codex/_wrapper.nix
@@ -3,10 +3,18 @@
   nixProjectSettings,
   configDir,
   codexPkg,
+  codexZshWrapper,
   lib,
   pkgs,
 }:
 let
+  # Repackaged codex closure that exposes the codex-package.json + bundled
+  # codex-resources layout required by `shell_zsh_fork = true;` starting in
+  # codex v0.135.0 (upstream removed the `zsh_path` config key).
+  codexPackaged = import ./_packaged-codex.nix {
+    inherit pkgs codexPkg codexZshWrapper;
+  };
+
   tomlFormat = pkgs.formats.toml { };
   coreutilsMktemp = lib.getExe' pkgs.coreutils "mktemp";
   coreutilsRm = lib.getExe' pkgs.coreutils "rm";
@@ -146,7 +154,7 @@ let
       fi
     fi
 
-    exec ${codexPkg}/bin/codex "$@"
+    exec ${codexPackaged}/bin/codex "$@"
   '';
 in
 {

--- a/modules/agents/codex/home-manager.nix
+++ b/modules/agents/codex/home-manager.nix
@@ -61,7 +61,6 @@ _: {
           lib
           pkgs
           ;
-        inherit (execPolicy) codexZshWrapper;
       };
 
       codexRuntime = import ./_wrapper.nix {
@@ -71,6 +70,7 @@ _: {
           lib
           pkgs
           ;
+        inherit (execPolicy) codexZshWrapper;
         inherit (codexSettings)
           baseSettings
           nixProjectSettings


### PR DESCRIPTION
## Summary

- With `shell_zsh_fork = true`, codex v0.133.0 (llm-agents.nix rev `da9d15d764d8f3b7ffb4be1c7dfedd72ff6049d5`) resolves the patched zsh exclusively through `InstallContext::bundled_zsh_path()`. The Nix codex closure ships neither the `codex-package.json` metadata file nor the `codex-resources/zsh/bin/zsh` artifact that helper requires, so session bootstrap aborts with `Failed to initialize session: zsh fork feature enabled, but no packaged zsh fork is available for this install`.
- Add `modules/agents/codex/_packaged-codex.nix`, a `runCommandLocal` derivation that exposes the layout codex now expects. It copies `.codex-wrapped` (the real ELF) so `current_exe()` canonicalises inside the new derivation, emits a bubblewrap-preserving trampoline, stubs `codex-package.json` with `{}`, and symlinks `codex-resources/zsh/bin/zsh` to `codexZshWrapper`. The upstream codex closure is not rebuilt.
- Drop the dead `zsh_path = lib.getExe codexZshWrapper;` key from `_settings.nix` and the commented entry in `_default-settings.nix`; forward `codexZshWrapper` from `home-manager.nix` into `_wrapper.nix` and switch the inner exec to `${codexPackaged}/bin/codex`.

`codex-path/` is intentionally omitted so `bundled_resource()` consumers (rg, etc.) fall back to the system PATH rather than pulling extra resources into the derivation.

## Test plan

- [x] `nix fmt -- modules/agents/codex/*.nix` (5 files, 1 reformatted)
- [x] `nix flake check --accept-flake-config --no-build --offline` (all checks passed)
- [x] `nix build --no-link --print-out-paths --no-write-lock-file .#nixosConfigurations.system76.config.home-manager.users.vx.home.path` builds `codex-packaged-0.133.0` plus the rebuilt `codexWrapped`
- [x] `CODEX_HOME=$(mktemp -d) <hm>/bin/codex --version` prints `codex-cli 0.133.0`
- [x] `CODEX_HOME=$(mktemp -d) <hm>/bin/codex exec --sandbox read-only --skip-git-repo-check 'echo ok'` reaches session init (prints `OpenAI Codex v0.133.0`, session id, model/sandbox lines); only error is the expected `401 Unauthorized` from the empty CODEX_HOME (no zsh-fork abort)
- [x] Layout assertion: `<codex-packaged>/codex-package.json` present, `<codex-packaged>/bin/.codex-wrapped` is the upstream ELF, `<codex-packaged>/codex-resources/zsh/bin/zsh` resolves to the `codexZshWrapper` script