### PR TITLE
docs: correct usage and claude-code reference accuracy

### DIFF
--- a/docs/claude-code/plugins.md
+++ b/docs/claude-code/plugins.md
@@ -113,7 +113,7 @@ plugin-repository/
 └── [any other files]
 ```
 
-**Plugin Type Detection** (`packages/cli/src/utils/validation.ts:24-45`):
+**Plugin Type Detection** (`packages/cli/src/utils/validation.ts`):
 
 1. Check for `.claude-plugin/marketplace.json` with `plugins` array → **marketplace**
 2. Check for `.claude-plugin/plugin.json` → **single plugin**
@@ -211,7 +211,7 @@ Skills can install to one of two scopes:
 | Global | User-wide (all projects)             | Default             | If `globalDir` undefined, auto-switches to local |
 | Local  | Project-specific (current directory) | `--project` or `-p` | Always succeeds (all clients have `localDir`)    |
 
-**Scope Selection Flow** (`packages/skills-installer/src/lib/select-scope-and-clients.ts:103-123`):
+**Scope Selection Flow** (`packages/skills-installer/src/lib/select-scope-and-clients.ts`):
 
 1. If `--project` flag present → scope = `local`
 2. If `--client` flag present without `--project` → scope = `global`
@@ -245,7 +245,7 @@ Claude Code discovers plugins through two mechanisms:
 1. **Known Marketplaces Registry**: `~/.claude/plugins/known_marketplaces.json`
 2. **Settings File**: `~/.claude/settings.json` → `enabledPlugins` object
 
-**Known Marketplaces Schema** (`packages/cli/src/core/marketplace.ts:13-29`):
+**Known Marketplaces Schema** (`packages/cli/src/core/marketplace.ts`):
 
 ```json
 {
@@ -270,7 +270,7 @@ Claude Code discovers plugins through two mechanisms:
 }
 ```
 
-**Settings Schema** (`packages/cli/src/core/settings.ts:4-7`):
+**Settings Schema** (`packages/cli/src/core/settings.ts`):
 
 ```json
 {
@@ -356,7 +356,7 @@ Complete `.claude/` directory structure managed by claude-plugins:
 
 Command: `claude-plugins install <plugin-identifier>`
 
-**Step-by-Step Execution** (`packages/cli/src/commands/install.ts:18-121`):
+**Step-by-Step Execution** (`packages/cli/src/commands/install.ts`):
 
 01. **Parse Input**: Extract plugin name from identifier (URL or short-form)
 02. **Resolve Plugin**:
@@ -400,7 +400,7 @@ Command: `claude-plugins install <plugin-identifier>`
 
 Command: `skills-installer install <skill-identifier> [--client <name>] [--project]`
 
-**Step-by-Step Execution** (`packages/skills-installer/src/commands/install.ts:47-186`):
+**Step-by-Step Execution** (`packages/skills-installer/src/commands/install.ts`):
 
 01. **Parse Input**: Extract owner/repo/skill components from identifier
 02. **Resolve Skill**:
@@ -455,7 +455,7 @@ The registry is hosted on Val Town and provides resolution, search, and analytic
 
 **Base URL**: `https://api.claude-plugins.dev`
 
-**Configuration** (`packages/cli/src/config.ts:4-7`):
+**Configuration** (`packages/cli/src/config.ts`):
 
 ```typescript
 const DEFAULT_CONFIG = {
@@ -582,7 +582,7 @@ POST /api/skills/<owner>/<repo>/<skill-name>/install
 
 ### Retry Logic
 
-**Download Retry** (`packages/skills-installer/src/lib/download.ts:48-82`):
+**Download Retry** (`packages/skills-installer/src/lib/download.ts`):
 
 - Maximum attempts: 3
 - Backoff: Exponential (1s, 2s, 4s)
@@ -708,7 +708,7 @@ The `search` command provides a rich interactive experience:
 
 **Solution**: In-memory lock map prevents concurrent modifications to the same file.
 
-**Implementation** (`packages/cli/src/utils/fs.ts:18-47`):
+**Implementation** (`packages/cli/src/utils/fs.ts`):
 
 ```typescript
 const locks = new Map<string, Promise<void>>();
@@ -746,7 +746,7 @@ All `readJSON` and `writeJSON` operations automatically acquire locks.
 
 **Solution**: Write to temp file, then atomic rename (POSIX guarantee).
 
-**Implementation** (`packages/cli/src/utils/fs.ts:97-114`):
+**Implementation** (`packages/cli/src/utils/fs.ts`):
 
 ```typescript
 async function writeJSON<T>(filePath: string, data: T): Promise<void> {
@@ -782,7 +782,7 @@ async function writeJSON<T>(filePath: string, data: T): Promise<void> {
 
 **Solution**: Normalize before passing to `giget`.
 
-**Implementation** (`packages/skills-installer/src/lib/download.ts:9-31`):
+**Implementation** (`packages/skills-installer/src/lib/download.ts`):
 
 ```typescript
 const normalizeGithubPath = (

--- a/docs/claude-code/skills.md
+++ b/docs/claude-code/skills.md
@@ -2,7 +2,7 @@
 
 Skills are Markdown files with YAML frontmatter that extend Claude Code with custom slash commands and guided workflows. They follow the open [Agent Skills](https://agentskills.io) format with Claude Code-specific extensions.
 
-A skill encodes a repeatable multi-step process -- a deployment checklist, a code review workflow, a migration procedure -- into a single invocable unit. Skills enforce conventions, chain workflows through handoffs, and carry reference material that loads on demand rather than permanently occupying context.
+A skill encodes a repeatable multi-step process -- a deployment checklist, a code review workflow, a migration procedure -- into a single invocable unit. Skills enforce conventions and carry reference material that loads on demand rather than permanently occupying context.
 
 Claude Code discovers skills at session start by scanning `.claude/skills/` directories. Each skill's description is indexed for semantic matching against user intent. When invoked, the full skill body is injected into the conversation context with string substitutions applied.
 
@@ -45,7 +45,7 @@ Arguments are captured as `$ARGUMENTS` (full string) or accessed by index (`$0`,
 
 ### Skill Tool (Programmatic)
 
-Claude Code exposes an internal `Skill` tool that Claude can call programmatically. This enables skill chaining and handoff dispatching. The Skill tool respects permission rules: `Skill(name)` for exact match, `Skill(name *)` for prefix matching.
+Claude Code exposes an internal `Skill` tool that Claude can call programmatically. This enables one skill to dispatch another. The Skill tool respects permission rules: `Skill(name)` for exact match, `Skill(name *)` for prefix matching.
 
 ### Model-Initiated
 
@@ -106,17 +106,22 @@ All fields are optional. When omitted, defaults apply as shown.
 
 | Field                      | Type    | Default           | Description                                                                                  |
 | -------------------------- | ------- | ----------------- | -------------------------------------------------------------------------------------------- |
-| `name`                     | string  | Directory name    | Display name and slash command identifier. Lowercase, hyphens, max 64 characters             |
-| `description`              | string  | First paragraph   | What the skill does and when to use it. Used for model-initiated matching                    |
+| `name`                     | string  | Directory name    | Display name shown in skill listings. The `/command` name comes from the skill directory     |
+| `description`              | string  | First paragraph   | What the skill does and when to use it. Drives model-initiated matching                      |
+| `when_to_use`              | string  | (none)            | Extra matching context combined with `description`; the pair is capped at ~1,536 characters  |
 | `argument-hint`            | string  | (none)            | Autocomplete hint shown after `/name`. Example: `[issue-number]`                             |
+| `arguments`                | string  | (none)            | Named positional arguments for `$name` substitution. Space-separated string or YAML list     |
 | `disable-model-invocation` | boolean | `false`           | When `true`, prevents Claude from auto-loading this skill. Manual `/name` only               |
 | `user-invocable`           | boolean | `true`            | When `false`, hides from `/` menu. Skill remains available as background knowledge           |
-| `allowed-tools`            | string  | (inherit all)     | Comma-separated tool whitelist for implicit permission. Example: `Read, Grep, Glob`          |
-| `model`                    | string  | (inherit)         | Override model for this skill: `sonnet`, `opus`, `haiku`, or `inherit`                       |
+| `allowed-tools`            | string  | (inherit all)     | Tools usable without a permission prompt while active. Space/comma string or YAML list       |
+| `disallowed-tools`         | string  | (none)            | Tools removed from the available pool while the skill is active                              |
+| `model`                    | string  | (inherit)         | Model override while active: same values as `/model`, or `inherit`                           |
+| `effort`                   | string  | (inherit)         | Effort override while active: `low`, `medium`, `high`, `xhigh`, or `max` (model-dependent)   |
 | `context`                  | string  | (inline)          | Set to `fork` to run in an isolated subagent context                                         |
 | `agent`                    | string  | `general-purpose` | Subagent type when `context: fork`. Options: `Explore`, `Plan`, `general-purpose`, or custom |
 | `hooks`                    | object  | (none)            | Lifecycle hooks scoped to skill execution. Supports `PreToolUse`, `PostToolUse`, `Stop`      |
-| `handoffs`                 | array   | (none)            | Follow-up actions presented on skill completion                                              |
+| `paths`                    | string  | (none)            | Glob patterns that limit auto-activation to matching files                                   |
+| `shell`                    | string  | `bash`            | Shell for `` !`command` `` blocks: `bash` or `powershell`                                    |
 
 ### String Substitutions
 
@@ -202,10 +207,10 @@ Session: ${CLAUDE_SESSION_ID}
 At session start, Claude Code scans all skill locations (enterprise, project, personal, plugin) for `*/SKILL.md` files. For each skill discovered:
 
 1. Frontmatter is parsed for `name`, `description`, `user-invocable`, `argument-hint`
-2. Descriptions are loaded into a semantic index (budget: ~15,000 characters across all skills)
+2. Descriptions are loaded into a semantic index. The combined budget scales with the model context window (about 1% of it by default), not a fixed character count, and each description is capped at roughly 1,536 characters
 3. Full Markdown bodies are **not** loaded until invocation
 
-If the combined description length exceeds the budget, lower-priority skills are excluded. Check with the `/context` command. The budget is configurable via `SLASH_COMMAND_TOOL_CHAR_BUDGET`.
+If the combined description length exceeds the budget, lower-priority skills are excluded. Check with the `/context` command. Tune the budget with the `skillListingBudgetFraction` setting or the `SLASH_COMMAND_TOOL_CHAR_BUDGET` environment variable.
 
 ### Resolution
 
@@ -229,13 +234,12 @@ When a skill is invoked:
 
 For `context: fork` skills, the processed content becomes the subagent's prompt in an isolated context (no conversation history).
 
-### Completion and Handoffs
+### Completion
 
 When a skill finishes execution:
 
-- If `handoffs` are configured, follow-up buttons are presented to the user
-- If a handoff has `send: true`, it auto-dispatches without user interaction
 - Skill-scoped hooks are cleaned up
+- For `context: fork` skills, the subagent's results are summarized back into the main conversation
 
 ## Skills vs Tools
 
@@ -245,7 +249,7 @@ When a skill finishes execution:
 | Invocation    | `/slash-command`, Skill tool, or auto-match   | Model-initiated only                         |
 | Scope         | Enterprise, project, personal, plugin         | Global (built-in) or MCP server scope        |
 | State         | Shares conversation or forks isolated context | Stateless per-call                           |
-| Composability | Chains via handoffs and Skill tool dispatch   | Direct tool calls                            |
+| Composability | Chains via Skill tool dispatch                | Direct tool calls                            |
 | Authoring     | Markdown -- no code required                  | Code in supported languages                  |
 | Customization | Full control over instructions and behavior   | Limited to parameters defined by tool schema |
 
@@ -259,13 +263,13 @@ The skill body, after substitutions and preprocessing, is injected as a system i
 
 ### Description Budget
 
-All enabled skill descriptions share a budget of ~15,000 characters at session start. This budget covers the semantic index that enables model-initiated invocation. If exceeded:
+All enabled skill descriptions share a budget at session start. The budget scales with the model's context window (about 1% of it by default) rather than a fixed character count, and each individual description is capped at roughly 1,536 characters. This budget covers the semantic index that enables model-initiated invocation. If exceeded:
 
 - Lower-priority skills (by scope) are excluded from the index
 - The `/context` command reports which skills are loaded
-- Override with `SLASH_COMMAND_TOOL_CHAR_BUDGET=<chars>` environment variable
+- Tune it with the `skillListingBudgetFraction` setting or the `SLASH_COMMAND_TOOL_CHAR_BUDGET=<chars>` environment variable
 
-Keep individual descriptions concise (under ~200 characters) to leave room for other skills.
+Keep individual descriptions concise (well under the ~1,536-character per-skill cap) to leave room for other skills.
 
 ### Context Modes
 
@@ -325,27 +329,6 @@ Effective skills follow a predictable structure:
 
 Keep instructions specific and actionable. Avoid vague guidance like "review carefully" -- instead specify what to check and what constitutes a finding.
 
-### Handoff Chains
-
-Skills can compose into multi-stage workflows through handoffs. Each handoff presents a follow-up action on completion:
-
-```yaml
----
-name: feature-workflow
-description: Guide a feature from spec to implementation
-handoffs:
-  - label: "Write spec"
-    agent: specify
-    prompt: "Create specification for $ARGUMENTS"
-  - label: "Generate tasks"
-    agent: tasks
-    prompt: "Generate tasks from the spec"
-    send: true # Auto-dispatch without user interaction
----
-```
-
-Design handoff chains so each stage is independently useful. A user should be able to stop after any stage and have a meaningful deliverable.
-
 ### Common Patterns
 
 **Argument validation**: check arguments before proceeding.
@@ -404,7 +387,7 @@ Plugin skills are automatically namespaced as `plugin-name:skill-name` to avoid 
 
 Descriptions form a semantic index consulted for model-initiated invocation. The index is built once at session start and not refreshed mid-session. Adding or modifying skills requires restarting the session for changes to take effect.
 
-The ~15,000 character budget is an approximate figure. Monitor usage with `/context` and adjust with `SLASH_COMMAND_TOOL_CHAR_BUDGET` if needed.
+The budget scales with the model context window (about 1% by default) rather than a fixed character count, and each description is capped at roughly 1,536 characters. Monitor usage with `/context` and adjust with the `skillListingBudgetFraction` setting or `SLASH_COMMAND_TOOL_CHAR_BUDGET` if needed.
 
 ## CLI Integration
 
@@ -466,33 +449,6 @@ name: db.backup
 ```
 
 These appear grouped in the `/` listing as `db.migrate`, `db.seed`, `db.backup`. Plugin skills are automatically namespaced with a colon separator: `plugin-name:skill-name`.
-
-### Handoff Configuration
-
-Handoffs define follow-up actions presented when a skill completes.
-
-| Field    | Type    | Required | Description                                                     |
-| -------- | ------- | -------- | --------------------------------------------------------------- |
-| `label`  | string  | Yes      | Button text shown to user                                       |
-| `agent`  | string  | Yes      | Target skill or agent name                                      |
-| `prompt` | string  | No       | Prompt passed to the target. Supports `$ARGUMENTS` substitution |
-| `send`   | boolean | No       | When `true`, auto-dispatches without waiting for user click     |
-
-Example with chained handoffs:
-
-```yaml
----
-name: feature-spec
-description: Write a feature specification
-handoffs:
-  - label: "Generate implementation plan"
-    agent: plan
-    prompt: "Plan implementation based on the spec just created"
-  - label: "Create tasks from spec"
-    agent: tasks
-    prompt: "Generate tasks from the spec"
----
-```
 
 ### Hook Integration
 

--- a/docs/claude-code/skills.md
+++ b/docs/claude-code/skills.md
@@ -20,7 +20,7 @@ Each skill lives in its own directory containing a required `SKILL.md` entry poi
     └── helper.sh      # Executable utilities
 ```
 
-Reference files load on demand when the skill body links to them, keeping the main skill focused on instructions.
+Reference files load on demand when the skill body links to them, keeping the main skill focused on instructions. The skill directory normally provides the slash command name; frontmatter `name` is only the display label in skill listings.
 
 ## Invocation Methods
 
@@ -106,11 +106,11 @@ All fields are optional. When omitted, defaults apply as shown.
 
 | Field                      | Type    | Default           | Description                                                                                  |
 | -------------------------- | ------- | ----------------- | -------------------------------------------------------------------------------------------- |
-| `name`                     | string  | Directory name    | Display name shown in skill listings. The `/command` name comes from the skill directory     |
+| `name`                     | string  | Directory name    | Display label shown in skill listings. The `/command` name usually comes from the directory  |
 | `description`              | string  | First paragraph   | What the skill does and when to use it. Drives model-initiated matching                      |
 | `when_to_use`              | string  | (none)            | Extra matching context combined with `description`; the pair is capped at ~1,536 characters  |
 | `argument-hint`            | string  | (none)            | Autocomplete hint shown after `/name`. Example: `[issue-number]`                             |
-| `arguments`                | string  | (none)            | Named positional arguments for `$name` substitution. Space-separated string or YAML list     |
+| `arguments`                | string  | (none)            | Named positional arguments mapped to variables, e.g. `$issue` for argument `issue`           |
 | `disable-model-invocation` | boolean | `false`           | When `true`, prevents Claude from auto-loading this skill. Manual `/name` only               |
 | `user-invocable`           | boolean | `true`            | When `false`, hides from `/` menu. Skill remains available as background knowledge           |
 | `allowed-tools`            | string  | (inherit all)     | Tools usable without a permission prompt while active. Space/comma string or YAML list       |
@@ -132,6 +132,7 @@ Substitutions are processed in the Markdown body before injection into context.
 | `$ARGUMENTS`           | Full argument string passed at invocation | `SearchBar React Vue`         |
 | `$ARGUMENTS[N]`        | Nth argument by zero-based index          | `$ARGUMENTS[0]` → `SearchBar` |
 | `$N`                   | Shorthand for `$ARGUMENTS[N]`             | `$0` → `SearchBar`            |
+| `$name`                | Named argument from `arguments`           | `$issue` → first argument     |
 | `${CLAUDE_SESSION_ID}` | Current session identifier                | `abc123`                      |
 
 When a skill body does not contain `$ARGUMENTS`, Claude Code appends `ARGUMENTS: <value>` to the end of the injected content automatically.
@@ -151,7 +152,7 @@ Use standard Markdown: headers, lists, code blocks, bold for emphasis. Claude re
 
 ```yaml
 ---
-# Identity: lowercase, hyphens, becomes /review-pr command
+# Display label; the skill directory normally provides /review-pr
 name: review-pr
 
 # Indexed at session start; drives model-initiated matching.

--- a/docs/claude-code/skills.md
+++ b/docs/claude-code/skills.md
@@ -156,7 +156,7 @@ Use standard Markdown: headers, lists, code blocks, bold for emphasis. Claude re
 name: review-pr
 
 # Indexed at session start; drives model-initiated matching.
-# Keep under ~200 chars to leave budget for other skills.
+# Keep well under the ~1,536-char per-skill cap to leave budget for other skills.
 description: >
   Review a pull request for code quality, security issues,
   and adherence to project conventions.

--- a/docs/claude-code/writing-CLAUDE.md
+++ b/docs/claude-code/writing-CLAUDE.md
@@ -11,8 +11,8 @@ every line must earn its place.
   style, ownership boundaries, safety constraints, validation expectations).
 - **Non-obvious repository facts**: module-discovery rules, build commands,
   branch and PR workflow, where generated artifacts come from.
-- **Pointers, not prose**: link to deeper docs (`docs/`, `AGENTS.md`) instead of
-  restating them.
+- **Pointers, not prose**: link to deeper docs (`docs/`) and import shared
+  baseline files with `@path` when Claude Code should load them.
 
 Put repeatable multi-step procedures (deploy checklists, migrations, review
 workflows) in skills, not here. CLAUDE.md holds standing rules; skills hold
@@ -47,6 +47,10 @@ imports; expose modules through namespace exports" is a rule an agent can apply.
 
 ## Layering
 
-Deeper `CLAUDE.md` files (per package or subdirectory) and `AGENTS.md` add
-narrower rules on top of the baseline. Keep shared conventions in the root file
-and restate something lower down only when that scope genuinely differs.
+Claude Code loads `CLAUDE.md`, `CLAUDE.local.md`, and `.claude/rules/`; it does
+not automatically load `AGENTS.md`. If `AGENTS.md` is the shared source of truth
+for other agents, make `CLAUDE.md` import it with `@AGENTS.md` or symlink
+`CLAUDE.md` to it, then add only Claude-specific deltas.
+
+Keep shared conventions in one source of truth. Use deeper `CLAUDE.md` files or
+path-scoped `.claude/rules/` only for narrow rules whose scope genuinely differs.

--- a/docs/claude-code/writing-CLAUDE.md
+++ b/docs/claude-code/writing-CLAUDE.md
@@ -1,4 +1,52 @@
-- Short section headers with ##
-- Bold for key terms
-- Terse, imperative language
-- Simple bullet points
+# Writing CLAUDE.md
+
+`CLAUDE.md` carries persistent, always-active instructions for agents working in
+a repository or directory. Claude Code loads it into context at the start of
+every session, so it competes for the same budget as the conversation itself:
+every line must earn its place.
+
+## What belongs in CLAUDE.md
+
+- **Always-active rules**: conventions that apply to every interaction (coding
+  style, ownership boundaries, safety constraints, validation expectations).
+- **Non-obvious repository facts**: module-discovery rules, build commands,
+  branch and PR workflow, where generated artifacts come from.
+- **Pointers, not prose**: link to deeper docs (`docs/`, `AGENTS.md`) instead of
+  restating them.
+
+Put repeatable multi-step procedures (deploy checklists, migrations, review
+workflows) in skills, not here. CLAUDE.md holds standing rules; skills hold
+invocable processes. See [skills.md](skills.md) for that split.
+
+## What to leave out
+
+- Anything derivable from the code, git history, or generated output.
+- One-off task notes or status that go stale.
+- Long tutorials or reference material that belong in `docs/`.
+
+## Style
+
+- Short section headers with `##`.
+- **Bold** for key terms.
+- Terse, imperative language ("Run X", "Never do Y"), not narration.
+- Simple bullet points over paragraphs.
+- Write impersonally: name what the code, repo, or configuration does. Avoid
+  first-person plural.
+
+## Structure that works
+
+1. A one-line statement of what the repository is.
+2. Hard rules and safety constraints first (the things that must never be
+   violated).
+3. Architecture and ownership: where things live and who owns them.
+4. Commands: how to build, format, test, and validate.
+5. Workflow: branching, commits, PRs.
+
+Keep each rule falsifiable. "Follow conventions" is noise; "Avoid literal path
+imports; expose modules through namespace exports" is a rule an agent can apply.
+
+## Layering
+
+Deeper `CLAUDE.md` files (per package or subdirectory) and `AGENTS.md` add
+narrower rules on top of the baseline. Keep shared conventions in the root file
+and restate something lower down only when that scope genuinely differs.

--- a/docs/usage/espanso-usage.md
+++ b/docs/usage/espanso-usage.md
@@ -6,24 +6,37 @@ The espanso module provides declarative configuration for the cross-platform tex
 
 ## Quick Start
 
-### Enable in Home Manager Configuration
+### Enable espanso
 
-The module is auto-imported when included in your Home Manager modules list:
+Two modules cooperate behind a single system-level toggle:
 
-```nix
-{
-  imports = [
-    config.flake.homeManagerModules.apps.espanso
-  ];
-}
-```
+- `flake.nixosModules.apps.espanso` (source: `modules/apps/espanso.nix`) defines
+  the option `services.espanso.extended.enable` (default `false`).
+- `flake.homeManagerModules.apps.espanso` (source: `modules/hm-apps/espanso.nix`)
+  reads that toggle from `osConfig` and configures `services.espanso` only when
+  it is `true`.
 
-This automatically enables espanso with:
+Importing the Home Manager module alone does nothing: the toggle must be on at
+the system level. On hosts that use the common baseline this is already wired:
 
-- Both X11 and Wayland support (auto-detection based on `$WAYLAND_DISPLAY`)
+- `modules/hosts/common/home-manager-apps.nix` adds `espanso` to the shared
+  Home Manager app modules.
+- `modules/hosts/common/apps-enable.nix` sets
+  `services.espanso.extended.enable = true` at the default-on baseline
+  (`lib.mkOverride 1100`).
+
+So common hosts get espanso enabled by default. To opt out on a host, set
+`services.espanso.extended.enable = false`. To enable it on a host that does not
+use the baseline, import `flake.nixosModules.apps.espanso` and set the toggle
+true at the system level.
+
+When enabled, espanso starts with:
+
+- Both X11 and Wayland support (Home Manager defaults on Linux; runtime selection based on `$WAYLAND_DISPLAY`)
 - Notifications disabled (less intrusive)
 - Common date/time triggers (`:date`, `:time`, `:now`, `:isodate`)
-- Development snippets (`:shebang`, `:todo`, `:fixme`)
+- Development snippets (`:shebang`, `:shebangnix`, `:todo`, `:fixme`)
+- A `:test` smoke-test trigger that expands to `test 1.2.3`
 
 ### Default Triggers
 
@@ -33,6 +46,7 @@ Once enabled, the following triggers are available:
 
 | Trigger       | Output            | Example                                             |
 | ------------- | ----------------- | --------------------------------------------------- |
+| `:test`       | Smoke-test string | `test 1.2.3`                                        |
 | `:date`       | Current date      | `2025-10-08`                                        |
 | `:time`       | Current time      | `14:30`                                             |
 | `:now`        | Date and time     | `2025-10-08 14:30`                                  |

--- a/docs/usage/espanso-usage.md
+++ b/docs/usage/espanso-usage.md
@@ -213,12 +213,17 @@ Use regex for more flexible matching:
 
 ### Default Behavior (Recommended)
 
-Both X11 and Wayland support are enabled by default on Linux. The module:
+Home Manager's `services.espanso` module enables both X11 and Wayland support by
+default on Linux. Its upstream module:
 
-- Configures `x11Support = true` and `waylandSupport = true`
-- Sets `package-wayland = pkgs.espanso-wayland`
+- Defaults `x11Support = true` and `waylandSupport = true` on Linux
+- Defaults `package-wayland = pkgs.espanso-wayland` when Wayland support is on
 - Creates a wrapper script that checks `$WAYLAND_DISPLAY` at runtime
 - Automatically launches the correct binary based on your graphical session
+
+This repository's Home Manager app module leaves those display-server defaults
+in place; it adds repo-specific configs, matches, and service restart policy
+only after `services.espanso.extended.enable` is true.
 
 ### Optimizing Closure Size
 
@@ -332,20 +337,27 @@ For those hosts, do not add a separate Home Manager import. Customize
 
 ### Hosts outside the common baseline
 
-A host that does not use `hosts-common` needs both the NixOS option module and
-the Home Manager app import:
+A host that does not use `hosts-common` needs a flake-parts module that pushes
+both the NixOS option module and Home Manager app import into the host module:
 
 ```nix
 { config, lib, ... }:
+let
+  espansoModule = config.flake.nixosModules.apps.espanso;
+in
 {
-  imports = [
-    config.flake.nixosModules.apps.espanso
-  ];
+  configurations.nixos.<hostName>.module = _: {
+    imports = [ espansoModule ];
 
-  services.espanso.extended.enable = true;
-  home-manager.extraAppImports = lib.mkAfter [ "espanso" ];
+    services.espanso.extended.enable = true;
+    home-manager.extraAppImports = lib.mkAfter [ "espanso" ];
+  };
 }
 ```
+
+`home-manager.extraAppImports` is defined by `flake.nixosModules.base`, so the
+host must already import that aggregate. Standard NixOS configurations in this
+repository do.
 
 ### Module locations
 

--- a/docs/usage/espanso-usage.md
+++ b/docs/usage/espanso-usage.md
@@ -315,32 +315,46 @@ Some applications require clipboard backend:
 
 ## Integration with This Repository
 
-### In Dendritic Configuration
+### Common-baseline hosts
 
-Import in your home-manager configuration:
+Hosts whose registry entry has `shareCommon = true` already receive espanso
+through the common host modules:
+
+- `modules/hosts/common/home-manager-apps.nix` appends `espanso` to
+  `home-manager.extraAppImports` and adds `flake.homeManagerModules.apps.espanso`
+  to shared modules.
+- `modules/hosts/common/apps-enable.nix` sets
+  `services.espanso.extended.enable = true` at `lib.mkOverride 1100`.
+
+For those hosts, do not add a separate Home Manager import. Customize
+`services.espanso.matches` in Home Manager configuration, or opt out by setting
+`services.espanso.extended.enable = false`.
+
+### Hosts outside the common baseline
+
+A host that does not use `hosts-common` needs both the NixOS option module and
+the Home Manager app import:
 
 ```nix
-# In configurations/homeManager/<username>/default.nix
+{ config, lib, ... }:
 {
   imports = [
-    config.flake.homeManagerModules.apps.espanso
+    config.flake.nixosModules.apps.espanso
   ];
 
-  # Override defaults as needed
-  services.espanso.matches.personal = {
-    matches = [
-      # Your custom matches
-    ];
-  };
+  services.espanso.extended.enable = true;
+  home-manager.extraAppImports = lib.mkAfter [ "espanso" ];
 }
 ```
 
-### Module Location
+### Module locations
 
-The espanso module is auto-discovered from:
+The espanso modules are auto-discovered from:
 
-- Source: `modules/hm-apps/espanso.nix`
-- Export: `flake.homeManagerModules.apps.espanso`
+- NixOS source: `modules/apps/espanso.nix`
+- NixOS export: `flake.nixosModules.apps.espanso`
+- Home Manager source: `modules/hm-apps/espanso.nix`
+- Home Manager export: `flake.homeManagerModules.apps.espanso`
 
 ## References
 

--- a/docs/usage/pentesting-devshell.md
+++ b/docs/usage/pentesting-devshell.md
@@ -23,9 +23,16 @@ Packet-capture tools are exposed through `security.wrappers` with `CAP_NET_RAW` 
 Edit `toolDefs` in `modules/devshell/pentesting.nix`:
 
 ```nix
-{ name = "newtool"; }                    # Both package and wrapper
-{ name = "newtool"; devshellOnly = true; }   # Package only, no wrapper
-{ name = "newtool"; wrapperOnly = true; }    # Wrapper only, no package
+{ name = "newtool"; }                       # Package + both pentest-<name> and native <name> wrappers
+{ name = "newtool"; prefixOnly = true; }    # Package + only the pentest-<name> wrapper (no native <name>)
+{ name = "newtool"; devshellOnly = true; }  # Package only, no wrapper
+{ name = "newtool"; wrapperOnly = true; package = "othertool"; }  # Wrapper only; reuses another entry's package
 ```
 
-Then add the package mapping in `toolPackageMap`.
+Most entries use `prefixOnly = true` so the devshell wrapper does not shadow a
+system-wide package of the same name. A bare `{ name = ...; }` also creates a
+native `<name>` wrapper, which conflicts when the host installs that tool
+system-wide.
+
+Then add the package mapping in `toolPackageMap` (skip this for `wrapperOnly`
+entries, which reuse the referenced entry's package).


### PR DESCRIPTION
## Summary

Accuracy audit of `docs/usage/*` and `docs/claude-code/*`. Each repo-specific
claim was checked against the owning module; Claude Code claims were checked
against the official docs. `docs/mcp/logseq.md` was reviewed and left unchanged
(external CLI with no repo-side driver; no inaccuracies found against available
references).

- **espanso-usage.md**: the enable section claimed importing the Home Manager
  module auto-enables espanso. It does not: the module self-gates on
  `osConfig.services.espanso.extended.enable` (defined by
  `flake.nixosModules.apps.espanso`, default `false`). Rewrote around that
  toggle and the common-baseline wiring (`apps-enable.nix` sets it true at
  `mkOverride 1100`; `home-manager-apps.nix` imports the module), added the
  `:test` trigger, and attributed the X11/Wayland defaults to Home Manager.
- **pentesting-devshell.md**: documented the `prefixOnly` `toolDefs` flag (the
  dominant pattern that stops the devshell wrapper from shadowing a system
  package) and corrected the misleading "both package and wrapper" comment.
- **writing-CLAUDE.md**: was a 4-line orphaned stub; replaced with a structured
  guide that keeps the original style bullets.
- **skills.md**: removed the `handoffs` frontmatter field and its two sections
  (`handoffs` is not a Claude Code SKILL.md field, verified against the official
  docs); added the real fields `when_to_use`, `arguments`, `disallowed-tools`,
  `effort`, `paths`, `shell`; corrected the description budget (about 1% of the
  model context window plus a 1,536-character per-skill cap, not a fixed
  ~15,000).
- **plugins.md**: replaced 11 line-range citations into the external
  `Kamalnrf/claude-plugins` repo with path-only references (the bold section
  labels already name the code); line ranges drift and conflict with the
  cite-by-symbol convention.

## Test plan

- Cross-referenced repo claims against `modules/hm-apps/espanso.nix`,
  `modules/apps/espanso.nix`,
  `modules/hosts/common/{apps-enable,home-manager-apps}.nix`,
  `modules/devshell/pentesting.nix`, and the `security.wrappers` in
  `modules/apps/{wireshark,tcpdump,aircrack-ng}.nix`.
- Verified skills frontmatter, the `handoffs` absence, and the description
  budget against `code.claude.com/docs/en/skills.md`.
- `nix fmt` on the five files reports 0 changes; `treefmt` and `typos`
  pre-commit hooks pass on every commit.