### PR TITLE
fix(system76): route video decode away from NVDEC

### DIFF
--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -4,19 +4,31 @@
 
 All System76-specific configuration lives in `modules/system76/`:
 
-| File                  | Purpose                                  |
-| --------------------- | ---------------------------------------- |
-| `hardware-config.nix` | Filesystems, LUKS, firmware, bluetooth   |
-| `nvidia-gpu.nix`      | NVIDIA PRIME sync/offload                |
-| `boot.nix`            | Kernel, crash dump, NVIDIA params        |
-| `services.nix`        | power management, scheduler, logging     |
-| `support.nix`         | System76 kernel modules, firmware daemon |
-| `packages.nix`        | System76 utilities, unfree allowlist     |
+| File                         | Purpose                                           |
+| ---------------------------- | ------------------------------------------------- |
+| `hardware-config.nix`        | Filesystems, LUKS, firmware, bluetooth, GPU mode  |
+| `nvidia-gpu.nix`             | NVIDIA driver, PRIME sync/nvidia-only mode        |
+| `boot.nix`                   | CachyOS kernel, crash dump, NVIDIA params         |
+| `cachyos-kernel.nix`         | CachyOS kernel overlay and binary cache           |
+| `services.nix`               | power management, scheduler, logging              |
+| `support.nix`                | System76 kernel modules, firmware daemon          |
+| `system76-power-overlay.nix` | `system76-power` patch (skip non-ALPM SCSI hosts) |
+| `packages.nix`               | System76 utilities, unfree allowlist              |
 
 ## Hardware Support
 
+`support.nix` defines the `system76-support` NixOS module behind the
+`hardware.system76.extended.enable` option. The host opts in from `imports.nix`:
+
 ```nix
-# modules/system76/support.nix
+# modules/system76/imports.nix
+hardware.system76.extended.enable = true;
+```
+
+When enabled, the module turns on the System76 hardware stack:
+
+```nix
+# modules/system76/support.nix (effect of extended.enable)
 hardware.system76 = {
   kernel-modules.enable = true;   # Fan monitoring, EC communication
   firmware-daemon.enable = true;  # Firmware updates via fwupd
@@ -29,26 +41,27 @@ services.fwupd.enable = true;
 
 ## Hardware Firmware
 
-Selective approach - only needed firmware declared explicitly:
+The host declares the firmware it needs explicitly, layered on top of the
+redistributable default via `lib.mkAfter`:
 
 ```nix
 # modules/system76/hardware-config.nix
-hardware = {
-  cpu.intel.updateMicrocode = true;
-
-  firmware = lib.mkAfter [
-    pkgs.linux-firmware  # Intel 8265 WiFi/BT, i915 GPU
-    pkgs.sof-firmware    # Intel audio DSP
-    pkgs.wireless-regdb  # WiFi regulatory
-  ];
-};
+hardware.firmware = lib.mkAfter [
+  pkgs.linux-firmware  # Intel 8265 WiFi/BT, i915 GPU
+  pkgs.sof-firmware    # Intel audio DSP
+  pkgs.wireless-regdb  # WiFi regulatory
+];
 
 # modules/base/hardware-scan.nix
 hardware = {
-  enableRedistributableFirmware = false;
+  enableRedistributableFirmware = lib.mkDefault true;
   enableAllFirmware = false;
 };
 ```
+
+Intel CPU microcode is not set here; it is provided by the
+`nixos-hardware` `common-cpu-intel-cpu-only` module imported in
+`imports.nix`.
 
 All firmware is redistributable (no unfree). See [system76-hardware.md](system76-hardware.md) for firmware details.
 
@@ -61,7 +74,8 @@ services = {
   thermald.enable = false;
 
   system76-scheduler.enable = true;  # Desktop responsiveness
-  power-profiles-daemon.enable = false;  # Conflicts with system76-power
+  power-profiles-daemon.enable = lib.mkForce false;  # Conflicts with system76-power
+  lact.enable = true;  # GPU control/monitoring (power limits, fan curves, clocks)
 };
 
 powerManagement.cpuFreqGovernor = "performance";
@@ -87,18 +101,32 @@ sudo system76-power charge-thresholds --profile full_charge   # 96-100%
 
 ```nix
 # modules/system76/nvidia-gpu.nix
-options.system76.gpu.mode = lib.mkOption {
-  type = lib.types.enum [ "hybrid-sync" "nvidia-only" ];
-  default = "hybrid-sync";
+options.system76.gpu = {
+  mode = lib.mkOption {
+    type = lib.types.enum [ "hybrid-sync" "nvidia-only" ];
+    default = "hybrid-sync";
+  };
+  intelBusId = lib.mkOption { type = lib.types.str; default = "PCI:0:2:0"; };
+  nvidiaBusId = lib.mkOption { type = lib.types.str; default = "PCI:1:0:0"; };
 };
 
 hardware.nvidia = {
+  # GTX 1070 Max-Q is supported by the 580.xx legacy branch only.
+  package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
   modesetting.enable = true;
   powerManagement.enable = true;
-  open = false;  # Proprietary driver
+  powerManagement.finegrained = false;  # Incompatible with PRIME sync
+  open = false;          # Proprietary driver
+  nvidiaSettings = true;
 };
+hardware.nvidia-container-toolkit.enable = true;  # GPU passthrough for containers
+```
 
-# PRIME sync (default)
+```nix
+# Active host mode is set in hardware-config.nix (overrides the hybrid-sync default):
+system76.gpu.mode = "nvidia-only";
+
+# hybrid-sync branch enables PRIME sync (NOT active on this host):
 hardware.nvidia.prime = {
   sync.enable = true;
   intelBusId = "PCI:0:2:0";
@@ -106,17 +134,19 @@ hardware.nvidia.prime = {
 };
 ```
 
-| Mode          | Description                                               |
-| ------------- | --------------------------------------------------------- |
-| `hybrid-sync` | iGPU drives display, dGPU renders (battery + performance) |
-| `nvidia-only` | Only dGPU active (maximum GPU performance)                |
+| Mode          | Description                                                | Active                       |
+| ------------- | ---------------------------------------------------------- | ---------------------------- |
+| `hybrid-sync` | iGPU drives display, dGPU renders (battery + performance)  | option default               |
+| `nvidia-only` | Only dGPU active, PRIME disabled (maximum GPU performance) | set in `hardware-config.nix` |
 
 ## Boot Configuration
 
 ```nix
 # modules/system76/boot.nix
 boot = {
-  kernelPackages = pkgs.linuxPackages_latest;
+  # CachyOS generic kernel (BORE scheduler + performance patches).
+  # Overlay and binary cache are wired in cachyos-kernel.nix.
+  kernelPackages = pkgs.cachyosKernels.linuxPackages-cachyos-latest;
   blacklistedKernelModules = [ "nouveau" ];
 
   kernelParams = [
@@ -132,12 +162,15 @@ boot = {
   kernel.sysctl = {
     "kernel.sysrq" = 1;
     "kernel.printk" = "7 4 1 7";
+    "kernel.dmesg_restrict" = 0;  # Allow dmesg without sudo
   };
+};
 
-  loader.systemd-boot = {
-    enable = true;
-    configurationLimit = 3;
-  };
+# The bootloader, LUKS devices, and filesystems live in hardware-config.nix:
+# modules/system76/hardware-config.nix
+boot.loader.systemd-boot = {
+  enable = true;
+  configurationLimit = 3;
 };
 ```
 
@@ -171,24 +204,30 @@ services.pipewire = {
   pulse.enable = true;
 };
 
-# Bluetooth
+# Bluetooth (modules/system76/hardware-config.nix)
 hardware.bluetooth = {
   enable = true;
   powerOnBoot = true;
+  settings.General = {
+    Experimental = true;        # battery-level reporting
+    KernelExperimental = true;
+  };
 };
 ```
 
 ## Unfree Packages
 
 ```nix
-# modules/system76/packages.nix
+# modules/system76/packages.nix - System76-branded artwork only
 nixpkgs.allowedUnfreePackages = [
-  "nvidia-x11"
-  "nvidia-settings"
   "system76-wallpapers"
-  # ... other unfree packages
+  "system76-wallpapers-0-unstable-2024-04-26"
 ];
 ```
+
+NVIDIA unfree entries (`nvidia-x11`, `nvidia-settings`) are allowed in the
+shared `modules/hosts/common/packages.nix` allowlist, not in the System76
+module. `imports.nix` additionally allows `p7zip-rar`, `rar`, and `unrar`.
 
 > **Note:** All firmware packages are redistributable, not unfree.
 
@@ -204,8 +243,8 @@ nixpkgs.allowedUnfreePackages = [
 ## Quick Reference
 
 ```bash
-# Services
-systemctl status com.system76.PowerDaemon
+# Services (unit is system76-power.service; com.system76.PowerDaemon is its D-Bus name)
+systemctl status system76-power
 systemctl status system76-scheduler
 
 # Power management

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -120,6 +120,10 @@ hardware.nvidia = {
   nvidiaSettings = true;
 };
 hardware.nvidia-container-toolkit.enable = true;  # GPU passthrough for containers
+
+# nvidia-only branch: libva uses Intel Quick Sync through the stable iGPU render node.
+environment.variables.LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
+environment.variables.LIBVA_DRM_DEVICE = lib.mkDefault "/dev/dri/by-path/pci-0000:00:02.0-render";
 ```
 
 ```nix

--- a/docs/system76/system76-hardware.md
+++ b/docs/system76/system76-hardware.md
@@ -22,10 +22,10 @@
 
 ### Graphics
 
-| Type | Model                | Driver               |
-| ---- | -------------------- | -------------------- |
-| iGPU | Intel UHD 630        | i915                 |
-| dGPU | NVIDIA GTX 10-series | nvidia (proprietary) |
+| Type | Model                   | Driver                          |
+| ---- | ----------------------- | ------------------------------- |
+| iGPU | Intel UHD 630           | i915                            |
+| dGPU | NVIDIA GTX 1070 (Max-Q) | nvidia proprietary (legacy_580) |
 
 ### Storage
 

--- a/docs/system76/system76-troubleshooting.md
+++ b/docs/system76/system76-troubleshooting.md
@@ -14,10 +14,11 @@ ______________________________________________________________________
 ## Thermal Management
 
 Thermal management is handled by `system76-power` (the System76 Power Daemon).
+The daemon is enabled through the `system76-support` module:
 
 ```nix
-# modules/system76/support.nix
-hardware.system76.power-daemon.enable = true;
+# modules/system76/imports.nix
+hardware.system76.extended.enable = true;  # turns on power-daemon, kernel-modules, firmware-daemon
 ```
 
 ### Power Profiles
@@ -47,9 +48,9 @@ watch -n 1 sensors
 # CPU package
 watch -n 1 'sensors coretemp-isa-0000 | grep Package'
 
-# system76-power status
-systemctl status com.system76.PowerDaemon
-journalctl -u com.system76.PowerDaemon -f
+# system76-power status (unit is system76-power.service)
+systemctl status system76-power
+journalctl -u system76-power -f
 
 # Fan status
 sensors system76-isa-0000 | grep fan

--- a/modules/system76/mpv.nix
+++ b/modules/system76/mpv.nix
@@ -1,0 +1,12 @@
+{ lib, ... }:
+{
+  # mpv-only; orthogonal to the VA-API -> iHD change in nvidia-gpu.nix (mpv decodes
+  # via FFmpeg NVCUVID, not libva). vo=gpu-next's default Vulkan backend deadlocks the
+  # GPU on render-context churn (rapid playlist switching), freezing the session; the
+  # GL backend avoids it while keeping vo=gpu-next and profile=high-quality.
+  configurations.nixos.system76.module = {
+    home-manager.sharedModules = [
+      { programs.mpv.config.gpu-api = lib.mkDefault "opengl"; }
+    ];
+  };
+}

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -106,11 +106,12 @@ _: {
           # depend on Intel graphics-side plumbing even when NVIDIA renders X11.
 
           # Route VA-API to Intel Quick Sync (iHD), not NVDEC, to avoid the Xid 31
-          # decode fault (see graphics.extraPackages above). i915 stays loaded here, so
-          # iHD has an Intel render node to use; an app that opens the NVIDIA node
-          # instead falls back to software decode. VDPAU_DRIVER is intentionally unset:
-          # VDPAU is legacy, and pointing it at nvidia would route back into NVDEC.
+          # decode fault (see graphics.extraPackages above). i915 stays loaded here,
+          # and the by-path render node keeps libva off the NVIDIA DRM device.
+          # VDPAU_DRIVER is intentionally unset: VDPAU is legacy, and pointing it at
+          # nvidia would route back into NVDEC.
           environment.variables = {
+            LIBVA_DRM_DEVICE = lib.mkDefault "/dev/dri/by-path/pci-0000:00:02.0-render";
             LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
           };
         })

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -52,9 +52,17 @@ _: {
           };
 
           hardware = {
-            # NVIDIA-related graphics libraries (generic graphics enablement lives in pc/graphics-support.nix)
+            # VA-API decode routes through Intel Quick Sync (iHD), not NVDEC.
+            # nvidia-vaapi-driver's VA-API -> NVDEC handoff faults under decode-context
+            # churn: switching videos quickly or reloading stalled SMB/SFTP streams
+            # produces an Xid 31 MMU page fault on ENGINE NVDEC, hanging the dGPU and
+            # freezing the session (the dGPU drives the display in nvidia-only mode).
+            # Intel UHD 630 (i915 stays loaded here, see the nvidia-only branch) decodes
+            # H.264/HEVC/VP9 in hardware; AV1 falls back to software. mpv is unaffected
+            # because hwdec=auto uses FFmpeg NVCUVID (nvdec), never libva.
+            # (generic graphics enablement lives in modules/hosts/common/graphics-support.nix)
             graphics.extraPackages = with pkgs; [
-              nvidia-vaapi-driver
+              intel-media-driver
               vulkan-validation-layers
             ];
 
@@ -62,6 +70,11 @@ _: {
               # GTX 1070 Max-Q is supported by the 580.xx legacy branch; newer production drivers ignore it.
               package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
               modesetting.enable = true;
+              # Suppress nixpkgs' default nvidia-vaapi-driver install (this option
+              # defaults to true and is its only consumer). VA-API decode is handled by
+              # Intel iHD instead; see the graphics.extraPackages note for the Xid 31
+              # NVDEC fault rationale.
+              videoAcceleration = false;
               powerManagement.enable = true;
               # Fine-grained power management (D3 power gating) is incompatible with PRIME sync.
               # Sync mode keeps the dGPU always on to drive display output through the iGPU.
@@ -92,10 +105,13 @@ _: {
           # Do not blacklist i915: internal HDA/SOF audio on this chassis can
           # depend on Intel graphics-side plumbing even when NVIDIA renders X11.
 
-          # Prefer NVIDIA VA-API/VDPAU implementations in dedicated mode.
+          # Route VA-API to Intel Quick Sync (iHD), not NVDEC, to avoid the Xid 31
+          # decode fault (see graphics.extraPackages above). i915 stays loaded here, so
+          # iHD has an Intel render node to use; an app that opens the NVIDIA node
+          # instead falls back to software decode. VDPAU_DRIVER is intentionally unset:
+          # VDPAU is legacy, and pointing it at nvidia would route back into NVDEC.
           environment.variables = {
-            LIBVA_DRIVER_NAME = lib.mkDefault "nvidia";
-            VDPAU_DRIVER = lib.mkDefault "nvidia";
+            LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
           };
         })
 


### PR DESCRIPTION
## Summary
- route System76 VA-API decode through Intel iHD instead of NVIDIA NVDEC
- disable nixpkgs' NVIDIA VA-API package injection for the host
- force mpv gpu-next to use the OpenGL backend on System76 and refresh related docs

## Test plan
- `nix fmt -- modules/system76/nvidia-gpu.nix modules/system76/mpv.nix docs/system76/system76-configuration.md docs/system76/system76-hardware.md docs/system76/system76-troubleshooting.md`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config --apply '<system76 video values>'`
- `nix flake check --accept-flake-config --no-build --offline`