### PR TITLE
feat(mirrors): add mpv source mirror

### DIFF
--- a/docs/mpv/README.md
+++ b/docs/mpv/README.md
@@ -12,7 +12,8 @@ bundle, and the `video-cache` shell helper.
 The docs cover what is true today across both supported hosts and intentionally
 omit host names. Each page is concise and concern-focused; cross-link the
 upstream mpv manual at <https://mpv.io/manual/stable/> for canonical option
-semantics.
+semantics. The upstream source is mirrored at `$LOCAL_MIRRORS/mpv-player-mpv`
+for offline reference.
 
 ## Contents
 

--- a/docs/reference/local-mirrors.md
+++ b/docs/reference/local-mirrors.md
@@ -89,6 +89,7 @@ Full URLs include a normalized host prefix and strip common host suffixes such a
 | `mozilla-firefox/firefox`                               | `$LOCAL_MIRRORS/mozilla-firefox-firefox`                   |
 | Firefox built docs                                      | `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs`              |
 | `mozilla/policy-templates`                              | `$LOCAL_MIRRORS/mozilla-policy-templates`                  |
+| `mpv-player/mpv`                                        | `$LOCAL_MIRRORS/mpv-player-mpv`                            |
 | `openai/codex`                                          | `$LOCAL_MIRRORS/openai-codex`                              |
 | `tridactyl/tridactyl`                                   | `$LOCAL_MIRRORS/tridactyl-tridactyl`                       |
 | `https://git.lix.systems/lix-project/lix.git`           | `$LOCAL_MIRRORS/git.lix.systems-lix-project-lix`           |

--- a/modules/agents/system-prompt.nix
+++ b/modules/agents/system-prompt.nix
@@ -313,6 +313,8 @@ let
         Browse Codex CLI source and internals.
       - tridactyl: `/data/git/tridactyl-tridactyl`
         Reference Tridactyl browser extension source and configuration.
+      - mpv: `/data/git/mpv-player-mpv`
+        Inspect mpv player source, option definitions, and scripting API.
     '';
   };
 

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -46,7 +46,10 @@
           pathParts = if parts == [ ] then [ ] else builtins.tail parts;
           rawName = lib.concatStringsSep "-" ([ hostName ] ++ pathParts);
         in
-        rawName |> sanitizeUrlDirName |> collapseDashes |> trimDashes;
+        rawName
+        |> sanitizeUrlDirName
+        |> collapseDashes
+        |> trimDashes;
       mirrorDirName =
         spec:
         if lib.hasPrefix "http://" spec || lib.hasPrefix "https://" spec then

--- a/modules/hosts/common/mirrors.nix
+++ b/modules/hosts/common/mirrors.nix
@@ -66,6 +66,7 @@ let
           "cloudflare/workers-sdk"
           "duplicati/duplicati"
           "logseq/logseq"
+          "mpv-player/mpv"
           "openai/codex"
           "rclone/rclone"
           "restic/restic"


### PR DESCRIPTION
## Summary
- add `mpv-player/mpv` to the shared local mirror list
- document the resulting `$LOCAL_MIRRORS/mpv-player-mpv` path in mpv and mirror docs
- expose the mpv mirror in the agent prompt local-mirror guidance

## Test plan
- `nix fmt -- modules/hosts/common/mirrors.nix modules/agents/system-prompt.nix modules/hm-apps/git-mirror.nix docs/reference/local-mirrors.md docs/mpv/README.md`
- `git diff --check`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config --apply '<git mirror values>'`