### PR TITLE
docs(repo): refresh module and toolkit references

### DIFF
--- a/docs/architecture/01-pattern-overview.md
+++ b/docs/architecture/01-pattern-overview.md
@@ -35,10 +35,30 @@ Each `.nix` file is a flake-parts module that registers itself under one or more
 
 ```nix
 # modules/apps/jq.nix
-_: {
-  flake.nixosModules.apps.jq = { pkgs, ... }: {
-    environment.systemPackages = [ pkgs.jq ];
-  };
+_:
+let
+  JqModule =
+    { config, lib, pkgs, ... }:
+    let
+      cfg = config.programs.jq.extended;
+    in
+    {
+      options.programs.jq.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable jq.";
+        };
+        package = lib.mkPackageOption pkgs "jq" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.jq = JqModule;
 }
 ```
 
@@ -49,18 +69,21 @@ The file:
 3. Contributes to `flake.nixosModules.apps.jq`
 4. Can be consumed by hosts via `config.flake.nixosModules.apps.jq`
 
+Per-app modules follow this `programs.<name>.extended.enable` shape (the header doc-comment is elided above). Hosts do not import each app by hand: the apps-enable baseline flips the toggles. See [NixOS Modules](03-nixos-modules.md) and [Host Composition](05-host-composition.md).
+
 ## Aggregator Namespaces
 
 This flake exposes the following top-level aggregators (all declared in `modules/meta/flake-output.nix`):
 
-| Namespace                  | Purpose                             | Typical Exports                                                                 |
-| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------- |
-| `flake.nixosModules`       | System-level configuration          | `base`, hardware profiles, `apps.<name>`                                        |
-| `flake.homeManagerModules` | Home Manager configuration          | `base`, `gui`, `apps.<name>`                                                    |
-| `flake.csec`               | Cybersecurity feature modules       | `wordlists` (per-feature, opt-in via host import + enable)                      |
-| `flake.lib.*`              | Helper functions and small metadata | `meta`, `nixos`, `homeManager`, `security`, `nixvim`, `xdg`, `agents`, `checks` |
+| Namespace                  | Purpose                             | Typical Exports                                                                                        |
+| -------------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `flake.nixosModules`       | System-level configuration          | `base`, hardware profiles, `apps.<name>`                                                               |
+| `flake.homeManagerModules` | Home Manager configuration          | `base`, `gui`, `apps.<name>`                                                                           |
+| `flake.csec`               | Cybersecurity feature modules       | `wordlists` (per-feature, opt-in via host import + enable)                                             |
+| `flake.customOverlays`     | Per-app `nixpkgs` overlay modules   | `<name>` (auto-discovered from `modules/custom-overlays/`, gated on `programs.<name>.extended.enable`) |
+| `flake.lib.*`              | Helper functions and small metadata | `meta`, `nixos`, `homeManager`, `security`, `nixvim`, `xdg`, `agents`, `checks`                        |
 
-`flake.nixosModules` and `flake.homeManagerModules` collect modules that hosts compose by name. `flake.csec` is a separate `attrsOf deferredModule` so each feature is a first-class entry that hosts opt into individually. `flake.lib` holds pure helper data (see [NixOS Modules](03-nixos-modules.md#flakelib-namespaces) for the full breakdown).
+`flake.nixosModules` and `flake.homeManagerModules` collect modules that hosts compose by name. `flake.csec` and `flake.customOverlays` are each a separate `attrsOf deferredModule` so every feature or overlay is a first-class entry that hosts opt into individually (see [NixOS Modules](03-nixos-modules.md#persystem-vs-host-overlays) for how overlays are wired). `flake.lib` holds pure helper data (see [NixOS Modules](03-nixos-modules.md#flakelib-namespaces) for the full breakdown).
 
 Modules register themselves under these namespaces. Consumers compose features by name rather than by file path.
 

--- a/docs/architecture/03-nixos-modules.md
+++ b/docs/architecture/03-nixos-modules.md
@@ -88,7 +88,7 @@ Helpers should stay pure and idempotent; anything that needs heavy evaluation be
 This repository uses both patterns, for different purposes:
 
 - `perSystem.packages` is used for flake-exposed tooling packages (for example, `generation-manager` and hook helpers in `modules/devshell.nix`).
-- App packages in `packages/<name>/default.nix` are injected through per-app overlay modules under `modules/custom-overlays/<name>.nix`. Each registers `flake.customOverlays.<name>` and adds `pkgs.<name> = final.callPackage ../../packages/<name> { }` to `nixpkgs.overlays`, gated on the matching `programs.<name>.extended.enable`. `modules/hosts/common/custom-overlays-base.nix` imports every registered overlay into the shared `flake.nixosModules.hosts-common` aggregate, so an overlay only takes effect on hosts where its app is enabled.
+- App packages in `packages/<name>/default.nix` are injected through per-app overlay modules under `modules/custom-overlays/<name>.nix`. Each registers `flake.customOverlays.<name>` and adds an overlay to `nixpkgs.overlays` that returns `<name> = final.callPackage ../../packages/<name> { }`, making the package available as `pkgs.<name>` when gated on the matching `programs.<name>.extended.enable`. `modules/hosts/common/custom-overlays-base.nix` imports every registered overlay into the shared `flake.nixosModules.hosts-common` aggregate, so an overlay only takes effect on hosts where its app is enabled.
 
 This means these packages are **not** exposed under `.#packages.<system>.<name>`; they materialize as `pkgs.<name>` only inside a `nixosConfigurations.<host>` evaluation where the matching app is enabled.
 

--- a/docs/architecture/03-nixos-modules.md
+++ b/docs/architecture/03-nixos-modules.md
@@ -88,9 +88,9 @@ Helpers should stay pure and idempotent; anything that needs heavy evaluation be
 This repository uses both patterns, for different purposes:
 
 - `perSystem.packages` is used for flake-exposed tooling packages (for example, `generation-manager` and hook helpers in `modules/devshell.nix`).
-- Host app packages in `packages/<name>/default.nix` are injected through host-scoped overlays (e.g. `modules/system76/custom-packages-overlay.nix`), then consumed as regular `pkgs.<name>` values by app modules.
+- App packages in `packages/<name>/default.nix` are injected through per-app overlay modules under `modules/custom-overlays/<name>.nix`. Each registers `flake.customOverlays.<name>` and adds `pkgs.<name> = final.callPackage ../../packages/<name> { }` to `nixpkgs.overlays`, gated on the matching `programs.<name>.extended.enable`. `modules/hosts/common/custom-overlays-base.nix` imports every registered overlay into the shared `flake.nixosModules.hosts-common` aggregate, so an overlay only takes effect on hosts where its app is enabled.
 
-This means many host-only packages are **not** available under `.#packages.<system>.<name>` directly; they are available inside each `nixosConfigurations.<host>` evaluation where its overlay is active.
+This means these packages are **not** exposed under `.#packages.<system>.<name>`; they materialize as `pkgs.<name>` only inside a `nixosConfigurations.<host>` evaluation where the matching app is enabled.
 
 ## Shared System Helpers
 

--- a/docs/architecture/04-home-manager.md
+++ b/docs/architecture/04-home-manager.md
@@ -6,12 +6,13 @@ This document covers the Home Manager aggregator namespace and app loading mecha
 
 Home Manager modules feed into `flake.homeManagerModules` for user-level configuration:
 
-| Key                                                                    | Type             | Description                                                           |
-| ---------------------------------------------------------------------- | ---------------- | --------------------------------------------------------------------- |
-| `base`                                                                 | Deferred module  | Bootstrap configuration (shell, git, shared defaults)                 |
-| `gui`                                                                  | Deferred module  | Reserved GUI aggregation point (currently mostly an empty merge root) |
-| `apps.<name>`                                                          | Deferred module  | Individual app modules loaded by key                                  |
-| `context7Secrets`, `greptileSecrets`, `r2Secrets`, `virustotalSecrets` | Deferred modules | Optional SOPS-managed secret modules                                  |
+| Key                                                                                    | Type             | Description                                                                  |
+| -------------------------------------------------------------------------------------- | ---------------- | ---------------------------------------------------------------------------- |
+| `base`                                                                                 | Deferred module  | Bootstrap configuration (shell, git, shared defaults)                        |
+| `gui`                                                                                  | Deferred module  | Reserved GUI aggregation point (currently mostly an empty merge root)        |
+| `apps.<name>`                                                                          | Deferred module  | Individual app modules loaded by key                                         |
+| `sopsRuntime`                                                                          | Deferred module  | HM-side SOPS runtime bootstrap (loaded for every host)                       |
+| `context7Secrets`, `geckoSecrets`, `greptileSecrets`, `r2Secrets`, `virustotalSecrets` | Deferred modules | Optional SOPS-managed secret modules (each guarded by `builtins.pathExists`) |
 
 ## Contributing to Namespaces
 
@@ -82,14 +83,15 @@ Each host appends to `home-manager.extraAppImports` and mirrors matching app mod
 
 The shared HM base is identical across hosts; per-host overrides live in each host's `imports.nix`. As a current snapshot:
 
-| HM toggle           | system76 default       | tpnix default                          | Notes                                                                                                                                  |
-| ------------------- | ---------------------- | -------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
-| `context7Secrets`   | `mkDefault true`       | `mkForce false`                        | Context7 API key rendering.                                                                                                            |
-| `greptileSecrets`   | `mkForce false`        | `mkForce false`                        | Disabled with the Greptile Claude Code plugin/MCP integration; re-enable only when that plugin is explicitly enabled.                  |
-| `virustotalSecrets` | `mkDefault true`       | `mkForce false`                        | VirusTotal API key rendering.                                                                                                          |
-| `r2Secrets`         | `mkForce false`        | `mkForce false`                        | NixOS-side `r2CloudSecrets` is also off in the current configuration.                                                                  |
-| `repoGpg`           | `mkDefault true`       | (not enabled, no shared module pulled) | system76 pulls `inputs.self.homeManagerModules.repoGpg` into `home-manager.sharedModules`; tpnix does not pull this shared module.     |
-| `services.espanso`  | (inherits HM upstream) | `x11Support = mkForce true`            | system76 leaves espanso's session-backend defaults alone; tpnix forces X11 via `home-manager.sharedModules` because it runs i3 on X11. |
+| HM toggle           | system76 default        | tpnix default                          | Notes                                                                                                                                                                 |
+| ------------------- | ----------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `context7Secrets`   | `mkDefault true`        | `mkForce false`                        | Context7 API key rendering.                                                                                                                                           |
+| `geckoSecrets`      | `true` (module default) | `mkForce false`                        | Gecko bookmark secret rendering; the module defaults `enable = true`, so system76 leaves it on (rendered only when the secret file exists) while tpnix forces it off. |
+| `greptileSecrets`   | `mkForce false`         | `mkForce false`                        | Disabled with the Greptile Claude Code plugin/MCP integration; re-enable only when that plugin is explicitly enabled.                                                 |
+| `virustotalSecrets` | `mkDefault true`        | `mkForce false`                        | VirusTotal API key rendering.                                                                                                                                         |
+| `r2Secrets`         | `mkForce false`         | `mkForce false`                        | NixOS-side `r2CloudSecrets` is also off in the current configuration.                                                                                                 |
+| `repoGpg`           | `mkDefault true`        | (not enabled, no shared module pulled) | system76 pulls `inputs.self.homeManagerModules.repoGpg` into `home-manager.sharedModules`; tpnix does not pull this shared module.                                    |
+| `services.espanso`  | (inherits HM upstream)  | `x11Support = mkForce true`            | system76 leaves espanso's session-backend defaults alone; tpnix forces X11 via `home-manager.sharedModules` because it runs i3 on X11.                                |
 
 Authoritative source for any host: that host's `imports.nix` (`modules/<host>/imports.nix`). When adding a new secret module, set both NixOS- and HM-side defaults explicitly per host so behavior is obvious from `imports.nix` rather than implicit through `mkDefault` chains.
 

--- a/docs/architecture/05-host-composition.md
+++ b/docs/architecture/05-host-composition.md
@@ -52,7 +52,6 @@ Every host follows the same shape: each `modules/<host>/*.nix` file extends `con
 | `modules/system76/imports.nix`                | Baseline module imports and hardware profile wiring                |
 | `modules/system76/home-manager-apps.nix`      | system76-only HM extras (awscli2, pentesting-devshell)             |
 | `modules/system76/nix-settings.nix`           | Hardware-tuned `max-jobs` and `min-free` overrides                 |
-| `modules/system76/nix-substituters.nix`       | Regional substituter mirror (ustc)                                 |
 | `modules/system76/ssh.nix`                    | system76 host public key + `services.openssh.enable` override      |
 | `modules/system76/packages.nix`               | system76-hardware packages (system76-power, firmware, etc.)        |
 | `modules/system76/system76-power-overlay.nix` | `system76-power` patch overlay (host-specific)                     |
@@ -73,7 +72,6 @@ Every host follows the same shape: each `modules/<host>/*.nix` file extends `con
 | `modules/tpnix/home-manager-apps.nix`    | tpnix-only HM extras (libreoffice)                                       |
 | `modules/tpnix/default-apps.nix`         | Per-host overrides for `host.defaults` (audioPlayer, videoPlayer = null) |
 | `modules/tpnix/nix-settings.nix`         | Hardware-tuned `max-jobs` and `min-free` overrides                       |
-| `modules/tpnix/nix-substituters.nix`     | Regional substituter mirror (sjtu)                                       |
 | `modules/tpnix/firmware-manager-fix.nix` | tpnix-only `services.fwupd.enable = true;` override                      |
 | `modules/tpnix/r2-runtime.nix`           | Host runtime bindings for external `r2-flake` modules                    |
 | `modules/tpnix/hardware-config.nix`      | Filesystems, firmware, low-level hardware settings                       |
@@ -126,7 +124,7 @@ After host-level changes, build every affected host closure and run flake-level 
 ```bash
 nix build .#nixosConfigurations.<host>.config.system.build.toplevel
 nix flake check --accept-flake-config --no-build --offline
-nix run .#generation-manager -- score   # target: 35/35
+nix run .#generation-manager -- score   # target: 20/20
 ```
 
 Use `nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames` to enumerate the host names available in the current checkout.

--- a/docs/architecture/06-reference.md
+++ b/docs/architecture/06-reference.md
@@ -10,7 +10,7 @@ Run the following before every push:
 nix fmt
 nix develop -c bash scripts/hooks/sync-pre-commit-hooks.sh
 nix develop -c pre-commit run --all-files --hook-stage manual
-nix run .#generation-manager -- score   # target: 35/35
+nix run .#generation-manager -- score   # target: 20/20
 nix flake check --accept-flake-config --no-build --offline
 ```
 

--- a/docs/guides/apps-module-style-guide.md
+++ b/docs/guides/apps-module-style-guide.md
@@ -454,7 +454,7 @@ sharedAppNames = [
 ];
 ```
 
-> **Pitfall:** HM modules exported to `flake.homeManagerModules.apps.<name>` are **not** auto-imported. They must be explicitly listed in `home-manager-apps.nix`. The `flake.homeManagerModules.gui` namespace (used by i3wm, terminal configs, etc.) is auto-loaded separately.
+> **Pitfall:** HM modules exported to `flake.homeManagerModules.apps.<name>` are **not** auto-imported. They must be explicitly listed in the `sharedAppNames` list in `home-manager-apps.nix` (or a host's `hostAppNames`). GUI session modules are no exception: `i3-config` and `stylix-gui` are themselves `flake.homeManagerModules.apps.*` modules listed in `sharedAppNames`.
 
 ### 8. Check for Stylix Integration
 
@@ -465,7 +465,8 @@ grep -r "<tool>" /data/git/nix-community-stylix/modules/
 
 ### 9. Add Stylix Configuration (if supported)
 
-Add to `modules/style/stylix.nix` under `flake.homeManagerModules.gui`:
+Add to the Home Manager Stylix module in `modules/stylix/stylix.nix`
+(`flake.homeManagerModules.apps.stylix-gui`), inside its `stylix.targets` block:
 
 ```nix
 stylix.targets.<tool> = {
@@ -480,7 +481,7 @@ stylix.targets.<tool> = {
 git add modules/apps/<tool>.nix modules/hm-apps/<tool>.nix
 git add modules/hosts/common/apps-enable.nix
 git add modules/hosts/common/home-manager-apps.nix
-git add modules/style/stylix.nix
+git add modules/stylix/stylix.nix
 
 nix fmt
 nix flake check --accept-flake-config --no-build

--- a/docs/guides/custom-packages-style-guide.md
+++ b/docs/guides/custom-packages-style-guide.md
@@ -24,15 +24,16 @@ Use lowercase, hyphenated names matching the package's `pname`. Keep the directo
 
 ```
 packages/
-├── age-plugin-fido2prf/
+├── dnsleak/
 │   └── default.nix
 ├── searchfox-cli/
 │   ├── default.nix
 │   ├── hashes.json
 │   └── update.py
-└── malimite/
+└── wfuzz/
     ├── default.nix
-    └── fix-classpath.patch
+    ├── python-313-shlex.patch
+    └── update.py
 ```
 
 Use `hashes.json` when a package has multiple update-managed pins, such as `version`, `srcHash`, and `cargoHash`. Add `update.py` when the package can be updated mechanically from upstream release metadata. Expose it from the derivation with `passthru.updateScript = ./update.py;`.

--- a/docs/guides/stylix-integration.md
+++ b/docs/guides/stylix-integration.md
@@ -8,7 +8,9 @@ This document covers how Stylix theming integrates with the Dendritic Pattern an
 
 The integration is configured in:
 
-- `modules/theming/stylix.nix` -- NixOS-level Stylix configuration
+- `modules/stylix/stylix.nix` -- NixOS and Home Manager Stylix configuration
+  (exports `flake.nixosModules.{base,workstation}` and
+  `flake.homeManagerModules.{base,apps.stylix-gui}`)
 - Individual app modules -- may interact with Stylix targets
 
 ## Key Concept: NixOS vs Home Manager Targets

--- a/docs/guides/tray-icon-theming.md
+++ b/docs/guides/tray-icon-theming.md
@@ -3,8 +3,11 @@
 This guide documents how tray icons are managed on each i3-based host in this
 repo and how to make them match the active theme.
 
-Scope: any host that enables `gui.i3` (currently `system76` and `tpnix`) and
-the `vx` user.
+Scope: every host that runs the i3 session and the `vx` user. The i3 session is
+enabled by importing `flake.nixosModules.i3` (wired in through
+`modules/hosts/common/window-manager.nix` for hosts with `shareCommon = true`);
+there is no `gui.i3.enable` toggle, and the `gui.i3` option tree only carries
+session sub-options.
 
 ## Runtime Model
 

--- a/docs/mcp/logseq.md
+++ b/docs/mcp/logseq.md
@@ -18,6 +18,12 @@ npm install -g @logseq/cli
 logseq mcp-server [options]
 ```
 
+> **Nix package note**: This repository installs the CLI through the
+> `logseq-cli` package (flake input `nix-logseq-git-flake`), which names the
+> binary `logseq-cli`. On these hosts the plain `logseq` binary is the desktop
+> app, so invoke `logseq-cli mcp-server ...`. The `npm install` above instead
+> provides a `logseq` binary.
+
 ### Options
 
 | Flag                         | Alias | Default   | Description                              |

--- a/docs/mpv/4-integrations.md
+++ b/docs/mpv/4-integrations.md
@@ -91,7 +91,8 @@ extension is a per-user choice and not modeled here.
 4. Execs `mpv` (optionally with `--shuffle`) on the matching list.
 
 The helper is exposed as a custom package via
-`modules/base/custom-packages-overlay.nix` and gated behind the standard
+`modules/custom-overlays/video-cache.nix` (registering
+`flake.customOverlays.video-cache`) and gated behind the standard
 `programs.video-cache.extended.enable` option in `modules/apps/video-cache.nix`.
 It is independent of the mpv app module: enabling `video-cache` on a host that
 has mpv disabled installs the helper but `mpv` itself comes from

--- a/docs/pdf/additional-tools-reference.md
+++ b/docs/pdf/additional-tools-reference.md
@@ -6,7 +6,7 @@ Promotion to a host happens by authoring a `modules/apps/<name>.nix` module and 
 
 Each entry lists a representative invocation, optional additional invocations, upstream repository, official documentation, a one-line description, a one-line decision hint, and an upstream maintenance classification. Verified against `nixpkgs` rev pinned in `flake.lock` on 2026-05-09.
 
-`Stat.` classifies upstream health as of 2026-05-09: **Maintained** (release on/after 2025-01-01), **Maintenance mode** (mature/stable; active commits but no recent tagged release), **Core utility** (foundational tooling whose release cadence does not map to the other categories), or **Deprecated** (archived, abandoned, or superseded).
+`Stat.` classifies upstream health as of 2026-06-02: **Maintained** (release on/after 2025-01-01), **Maintenance mode** (mature/stable; active commits but no recent tagged release), **Core utility** (foundational tooling whose release cadence does not map to the other categories), or **Deprecated** (archived, abandoned, or superseded). Release dates were refreshed via the GitHub release API and PyPI on 2026-06-02.
 
 ## Convert To Markdown Or Structured Output
 
@@ -20,7 +20,7 @@ Each entry lists a representative invocation, optional additional invocations, u
   - Docs.: <https://docling-project.github.io/docling/>
   - Desc.: Layout-aware conversion of PDFs and other office formats (DOCX, PPTX, HTML, images) into Markdown, JSON, or chunks for RAG and LLM pipelines.
   - Use..: Mixed-format inputs or when an explicit document model with sections, tables, and figures must be preserved; prefer over `marker` for non-PDF sources.
-  - Stat.: Maintained (v2.93.0, 2026-05-07).
+  - Stat.: Maintained (v2.96.1, 2026-06-01).
 - marker
   - run..: `uvx --from marker-pdf marker_single report.pdf --output_dir out/`
   - More..:

--- a/docs/pdf/toolkit.md
+++ b/docs/pdf/toolkit.md
@@ -98,6 +98,16 @@ Tools that complement this toolkit but do not yet have a `modules/apps/` module 
   - Desc.: Adds a searchable OCR text layer to scanned PDFs while preserving the original page image.
   - Use..: Scanned PDF input; prefer over raw `tesseract` when the source is already a PDF.
   - Stat.: Maintained (v17.4.1, 2026-04-06).
+- readpdf
+  - run..: `readpdf report.pdf`
+  - More..:
+    - pages: `readpdf -p 2-5 report.pdf`
+    - file: `readpdf -o out.txt report.pdf`
+  - Repo.: Local module `modules/apps/readpdf.nix` (no upstream project).
+  - Docs.: Module header in `modules/apps/readpdf.nix`.
+  - Desc.: Force-OCR text extractor that wraps `ocrmypdf` for image-based or broken-text-layer PDFs; prints to stdout and adds `pdf-cat`/`cat-pdf` aliases.
+  - Use..: Pull plain text from a scanned or bad-text-layer PDF without producing a searchable PDF; prefer over `ocrmypdf` when only the text is needed.
+  - Stat.: Maintained (repo-local wrapper; tracks `ocrmypdf`).
 - tesseract
   - run..: `tesseract receipt.png stdout`
   - More..:
@@ -133,6 +143,7 @@ Tools that complement this toolkit but do not yet have a `modules/apps/` module 
 - Existing PDF, ML-driven Markdown/JSON for RAG pipelines: see [`additional-tools-reference.md`](additional-tools-reference.md) for `marker` and `docling`.
 - Existing PDF, layout-aware Markdown for RAG pipelines without bundled ML models: see [`additional-tools-reference.md`](additional-tools-reference.md) for `pymupdf4llm`.
 - Scanned PDF needing a searchable text layer: use `ocrmypdf`.
+- Scanned or broken-text-layer PDF, plain-text dump only: use `readpdf`.
 - Image OCR or OCR format debugging: use `tesseract`.
 - Full-featured GUI review with annotations: use `okular`.
 - Keyboard-centric reading or LaTeX workflows: use `zathura`.

--- a/docs/troubleshooting/nix-store-maintenance.md
+++ b/docs/troubleshooting/nix-store-maintenance.md
@@ -1,6 +1,6 @@
 # Nix Store Maintenance
 
-This runbook defines the default repair workflow for this host.
+This runbook defines the default repair workflow for each opted-in host.
 
 ## Host Defaults
 
@@ -40,6 +40,7 @@ sss-nix-repair --yes
 sss-nix-repair --keep-since 30d --keep 5
 sss-nix-repair --trust
 sss-nix-repair --no-clean --no-verify
+sss-nix-repair --help # or -h
 ```
 
 ## Manual Fallback Commands

--- a/modules/meta/flake-output.nix
+++ b/modules/meta/flake-output.nix
@@ -89,7 +89,7 @@
       # `modules/custom-overlays/`. Declared with attrsOf deferredModule for
       # the same reason as `flake.csec` above: each entry must be a
       # first-class submodule rather than collapse into the parent.
-      # Imported into each host by `modules/<host>/custom-overlays-base.nix`.
+      # Imported into each host by `modules/hosts/common/custom-overlays-base.nix`.
       customOverlays = lib.mkOption {
         type = lib.types.attrsOf lib.types.deferredModule;
         default = { };


### PR DESCRIPTION
## Summary
- refresh architecture and guide references for custom overlays, Stylix, i3, and generation-manager scoring
- document enabled local tools such as `readpdf`, `sss-nix-repair`, and the pinned `logseq-cli` binary
- update mpv/video-cache and PDF toolkit references against current repo and package state

## Test plan
- `nix fmt -- docs/architecture/01-pattern-overview.md docs/architecture/03-nixos-modules.md docs/architecture/04-home-manager.md docs/architecture/05-host-composition.md docs/architecture/06-reference.md docs/guides/apps-module-style-guide.md docs/guides/custom-packages-style-guide.md docs/guides/stylix-integration.md docs/guides/tray-icon-theming.md docs/mcp/logseq.md docs/mpv/4-integrations.md docs/pdf/additional-tools-reference.md docs/pdf/toolkit.md docs/troubleshooting/nix-store-maintenance.md modules/meta/flake-output.nix`
- `git diff --check`
- `nix eval --accept-flake-config --json .#homeManagerModules --apply '<stylix module checks>'`
- `nix eval --accept-flake-config --json .#customOverlays --apply '<video-cache overlay checks>'`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config --apply '<enabled tool checks>'`
- `nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames`
- `nix run .#generation-manager -- score`
- `curl -fsSL https://pypi.org/pypi/docling/json | jq -r '<docling version and upload time>'`