### PR TITLE
feat(i3wm): refresh i3status-rust status blocks

### DIFF
--- a/modules/apps/i3wm/status.nix
+++ b/modules/apps/i3wm/status.nix
@@ -105,7 +105,6 @@
           block = "time";
           interval = 60;
           format = " $icon $timestamp.datetime(f:'%a %d/%m %R') ";
-          format_alt = " $icon $timestamp.datetime(f:'%A %d %B %Y') ";
         }
       ];
 

--- a/modules/apps/i3wm/status.nix
+++ b/modules/apps/i3wm/status.nix
@@ -13,8 +13,8 @@
       netBlockBase = {
         block = "net";
         interval = 2;
-        format = " $icon {$ssid|$device} $ip ";
-        format_alt = "  $speed_down.eng(prefix:K)/s  $speed_up.eng(prefix:K)/s ";
+        format = " $icon {$ssid $signal_strength|$device} {$ip|} ";
+        format_alt = " $icon $device ^icon_net_down $speed_down.eng(prefix:K)/s ^icon_net_up $speed_up.eng(prefix:K)/s ";
       };
 
       netBlock = netBlockBase // lib.optionalAttrs (netInterface != null) { device = netInterface; };
@@ -50,11 +50,25 @@
         {
           block = "temperature";
           interval = 10;
+          info = 81.0;
+          warning = 90.0;
           format = " $icon $max ";
+          format_alt = " $icon $min min, $average avg, $max max ";
+        }
+        {
+          block = "backlight";
+          step_width = 10.0;
+          minimum = 1.0;
+          missing_format = "";
         }
         {
           block = "sound";
+          driver = "pipewire";
           format = " $icon {$volume|muted} ";
+          format_alt = " $icon $output_description.str(max_w:18) {$volume|muted} ";
+          step_width = 2;
+          max_vol = 100;
+          headphones_indicator = true;
           show_volume_when_muted = false;
           click = [
             {
@@ -64,14 +78,34 @@
           ];
         }
         {
+          block = "privacy";
+          driver = [
+            {
+              name = "v4l";
+            }
+            {
+              name = "pipewire";
+            }
+          ];
+        }
+        {
           block = "battery";
           interval = 30;
-          format = " $icon $percentage ";
+          format = " $icon $percentage {$time_remaining.dur(hms:true, min_unit:m) |}";
+          full_format = " $icon $percentage ";
+          not_charging_format = " $icon $percentage ";
+          missing_format = "";
+        }
+        {
+          block = "notify";
+          driver = "dunst";
+          format = " $icon {$notification_count.eng(w:1)|} ";
         }
         {
           block = "time";
           interval = 60;
           format = " $icon $timestamp.datetime(f:'%a %d/%m %R') ";
+          format_alt = " $icon $timestamp.datetime(f:'%A %d %B %Y') ";
         }
       ];
 

--- a/modules/apps/i3wm/status.nix
+++ b/modules/apps/i3wm/status.nix
@@ -56,12 +56,6 @@
           format_alt = " $icon $min min, $average avg, $max max ";
         }
         {
-          block = "backlight";
-          step_width = 10.0;
-          minimum = 1.0;
-          missing_format = "";
-        }
-        {
           block = "sound";
           driver = "pipewire";
           format = " $icon {$volume|muted} ";


### PR DESCRIPTION
## Summary
- Refresh the shared i3status-rust bar with better network, temperature, audio, battery, notification, and time displays.
- Add backlight, dunst notify, and privacy capture indicators while preserving the UX-significant block order.
- Keep the music block out of the bar, set the sound block to the native PipeWire driver, and set temperature thresholds to info through 81 C and warning from 82 C through 90 C.

## Test plan
- `nix fmt -- modules/apps/i3wm/status.nix`
- `nix eval --accept-flake-config --json .#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.i3status-rust.bars.default.blocks | jq 'map(select(.block == "temperature"))'`
- `nix eval --accept-flake-config --json .#nixosConfigurations.system76.config.home-manager.users.vx.programs.i3status-rust.bars.default.blocks | jq 'map(select(.block == "temperature"))'`
- `nix build --accept-flake-config --no-link --print-out-paths '.#nixosConfigurations.tpnix.config.home-manager.users.vx.xdg.configFile."i3status-rust/config-default.toml".source'`
- `rg -n '^block = |^info = |^warning = |music' /nix/store/glnlw9sgnxy3srx6ckcm3r9l69bn5qhp-config-default.toml`
- Commit hooks: `deadnix`, `nix-parse`, `statix`, `treefmt`, `typos`
- Pre-push hooks: `apps-catalog-sync`, `flake-checker`, `gitleaks`, `managed-files-drift`