### PR TITLE
fix: disable DMABUF on NVIDIA hosts (Gecko images + WebKitGTK apps)

### DIFF
--- a/modules/hm-apps/_gecko-mk-profile.nix
+++ b/modules/hm-apps/_gecko-mk-profile.nix
@@ -6,8 +6,8 @@
 
   Arguments:
     pkgs, lib, config: standard module args from the caller.
-    nvidiaProprietary: host runs the NVIDIA proprietary X driver; forwarded to
-      _gecko-prefs.nix to gate the widget.dmabuf workaround.
+    osConfig: NixOS configuration of the host, used to detect hardware facts;
+      forwarded to _gecko-prefs.nix to gate the widget.dmabuf workaround.
   Returns:
     mkProfile, policies, nativeMessagingHosts, profile packages, and helpers.
 */
@@ -16,9 +16,13 @@
   pkgs,
   lib,
   config,
-  nvidiaProprietary ? false,
+  osConfig ? { },
 }:
 let
+  # Gate on videoDrivers only: the proprietary NVIDIA DMABUF issue also affects Wayland.
+  nvidiaProprietary = lib.elem "nvidia" (
+    lib.attrByPath [ "services" "xserver" "videoDrivers" ] [ ] osConfig
+  );
   geckoPrefs = import ./_gecko-prefs.nix {
     inherit lib nvidiaProprietary;
     fonts = if (config.stylix.enable or false) then config.stylix.fonts else null;

--- a/modules/hm-apps/_gecko-mk-profile.nix
+++ b/modules/hm-apps/_gecko-mk-profile.nix
@@ -6,6 +6,8 @@
 
   Arguments:
     pkgs, lib, config: standard module args from the caller.
+    nvidiaProprietary: host runs the NVIDIA proprietary X driver; forwarded to
+      _gecko-prefs.nix to gate the widget.dmabuf workaround.
   Returns:
     mkProfile, policies, nativeMessagingHosts, profile packages, and helpers.
 */
@@ -14,10 +16,11 @@
   pkgs,
   lib,
   config,
+  nvidiaProprietary ? false,
 }:
 let
   geckoPrefs = import ./_gecko-prefs.nix {
-    inherit lib;
+    inherit lib nvidiaProprietary;
     fonts = if (config.stylix.enable or false) then config.stylix.fonts else null;
   };
   geckoBookmarks = import ./_gecko-bookmarks.nix { inherit lib; };

--- a/modules/hm-apps/_gecko-prefs.nix
+++ b/modules/hm-apps/_gecko-prefs.nix
@@ -199,7 +199,8 @@ in
       "network.dns.disableIPv6" = true;
     }
     // lib.optionalAttrs nvidiaProprietary {
-      # MOZ_X11_EGL bypasses gfx.x11-egl.force-disabled; widget.dmabuf is the effective switch.
+      # MOZ_X11_EGL bypasses gfx.x11-egl.force-disabled; widget.dmabuf is the effective
+      # switch, but it also disables VA-API surface import zero-copy on NVIDIA hosts.
       "widget.dmabuf.enabled" = false;
     };
 }

--- a/modules/hm-apps/_gecko-prefs.nix
+++ b/modules/hm-apps/_gecko-prefs.nix
@@ -11,6 +11,9 @@
 {
   lib,
   fonts ? null,
+  # True when the host runs the NVIDIA proprietary X driver (videoDrivers
+  # contains "nvidia"); gates the DMABUF workaround at the end of commonSettings.
+  nvidiaProprietary ? false,
 }:
 let
   geckoSearch = import ./_gecko-search.nix { };
@@ -194,5 +197,12 @@ in
 
       # Disable IPv6 address lookups.
       "network.dns.disableIPv6" = true;
+    }
+    // lib.optionalAttrs nvidiaProprietary {
+      # Disable DMABUF on the NVIDIA proprietary driver: its EGL/DMABUF zero-copy
+      # path corrupts images into color stripes under X11. widget.dmabuf is the
+      # reliable kill switch since gfx.x11-egl.force-disabled is overridden by the
+      # MOZ_X11_EGL env var. Host fact derives from services.xserver.videoDrivers.
+      "widget.dmabuf.enabled" = false;
     };
 }

--- a/modules/hm-apps/_gecko-prefs.nix
+++ b/modules/hm-apps/_gecko-prefs.nix
@@ -199,10 +199,7 @@ in
       "network.dns.disableIPv6" = true;
     }
     // lib.optionalAttrs nvidiaProprietary {
-      # Disable DMABUF on the NVIDIA proprietary driver: its EGL/DMABUF zero-copy
-      # path corrupts images into color stripes under X11. widget.dmabuf is the
-      # reliable kill switch since gfx.x11-egl.force-disabled is overridden by the
-      # MOZ_X11_EGL env var. Host fact derives from services.xserver.videoDrivers.
+      # MOZ_X11_EGL bypasses gfx.x11-egl.force-disabled; widget.dmabuf is the effective switch.
       "widget.dmabuf.enabled" = false;
     };
 }

--- a/modules/hm-apps/firefox.nix
+++ b/modules/hm-apps/firefox.nix
@@ -11,17 +11,12 @@ _: {
       legacyProfilesPath = ".mozilla/firefox";
       xdgProfilesPath = ".config/mozilla/firefox";
       nixosEnabled = lib.attrByPath [ "programs" "firefox" "extended" "enable" ] false osConfig;
-      # The NVIDIA proprietary X driver's EGL/DMABUF path corrupts images; detect
-      # it from the host so the gecko prefs disable widget.dmabuf on that host only.
-      nvidiaProprietary = lib.elem "nvidia" (
-        lib.attrByPath [ "services" "xserver" "videoDrivers" ] [ ] osConfig
-      );
       gecko = import ./_gecko-mk-profile.nix {
         inherit
           pkgs
           lib
           config
-          nvidiaProprietary
+          osConfig
           ;
       };
       xdgProfileRoot = gecko.mkXdgProfileRoot {

--- a/modules/hm-apps/firefox.nix
+++ b/modules/hm-apps/firefox.nix
@@ -11,11 +11,17 @@ _: {
       legacyProfilesPath = ".mozilla/firefox";
       xdgProfilesPath = ".config/mozilla/firefox";
       nixosEnabled = lib.attrByPath [ "programs" "firefox" "extended" "enable" ] false osConfig;
+      # The NVIDIA proprietary X driver's EGL/DMABUF path corrupts images; detect
+      # it from the host so the gecko prefs disable widget.dmabuf on that host only.
+      nvidiaProprietary = lib.elem "nvidia" (
+        lib.attrByPath [ "services" "xserver" "videoDrivers" ] [ ] osConfig
+      );
       gecko = import ./_gecko-mk-profile.nix {
         inherit
           pkgs
           lib
           config
+          nvidiaProprietary
           ;
       };
       xdgProfileRoot = gecko.mkXdgProfileRoot {

--- a/modules/hm-apps/librewolf.nix
+++ b/modules/hm-apps/librewolf.nix
@@ -30,11 +30,17 @@ _: {
       legacyProfilesPath = ".librewolf";
       xdgProfilesPath = ".config/librewolf/librewolf";
       nixosEnabled = lib.attrByPath [ "programs" "librewolf" "extended" "enable" ] false osConfig;
+      # The NVIDIA proprietary X driver's EGL/DMABUF path corrupts images; detect
+      # it from the host so the gecko prefs disable widget.dmabuf on that host only.
+      nvidiaProprietary = lib.elem "nvidia" (
+        lib.attrByPath [ "services" "xserver" "videoDrivers" ] [ ] osConfig
+      );
       gecko = import ./_gecko-mk-profile.nix {
         inherit
           pkgs
           lib
           config
+          nvidiaProprietary
           ;
       };
       xdgProfileRoot = gecko.mkXdgProfileRoot {

--- a/modules/hm-apps/librewolf.nix
+++ b/modules/hm-apps/librewolf.nix
@@ -30,17 +30,12 @@ _: {
       legacyProfilesPath = ".librewolf";
       xdgProfilesPath = ".config/librewolf/librewolf";
       nixosEnabled = lib.attrByPath [ "programs" "librewolf" "extended" "enable" ] false osConfig;
-      # The NVIDIA proprietary X driver's EGL/DMABUF path corrupts images; detect
-      # it from the host so the gecko prefs disable widget.dmabuf on that host only.
-      nvidiaProprietary = lib.elem "nvidia" (
-        lib.attrByPath [ "services" "xserver" "videoDrivers" ] [ ] osConfig
-      );
       gecko = import ./_gecko-mk-profile.nix {
         inherit
           pkgs
           lib
           config
-          nvidiaProprietary
+          osConfig
           ;
       };
       xdgProfileRoot = gecko.mkXdgProfileRoot {

--- a/modules/hosts/common/webkitgtk-dmabuf.nix
+++ b/modules/hosts/common/webkitgtk-dmabuf.nix
@@ -1,17 +1,3 @@
-/*
-  Internal: WebKitGTK DMABUF workaround for NVIDIA hosts
-  Description: WebKitGTK's EGL/DMABUF zero-copy renderer corrupts surfaces on the
-  NVIDIA proprietary driver under X11, the same root cause as the Gecko
-  widget.dmabuf image corruption. Symptoms: Tauri apps (yaak) render a blank
-  window; the WhatsApp-in-WebKitGTK client (karere) garbles its web surface.
-  WebKitGTK honors WEBKIT_DISABLE_DMABUF_RENDERER=1 to fall back to a glReadPixels
-  copy path; Gecko ignores this variable (it uses widget.dmabuf.enabled instead).
-
-  Set as a session-wide environment variable, matching how the NVIDIA VA-API vars
-  are wired in modules/system76/nvidia-gpu.nix, so launcher-started GTK apps
-  inherit it. Gated on the NVIDIA proprietary X driver via
-  services.xserver.videoDrivers so Intel/AMD hosts keep the zero-copy renderer.
-*/
 _:
 let
   body =

--- a/modules/hosts/common/webkitgtk-dmabuf.nix
+++ b/modules/hosts/common/webkitgtk-dmabuf.nix
@@ -1,0 +1,25 @@
+/*
+  Internal: WebKitGTK DMABUF workaround for NVIDIA hosts
+  Description: WebKitGTK's EGL/DMABUF zero-copy renderer corrupts surfaces on the
+  NVIDIA proprietary driver under X11, the same root cause as the Gecko
+  widget.dmabuf image corruption. Symptoms: Tauri apps (yaak) render a blank
+  window; the WhatsApp-in-WebKitGTK client (karere) garbles its web surface.
+  WebKitGTK honors WEBKIT_DISABLE_DMABUF_RENDERER=1 to fall back to a glReadPixels
+  copy path; Gecko ignores this variable (it uses widget.dmabuf.enabled instead).
+
+  Set as a session-wide environment variable, matching how the NVIDIA VA-API vars
+  are wired in modules/system76/nvidia-gpu.nix, so launcher-started GTK apps
+  inherit it. Gated on the NVIDIA proprietary X driver via
+  services.xserver.videoDrivers so Intel/AMD hosts keep the zero-copy renderer.
+*/
+_:
+let
+  body =
+    { config, lib, ... }:
+    lib.mkIf (lib.elem "nvidia" config.services.xserver.videoDrivers) {
+      environment.variables.WEBKIT_DISABLE_DMABUF_RENDERER = "1";
+    };
+in
+{
+  flake.nixosModules.hosts-common.imports = [ body ];
+}


### PR DESCRIPTION
## Summary

Two related fixes for the NVIDIA proprietary driver's broken EGL/DMABUF zero-copy path under X11, which corrupts GPU
surfaces. Both current hosts (`tpnix`, `system76`) run NVIDIA, so both apply today; each is gated so a future Intel/AMD
host keeps the zero-copy path.

### 1. Gecko (Firefox/LibreWolf): image corruption
LibreWolf/Firefox rendered every `<img>` as vertical color stripes. The dotfiles export `MOZ_X11_EGL=1`, forcing the
EGL/DMABUF path. `gfxPlatformGtk.cpp` reads `MOZ_X11_EGL` ahead of `gfx.x11-egl.force-disabled`, so the reliable switch
is `widget.dmabuf.enabled = false`. Scoped to NVIDIA via `nvidiaProprietary` (derived from
`osConfig.services.xserver.videoDrivers`), threaded through `_gecko-mk-profile.nix` into `_gecko-prefs.nix`.

### 2. WebKitGTK apps: blank / garbled UI
The same DMABUF path blanks WebKitGTK apps on NVIDIA. Removing the stale dotfiles `WEBKIT_DISABLE_DMABUF_RENDERER`
export blanked **yaak** (Tauri, whole UI is WebKitGTK); **karere** (WhatsApp-in-WebKitGTK) garbles likewise. Gecko
ignores this variable. New `modules/hosts/common/webkitgtk-dmabuf.nix` sets
`environment.variables.WEBKIT_DISABLE_DMABUF_RENDERER = "1"` session-wide (so launcher-started apps inherit it), gated
on `services.xserver.videoDrivers` containing `nvidia`.

Not a VA-API decode problem: `system76` routes VA-API to Intel `iHD` and still showed both symptoms.

The stale dotfiles `WEBKIT_DISABLE_DMABUF_RENDERER=1` (a WebKitGTK-only var that never affected Gecko, and lived in
interactive zsh so it did not reliably reach launcher-started GUI apps) is removed there and now owned declaratively by
nix.

## Test plan

- `nix fmt` on all changed modules (clean)
- Gecko: standalone eval shows `widget.dmabuf.enabled` present iff `nvidiaProprietary`; `tpnix`/`system76` generated
  user.js (librewolf + firefox) resolve it to `false`; both host toplevels build
- WebKitGTK: `tpnix`/`system76` resolve `environment.variables.WEBKIT_DISABLE_DMABUF_RENDERER = "1"`; standalone
  `evalModules` shows the var present for `videoDrivers=["nvidia"]` and absent for `["modesetting"]`
- After rebuild + relaunch: Firefox/LibreWolf images render; yaak and karere render correctly; `about:support`
  Graphics shows DMABUF "Force disable by pref"
