### PR TITLE
fix(codex): run agent shell through bash

### DIFF
--- a/modules/agents/codex/_exec-policy.nix
+++ b/modules/agents/codex/_exec-policy.nix
@@ -84,15 +84,29 @@ let
   # Scope recoverable bare `rm` rewrites to the top-level Codex shell command
   # instead of mutating PATH for every subprocess those commands spawn.
   #
-  # Keep the wrapper executable named `zsh` so Codex continues to classify
-  # `zsh -lc ...` invocations as shell commands and applies execpolicy to the
+  # Keep the wrapper executable named `bash` so Codex continues to classify
+  # `bash -lc ...` invocations as shell commands and applies execpolicy to the
   # inner script instead of requiring a blanket allowlist for the wrapper.
-  codexZshWrapper = pkgs.writeShellScriptBin "zsh" ''
+  codexBashWrapper = pkgs.writeShellScriptBin "bash" ''
     set -euo pipefail
 
     direnvBin=${lib.getExe pkgs.direnv}
-    realZsh=${lib.getExe pkgs.zsh}
+    realBash=${lib.getExe pkgs.bashInteractive}
     rmShimPath=${rmShim}/bin/rm
+
+    restoreCodexShellEnv() {
+      if [ -n "''${CODEX_ORIGINAL_LD_PRELOAD+x}" ]; then
+        if [ -n "$CODEX_ORIGINAL_LD_PRELOAD" ]; then
+          export LD_PRELOAD="$CODEX_ORIGINAL_LD_PRELOAD"
+        else
+          unset LD_PRELOAD
+        fi
+        unset CODEX_ORIGINAL_LD_PRELOAD
+      else
+        unset LD_PRELOAD
+      fi
+      unset NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+    }
 
     if [ "$#" -ge 2 ] && { [ "$1" = "-c" ] || [ "$1" = "-lc" ]; }; then
       shellFlag="$1"
@@ -100,9 +114,10 @@ let
       shift 2
 
       export CODEX_WRAPPED_COMMAND="$wrappedCommand"
-      exec "$realZsh" "$shellFlag" '
+      restoreCodexShellEnv
+      exec "$realBash" "$shellFlag" '
         # Mirror interactive direnv behavior for Codex non-interactive shell commands.
-        if direnvExports="$("'"$direnvBin"'" export zsh 2>/dev/null)"; then
+        if direnvExports="$("'"$direnvBin"'" export bash 2>/dev/null)"; then
           eval "$direnvExports"
         fi
         rm() {
@@ -112,7 +127,8 @@ let
       ' "$@"
     fi
 
-    exec "$realZsh" "$@"
+    restoreCodexShellEnv
+    exec "$realBash" "$@"
   '';
 
   execPolicyManagedRules =
@@ -507,7 +523,7 @@ let
 in
 {
   inherit
-    codexZshWrapper
+    codexBashWrapper
     execPolicyManagedRulesFile
     rmShim
     ;

--- a/modules/agents/codex/_exec-policy.nix
+++ b/modules/agents/codex/_exec-policy.nix
@@ -95,17 +95,12 @@ let
     rmShimPath=${rmShim}/bin/rm
 
     restoreCodexShellEnv() {
-      if [ -n "''${CODEX_ORIGINAL_LD_PRELOAD+x}" ]; then
-        if [ -n "$CODEX_ORIGINAL_LD_PRELOAD" ]; then
-          export LD_PRELOAD="$CODEX_ORIGINAL_LD_PRELOAD"
-        else
-          unset LD_PRELOAD
-        fi
-        unset CODEX_ORIGINAL_LD_PRELOAD
+      if [ -n "''${CODEX_ORIGINAL_LD_PRELOAD-}" ]; then
+        export LD_PRELOAD="$CODEX_ORIGINAL_LD_PRELOAD"
       else
         unset LD_PRELOAD
       fi
-      unset NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+      unset CODEX_ORIGINAL_LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
     }
 
     if [ "$#" -ge 2 ] && { [ "$1" = "-c" ] || [ "$1" = "-lc" ]; }; then

--- a/modules/agents/codex/_packaged-codex.nix
+++ b/modules/agents/codex/_packaged-codex.nix
@@ -1,20 +1,17 @@
 {
   pkgs,
   codexPkg,
-  codexZshWrapper,
 }:
 let
   version = codexPkg.version or "unknown";
   pname = codexPkg.pname or "codex";
 in
-# Rewrap upstream codex so InstallContext::from_exe finds the layout expected
-# by `shell_zsh_fork = true;` and other bundled-resource consumers.
+# Rewrap upstream codex so InstallContext::from_exe finds the package layout.
 # Invariants required by codex-rs/install-context/src/lib.rs:
 #   * $out/bin must be the parent of the resolved exe (canonicalised).
 #   * $out/codex-package.json must be a regular file (contents not parsed).
-#   * $out/codex-resources/zsh/bin/zsh must satisfy is_file() (symlink ok).
-# `codex-path/` is intentionally omitted so codex falls back to the system rg
-# from PATH; the same applies to every other bundled_resource() consumer.
+# `codex-path/` and `codex-resources/` are intentionally omitted so codex falls
+# back to PATH-managed tools instead of package-local resources.
 pkgs.runCommandLocal "${pname}-packaged-${version}"
   {
     passthru = {
@@ -25,9 +22,9 @@ pkgs.runCommandLocal "${pname}-packaged-${version}"
     };
   }
   ''
-    mkdir -p $out/bin $out/codex-resources/zsh/bin
+    mkdir -p $out/bin
 
-    # Copy the real ELF, not the upstream bash trampoline. current_exe() after
+    # Copy the real ELF, not the upstream binary wrapper. current_exe() after
     # execve must canonicalise inside $out so CodexPackageLayout::from_exe
     # locates $out/codex-package.json (the trampoline would leave it pointing
     # at upstream's store path, which has no metadata file).
@@ -47,6 +44,4 @@ pkgs.runCommandLocal "${pname}-packaged-${version}"
     # InstallContext::from_exe only checks is_file(); upstream's own tests
     # write literal `{}` here.
     printf '{}' > $out/codex-package.json
-
-    ln -s ${codexZshWrapper}/bin/zsh $out/codex-resources/zsh/bin/zsh
   ''

--- a/modules/agents/codex/_settings.nix
+++ b/modules/agents/codex/_settings.nix
@@ -102,9 +102,9 @@ let
       mentions_v2 = true;
       realtime_conversation = true;
       exec_permission_approvals = true;
-      # Patched zsh layout provided by ./_packaged-codex.nix; upstream removed
-      # the `zsh_path` key in v0.135.0 and now resolves via InstallContext.
-      shell_zsh_fork = true;
+      # Codex does not expose a config key for shell selection; ./_wrapper.nix
+      # supplies bash as the detected passwd shell instead.
+      shell_zsh_fork = false;
     };
 
     memories = {
@@ -149,6 +149,9 @@ let
       exclude = [
         "AWS_*"
         "AZURE_*"
+        "CODEX_ORIGINAL_LD_PRELOAD"
+        "LD_PRELOAD"
+        "NSS_WRAPPER_*"
       ];
     };
 

--- a/modules/agents/codex/_settings.nix
+++ b/modules/agents/codex/_settings.nix
@@ -149,7 +149,6 @@ let
       exclude = [
         "AWS_*"
         "AZURE_*"
-        "CODEX_ORIGINAL_LD_PRELOAD"
         "LD_PRELOAD"
         "NSS_WRAPPER_*"
       ];

--- a/modules/agents/codex/_wrapper.nix
+++ b/modules/agents/codex/_wrapper.nix
@@ -18,6 +18,7 @@ let
   tomlFormat = pkgs.formats.toml { };
   coreutilsId = lib.getExe' pkgs.coreutils "id";
   coreutilsMktemp = lib.getExe' pkgs.coreutils "mktemp";
+  coreutilsMv = lib.getExe' pkgs.coreutils "mv";
   coreutilsRm = lib.getExe' pkgs.coreutils "rm";
   coreutilsSha256sum = lib.getExe' pkgs.coreutils "sha256sum";
   nssWrapperLib = "${pkgs.nss_wrapper}/lib/libnss_wrapper.so";
@@ -93,6 +94,8 @@ let
     tmpDir="/tmp/agents"
     tmpOut=""
     tmpStamp=""
+    tmpPasswd=""
+    tmpGroup=""
 
     mkdir -p "$cfgDir"
     mkdir -p "$tmpDir"
@@ -104,6 +107,15 @@ let
       fi
       if [ -n "$tmpStamp" ] && [ -e "$tmpStamp" ]; then
         ${coreutilsRm} -f -- "$tmpStamp"
+      fi
+    }
+
+    cleanupNssArtifacts() {
+      if [ -n "$tmpPasswd" ] && [ -e "$tmpPasswd" ]; then
+        ${coreutilsRm} -f -- "$tmpPasswd"
+      fi
+      if [ -n "$tmpGroup" ] && [ -e "$tmpGroup" ]; then
+        ${coreutilsRm} -f -- "$tmpGroup"
       fi
     }
 
@@ -127,17 +139,20 @@ let
         echo "codex-wrapper: ERROR: failed to resolve current gid" >&2
         exit 1
       }
-      user="$(${coreutilsId} -un)" || {
-        echo "codex-wrapper: ERROR: failed to resolve current user name" >&2
-        exit 1
-      }
-      group="$(${coreutilsId} -gn)" || {
-        echo "codex-wrapper: ERROR: failed to resolve current group name" >&2
-        exit 1
-      }
+      user="$(${coreutilsId} -un 2>/dev/null)" || user="user"
+      group="$(${coreutilsId} -gn 2>/dev/null)" || group="group"
 
       mkdir -p "$nssDir" || {
         echo "codex-wrapper: ERROR: failed to create NSS runtime dir at $nssDir" >&2
+        exit 1
+      }
+      tmpPasswd="$(${coreutilsMktemp} "$nssDir/passwd.XXXXXXXX")" || {
+        echo "codex-wrapper: ERROR: failed to create temp NSS passwd file in $nssDir" >&2
+        exit 1
+      }
+      tmpGroup="$(${coreutilsMktemp} "$nssDir/group.XXXXXXXX")" || {
+        echo "codex-wrapper: ERROR: failed to create temp NSS group file in $nssDir" >&2
+        cleanupNssArtifacts
         exit 1
       }
       printf '%s:x:%s:%s::%s:%s\n' \
@@ -145,14 +160,28 @@ let
         "$uid" \
         "$gid" \
         "''${HOME:-${homeDir}}" \
-        "${codexBashWrapper}/bin/bash" > "$passwdFile" || {
-          echo "codex-wrapper: ERROR: failed to write NSS passwd override at $passwdFile" >&2
+        "${codexBashWrapper}/bin/bash" > "$tmpPasswd" || {
+          echo "codex-wrapper: ERROR: failed to write NSS passwd override at $tmpPasswd" >&2
+          cleanupNssArtifacts
           exit 1
         }
-      printf '%s:x:%s:\n' "$group" "$gid" > "$groupFile" || {
-        echo "codex-wrapper: ERROR: failed to write NSS group override at $groupFile" >&2
+      printf '%s:x:%s:\n' "$group" "$gid" > "$tmpGroup" || {
+        echo "codex-wrapper: ERROR: failed to write NSS group override at $tmpGroup" >&2
+        cleanupNssArtifacts
         exit 1
       }
+      ${coreutilsMv} -f -- "$tmpGroup" "$groupFile" || {
+        echo "codex-wrapper: ERROR: failed to install NSS group override at $groupFile" >&2
+        cleanupNssArtifacts
+        exit 1
+      }
+      tmpGroup=""
+      ${coreutilsMv} -f -- "$tmpPasswd" "$passwdFile" || {
+        echo "codex-wrapper: ERROR: failed to install NSS passwd override at $passwdFile" >&2
+        cleanupNssArtifacts
+        exit 1
+      }
+      tmpPasswd=""
 
       export CODEX_ORIGINAL_LD_PRELOAD="''${LD_PRELOAD-}"
       export LD_PRELOAD="${nssWrapperLib}''${LD_PRELOAD:+:$LD_PRELOAD}"

--- a/modules/agents/codex/_wrapper.nix
+++ b/modules/agents/codex/_wrapper.nix
@@ -3,22 +3,24 @@
   nixProjectSettings,
   configDir,
   codexPkg,
-  codexZshWrapper,
+  codexBashWrapper,
+  homeDir,
   lib,
   pkgs,
 }:
 let
-  # Repackaged codex closure that exposes the codex-package.json + bundled
-  # codex-resources layout required by `shell_zsh_fork = true;` starting in
-  # codex v0.135.0 (upstream removed the `zsh_path` config key).
+  # Repackaged codex closure that exposes codex-package.json for
+  # InstallContext::from_exe without enabling upstream's zsh fork path.
   codexPackaged = import ./_packaged-codex.nix {
-    inherit pkgs codexPkg codexZshWrapper;
+    inherit pkgs codexPkg;
   };
 
   tomlFormat = pkgs.formats.toml { };
+  coreutilsId = lib.getExe' pkgs.coreutils "id";
   coreutilsMktemp = lib.getExe' pkgs.coreutils "mktemp";
   coreutilsRm = lib.getExe' pkgs.coreutils "rm";
   coreutilsSha256sum = lib.getExe' pkgs.coreutils "sha256sum";
+  nssWrapperLib = "${pkgs.nss_wrapper}/lib/libnss_wrapper.so";
 
   baseConfigFile = tomlFormat.generate "codex-config-base" baseSettings;
   nixProjectsFile = tomlFormat.generate "codex-nix-projects" nixProjectSettings;
@@ -85,10 +87,14 @@ let
     userProjects="$cfgDir/trusted-projects.toml"
     out="$cfgDir/config.toml"
     mergeStamp="$cfgDir/config.merge.sha256"
+    nssDir="$cfgDir/runtime/nss"
+    passwdFile="$nssDir/passwd"
+    groupFile="$nssDir/group"
     tmpDir="/tmp/agents"
     tmpOut=""
     tmpStamp=""
 
+    mkdir -p "$cfgDir"
     mkdir -p "$tmpDir"
     export TMPDIR="$tmpDir"
 
@@ -110,6 +116,48 @@ let
           printf 'missing\t%s\n' "$path"
         fi
       done | ${coreutilsSha256sum} | awk '{print $1}'
+    }
+
+    prepareBashShellOverride() {
+      uid="$(${coreutilsId} -u)" || {
+        echo "codex-wrapper: ERROR: failed to resolve current uid" >&2
+        exit 1
+      }
+      gid="$(${coreutilsId} -g)" || {
+        echo "codex-wrapper: ERROR: failed to resolve current gid" >&2
+        exit 1
+      }
+      user="$(${coreutilsId} -un)" || {
+        echo "codex-wrapper: ERROR: failed to resolve current user name" >&2
+        exit 1
+      }
+      group="$(${coreutilsId} -gn)" || {
+        echo "codex-wrapper: ERROR: failed to resolve current group name" >&2
+        exit 1
+      }
+
+      mkdir -p "$nssDir" || {
+        echo "codex-wrapper: ERROR: failed to create NSS runtime dir at $nssDir" >&2
+        exit 1
+      }
+      printf '%s:x:%s:%s::%s:%s\n' \
+        "$user" \
+        "$uid" \
+        "$gid" \
+        "''${HOME:-${homeDir}}" \
+        "${codexBashWrapper}/bin/bash" > "$passwdFile" || {
+          echo "codex-wrapper: ERROR: failed to write NSS passwd override at $passwdFile" >&2
+          exit 1
+        }
+      printf '%s:x:%s:\n' "$group" "$gid" > "$groupFile" || {
+        echo "codex-wrapper: ERROR: failed to write NSS group override at $groupFile" >&2
+        exit 1
+      }
+
+      export CODEX_ORIGINAL_LD_PRELOAD="''${LD_PRELOAD-}"
+      export LD_PRELOAD="${nssWrapperLib}''${LD_PRELOAD:+:$LD_PRELOAD}"
+      export NSS_WRAPPER_PASSWD="$passwdFile"
+      export NSS_WRAPPER_GROUP="$groupFile"
     }
 
     if [ -f "$base" ]; then
@@ -154,6 +202,7 @@ let
       fi
     fi
 
+    prepareBashShellOverride
     exec ${codexPackaged}/bin/codex "$@"
   '';
 in

--- a/modules/agents/codex/home-manager.nix
+++ b/modules/agents/codex/home-manager.nix
@@ -67,10 +67,11 @@ _: {
         inherit
           configDir
           codexPkg
+          homeDir
           lib
           pkgs
           ;
-        inherit (execPolicy) codexZshWrapper;
+        inherit (execPolicy) codexBashWrapper;
         inherit (codexSettings)
           baseSettings
           nixProjectSettings


### PR DESCRIPTION
## Summary

- Disable Codex zsh-fork mode and stop packaging a zsh resource for the wrapper.
- Provide bash as Codex's detected passwd shell through a scoped nss_wrapper passwd entry.
- Keep the execpolicy shell wrapper behavior for direnv and recoverable rm while stripping the temporary NSS preload environment before shell commands run.

## Test plan

- `nix fmt -- modules/agents/codex/_wrapper.nix modules/agents/codex/_exec-policy.nix modules/agents/codex/_packaged-codex.nix modules/agents/codex/_settings.nix modules/agents/codex/home-manager.nix`
- `nix-instantiate --parse modules/agents/codex/_wrapper.nix >/dev/null && nix-instantiate --parse modules/agents/codex/_exec-policy.nix >/dev/null && nix-instantiate --parse modules/agents/codex/_packaged-codex.nix >/dev/null && nix-instantiate --parse modules/agents/codex/_settings.nix >/dev/null && nix-instantiate --parse modules/agents/codex/home-manager.nix >/dev/null`
- `nix build --no-link --print-out-paths .#nixosConfigurations.tpnix.config.home-manager.users.vx.home.activationPackage`
- `CODEX_HOME="$tmpHome" "$homePath/bin/codex" debug prompt-input 'shell smoke test'`
- `nix flake check --accept-flake-config --no-build --offline`