### PR TITLE
feat(gecko): migrate Firefox/Gecko dotfiles state into the flake

### DIFF
--- a/modules/hm-apps/_gecko-chrome.nix
+++ b/modules/hm-apps/_gecko-chrome.nix
@@ -1,0 +1,21 @@
+/*
+  Internal: shared Gecko-browser chrome stylesheet
+  Description: userChrome.css payload applied to every gecko browser
+  profile via _gecko-mk-profile.nix. Loading requires the
+  `toolkit.legacyUserProfileCustomizations.stylesheets` pref, which
+  _gecko-prefs.nix enables.
+
+  Notes:
+    * The dotfiles file opens with an invalid "# Font Settings" line. The
+      imported stylesheet keeps that font-family rule disabled with a CSS
+      comment so the inert behavior is explicit; activating it is a separate
+      decision, not part of this import.
+    * The dotfiles `userContent.css` is empty at the inspected revision and
+      is intentionally not recreated.
+    * The dotfiles `chrome/icons/*.svg` assets are referenced by no rule in
+      this stylesheet and are intentionally not copied.
+*/
+
+_: {
+  userChrome = builtins.readFile ./gecko-chrome/userChrome.css;
+}

--- a/modules/hm-apps/_gecko-darkreader-settings.json
+++ b/modules/hm-apps/_gecko-darkreader-settings.json
@@ -1,0 +1,123 @@
+{
+	"schemeVersion": 2,
+	"enabled": true,
+	"fetchNews": true,
+	"theme": {
+		"mode": 1,
+		"brightness": 100,
+		"contrast": 100,
+		"grayscale": 0,
+		"sepia": 0,
+		"useFont": false,
+		"fontFamily": "system-ui",
+		"textStroke": 0,
+		"engine": "dynamicTheme",
+		"stylesheet": "",
+		"styleSystemControls": true,
+		"lightColorScheme": "Default",
+		"darkColorScheme": "Default",
+		"immediateModify": false
+	},
+	"presets": [],
+	"customThemes": [
+		{
+			"url": ["*.officeapps.live.com"],
+			"theme": {
+				"mode": 1,
+				"brightness": 100,
+				"contrast": 100,
+				"grayscale": 0,
+				"sepia": 0,
+				"useFont": false,
+				"fontFamily": "Open Sans",
+				"textStroke": 0,
+				"engine": "cssFilter",
+				"stylesheet": "",
+				"styleSystemControls": true,
+				"lightColorScheme": "Default",
+				"darkColorScheme": "Default",
+				"immediateModify": false
+			},
+			"builtIn": true
+		},
+		{
+			"url": ["*.sharepoint.com"],
+			"theme": {
+				"mode": 1,
+				"brightness": 100,
+				"contrast": 100,
+				"grayscale": 0,
+				"sepia": 0,
+				"useFont": false,
+				"fontFamily": "Open Sans",
+				"textStroke": 0,
+				"engine": "cssFilter",
+				"stylesheet": "",
+				"styleSystemControls": true,
+				"lightColorScheme": "Default",
+				"darkColorScheme": "Default",
+				"immediateModify": false
+			},
+			"builtIn": true
+		},
+		{
+			"url": ["docs.google.com"],
+			"theme": {
+				"mode": 1,
+				"brightness": 100,
+				"contrast": 100,
+				"grayscale": 0,
+				"sepia": 0,
+				"useFont": false,
+				"fontFamily": "Open Sans",
+				"textStroke": 0,
+				"engine": "cssFilter",
+				"stylesheet": "",
+				"styleSystemControls": true,
+				"lightColorScheme": "Default",
+				"darkColorScheme": "Default",
+				"immediateModify": false
+			},
+			"builtIn": true
+		},
+		{
+			"url": ["onedrive.live.com"],
+			"theme": {
+				"mode": 1,
+				"brightness": 100,
+				"contrast": 100,
+				"grayscale": 0,
+				"sepia": 0,
+				"useFont": false,
+				"fontFamily": "Open Sans",
+				"textStroke": 0,
+				"engine": "cssFilter",
+				"stylesheet": "",
+				"styleSystemControls": true,
+				"lightColorScheme": "Default",
+				"darkColorScheme": "Default",
+				"immediateModify": false
+			},
+			"builtIn": true
+		}
+	],
+	"enabledByDefault": true,
+	"enabledFor": [],
+	"disabledFor": [],
+	"changeBrowserTheme": false,
+	"syncSettings": false,
+	"syncSitesFixes": true,
+	"automation": {
+		"enabled": false,
+		"mode": "",
+		"behavior": "OnOff"
+	},
+	"location": {
+		"latitude": null,
+		"longitude": null
+	},
+	"enableForPDF": true,
+	"enableForProtectedPages": true,
+	"enableContextMenus": true,
+	"detectDarkTheme": true
+}

--- a/modules/hm-apps/_gecko-extensions.nix
+++ b/modules/hm-apps/_gecko-extensions.nix
@@ -214,6 +214,35 @@ let
     list: !(builtins.elem list disabledLibrewolfLists)
   ) librewolfUblockOriginListData.lists;
 
+  darkreaderBaseSettings = lib.importJSON ./_gecko-darkreader-settings.json;
+  darkreaderStylixThemeColors = {
+    darkSchemeBackgroundColor = getStylixColor "base00" "#282c34";
+    darkSchemeTextColor = getStylixColor "base05" "#abb2bf";
+    lightSchemeBackgroundColor = getStylixColor "base06" "#b6bdca";
+    lightSchemeTextColor = getStylixColor "base00" "#282c34";
+    scrollbarColor = getStylixColor "base00" "#282c34";
+    selectionColor = getStylixColor "base0D" "#aca0f7";
+  };
+  withDarkreaderStylixColors = theme: theme // darkreaderStylixThemeColors;
+  # Stylix owns colors only for the dynamicTheme engine; cssFilter/svgFilter
+  # entries derive their output from the page, so the scheme colors are inert
+  # there and would just be dead keys in storage.
+  withStylixColorsIfDynamic =
+    theme: if (theme.engine or null) == "dynamicTheme" then withDarkreaderStylixColors theme else theme;
+  darkreaderSettings = darkreaderBaseSettings // {
+    theme = withStylixColorsIfDynamic darkreaderBaseSettings.theme;
+    customThemes = builtins.map (
+      customTheme: customTheme // { theme = withStylixColorsIfDynamic customTheme.theme; }
+    ) darkreaderBaseSettings.customThemes;
+  };
+  # Seed payload for Dark Reader. Written once as a writable file by
+  # mkDarkreaderSeed (_gecko-mk-profile.nix) instead of through
+  # extensions.settings, which force-rewrites storage.js on every activation
+  # and would discard the user's runtime Dark Reader changes.
+  darkreaderStorageSeed = pkgs.writeText "darkreader-storage.js" (
+    lib.generators.toJSON { } darkreaderSettings
+  );
+
   userscripts = builtins.fromJSON (builtins.readFile ./_gecko-userscripts.json);
   nixpkgsReviewGhaScript = userscripts."nixpkgs-review-gha";
   nixpkgsReviewGhaScriptId = toString nixpkgsReviewGhaScript.id;
@@ -402,89 +431,102 @@ in
   };
 
   inherit userChrome;
+  inherit darkreaderStorageSeed;
 
-  # uBO
-  extensionStorage."${ublockOrigin}".settings = {
-    advancedUserEnabled = true;
-    cloudStorageEnabled = false;
+  extensionStorage = {
+    # uBO
+    "${ublockOrigin}".settings = {
+      advancedUserEnabled = true;
+      cloudStorageEnabled = false;
 
-    hiddenSettings = { };
-    importedLists = [ ];
+      hiddenSettings = { };
+      importedLists = [ ];
 
-    showIconBadge = false;
-    uiAccentCustom = stylixEnabled;
-    uiAccentCustom0 = ublockOriginAccentColor;
-    uiTheme = ublockOriginUiTheme;
+      showIconBadge = false;
+      uiAccentCustom = stylixEnabled;
+      uiAccentCustom0 = ublockOriginAccentColor;
+      uiTheme = ublockOriginUiTheme;
 
-    hostnameSwitchesString = builtins.concatStringsSep "\n" [
-      "no-csp-reports: * true"
-      "no-large-media: behind-the-scene false"
-    ];
+      hostnameSwitchesString = builtins.concatStringsSep "\n" [
+        "no-csp-reports: * true"
+        "no-large-media: behind-the-scene false"
+      ];
 
-    dynamicFilteringString = builtins.concatStringsSep "\n" ublockOriginMediumModeRules;
+      dynamicFilteringString = builtins.concatStringsSep "\n" ublockOriginMediumModeRules;
 
-    netWhitelist = [
-      "chrome-extension-scheme"
-      "moz-extension-scheme"
-    ];
+      netWhitelist = [
+        "chrome-extension-scheme"
+        "moz-extension-scheme"
+      ];
 
-    urlFilteringString = "";
+      urlFilteringString = "";
 
-    userFilters = ''
-      ! https://octobox.io
-      octobox.io##.btn-outline-light.btn-sm.btn
+      userFilters = ''
+        ! https://octobox.io
+        octobox.io##.btn-outline-light.btn-sm.btn
 
-      ! https://web.webex.com
-      web.webex.com##.cookie-banner-body
+        ! https://web.webex.com
+        web.webex.com##.cookie-banner-body
 
-      ! https://www.google.com/sorry
-      @@||www.google.com/sorry^$document
-    '';
+        ! https://www.google.com/sorry
+        @@||www.google.com/sorry^$document
+      '';
 
-    selectedFilterLists = lib.unique (
-      librewolfUblockOriginLists
-      ++ [
-        # Keep "My filters" enabled; uBO hides the element picker without it.
-        "user-filters"
+      selectedFilterLists = lib.unique (
+        librewolfUblockOriginLists
+        ++ [
+          # Keep "My filters" enabled; uBO hides the element picker without it.
+          "user-filters"
 
-        # uBO Lists
-        "ublock-filters"
-        "ublock-privacy"
-        "ublock-quick-fixes"
-        "ublock-unbreak"
+          # uBO Lists
+          "ublock-filters"
+          "ublock-privacy"
+          "ublock-quick-fixes"
+          "ublock-unbreak"
 
-        # Ads Lists
-        "easylist"
-        "adguard-generic"
+          # Ads Lists
+          "easylist"
+          "adguard-generic"
 
-        # Privacy Lists
-        "easyprivacy"
-        "LegitimateURLShortener"
-        "adguard-spyware-url" # AdGuard/uBO - URL Tracking Protection
-        "block-lan"
+          # Privacy Lists
+          "easyprivacy"
+          "LegitimateURLShortener"
+          "adguard-spyware-url" # AdGuard/uBO - URL Tracking Protection
+          "block-lan"
 
-        # Multipurpose
-        "plowe-0"
+          # Multipurpose
+          "plowe-0"
 
-        # Cookie notices
-        "adguard-cookies"
-        "ublock-cookies-adguard" # Fanboy - Anti-Facebook
+          # Cookie notices
+          "adguard-cookies"
+          "ublock-cookies-adguard" # Fanboy - Anti-Facebook
 
-        # Annoyances
-        "adguard-other-annoyances"
-        "adguard-popup-overlays"
-        "adguard-widgets"
-        "ublock-annoyances"
+          # Annoyances
+          "adguard-other-annoyances"
+          "adguard-popup-overlays"
+          "adguard-widgets"
+          "ublock-annoyances"
 
-        # Additional regional lists
-        "ara-0"
-      ]
-    );
-  };
+          # Additional regional lists
+          "ara-0"
+        ]
+      );
+    };
 
-  # ViolentMonkey
-  extensionStorage."${violentmonkey}".settings = {
-    "code:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaCode;
-    "scr:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaRecord;
+    # ViolentMonkey
+    "${violentmonkey}".settings = {
+      "code:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaCode;
+      "scr:${nixpkgsReviewGhaScriptId}" = nixpkgsReviewGhaRecord;
+    };
+
+    # Dark Reader is intentionally absent here: extensions.settings force-writes
+    # storage.js on every activation, discarding the user's runtime Dark Reader
+    # changes. It is seeded once as a writable file instead; see
+    # darkreaderStorageSeed above and mkDarkreaderSeed in _gecko-mk-profile.nix.
+
+    # Tabliss is intentionally unmanaged: it is not in the extension policy set,
+    # and the archived dotfiles export (tabliss/tabliss.json) is dropped rather
+    # than ported. The managed new-tab surface stays Firefox's activity-stream,
+    # configured in _gecko-prefs.nix.
   };
 }

--- a/modules/hm-apps/_gecko-mk-profile.nix
+++ b/modules/hm-apps/_gecko-mk-profile.nix
@@ -113,9 +113,36 @@ let
         };
       };
     };
+
+  # Seed Dark Reader's storage.js once per profile as a writable file. Home
+  # Manager's extensions.settings would force-rewrite it on every activation
+  # and discard the extension's runtime state, so the seed is skipped whenever a
+  # real storage.js already exists. `addon@darkreader.org` is the extension ID
+  # (the browser-extension-data directory name); see _gecko-extensions.nix.
+  mkDarkreaderSeed =
+    {
+      profilesPath,
+      profiles,
+    }:
+    lib.hm.dag.entryAfter [ "writeBoundary" ] (
+      lib.concatMapStringsSep "\n" (profileName: ''
+        dr_dir="${config.home.homeDirectory}/${profilesPath}/${profileName}/browser-extension-data/addon@darkreader.org"
+        dr_file="$dr_dir/storage.js"
+        if [ -L "$dr_file" ] || [ ! -e "$dr_file" ]; then
+          $DRY_RUN_CMD rm -f "$dr_file"
+          $DRY_RUN_CMD mkdir -p "$dr_dir"
+          $DRY_RUN_CMD install -m644 ${geckoExtensions.darkreaderStorageSeed} "$dr_file"
+        fi
+      '') profiles
+    );
 in
 {
-  inherit mkProfile mkXdgProfileRoot policies;
+  inherit
+    mkProfile
+    mkXdgProfileRoot
+    mkDarkreaderSeed
+    policies
+    ;
   inherit (geckoShortcuts) mkCustomKeysFiles;
   inherit (geckoExtensions)
     nativeMessagingHosts

--- a/modules/hm-apps/_gecko-mk-profile.nix
+++ b/modules/hm-apps/_gecko-mk-profile.nix
@@ -35,6 +35,7 @@ let
       pkgs
       ;
   };
+  geckoChrome = import ./_gecko-chrome.nix { };
   geckoPolicies = import ./_gecko-policies.nix { };
   geckoShortcuts = import ./_gecko-mk-shortcuts.nix { inherit lib; };
 
@@ -61,7 +62,9 @@ let
         // geckoExtensions.toolbarSettings
         // (geckoBookmarks.settings bookmarksFile)
         // extraSettings;
-      inherit (geckoExtensions) userChrome;
+      # Imported dotfiles chrome first; the extension fragment appends so its
+      # widget-specific icon override wins the cascade.
+      userChrome = geckoChrome.userChrome + geckoExtensions.userChrome;
       extensions = {
         force = true;
         inherit packages;

--- a/modules/hm-apps/_gecko-mk-profile.nix
+++ b/modules/hm-apps/_gecko-mk-profile.nix
@@ -6,8 +6,6 @@
 
   Arguments:
     pkgs, lib, config: standard module args from the caller.
-    osConfig: NixOS configuration of the host, used to detect hardware facts;
-      forwarded to _gecko-prefs.nix to gate the widget.dmabuf workaround.
   Returns:
     mkProfile, policies, nativeMessagingHosts, profile packages, and helpers.
 */
@@ -16,15 +14,10 @@
   pkgs,
   lib,
   config,
-  osConfig ? { },
 }:
 let
-  # Gate on videoDrivers only: the proprietary NVIDIA DMABUF issue also affects Wayland.
-  nvidiaProprietary = lib.elem "nvidia" (
-    lib.attrByPath [ "services" "xserver" "videoDrivers" ] [ ] osConfig
-  );
   geckoPrefs = import ./_gecko-prefs.nix {
-    inherit lib nvidiaProprietary;
+    inherit lib;
     fonts = if (config.stylix.enable or false) then config.stylix.fonts else null;
   };
   geckoBookmarks = import ./_gecko-bookmarks.nix { inherit lib; };

--- a/modules/hm-apps/_gecko-prefs.nix
+++ b/modules/hm-apps/_gecko-prefs.nix
@@ -1,9 +1,8 @@
 /*
   Internal: shared Gecko-browser preferences
-  Description: user_pref values applied to every Firefox/LibreWolf profile.
+  Description: user_pref values applied to every Gecko-browser profile.
 
   Notes:
-    * Reader-mode colors come from Stylix's own reader-mode wiring.
     * `fonts` is forwarded from `config.stylix.fonts`; pass `null` to let
       the browser use its built-in defaults.
 */
@@ -11,9 +10,6 @@
 {
   lib,
   fonts ? null,
-  # True when the host runs the NVIDIA proprietary X driver (videoDrivers
-  # contains "nvidia"); gates the DMABUF workaround at the end of commonSettings.
-  nvidiaProprietary ? false,
 }:
 let
   geckoSearch = import ./_gecko-search.nix { };
@@ -197,10 +193,5 @@ in
 
       # Disable IPv6 address lookups.
       "network.dns.disableIPv6" = true;
-    }
-    // lib.optionalAttrs nvidiaProprietary {
-      # MOZ_X11_EGL bypasses gfx.x11-egl.force-disabled; widget.dmabuf is the effective
-      # switch, but it also disables VA-API surface import zero-copy on NVIDIA hosts.
-      "widget.dmabuf.enabled" = false;
     };
 }

--- a/modules/hm-apps/_gecko-prefs.nix
+++ b/modules/hm-apps/_gecko-prefs.nix
@@ -164,6 +164,7 @@ in
       "privacy.partition.network_state" = true;
       "network.cookie.cookieBehavior" = 5;
       "privacy.resistFingerprinting" = true;
+      "privacy.fingerprintingProtection" = true;
       # Disabling timer jitter dodges a Claude AI infinite-loop freeze.
       # See codeberg.org/librewolf/issues/issues/1934
       "privacy.resistFingerprinting.reduceTimerPrecision.jitter" = false;

--- a/modules/hm-apps/firefox.nix
+++ b/modules/hm-apps/firefox.nix
@@ -39,12 +39,7 @@ _: {
           # runtime changes survive home-manager switches.
           activation.seedDarkreaderFirefox = gecko.mkDarkreaderSeed {
             profilesPath = legacyProfilesPath;
-            # Mirrors programs.firefox.profiles below.
-            profiles = [
-              "primary"
-              "pentesting"
-              "work"
-            ];
+            profiles = lib.attrNames config.programs.firefox.profiles;
           };
 
           file = gecko.mkCustomKeysFiles config.programs.firefox // xdgProfileRoot.file;

--- a/modules/hm-apps/firefox.nix
+++ b/modules/hm-apps/firefox.nix
@@ -16,7 +16,6 @@ _: {
           pkgs
           lib
           config
-          osConfig
           ;
       };
       xdgProfileRoot = gecko.mkXdgProfileRoot {

--- a/modules/hm-apps/firefox.nix
+++ b/modules/hm-apps/firefox.nix
@@ -33,9 +33,23 @@ _: {
           }
         ];
 
-        home.activation.checkFirefoxXdgProfileRoot = xdgProfileRoot.activation;
+        home = {
+          activation.checkFirefoxXdgProfileRoot = xdgProfileRoot.activation;
 
-        home.file = gecko.mkCustomKeysFiles config.programs.firefox // xdgProfileRoot.file;
+          # Seed Dark Reader storage once as a writable file so the extension's
+          # runtime changes survive home-manager switches.
+          activation.seedDarkreaderFirefox = gecko.mkDarkreaderSeed {
+            profilesPath = legacyProfilesPath;
+            # Mirrors programs.firefox.profiles below.
+            profiles = [
+              "primary"
+              "pentesting"
+              "work"
+            ];
+          };
+
+          file = gecko.mkCustomKeysFiles config.programs.firefox // xdgProfileRoot.file;
+        };
 
         programs.firefox = {
           enable = true;

--- a/modules/hm-apps/gecko-chrome/userChrome.css
+++ b/modules/hm-apps/gecko-chrome/userChrome.css
@@ -1,0 +1,228 @@
+/*
+#Font Settings * {
+	font-family: "MonoLisa Variable" !important;
+	font-variation-settings: "wght" 500 !important;
+	font-feature-settings:
+		"ss01" 1,
+		"ss02" 1,
+		"ss07" 1,
+		"ss08" 1,
+		"ss10" 1,
+		"ss11" 1,
+		"ss15" 1,
+		"ss16" 1,
+		"ss17" 1,
+		"zero" 1,
+		"liga" 1,
+		"calt" 1,
+		"frac" 1,
+		"rlig" 1,
+		"rvrn" 1 !important;
+	line-height: 1.4 !important;
+	font-size: 12px !important;
+}
+*/
+
+/* Hide Tab Toolbar */
+:root {
+	--uc-window-control-width: 0px; /* Space reserved for window controls regular 138px */
+	--uc-window-drag-space-width: 4px; /* Extra space reserved on both sides of the nav-bar to be able to drag the window */
+	--uc-toolbar-height: 32px;
+}
+
+#nav-bar::before,
+#nav-bar::after {
+	content: "";
+	display: -moz-box;
+	width: var(--uc-window-drag-space-width);
+}
+
+toolbar#nav-bar::after {
+	width: calc(
+		var(--uc-window-control-width) +
+		var(--uc-window-drag-space-width, 0px)
+	);
+}
+
+:root:not([uidensity="compact"]) {
+	--uc-toolbar-height: 38px;
+}
+
+#TabsToolbar {
+	visibility: collapse !important;
+}
+
+:root:not([inFullscreen]) #nav-bar {
+	margin-top: calc(0px - var(--uc-toolbar-height));
+}
+
+#toolbar-menubar {
+	min-height: unset !important;
+	height: var(--uc-toolbar-height) !important;
+	position: relative;
+}
+
+#main-menubar {
+	-moz-box-flex: 1;
+	background-color: var(--toolbar-bgcolor, var(--toolbar-non-lwt-bgcolor));
+	background-clip: padding-box;
+	border-image:
+		linear-gradient(
+			to left,
+			transparent,
+			var(--toolbar-bgcolor, var(--toolbar-non-lwt-bgcolor)) 30px
+		)
+		20 / 30px;
+}
+
+#toolbar-menubar:not([inactive]) {
+	z-index: 2;
+}
+#toolbar-menubar[inactive] > #menubar-items {
+	opacity: 0;
+	pointer-events: none;
+	margin-left: var(--uc-window-drag-space-width, 0px);
+}
+
+#navigator-toolbox {
+	border-bottom: none !important;
+}
+
+/* Autohide Sidebar */
+#sidebar {
+	max-width: none !important;
+	min-width: 0px !important;
+}
+/* Hide splitter, when using Tree Style Tab. */
+#sidebar-box[sidebarcommand="treestyletab_piro_sakura_ne_jp-sidebar-action"]
+	+ #sidebar-splitter {
+	display: none !important;
+}
+/* Hide sidebar header, when using Tree Style Tab. */
+#sidebar-box[sidebarcommand="treestyletab_piro_sakura_ne_jp-sidebar-action"]
+	#sidebar-header {
+	visibility: collapse;
+}
+/* Shrink sidebar until hovered, when using Tree Style Tab. */
+:root {
+	--thin-tab-width: 38px;
+	--wide-tab-width: 200px;
+}
+#sidebar-box:not(
+	[sidebarcommand="treestyletab_piro_sakura_ne_jp-sidebar-action"]
+) {
+	min-width: var(--wide-tab-width) !important;
+	max-width: none !important;
+}
+#sidebar-box[sidebarcommand="treestyletab_piro_sakura_ne_jp-sidebar-action"] {
+	overflow: hidden !important;
+	position: relative !important;
+	transition: all 300ms !important;
+	min-width: var(--thin-tab-width) !important;
+	max-width: var(--thin-tab-width) !important;
+}
+#sidebar-box[sidebarcommand="treestyletab_piro_sakura_ne_jp-sidebar-action"]:hover,
+#sidebar-box[sidebarcommand="treestyletab_piro_sakura_ne_jp-sidebar-action"]
+	#sidebar {
+	transition: all 300ms !important;
+	min-width: var(--wide-tab-width) !important;
+	max-width: var(--wide-tab-width) !important;
+
+	/* Negative right-margin to keep page from being pushed to the side. */
+	margin-right: calc(var(--thin-tab-width) - var(--wide-tab-width)) !important;
+	z-index: 1;
+}
+
+/* Stylix feeds these browser theme variables through Firefox Color. */
+
+:root {
+	--uc-menu-bkgnd: var(
+		--panel-background-color,
+		var(--toolbar-background-color, Canvas)
+	);
+	--uc-menu-color: var(
+		--panel-text-color,
+		var(--toolbar-text-color, CanvasText)
+	);
+	--uc-menu-dimmed: var(--button-background-color-hover, SelectedItem);
+	--uc-menu-disabled: GrayText;
+}
+panel richlistbox,
+panel tree,
+panel button,
+panel menulist,
+panel textbox,
+panel input,
+menupopup,
+menu,
+menuitem {
+	-moz-appearance: none !important;
+}
+
+menulist,
+menuitem,
+menu {
+	min-height: 1.8em;
+}
+
+panel menulist {
+	border: 1px solid transparent;
+}
+
+panel richlistbox,
+panel tree,
+panel button,
+panel menulist,
+panel textbox,
+panel input,
+panel #searchbar,
+menupopup:not(#BMB_bookmarksPopup),
+#main-menubar > menu > menupopup,
+#context-navigation {
+	color: var(--uc-menu-color) !important;
+	padding: 2px;
+	background-color: var(--uc-menu-bkgnd) !important;
+	border: 1px solid var(--uc-menu-disabled) !important;
+}
+
+panel textbox input {
+	padding: 2px !important;
+}
+
+panel input {
+	border-width: 1px;
+	border-style: solid;
+	background-color: var(--uc-menu-bkgnd) !important;
+}
+panel #searchbar {
+	background-color: var(--uc-menu-bkgnd) !important;
+	padding: 0 !important;
+}
+panel #searchbar input {
+	background-color: transparent !important;
+}
+
+panel menulist:hover,
+panel menulist[open] {
+	border-color: SelectedItem !important;
+}
+
+#editBMPanel_folderMenuList > menupopup > menuitem {
+	color: var(--uc-menu-color) !important;
+}
+
+panel treechildren::-moz-tree-row(selected),
+panel button:hover,
+menu:hover,
+menu[_moz-menuactive],
+menu[open],
+menuitem:hover,
+menuitem[_moz-menuactive] {
+	background-color: var(--uc-menu-dimmed) !important;
+	color: inherit !important;
+}
+
+menu[disabled="true"],
+menuitem[disabled="true"] {
+	color: var(--uc-menu-disabled) !important;
+}

--- a/modules/hm-apps/librewolf.nix
+++ b/modules/hm-apps/librewolf.nix
@@ -52,9 +52,23 @@ _: {
           }
         ];
 
-        home.activation.checkLibreWolfXdgProfileRoot = xdgProfileRoot.activation;
+        home = {
+          activation.checkLibreWolfXdgProfileRoot = xdgProfileRoot.activation;
 
-        home.file = gecko.mkCustomKeysFiles config.programs.librewolf // xdgProfileRoot.file;
+          # Seed Dark Reader storage once as a writable file so the extension's
+          # runtime changes survive home-manager switches.
+          activation.seedDarkreaderLibrewolf = gecko.mkDarkreaderSeed {
+            profilesPath = legacyProfilesPath;
+            # Mirrors programs.librewolf.profiles below.
+            profiles = [
+              "primary"
+              "pentesting"
+              "work"
+            ];
+          };
+
+          file = gecko.mkCustomKeysFiles config.programs.librewolf // xdgProfileRoot.file;
+        };
 
         programs.librewolf = {
           enable = true;

--- a/modules/hm-apps/librewolf.nix
+++ b/modules/hm-apps/librewolf.nix
@@ -58,12 +58,7 @@ _: {
           # runtime changes survive home-manager switches.
           activation.seedDarkreaderLibrewolf = gecko.mkDarkreaderSeed {
             profilesPath = legacyProfilesPath;
-            # Mirrors programs.librewolf.profiles below.
-            profiles = [
-              "primary"
-              "pentesting"
-              "work"
-            ];
+            profiles = lib.attrNames config.programs.librewolf.profiles;
           };
 
           file = gecko.mkCustomKeysFiles config.programs.librewolf // xdgProfileRoot.file;

--- a/modules/hm-apps/librewolf.nix
+++ b/modules/hm-apps/librewolf.nix
@@ -35,7 +35,6 @@ _: {
           pkgs
           lib
           config
-          osConfig
           ;
       };
       xdgProfileRoot = gecko.mkXdgProfileRoot {

--- a/modules/hosts/common/gecko-env.nix
+++ b/modules/hosts/common/gecko-env.nix
@@ -10,24 +10,35 @@
   it, not just terminal-spawned ones.
 
   The dotfiles NVIDIA branch (NVD_BACKEND=direct, LIBVA_DRIVER_NAME=nvidia,
-  MOZ_DISABLE_RDD_SANDBOX=1) is intentionally not ported. Those variables
-  configure nvidia-vaapi-driver, which modules/system76/nvidia-gpu.nix
-  deliberately rejects: hardware.nvidia.videoAcceleration is false and
-  VA-API routes through Intel iHD to avoid Xid 31 NVDEC faults, so
-  LIBVA_DRIVER_NAME=nvidia would point libva at an uninstalled driver and
-  override the host's iHD routing, while MOZ_DISABLE_RDD_SANDBOX would
-  weaken the RDD process sandbox for a decode path that does not exist.
+  MOZ_DISABLE_RDD_SANDBOX=1) is preserved only when the host installs
+  nvidia-vaapi-driver. modules/system76/nvidia-gpu.nix deliberately rejects
+  that driver: hardware.nvidia.videoAcceleration is false and VA-API routes
+  through Intel iHD to avoid Xid 31 NVDEC faults, so the NVIDIA VA-API
+  variables would override the host's iHD routing and weaken the RDD process
+  sandbox for a decode path that does not exist.
 
   WEBKIT_DISABLE_DMABUF_RENDERER from the same dotfiles branch is
   WebKit-specific and owned by modules/hosts/common/webkitgtk-dmabuf.nix.
 */
-_:
+{ lib, ... }:
 let
-  body = {
-    environment.sessionVariables = {
-      MOZ_X11_EGL = "1";
+  body =
+    { config, ... }:
+    let
+      hasNvidiaVaapiDriver = builtins.any (
+        package: lib.getName package == "nvidia-vaapi-driver"
+      ) config.hardware.graphics.extraPackages;
+    in
+    {
+      environment.sessionVariables = {
+        MOZ_X11_EGL = "1";
+      }
+      // lib.optionalAttrs hasNvidiaVaapiDriver {
+        NVD_BACKEND = lib.mkDefault "direct";
+        LIBVA_DRIVER_NAME = lib.mkDefault "nvidia";
+        MOZ_DISABLE_RDD_SANDBOX = lib.mkDefault "1";
+      };
     };
-  };
 in
 {
   flake.nixosModules.hosts-common.imports = [ body ];

--- a/modules/hosts/common/gecko-env.nix
+++ b/modules/hosts/common/gecko-env.nix
@@ -1,0 +1,34 @@
+/*
+  Gecko launch environment, migrated from dotfiles zsh startup
+  (Bad3r/dotfiles config/zsh/rc.d/firefox.zsh).
+
+  MOZ_X11_EGL selects the EGL GL backend on X11 and bypasses
+  gfx.x11-egl.force-disabled, which VA-API decode depends on.
+
+  Exported through sessionVariables (PAM-initialised) rather than variables
+  (shell-profile only) so browsers started from the desktop/app menu inherit
+  it, not just terminal-spawned ones.
+
+  The dotfiles NVIDIA branch (NVD_BACKEND=direct, LIBVA_DRIVER_NAME=nvidia,
+  MOZ_DISABLE_RDD_SANDBOX=1) is intentionally not ported. Those variables
+  configure nvidia-vaapi-driver, which modules/system76/nvidia-gpu.nix
+  deliberately rejects: hardware.nvidia.videoAcceleration is false and
+  VA-API routes through Intel iHD to avoid Xid 31 NVDEC faults, so
+  LIBVA_DRIVER_NAME=nvidia would point libva at an uninstalled driver and
+  override the host's iHD routing, while MOZ_DISABLE_RDD_SANDBOX would
+  weaken the RDD process sandbox for a decode path that does not exist.
+
+  WEBKIT_DISABLE_DMABUF_RENDERER from the same dotfiles branch is
+  WebKit-specific and owned by modules/hosts/common/webkitgtk-dmabuf.nix.
+*/
+_:
+let
+  body = {
+    environment.sessionVariables = {
+      MOZ_X11_EGL = "1";
+    };
+  };
+in
+{
+  flake.nixosModules.hosts-common.imports = [ body ];
+}

--- a/modules/hosts/common/webkitgtk-dmabuf.nix
+++ b/modules/hosts/common/webkitgtk-dmabuf.nix
@@ -3,7 +3,9 @@ let
   body =
     { config, lib, ... }:
     lib.mkIf (lib.elem "nvidia" config.services.xserver.videoDrivers) {
-      environment.variables.WEBKIT_DISABLE_DMABUF_RENDERER = "1";
+      # sessionVariables (PAM-initialised) so launcher-started GTK apps inherit
+      # the DMABUF-renderer disable, not just shell-spawned ones.
+      environment.sessionVariables.WEBKIT_DISABLE_DMABUF_RENDERER = "1";
     };
 in
 {

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -110,7 +110,9 @@ _: {
           # and the by-path render node keeps libva off the NVIDIA DRM device.
           # VDPAU_DRIVER is intentionally unset: VDPAU is legacy, and pointing it at
           # nvidia would route back into NVDEC.
-          environment.variables = {
+          # sessionVariables (PAM-initialised) so GUI apps launched outside a
+          # shell inherit the iHD routing, not just terminal-spawned ones.
+          environment.sessionVariables = {
             LIBVA_DRM_DEVICE = lib.mkDefault "/dev/dri/by-path/pci-0000:00:02.0-render";
             LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
           };


### PR DESCRIPTION
## Summary

Implements the Nix side of #295. The remaining Firefox/Gecko state from `Bad3r/dotfiles@c2ae2c0ba55c7f804cd0ec0d3602a951c509f620` is now owned by this flake; the follow-up dotfiles cleanup is queued below.

- `modules/hm-apps/_gecko-chrome.nix` plus `modules/hm-apps/gecko-chrome/userChrome.css`: imports the dotfiles `userChrome.css` with review corrections. The intentionally inert font block is a CSS comment, the toolbar color fallback uses nested `var()`, and menu colors consume Firefox theme variables so Stylix remains the color owner. `_gecko-mk-profile.nix` concatenates it before the existing 1Password toolbar fragment, so every Firefox and LibreWolf profile carries both.
- `modules/hm-apps/_gecko-darkreader-settings.json` plus `_gecko-extensions.nix`: ports the Dark Reader defaults as a pruned seed payload. The seed is installed once as a writable `browser-extension-data/addon@darkreader.org/storage.js` file by Home Manager activation, instead of force-managing it through `extensions.settings`, so user runtime changes survive future switches.
- `modules/hosts/common/gecko-env.nix`: owns `MOZ_X11_EGL=1` through `environment.sessionVariables`, replacing the active Gecko hardware-acceleration export from dotfiles for GUI-launched browsers as well as shell-launched browsers. `MOZ_WEBRENDER=1` is intentionally not ported because current Firefox enables WebRender by default and still treats the env var as a force-enable path.
- `modules/hosts/common/webkitgtk-dmabuf.nix` and `modules/system76/nvidia-gpu.nix`: move GUI-relevant browser and VA-API variables from shell-profile `environment.variables` declarations to PAM-initialized `environment.sessionVariables`.
- `_gecko-prefs.nix`, `_gecko-mk-profile.nix`, `firefox.nix`, and `librewolf.nix`: drop the stale NVIDIA `widget.dmabuf.enabled = false` profile gate and the now-dead `osConfig` plumbing from the shared profile builder.
- Tabliss: the archived export is intentionally dropped, documented in `_gecko-extensions.nix`.
- No default-browser logic is added. `host.defaults.browser` and `xdg.mime` stay the only authority.

## Decisions

| Dotfiles state | Decision | Reason |
| --- | --- | --- |
| `.mozilla/firefox/Bad3r/chrome/userChrome.css` | ported with review corrections | Issue steps 1 to 3. The stylesheet is merged with the 1Password fragment in `_gecko-mk-profile.nix`; the invalid dotfiles font marker is a CSS comment, toolbar fallback syntax is valid nested `var()`, and menu colors consume Firefox theme variables instead of embedded Nord hex values. |
| `chrome/userContent.css` | not recreated | Empty at the inspected revision. |
| `chrome/icons/*.svg` | omitted | No rule in the imported stylesheet references them. |
| `MOZ_X11_EGL` | ported through `environment.sessionVariables` | Issue step 6. This remains the active Gecko env setting needed for the X11 EGL VA-API path, and session variables reach desktop or app-menu launched browsers. |
| `MOZ_WEBRENDER` | dropped | WebRender is enabled by default in current Firefox and LibreWolf. Local Firefox source still parses `MOZ_WEBRENDER` through `WebRenderEnvvarEnabled` and can `UserForceEnable` WebRender from it, so a global session export would bypass normal graphics decisions rather than provide useful parity. |
| `NVD_BACKEND=direct`, `LIBVA_DRIVER_NAME=nvidia`, `MOZ_DISABLE_RDD_SANDBOX=1` | dropped, documented in `gecko-env.nix` | These configure nvidia-vaapi-driver, which `modules/system76/nvidia-gpu.nix` deliberately rejects: `hardware.nvidia.videoAcceleration = false` and VA-API routes through Intel iHD to avoid Xid 31 NVDEC faults. `LIBVA_DRIVER_NAME=nvidia` would point libva at an uninstalled driver and override the host iHD routing; `MOZ_DISABLE_RDD_SANDBOX` would weaken the RDD sandbox for a decode path that does not exist. |
| `WEBKIT_DISABLE_DMABUF_RENDERER=1` | stays WebKit-owned, exported through sessions | WebKit-specific, already owned NVIDIA-gated by `modules/hosts/common/webkitgtk-dmabuf.nix` (#294), per issue step 7. This PR only moves the owning declaration to `environment.sessionVariables` so launcher-started GTK apps inherit it. |
| `dark-Reader-Settings/Dark-Reader-Settings.json` | ported as a writable seed, pruned | Only keys in Dark Reader's storage shape are kept; export-only keys are dropped, personal site lists are left runtime-owned, and only built-in Office, SharePoint, Google Docs, and OneDrive presets remain. `syncSettings` is false because sync storage would shadow the local seed. |
| `tabliss/tabliss.json` | dropped, documented | Tabliss is not in the managed extension set; the managed new-tab surface stays activity-stream. Adding the extension would be a side effect the issue excludes. |

Review notes:

- The imported stylesheet opened with an invalid `# Font Settings` line in dotfiles. The Nix-managed CSS keeps the MonoLisa chrome font rule disabled with a standard CSS comment so the previously inert behavior is explicit. Activating it is a separate decision, noted in `_gecko-chrome.nix`.
- The stylesheet now resolves the toolbar fallback color as `var(--toolbar-bgcolor, var(--toolbar-non-lwt-bgcolor))` instead of treating `--toolbar-non-lwt-bgcolor` as a literal fallback token.
- The stylesheet no longer embeds the dotfiles Nord menu palette. Menu popup colors use Firefox theme variables such as `--panel-background-color`, `--panel-text-color`, `--toolbar-background-color`, and `--toolbar-text-color`; Stylix feeds those through its Firefox Color target for Firefox and LibreWolf.
- Dark Reader is intentionally absent from `extensions.settings`. Home Manager force-writes that storage path on every activation, so the profile activation hook seeds only missing or still-symlinked `storage.js` files and then leaves runtime state writable.
- `services.xserver.videoDrivers` currently resolves to `[ "nvidia" ]` on both `system76` and `tpnix`, so the WebKitGTK DMABUF session variable is expected on both hosts. The System76-only VA-API routing variables remain System76-only.

## Test plan

- [x] `nix fmt`
- [ ] `nix flake check --accept-flake-config --no-build --offline` failed before branch-specific checks completed because this checkout references an invalid local Nix store path for the `secrets` input: `path 'ymxydjzqms2zra9fj93zs33va33ycl44-secrets' is not valid`.
- [x] `nix eval --accept-flake-config --raw '.#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.firefox.profiles.primary.userChrome' | rg 'MonoLisa Variable|toolbarbutton-icon|var\(--toolbar-bgcolor, var\(--toolbar-non-lwt-bgcolor\)\)|--panel-background-color'`
- [x] `nix eval --accept-flake-config --raw '.#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.librewolf.profiles.primary.userChrome' | rg 'MonoLisa Variable|toolbarbutton-icon|var\(--toolbar-bgcolor, var\(--toolbar-non-lwt-bgcolor\)\)|--panel-background-color'`
- [x] `nix eval --accept-flake-config --json '.#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.firefox.profiles.primary.extensions.settings' | jq -e 'has("addon@darkreader.org") | not'`
- [x] `nix eval --accept-flake-config --json '.#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.librewolf.profiles.primary.extensions.settings' | jq -e 'has("addon@darkreader.org") | not'`
- [x] `nix eval --accept-flake-config --raw '.#nixosConfigurations.tpnix.config.home-manager.users.vx.home.activation.seedDarkreaderFirefox.data' | rg 'addon@darkreader.org|install -m644|storage.js'`
- [x] `nix eval --accept-flake-config --json '.#nixosConfigurations.system76.config.environment.sessionVariables' | jq -e '.MOZ_X11_EGL == "1" and .WEBKIT_DISABLE_DMABUF_RENDERER == "1" and .LIBVA_DRIVER_NAME == "iHD" and .LIBVA_DRM_DEVICE == "/dev/dri/by-path/pci-0000:00:02.0-render"'`
- [x] `nix eval --accept-flake-config --json '.#nixosConfigurations.tpnix.config.environment.sessionVariables' | jq -e '.MOZ_X11_EGL == "1" and .WEBKIT_DISABLE_DMABUF_RENDERER == "1" and (has("LIBVA_DRIVER_NAME") | not) and (has("LIBVA_DRM_DEVICE") | not)'`
- [x] `nix eval --accept-flake-config --json '.#nixosConfigurations.{system76,tpnix}.config.environment.sessionVariables'` checks confirm `MOZ_WEBRENDER` is absent on both hosts.
- [x] `nix build --accept-flake-config --no-link '.#nixosConfigurations.system76.config.home-manager.users.vx.home-files'`
- [x] `nix build --accept-flake-config --no-link --print-out-paths '.#nixosConfigurations.system76.config.home-manager.users.vx.home-files'` followed by checks that the output contains Firefox and LibreWolf primary `chrome/userChrome.css` files with both the imported chrome block and the 1Password toolbar fragment.
- [ ] Toplevel closure builds: not rerun in this rewrite pass. The earlier PR validation recorded them as blocked at main HEAD by an unrelated `logseq-cli-clj-deps-2.0.1-alpha+nightly.20260607` fixed-output hash mismatch.
- [ ] Runtime, after activation: `about:support` shows the managed profile `chrome/userChrome.css`; `$BROWSER` resolves from Nix-managed session variables; `xdg-open https://` opens `host.defaults.browser`; Dark Reader keeps the seeded settings while preserving runtime edits across Home Manager switches.

## Dotfiles cleanup (separate change, after this lands)

Remove or stop managing in `Bad3r/dotfiles`:

- `config/zsh/rc.d/firefox.zsh` (`MOZ_X11_EGL` is now in `modules/hosts/common/gecko-env.nix`, WebKit DMABUF is in `modules/hosts/common/webkitgtk-dmabuf.nix`, and `MOZ_WEBRENDER` is intentionally dropped)
- `config/zsh/rc.d/_browser.zsh` and the `BROWSER` export in `x11/xprofile` (owned by `host.defaults.browser`)
- `config/mimeapps.list` (owned by `modules/xdg/mime.nix`; note NixOS resolves to `librewolf.desktop`, not the stale `firefox.desktop` entries)
- `.mozilla/firefox/Bad3r/chrome/` including `userChrome.css`, empty `userContent.css`, and unreferenced `icons/`
- `dark-Reader-Settings/Dark-Reader-Settings.json` and `tabliss/tabliss.json`
- `firefox`, `firefox-developer-edition`, `zen-browser-bin` lines in `packages.txt`

Refs #295
