### PR TITLE
feat(mirrors): publish stable Python docs locally

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,11 @@ Prefer GitHub `owner/repo` shorthand for GitHub repositories, even when the
 input is a `https://github.com/owner/repo/` URL. For example,
 `tridactyl/tridactyl` maps to `/data/git/tridactyl-tridactyl`.
 
+The full path inventory lives in `docs/reference/local-mirrors.md`. When a
+common mirror is added or removed, keep `docs/reference/local-mirrors.md`,
+`docs/architecture/06-reference.md`, and `modules/agents/system-prompt.nix` in
+sync with `modules/hosts/common/mirrors.nix`.
+
 ## Execution Playbooks
 
 ### Branch Workflow

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,11 @@ Prefer GitHub `owner/repo` shorthand for GitHub repositories, even when the
 input is an `https://github.com/owner/repo/` URL. For example,
 `tridactyl/tridactyl` maps to `/data/git/tridactyl-tridactyl`.
 
+The full path inventory lives in `docs/reference/local-mirrors.md`. When a
+common mirror is added or removed, keep `docs/reference/local-mirrors.md`,
+`docs/architecture/06-reference.md`, and `modules/agents/system-prompt.nix` in
+sync with `modules/hosts/common/mirrors.nix`.
+
 ## Branch And PR Workflow
 
 Use a dedicated worktree and PR for changes. Do not commit directly to `main`

--- a/docs/architecture/06-reference.md
+++ b/docs/architecture/06-reference.md
@@ -103,6 +103,8 @@ Available after `nix develop`:
 | Firefox source/docs        | `/data/git/mozilla-firefox-firefox`                   |
 | Firefox built docs         | `/data/git/mozilla-firefox-firefox-docs/current`      |
 | MDN Web Docs               | `/data/git/mdn-content`                               |
+| CPython source/docs        | `/data/git/python-cpython`                            |
+| Python stable docs source  | `/data/git/python-cpython-docs/current`               |
 | NixOS manual mirror        | `docs/nixos-manual/`                                  |
 | Home Manager manual        | `/data/git/nix-community-home-manager/docs/manual/`   |
 | Stylix source              | `/data/git/nix-community-stylix`                      |

--- a/docs/architecture/06-reference.md
+++ b/docs/architecture/06-reference.md
@@ -98,28 +98,68 @@ Available after `nix develop`:
 
 ## Resource Links
 
+The complete shared mirror inventory is documented in
+[`../reference/local-mirrors.md`](../reference/local-mirrors.md). The table
+below mirrors the configured common-host paths from
+`modules/hosts/common/mirrors.nix` plus generated documentation paths.
+
 | Resource                   | Location                                              |
 | -------------------------- | ----------------------------------------------------- |
-| Firefox source/docs        | `/data/git/mozilla-firefox-firefox`                   |
-| Firefox built docs         | `/data/git/mozilla-firefox-firefox-docs/current`      |
-| MDN Web Docs               | `/data/git/mdn-content`                               |
-| CPython source/docs        | `/data/git/python-cpython`                            |
-| Python stable docs source  | `/data/git/python-cpython-docs/current`               |
-| NixOS manual mirror        | `docs/nixos-manual/`                                  |
-| Home Manager manual        | `/data/git/nix-community-home-manager/docs/manual/`   |
-| Stylix source              | `/data/git/nix-community-stylix`                      |
-| Firefox policies           | `/data/git/mozilla-policy-templates`                  |
-| Enterprise admin reference | `/data/git/mozilla-enterprise-admin-reference`        |
-| LibreWolf settings         | `/data/git/codeberg-librewolf-settings`               |
 | Nix source                 | `/data/git/NixOS-nix`                                 |
-| Nix RFCs                   | `/data/git/NixOS-rfcs`                                |
+| nixos-hardware             | `/data/git/NixOS-nixos-hardware`                      |
 | nixpkgs                    | `/data/git/NixOS-nixpkgs`                             |
+| Nix RFCs                   | `/data/git/NixOS-rfcs`                                |
 | Lix source                 | `/data/git/git.lix.systems-lix-project-lix`           |
 | Lix installer              | `/data/git/git.lix.systems-lix-project-lix-installer` |
 | Lix NixOS module           | `/data/git/git.lix.systems-lix-project-nixos-module`  |
 | Determinate Nix installer  | `/data/git/DeterminateSystems-nix-installer`          |
+| Home Manager source        | `/data/git/nix-community-home-manager`                |
+| Home Manager manual        | `/data/git/nix-community-home-manager/docs/manual/`   |
+| nh                         | `/data/git/nix-community-nh`                          |
+| nixd                       | `/data/git/nix-community-nixd`                        |
+| nixvim                     | `/data/git/nix-community-nixvim`                      |
+| noogle                     | `/data/git/nix-community-noogle`                      |
+| Stylix source              | `/data/git/nix-community-stylix`                      |
+| llm-agents.nix             | `/data/git/numtide-llm-agents.nix`                    |
 | sops-nix                   | `/data/git/Mic92-sops-nix`                            |
+| devenv                     | `/data/git/cachix-devenv`                             |
+| git-hooks.nix              | `/data/git/cachix-git-hooks.nix`                      |
+| Cachix docs                | `/data/git/cachix-docs.cachix.org`                    |
+| lefthook                   | `/data/git/evilmartians-lefthook`                     |
+| flake-parts                | `/data/git/hercules-ci-flake-parts`                   |
+| flake.parts website        | `/data/git/hercules-ci-flake.parts-website`           |
+| files module               | `/data/git/mightyiam-files`                           |
+| treefmt                    | `/data/git/numtide-treefmt`                           |
+| treefmt-nix                | `/data/git/numtide-treefmt-nix`                       |
 | import-tree                | `/data/git/vic-import-tree`                           |
+| Duplicati docs             | `/data/git/duplicati-documentation`                   |
+| GitHub docs                | `/data/git/github-docs`                               |
+| i3 Docs                    | `/data/git/i3-i3.github.io`                           |
+| Firefox source/docs        | `/data/git/mozilla-firefox-firefox`                   |
+| Firefox built docs         | `/data/git/mozilla-firefox-firefox-docs/current`      |
+| MDN Web Docs               | `/data/git/mdn-content`                               |
+| Firefox policies           | `/data/git/mozilla-policy-templates`                  |
+| Enterprise admin reference | `/data/git/mozilla-enterprise-admin-reference`        |
+| CPython source/docs        | `/data/git/python-cpython`                            |
+| Python stable docs source  | `/data/git/python-cpython-docs/current`               |
+| LibreWolf settings         | `/data/git/codeberg-librewolf-settings`               |
+| better-auth                | `/data/git/better-auth-better-auth`                   |
+| Cloudflare Workers SDK     | `/data/git/cloudflare-workers-sdk`                    |
+| Duplicati source           | `/data/git/duplicati-duplicati`                       |
+| Logseq source              | `/data/git/logseq-logseq`                             |
+| mpv source                 | `/data/git/mpv-player-mpv`                            |
+| openai/codex               | `/data/git/openai-codex`                              |
+| rclone source              | `/data/git/rclone-rclone`                             |
+| restic source              | `/data/git/restic-restic`                             |
+| wappalyzer-next            | `/data/git/s0md3v-wappalyzer-next`                    |
+| tridactyl                  | `/data/git/tridactyl-tridactyl`                       |
+| ZAP source                 | `/data/git/zaproxy-zaproxy`                           |
+| ZAP extensions             | `/data/git/zaproxy-zap-extensions`                    |
+| ZAP Python API             | `/data/git/zaproxy-zap-api-python`                    |
+| ZAP community scripts      | `/data/git/zaproxy-community-scripts`                 |
+| fuzzdb                     | `/data/git/fuzzdb-project-fuzzdb`                     |
+| mcp-zap-server             | `/data/git/dtkmn-mcp-zap-server`                      |
+| NixOS manual mirror        | `docs/nixos-manual/`                                  |
 
 ## Next Steps
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -136,7 +136,7 @@
 - [reference/github-labels.md](reference/github-labels.md)
   - GitHub label taxonomy, application rules, and label-family reference for issues and pull requests.
 - [reference/local-mirrors.md](reference/local-mirrors.md)
-  - List of repositories mirrored locally via ghq for offline access and patching.
+  - List of repositories mirrored locally via `git-mirror` for offline access and patching.
 - [reference/mcp-tools.md](reference/mcp-tools.md)
   - Quick reference for available MCP tools including context7, cfdocs, cfbrowser, and deepwiki.
 

--- a/docs/reference/local-mirrors.md
+++ b/docs/reference/local-mirrors.md
@@ -84,27 +84,66 @@ Prefer shorthand for GitHub repositories even when the source is given as a
 `https://github.com/owner/repo/` URL.
 Full URLs include a normalized host prefix and strip common host suffixes such as `.org`.
 
+The configured shared repository rows mirror `programs.gitMirror.repos` in
+`modules/hosts/common/mirrors.nix`. Generated documentation rows are owned by
+`programs.gitMirror.firefoxDocs` and `programs.gitMirror.pythonDocs`.
+
 | Repository spec                                         | Local path                                                 |
 | ------------------------------------------------------- | ---------------------------------------------------------- |
 | `owner/repo`                                            | `$LOCAL_MIRRORS/owner-repo`                                |
 | `NixOS/nix`                                             | `$LOCAL_MIRRORS/NixOS-nix`                                 |
+| `NixOS/nixos-hardware`                                  | `$LOCAL_MIRRORS/NixOS-nixos-hardware`                      |
+| `NixOS/nixpkgs`                                         | `$LOCAL_MIRRORS/NixOS-nixpkgs`                             |
 | `NixOS/rfcs`                                            | `$LOCAL_MIRRORS/NixOS-rfcs`                                |
-| `DeterminateSystems/nix-installer`                      | `$LOCAL_MIRRORS/DeterminateSystems-nix-installer`          |
-| `nix-community/noogle`                                  | `$LOCAL_MIRRORS/nix-community-noogle`                      |
-| `mdn/content`                                           | `$LOCAL_MIRRORS/mdn-content`                               |
-| `mozilla/enterprise-admin-reference`                    | `$LOCAL_MIRRORS/mozilla-enterprise-admin-reference`        |
-| `mozilla-firefox/firefox`                               | `$LOCAL_MIRRORS/mozilla-firefox-firefox`                   |
-| Firefox built docs                                      | `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs`              |
-| `mozilla/policy-templates`                              | `$LOCAL_MIRRORS/mozilla-policy-templates`                  |
-| `mpv-player/mpv`                                        | `$LOCAL_MIRRORS/mpv-player-mpv`                            |
-| `openai/codex`                                          | `$LOCAL_MIRRORS/openai-codex`                              |
-| `python/cpython`                                        | `$LOCAL_MIRRORS/python-cpython`                            |
-| Current stable Python docs source                       | `$LOCAL_MIRRORS/python-cpython-docs/current`               |
-| `tridactyl/tridactyl`                                   | `$LOCAL_MIRRORS/tridactyl-tridactyl`                       |
 | `https://git.lix.systems/lix-project/lix.git`           | `$LOCAL_MIRRORS/git.lix.systems-lix-project-lix`           |
 | `https://git.lix.systems/lix-project/lix-installer.git` | `$LOCAL_MIRRORS/git.lix.systems-lix-project-lix-installer` |
 | `https://git.lix.systems/lix-project/nixos-module.git`  | `$LOCAL_MIRRORS/git.lix.systems-lix-project-nixos-module`  |
+| `DeterminateSystems/nix-installer`                      | `$LOCAL_MIRRORS/DeterminateSystems-nix-installer`          |
+| `nix-community/home-manager`                            | `$LOCAL_MIRRORS/nix-community-home-manager`                |
+| `nix-community/nh`                                      | `$LOCAL_MIRRORS/nix-community-nh`                          |
+| `nix-community/nixd`                                    | `$LOCAL_MIRRORS/nix-community-nixd`                        |
+| `nix-community/nixvim`                                  | `$LOCAL_MIRRORS/nix-community-nixvim`                      |
+| `nix-community/noogle`                                  | `$LOCAL_MIRRORS/nix-community-noogle`                      |
+| `nix-community/stylix`                                  | `$LOCAL_MIRRORS/nix-community-stylix`                      |
+| `numtide/llm-agents.nix`                                | `$LOCAL_MIRRORS/numtide-llm-agents.nix`                    |
+| `Mic92/sops-nix`                                        | `$LOCAL_MIRRORS/Mic92-sops-nix`                            |
+| `cachix/devenv`                                         | `$LOCAL_MIRRORS/cachix-devenv`                             |
+| `cachix/git-hooks.nix`                                  | `$LOCAL_MIRRORS/cachix-git-hooks.nix`                      |
+| `cachix/docs.cachix.org`                                | `$LOCAL_MIRRORS/cachix-docs.cachix.org`                    |
+| `evilmartians/lefthook`                                 | `$LOCAL_MIRRORS/evilmartians-lefthook`                     |
+| `hercules-ci/flake-parts`                               | `$LOCAL_MIRRORS/hercules-ci-flake-parts`                   |
+| `hercules-ci/flake.parts-website`                       | `$LOCAL_MIRRORS/hercules-ci-flake.parts-website`           |
+| `mightyiam/files`                                       | `$LOCAL_MIRRORS/mightyiam-files`                           |
+| `numtide/treefmt`                                       | `$LOCAL_MIRRORS/numtide-treefmt`                           |
+| `numtide/treefmt-nix`                                   | `$LOCAL_MIRRORS/numtide-treefmt-nix`                       |
+| `vic/import-tree`                                       | `$LOCAL_MIRRORS/vic-import-tree`                           |
+| `duplicati/documentation`                               | `$LOCAL_MIRRORS/duplicati-documentation`                   |
+| `github/docs`                                           | `$LOCAL_MIRRORS/github-docs`                               |
+| `i3/i3.github.io`                                       | `$LOCAL_MIRRORS/i3-i3.github.io`                           |
+| `mozilla-firefox/firefox`                               | `$LOCAL_MIRRORS/mozilla-firefox-firefox`                   |
+| Firefox built docs                                      | `$LOCAL_MIRRORS/mozilla-firefox-firefox-docs/current`      |
+| `mdn/content`                                           | `$LOCAL_MIRRORS/mdn-content`                               |
+| `mozilla/policy-templates`                              | `$LOCAL_MIRRORS/mozilla-policy-templates`                  |
+| `mozilla/enterprise-admin-reference`                    | `$LOCAL_MIRRORS/mozilla-enterprise-admin-reference`        |
+| `python/cpython`                                        | `$LOCAL_MIRRORS/python-cpython`                            |
+| Current stable Python docs source                       | `$LOCAL_MIRRORS/python-cpython-docs/current`               |
 | `https://codeberg.org/librewolf/settings.git`           | `$LOCAL_MIRRORS/codeberg-librewolf-settings`               |
+| `better-auth/better-auth`                               | `$LOCAL_MIRRORS/better-auth-better-auth`                   |
+| `cloudflare/workers-sdk`                                | `$LOCAL_MIRRORS/cloudflare-workers-sdk`                    |
+| `duplicati/duplicati`                                   | `$LOCAL_MIRRORS/duplicati-duplicati`                       |
+| `logseq/logseq`                                         | `$LOCAL_MIRRORS/logseq-logseq`                             |
+| `mpv-player/mpv`                                        | `$LOCAL_MIRRORS/mpv-player-mpv`                            |
+| `openai/codex`                                          | `$LOCAL_MIRRORS/openai-codex`                              |
+| `rclone/rclone`                                         | `$LOCAL_MIRRORS/rclone-rclone`                             |
+| `restic/restic`                                         | `$LOCAL_MIRRORS/restic-restic`                             |
+| `s0md3v/wappalyzer-next`                                | `$LOCAL_MIRRORS/s0md3v-wappalyzer-next`                    |
+| `tridactyl/tridactyl`                                   | `$LOCAL_MIRRORS/tridactyl-tridactyl`                       |
+| `zaproxy/zaproxy`                                       | `$LOCAL_MIRRORS/zaproxy-zaproxy`                           |
+| `zaproxy/zap-extensions`                                | `$LOCAL_MIRRORS/zaproxy-zap-extensions`                    |
+| `zaproxy/zap-api-python`                                | `$LOCAL_MIRRORS/zaproxy-zap-api-python`                    |
+| `zaproxy/community-scripts`                             | `$LOCAL_MIRRORS/zaproxy-community-scripts`                 |
+| `fuzzdb-project/fuzzdb`                                 | `$LOCAL_MIRRORS/fuzzdb-project-fuzzdb`                     |
+| `dtkmn/mcp-zap-server`                                  | `$LOCAL_MIRRORS/dtkmn-mcp-zap-server`                      |
 
 ## Firefox Source Docs
 
@@ -172,18 +211,56 @@ mirrors that should exist on every managed host:
 programs.gitMirror.repos = [
   "owner/repo"
   "NixOS/nix"
+  "NixOS/nixos-hardware"
+  "NixOS/nixpkgs"
   "NixOS/rfcs"
   "https://git.lix.systems/lix-project/lix.git"
   "https://git.lix.systems/lix-project/lix-installer.git"
   "https://git.lix.systems/lix-project/nixos-module.git"
   "DeterminateSystems/nix-installer"
+  "nix-community/home-manager"
+  "nix-community/nh"
+  "nix-community/nixd"
+  "nix-community/nixvim"
+  "nix-community/noogle"
+  "nix-community/stylix"
+  "numtide/llm-agents.nix"
+  "Mic92/sops-nix"
+  "cachix/devenv"
+  "cachix/git-hooks.nix"
+  "cachix/docs.cachix.org"
+  "evilmartians/lefthook"
+  "hercules-ci/flake-parts"
+  "hercules-ci/flake.parts-website"
+  "mightyiam/files"
+  "numtide/treefmt"
+  "numtide/treefmt-nix"
+  "vic/import-tree"
+  "duplicati/documentation"
+  "github/docs"
+  "i3/i3.github.io"
   "mozilla-firefox/firefox"
   "mdn/content" # https://developer.mozilla.org
   "mozilla/policy-templates"
   "mozilla/enterprise-admin-reference" # Documentation for policy behavior and syntax
   "python/cpython" # Source for docs.python.org
-  "tridactyl/tridactyl"
   "https://codeberg.org/librewolf/settings.git"
+  "better-auth/better-auth"
+  "cloudflare/workers-sdk"
+  "duplicati/duplicati"
+  "logseq/logseq"
+  "mpv-player/mpv"
+  "openai/codex"
+  "rclone/rclone"
+  "restic/restic"
+  "s0md3v/wappalyzer-next"
+  "tridactyl/tridactyl"
+  "zaproxy/zaproxy"
+  "zaproxy/zap-extensions"
+  "zaproxy/zap-api-python"
+  "zaproxy/community-scripts"
+  "fuzzdb-project/fuzzdb"
+  "dtkmn/mcp-zap-server"
   # ...
 ];
 ```

--- a/docs/reference/local-mirrors.md
+++ b/docs/reference/local-mirrors.md
@@ -22,9 +22,15 @@ Repositories sync to flat paths under `/data/git`.
   `git-mirror-firefox-docs.service` with `OnSuccess=` after sync when
   `programs.gitMirror.firefoxDocs.enable = true;`, so the docs build is not
   part of the mirror sync start transaction
-- **Switch behavior**: The mirror sync and Firefox docs build services use
-  `X-SwitchMethod=keep-old`; rebuilds update the unit files without starting
-  or restarting long-running mirror jobs during Home Manager activation
+- **Python documentation sources**: `git-mirror.service` queues
+  `git-mirror-python-docs.service` with `OnSuccess=` after sync when
+  `programs.gitMirror.pythonDocs.enable = true;`. The publisher resolves the
+  current stable Python minor version from `https://docs.python.org/3/`, then
+  publishes CPython `Doc/` from the matching upstream branch.
+- **Switch behavior**: The mirror sync, Firefox docs build, and Python docs
+  source publishing services use `X-SwitchMethod=keep-old`; rebuilds update the
+  unit files without starting or restarting long-running mirror jobs during Home
+  Manager activation
 - **Failure recovery**: `git-mirror.service` restarts on failure after 5
   minutes, bounded to three attempts per hour, so transient Git or network
   failures retry without churning forever
@@ -39,6 +45,7 @@ localMirrors.enable = true;
 home-manager.users.${metaOwner.username}.programs.gitMirror = {
   enable = true;
   firefoxDocs.enable = true;
+  pythonDocs.enable = true;
   repos = [
     "owner/repo"
     # ...
@@ -91,6 +98,8 @@ Full URLs include a normalized host prefix and strip common host suffixes such a
 | `mozilla/policy-templates`                              | `$LOCAL_MIRRORS/mozilla-policy-templates`                  |
 | `mpv-player/mpv`                                        | `$LOCAL_MIRRORS/mpv-player-mpv`                            |
 | `openai/codex`                                          | `$LOCAL_MIRRORS/openai-codex`                              |
+| `python/cpython`                                        | `$LOCAL_MIRRORS/python-cpython`                            |
+| Current stable Python docs source                       | `$LOCAL_MIRRORS/python-cpython-docs/current`               |
 | `tridactyl/tridactyl`                                   | `$LOCAL_MIRRORS/tridactyl-tridactyl`                       |
 | `https://git.lix.systems/lix-project/lix.git`           | `$LOCAL_MIRRORS/git.lix.systems-lix-project-lix`           |
 | `https://git.lix.systems/lix-project/lix-installer.git` | `$LOCAL_MIRRORS/git.lix.systems-lix-project-lix-installer` |
@@ -124,6 +133,36 @@ The service skips incomplete mirrors, dirty Firefox checkouts, and revisions
 that already have a successful generated docs tree. After publishing a new
 `current` symlink, it prunes old revision and linkcheck output directories.
 
+## Python Documentation Sources
+
+The CPython mirror publishes the current stable Python documentation source tree
+after the mirror updates. CPython `main` tracks future Python development, so
+the publisher does not use the checkout's default branch. It reads
+`https://docs.python.org/3/`, extracts the current stable minor branch from the
+page title, and archives `Doc/` from `origin/<major.minor>`.
+
+- Source checkout: `$LOCAL_MIRRORS/python-cpython`
+- Current stable docs source: `$LOCAL_MIRRORS/python-cpython-docs/current`
+- Revision sources:
+  `$LOCAL_MIRRORS/python-cpython-docs/revisions/<major.minor>-<sha>/Doc`
+- State marker: `$LOCAL_MIRRORS/python-cpython-docs/current-branch` records the
+  resolved branch, commit, and version URL
+- Retention: `programs.gitMirror.pythonDocs.maxRevisions` keeps the newest
+  source revisions, defaulting to `2`
+
+Run or inspect the docs source publisher directly:
+
+```bash
+systemctl --user start git-mirror-python-docs.service
+journalctl --user -u git-mirror-python-docs.service -n 100 --no-pager
+test -f /data/git/python-cpython-docs/current/conf.py
+```
+
+When `docs.python.org/3/` reports Python 3.14.x, the published source comes
+from CPython branch `3.14`. When the Python project promotes a newer stable
+minor version and updates `docs.python.org/3/`, the next successful sync moves
+`current` to that branch automatically.
+
 ## Adding Repositories
 
 Edit `programs.gitMirror.repos` in `modules/hosts/common/mirrors.nix` for
@@ -142,6 +181,7 @@ programs.gitMirror.repos = [
   "mdn/content" # https://developer.mozilla.org
   "mozilla/policy-templates"
   "mozilla/enterprise-admin-reference" # Documentation for policy behavior and syntax
+  "python/cpython" # Source for docs.python.org
   "tridactyl/tridactyl"
   "https://codeberg.org/librewolf/settings.git"
   # ...

--- a/modules/agents/system-prompt.nix
+++ b/modules/agents/system-prompt.nix
@@ -259,71 +259,44 @@ let
       ## Local Mirrors
 
       Use local source and documentation mirrors before web lookup when a mirror is
-      listed for the subject:
+      listed for the subject. The shared mirror list is managed in
+      `modules/hosts/common/mirrors.nix`, and operator path documentation lives in
+      `docs/reference/local-mirrors.md`.
 
-      - Stylix: `/data/git/nix-community-stylix`
-        Inspect source or apply local patches.
-      - Home Manager: `/data/git/nix-community-home-manager`
-        Review module behavior or backport fixes.
-      - Firefox source/docs: `/data/git/mozilla-firefox-firefox`
-        Inspect Firefox source behavior, Gecko internals, or preferences.
-      - Firefox built docs: `/data/git/mozilla-firefox-firefox-docs/current`
-        Browse generated Firefox source docs built by
-        `git-mirror-firefox-docs.service`.
-      - MDN Web Docs: `/data/git/mdn-content`
-        Reference MDN Web and API documentation offline.
-      - CPython source/docs: `/data/git/python-cpython`
-        Inspect Python implementation behavior and documentation sources.
-      - Python stable docs source: `/data/git/python-cpython-docs/current`
-        Browse the current stable Python documentation source tree published by
-        `git-mirror-python-docs.service`.
-      - Firefox policies: `/data/git/mozilla-policy-templates`
-        Inspect supported Firefox managed-policy templates and schema.
-      - Enterprise admin reference:
-        `/data/git/mozilla-enterprise-admin-reference`
-        Check Firefox enterprise policy behavior and syntax documentation.
-      - LibreWolf settings: `/data/git/codeberg-librewolf-settings`
-        Inspect upstream LibreWolf default settings and uBO assets.
-      - i3 Docs: `/data/git/i3-i3.github.io`
-        Reference i3 documentation offline.
-      - Duplicati Docs: `/data/git/duplicati-documentation`
-        Look up `duplicati-cli` commands, options, or backup format.
-      - Nix source: `/data/git/NixOS-nix`
-        Inspect Nix CLI, daemon, evaluator, or store behavior.
-      - Nix RFCs: `/data/git/NixOS-rfcs`
-        Review accepted and proposed NixOS RFCs offline.
-      - nixpkgs: `/data/git/NixOS-nixpkgs`
-        Inspect or patch upstream expressions.
-      - nixos-hardware: `/data/git/NixOS-nixos-hardware`
-        Pull hardware profiles and troubleshoot host hardware options.
-      - Lix source: `/data/git/git.lix.systems-lix-project-lix`
-        Inspect Lix implementation behavior or release history.
-      - Lix installer: `/data/git/git.lix.systems-lix-project-lix-installer`
-        Review Lix installer behavior and packaging.
-      - Lix NixOS module: `/data/git/git.lix.systems-lix-project-nixos-module`
-        Inspect the Lix NixOS module integration.
-      - Determinate Nix installer: `/data/git/DeterminateSystems-nix-installer`
-        Review Determinate installer behavior and Nix setup logic.
-      - nixvim: `/data/git/nix-community-nixvim`
-        Examine NixVim modules and options.
-      - noogle: `/data/git/nix-community-noogle`
-        Search Nix function signatures and documentation offline.
-      - treefmt-nix: `/data/git/numtide-treefmt-nix`
-        Adjust formatter behavior or pinning.
-      - git-hooks.nix: `/data/git/cachix-git-hooks.nix`
-        Update hook definitions or debug pre-commit failures.
-      - sops-nix: `/data/git/Mic92-sops-nix`
-        Manage encrypted secret integrations.
-      - import-tree: `/data/git/vic-import-tree`
-        Review or extend auto-loading behavior.
-      - files module: `/data/git/mightyiam-files`
-        Update generated NixOS artifact sources such as `.gitignore`.
-      - openai/codex: `/data/git/openai-codex`
-        Browse Codex CLI source and internals.
-      - tridactyl: `/data/git/tridactyl-tridactyl`
-        Reference Tridactyl browser extension source and configuration.
-      - mpv: `/data/git/mpv-player-mpv`
-        Inspect mpv player source, option definitions, and scripting API.
+      - Nix: `/data/git/NixOS-nix`, `/data/git/NixOS-nixos-hardware`,
+        `/data/git/NixOS-nixpkgs`, `/data/git/NixOS-rfcs`,
+        `/data/git/DeterminateSystems-nix-installer`
+      - Lix: `/data/git/git.lix.systems-lix-project-lix`,
+        `/data/git/git.lix.systems-lix-project-lix-installer`,
+        `/data/git/git.lix.systems-lix-project-nixos-module`
+      - Nix community: `/data/git/nix-community-home-manager`,
+        `/data/git/nix-community-nh`, `/data/git/nix-community-nixd`,
+        `/data/git/nix-community-nixvim`, `/data/git/nix-community-noogle`,
+        `/data/git/nix-community-stylix`
+      - Flake inputs and tooling: `/data/git/numtide-llm-agents.nix`,
+        `/data/git/Mic92-sops-nix`, `/data/git/cachix-devenv`,
+        `/data/git/cachix-git-hooks.nix`, `/data/git/cachix-docs.cachix.org`,
+        `/data/git/evilmartians-lefthook`, `/data/git/hercules-ci-flake-parts`,
+        `/data/git/hercules-ci-flake.parts-website`, `/data/git/mightyiam-files`,
+        `/data/git/numtide-treefmt`, `/data/git/numtide-treefmt-nix`,
+        `/data/git/vic-import-tree`
+      - Documentation: `/data/git/duplicati-documentation`,
+        `/data/git/github-docs`, `/data/git/i3-i3.github.io`,
+        `/data/git/mozilla-firefox-firefox`,
+        `/data/git/mozilla-firefox-firefox-docs/current`,
+        `/data/git/mdn-content`, `/data/git/mozilla-policy-templates`,
+        `/data/git/mozilla-enterprise-admin-reference`, `/data/git/python-cpython`,
+        `/data/git/python-cpython-docs/current`
+      - Applications and services: `/data/git/codeberg-librewolf-settings`,
+        `/data/git/better-auth-better-auth`, `/data/git/cloudflare-workers-sdk`,
+        `/data/git/duplicati-duplicati`, `/data/git/logseq-logseq`,
+        `/data/git/mpv-player-mpv`, `/data/git/openai-codex`,
+        `/data/git/rclone-rclone`, `/data/git/restic-restic`,
+        `/data/git/s0md3v-wappalyzer-next`, `/data/git/tridactyl-tridactyl`
+      - ZAP: `/data/git/zaproxy-zaproxy`,
+        `/data/git/zaproxy-zap-extensions`, `/data/git/zaproxy-zap-api-python`,
+        `/data/git/zaproxy-community-scripts`, `/data/git/fuzzdb-project-fuzzdb`,
+        `/data/git/dtkmn-mcp-zap-server`
     '';
   };
 

--- a/modules/agents/system-prompt.nix
+++ b/modules/agents/system-prompt.nix
@@ -191,6 +191,10 @@ let
     python = _vars: ''
       ## Python
 
+      Target Python 3.14 when using Python. Use the cloned docs at
+      `/data/git/python-cpython-docs/current` before web lookup when Python
+      behavior or documentation is relevant.
+
       Use `uv` and `uvx` for Python work. Do not use `pip`, `venv`, or direct
       `python` invocations. For inline or one-off dependencies, use
       `uv run --with <pkg> <script>`.

--- a/modules/agents/system-prompt.nix
+++ b/modules/agents/system-prompt.nix
@@ -195,7 +195,7 @@ let
       `/data/git/python-cpython-docs/current` before web lookup when Python
       behavior or documentation is relevant.
 
-      Use `uv` and `uvx` for Python work. Do not use `pip`, `venv`, or direct
+      Use `uv` and `uvx` for Python work. Do not directly use `pip`, `venv`, or
       `python` invocations. For inline or one-off dependencies, use
       `uv run --with <pkg> <script>`.
     '';

--- a/modules/agents/system-prompt.nix
+++ b/modules/agents/system-prompt.nix
@@ -268,6 +268,11 @@ let
         `git-mirror-firefox-docs.service`.
       - MDN Web Docs: `/data/git/mdn-content`
         Reference MDN Web and API documentation offline.
+      - CPython source/docs: `/data/git/python-cpython`
+        Inspect Python implementation behavior and documentation sources.
+      - Python stable docs source: `/data/git/python-cpython-docs/current`
+        Browse the current stable Python documentation source tree published by
+        `git-mirror-python-docs.service`.
       - Firefox policies: `/data/git/mozilla-policy-templates`
         Inspect supported Firefox managed-policy templates and schema.
       - Enterprise admin reference:

--- a/modules/hm-apps/_python-docs-publisher.nix
+++ b/modules/hm-apps/_python-docs-publisher.nix
@@ -18,6 +18,7 @@ pkgs.writeShellApplication {
   ];
   text = ''
     set -euo pipefail
+    export LC_ALL=C
 
     repo_path=${lib.escapeShellArg pythonDocs.repoPath}
     output_root=${lib.escapeShellArg pythonDocs.outputRoot}
@@ -54,8 +55,7 @@ pkgs.writeShellApplication {
     }
 
     resolve_stable_branch() {
-      page=$(curl --fail --location --silent --show-error "$version_url")
-      printf '%s\n' "$page" |
+      curl --fail --location --silent --show-error "$version_url" |
         sed -nE '/Python 3\.[0-9]+(\.[0-9]+)? [Dd]ocumentation/ {
           s/.*Python (3\.[0-9]+)(\.[0-9]+)? [Dd]ocumentation.*/\1/p
           q

--- a/modules/hm-apps/_python-docs-publisher.nix
+++ b/modules/hm-apps/_python-docs-publisher.nix
@@ -29,7 +29,7 @@ pkgs.writeShellApplication {
     log() { printf '%s python-docs: %s\n' "$(date -Is)" "$*" >&2; }
 
     has_docs_source() {
-      [ -f "$1/conf.py" ] && [ -f "$1/index.rst" ] && [ -d "$1/library" ]
+      [ -f "$1/conf.py" ] && [ -f "$1/contents.rst" ] && [ -d "$1/library" ]
     }
 
     cleanup_tmp() {
@@ -118,7 +118,7 @@ pkgs.writeShellApplication {
       tmp_revision=$(mktemp -d "$output_root/revisions/.tmp-$branch-$sha.XXXXXX")
       git -C "$repo_path" archive "$sha" Doc | tar -x -C "$tmp_revision"
       if ! has_docs_source "$tmp_revision/Doc"; then
-        log "expected CPython $branch Doc/ to contain conf.py, index.rst, and library/"
+        log "expected CPython $branch Doc/ to contain conf.py, contents.rst, and library/"
         exit 1
       fi
       mv -T "$tmp_revision" "$revision_root"

--- a/modules/hm-apps/_python-docs-publisher.nix
+++ b/modules/hm-apps/_python-docs-publisher.nix
@@ -1,0 +1,140 @@
+{
+  lib,
+  pkgs,
+  pythonDocs,
+}:
+
+pkgs.writeShellApplication {
+  name = "git-mirror-publish-python-docs";
+  runtimeInputs = with pkgs; [
+    coreutils
+    curl
+    findutils
+    git
+    gnugrep
+    gnused
+    gnutar
+    util-linux
+  ];
+  text = ''
+    set -euo pipefail
+
+    repo_path=${lib.escapeShellArg pythonDocs.repoPath}
+    output_root=${lib.escapeShellArg pythonDocs.outputRoot}
+    version_url=${lib.escapeShellArg pythonDocs.versionUrl}
+    max_revisions=${lib.escapeShellArg (toString pythonDocs.maxRevisions)}
+    lock_file=${lib.escapeShellArg pythonDocs.lockPath}
+    tmp_revision=
+
+    log() { printf '%s python-docs: %s\n' "$(date -Is)" "$*" >&2; }
+
+    has_docs_source() {
+      [ -f "$1/conf.py" ] && [ -f "$1/index.rst" ] && [ -d "$1/library" ]
+    }
+
+    cleanup_tmp() {
+      if [ -n "''${tmp_revision:-}" ] && [ -d "$tmp_revision" ]; then
+        find "$tmp_revision" -depth -mindepth 1 -delete
+        rmdir "$tmp_revision"
+      fi
+    }
+
+    prune_revisions() {
+      [ -d "$output_root/revisions" ] || return 0
+
+      find "$output_root/revisions" -mindepth 1 -maxdepth 1 -type d ! -name '.tmp-*' -printf '%T@ %p\0' |
+        sort -z -nr |
+        tail -z -n +"$((max_revisions + 1))" |
+        while IFS= read -r -d "" entry; do
+          old_path=''${entry#* }
+          log "pruning old Python docs revision: $old_path"
+          find "$old_path" -depth -mindepth 1 -delete
+          rmdir "$old_path"
+        done
+    }
+
+    resolve_stable_branch() {
+      page=$(curl --fail --location --silent --show-error "$version_url")
+      printf '%s\n' "$page" |
+        sed -nE '/Python 3\.[0-9]+(\.[0-9]+)? [Dd]ocumentation/ {
+          s/.*Python (3\.[0-9]+)(\.[0-9]+)? [Dd]ocumentation.*/\1/p
+          q
+        }'
+    }
+
+    trap cleanup_tmp EXIT
+
+    mkdir -p "$(dirname "$lock_file")"
+    exec 9>"$lock_file"
+    flock 9
+
+    if [ ! -d "$repo_path/.git" ]; then
+      log "skipping; $repo_path is not a git checkout"
+      exit 0
+    fi
+
+    branch=$(resolve_stable_branch)
+    if [ -z "$branch" ]; then
+      log "failed to resolve current stable Python branch from $version_url"
+      exit 1
+    fi
+
+    remote_ref="refs/remotes/origin/$branch"
+    if ! git -C "$repo_path" show-ref --verify --quiet "$remote_ref"; then
+      log "fetching missing CPython branch $branch"
+      git -C "$repo_path" fetch origin "+refs/heads/$branch:$remote_ref"
+    fi
+
+    if ! sha=$(git -C "$repo_path" rev-parse --verify "origin/$branch^{commit}" 2>/dev/null); then
+      log "origin/$branch is not available in $repo_path"
+      exit 1
+    fi
+
+    mkdir -p "$output_root/revisions"
+
+    revision_root="$output_root/revisions/$branch-$sha"
+    docs_dir="$revision_root/Doc"
+    marker="$output_root/current-branch"
+    publish_marker="$branch $sha $version_url"
+    current_target=$(readlink "$output_root/current" 2>/dev/null || true)
+
+    if [ -r "$marker" ] &&
+      [ "$(cat "$marker")" = "$publish_marker" ] &&
+      [ "$current_target" = "$docs_dir" ] &&
+      has_docs_source "$docs_dir"; then
+      touch "$revision_root"
+      prune_revisions
+      log "skipping; Python docs for $branch at $sha are already current"
+      exit 0
+    fi
+
+    if [ -d "$revision_root" ] && ! has_docs_source "$docs_dir"; then
+      log "removing incomplete Python docs revision: $revision_root"
+      find "$revision_root" -depth -mindepth 1 -delete
+      rmdir "$revision_root"
+    fi
+
+    if ! has_docs_source "$docs_dir"; then
+      tmp_revision=$(mktemp -d "$output_root/revisions/.tmp-$branch-$sha.XXXXXX")
+      git -C "$repo_path" archive "$sha" Doc | tar -x -C "$tmp_revision"
+      if ! has_docs_source "$tmp_revision/Doc"; then
+        log "expected CPython $branch Doc/ to contain conf.py, index.rst, and library/"
+        exit 1
+      fi
+      mv -T "$tmp_revision" "$revision_root"
+      tmp_revision=
+    fi
+
+    tmp_link="$output_root/current.tmp"
+    ln -sfnT "$docs_dir" "$tmp_link"
+    mv -Tf "$tmp_link" "$output_root/current"
+
+    printf '%s\n' "$publish_marker" > "$marker.tmp"
+    mv -Tf "$marker.tmp" "$marker"
+
+    touch "$revision_root"
+    prune_revisions
+
+    log "published $output_root/current from CPython $branch at $sha"
+  '';
+}

--- a/modules/hm-apps/git-mirror.nix
+++ b/modules/hm-apps/git-mirror.nix
@@ -14,7 +14,7 @@
     }:
     let
       cfg = config.programs.gitMirror;
-      inherit (cfg) firefoxDocs;
+      inherit (cfg) firefoxDocs pythonDocs;
       allowedUrlDirChars = lib.stringToCharacters "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789._-";
       stripAfter = separator: value: builtins.head (lib.splitString separator value);
       sanitizeUrlDirName =
@@ -56,7 +56,11 @@
           urlToDirName spec
         else
           builtins.replaceStrings [ "/" ] [ "-" ] spec;
+      onSuccessUnits =
+        lib.optionals firefoxDocs.enable [ "git-mirror-firefox-docs.service" ]
+        ++ lib.optionals pythonDocs.enable [ "git-mirror-python-docs.service" ];
       firefoxDocsLockPath = "${firefoxDocs.repoPath}.git-mirror.lock";
+      pythonDocsLockPath = "${pythonDocs.outputRoot}.git-mirror.lock";
       reposFile = pkgs.writeText "repos.txt" (lib.concatStringsSep "\n" cfg.repos);
 
       # Helper script for syncing a single repo (called by parallel)
@@ -196,6 +200,13 @@
         };
       };
 
+      pythonDocsScript = import ./_python-docs-publisher.nix {
+        inherit lib pkgs;
+        pythonDocs = pythonDocs // {
+          lockPath = pythonDocsLockPath;
+        };
+      };
+
       # Main entry point
       mirrorScript = pkgs.writeShellApplication {
         name = "git-mirror";
@@ -321,6 +332,40 @@
           };
         };
 
+        pythonDocs = {
+          enable = lib.mkEnableOption "publishing current stable Python documentation sources after mirror sync";
+
+          repoSpec = lib.mkOption {
+            type = lib.types.str;
+            default = "python/cpython";
+            description = "Repository spec from programs.gitMirror.repos that provides CPython documentation sources.";
+          };
+
+          repoPath = lib.mkOption {
+            type = lib.types.str;
+            default = "${cfg.root}/${mirrorDirName pythonDocs.repoSpec}";
+            description = "Local CPython checkout used as the Python documentation source repository. Defaults to the mirror path derived from repoSpec.";
+          };
+
+          outputRoot = lib.mkOption {
+            type = lib.types.str;
+            default = "${cfg.root}/${mirrorDirName pythonDocs.repoSpec}-docs";
+            description = "Directory where current stable Python documentation sources are published. Defaults to the mirror path derived from repoSpec with a -docs suffix.";
+          };
+
+          versionUrl = lib.mkOption {
+            type = lib.types.str;
+            default = "https://docs.python.org/3/";
+            description = "Python documentation URL used to resolve the current stable CPython minor branch.";
+          };
+
+          maxRevisions = lib.mkOption {
+            type = lib.types.ints.positive;
+            default = 2;
+            description = "Maximum published Python documentation source revisions to keep.";
+          };
+        };
+
         maxBackups = lib.mkOption {
           type = lib.types.ints.positive;
           default = 5;
@@ -350,9 +395,17 @@
             assertion = !firefoxDocs.enable || builtins.elem firefoxDocs.repoSpec cfg.repos;
             message = "programs.gitMirror.firefoxDocs.repoSpec must be present in programs.gitMirror.repos.";
           }
+          {
+            assertion = !pythonDocs.enable || builtins.elem pythonDocs.repoSpec cfg.repos;
+            message = "programs.gitMirror.pythonDocs.repoSpec must be present in programs.gitMirror.repos.";
+          }
         ];
 
-        home.packages = [ mirrorScript ] ++ lib.optional firefoxDocs.enable firefoxDocsScript;
+        home.packages = [
+          mirrorScript
+        ]
+        ++ lib.optional firefoxDocs.enable firefoxDocsScript
+        ++ lib.optional pythonDocs.enable pythonDocsScript;
 
         systemd.user = {
           services = {
@@ -363,8 +416,8 @@
                 StartLimitBurst = 3;
                 StartLimitIntervalSec = "1h";
               }
-              // lib.optionalAttrs firefoxDocs.enable {
-                OnSuccess = [ "git-mirror-firefox-docs.service" ];
+              // lib.optionalAttrs (onSuccessUnits != [ ]) {
+                OnSuccess = onSuccessUnits;
               };
               Service = {
                 Type = "oneshot";
@@ -386,6 +439,22 @@
                 ExecStart = "${firefoxDocsScript}/bin/git-mirror-build-firefox-docs";
                 Environment = [ "GIT_TERMINAL_PROMPT=0" ];
                 TimeoutStartSec = "6h";
+                Nice = 10;
+                IOSchedulingClass = "idle";
+              };
+            };
+
+            git-mirror-python-docs = lib.mkIf pythonDocs.enable {
+              Unit = {
+                Description = "Publish current stable Python documentation sources";
+                After = [ "git-mirror.service" ];
+                X-SwitchMethod = "keep-old";
+              };
+              Service = {
+                Type = "oneshot";
+                ExecStart = "${pythonDocsScript}/bin/git-mirror-publish-python-docs";
+                Environment = [ "GIT_TERMINAL_PROMPT=0" ];
+                TimeoutStartSec = "30m";
                 Nice = 10;
                 IOSchedulingClass = "idle";
               };

--- a/modules/hosts/common/mirrors.nix
+++ b/modules/hosts/common/mirrors.nix
@@ -13,6 +13,7 @@ let
       home-manager.users.${metaOwner.username}.programs.gitMirror = {
         enable = true;
         firefoxDocs.enable = true;
+        pythonDocs.enable = true;
         jobs = 2;
         repos = [
           # NixOS
@@ -59,6 +60,7 @@ let
           "mdn/content" # https://developer.mozilla.org
           "mozilla/policy-templates"
           "mozilla/enterprise-admin-reference" # Documentation for policy behavior and syntax
+          "python/cpython" # Source for docs.python.org
 
           # Applications
           "https://codeberg.org/librewolf/settings.git"

--- a/modules/hosts/common/mirrors.nix
+++ b/modules/hosts/common/mirrors.nix
@@ -1,6 +1,8 @@
 # Local repository mirrors (shared hosts).
 # GitHub shorthand syncs daily to /data/git/{owner}-{repo}; full URLs use
 # a normalized host-prefixed path.
+# Keep docs/reference/local-mirrors.md, docs/architecture/06-reference.md, and
+# modules/agents/system-prompt.nix synchronized with the repos list below.
 {
   metaOwner,
   ...


### PR DESCRIPTION
## Summary

- add a `programs.gitMirror.pythonDocs` publisher that resolves `docs.python.org/3/` and publishes CPython `Doc/` from the current stable branch
- enable the CPython mirror and Python docs publisher for common hosts
- document the new `/data/git/python-cpython` and `/data/git/python-cpython-docs/current` mirror paths
- teach the shared Codex and Claude prompt rules to target Python 3.14 and use `/data/git/python-cpython-docs/current` before web lookup
- sync the local mirror inventories in `docs/reference/local-mirrors.md`, `docs/architecture/06-reference.md`, root agent docs, and the shared prompt renderer with `modules/hosts/common/mirrors.nix`

## Test plan

- `nix fmt`
- `nix-instantiate --parse --option extra-experimental-features pipe-operators modules/hm-apps/git-mirror.nix modules/hm-apps/_python-docs-publisher.nix modules/hosts/common/mirrors.nix modules/agents/system-prompt.nix`
- `curl https://docs.python.org/3/` branch resolver check, returned `3.14`
- `nix eval --accept-flake-config --impure --json path:/home/vx/trees/nixos/feat-python-docs-mirror#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.gitMirror.pythonDocs`
- `nix eval --accept-flake-config --impure --json path:/home/vx/trees/nixos/feat-python-docs-mirror#nixosConfigurations.system76.config.home-manager.users.vx.programs.gitMirror.pythonDocs`
- `nix eval --accept-flake-config --impure --json path:/home/vx/trees/nixos/feat-python-docs-mirror#nixosConfigurations.tpnix.config.home-manager.users.vx.systemd.user.services.git-mirror.Unit.OnSuccess`
- `nix eval --accept-flake-config --impure --json path:/home/vx/trees/nixos/feat-python-docs-mirror#nixosConfigurations.system76.config.home-manager.users.vx.systemd.user.services.git-mirror.Unit.OnSuccess`
- `nix build --no-link --impure --expr '<python docs publisher derivation>'`
- `git diff --check`
- `nix flake check --accept-flake-config --no-build --offline path:/home/vx/trees/nixos/feat-python-docs-mirror`
- `nix eval --accept-flake-config --impure --raw .#lib.agents.systemPrompt.default | rg -n "Target Python 3\\.14|Do not directly use `pip`|docs/reference/local-mirrors.md|/data/git/zaproxy-zap-api-python|/data/git/python-cpython-docs/current"`
- compare `docs/reference/local-mirrors.md` repository rows against evaluated `programs.gitMirror.repos`
- verify every evaluated `/data/git` mirror path appears in `docs/architecture/06-reference.md` and `modules/agents/system-prompt.nix`