### PR TITLE
fix(nemo): enable preview integrations

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -10,9 +10,10 @@ extend-ignore-re = [
 [default.extend-words]
 # General terms
 example = "example"
-UE = "UE"           # minified JS variable name in docs
-fpt = "fpt"         # Intel Flash Programming Tool
-PN = "PN"           # Part Number
+UE = "UE"                     # minified JS variable name in docs
+fpt = "fpt"                   # Intel Flash Programming Tool
+PN = "PN"                     # Part Number
+thumbnailers = "thumbnailers" # XDG thumbnail generator terminology
 
 # App/tool names
 iterm2_with_bell = "iterm2_with_bell"

--- a/modules/apps/burpsuitepro.nix
+++ b/modules/apps/burpsuitepro.nix
@@ -45,7 +45,7 @@ let
         else if cfg.package ? override then
           cfg.package.override { pythonModuleDir = cfg.python.moduleDirectory; }
         else
-          throw "programs.burpsuitepro.extended.python.moduleDirectory requires a package with override support";
+          cfg.package;
     in
     {
       options.programs.burpsuitepro.extended = {
@@ -70,6 +70,13 @@ let
       };
 
       config = {
+        assertions = lib.optionals cfg.enable [
+          {
+            assertion = cfg.python.moduleDirectory == null || cfg.package ? override;
+            message = "programs.burpsuitepro.extended.python.moduleDirectory requires a package with override support";
+          }
+        ];
+
         # Overlay is unconditional so `pkgs.burpsuitepro` resolves even when the
         # module is not enabled — sibling modules (burpsuite-loader, devshell
         # consumers, local overrides) rely on that attribute being present.

--- a/modules/apps/cewl.nix
+++ b/modules/apps/cewl.nix
@@ -32,6 +32,7 @@ let
     }:
     let
       cfg = config.programs.cewl.extended;
+      cewlGemdirFor = pkgs': pkgs'.path + "/pkgs/by-name/ce/cewl";
 
       gemfile = builtins.toFile "cewl-Gemfile" ''
         source 'https://rubygems.org'
@@ -254,20 +255,23 @@ let
       };
 
       config = {
+        assertions = [
+          {
+            assertion = builtins.pathExists (cewlGemdirFor pkgs);
+            message = "cewl overlay: expected nixpkgs CeWL package directory at ${toString (cewlGemdirFor pkgs)}";
+          }
+        ];
+
         # Overlay is unconditional so `pkgs.cewl` resolves to the fixed runtime
         # for package-option consumers and ad-hoc host package access.
         nixpkgs.overlays = [
           (
             _final: prev:
             let
-              cewlGemdir = prev.path + "/pkgs/by-name/ce/cewl";
+              cewlGemdir = cewlGemdirFor prev;
               rubyEnv = prev.bundlerEnv {
                 name = "cewl-ruby-env";
-                gemdir =
-                  if builtins.pathExists cewlGemdir then
-                    cewlGemdir
-                  else
-                    throw "cewl overlay: expected nixpkgs CeWL package directory at ${toString cewlGemdir}";
+                gemdir = cewlGemdir;
                 inherit gemfile lockfile gemset;
               };
             in

--- a/modules/apps/nemo.nix
+++ b/modules/apps/nemo.nix
@@ -7,6 +7,8 @@
 
   Summary:
     * Provides a feature-rich file manager supporting SMB/NFS/GVFS mounts, context-menu extensions, bulk rename, and media previews.
+    * Installs video and XApp thumbnail generators so XDG thumbnail lookup can generate previews for common media formats.
+    * Enables Nemo quick previews and Seahorse encryption/signing integration by default.
     * Integrates Cinnamon desktop conventions while remaining usable in other desktop environments with underlying GNOME services.
 
   Options:
@@ -31,6 +33,26 @@ let
     }:
     let
       cfg = config.programs.nemo.extended;
+      nemoExtensionPackages =
+        lib.optional cfg.preview.enable cfg.preview.package
+        ++ lib.optional cfg.seahorse.enable cfg.seahorse.package;
+
+      configuredPackage =
+        if nemoExtensionPackages == [ ] then
+          cfg.package
+        else if cfg.package ? override then
+          cfg.package.override {
+            extensions = nemoExtensionPackages;
+          }
+        else
+          throw "programs.nemo.extended.package requires override support when preview or seahorse integration is enabled";
+
+      seahorseGSettingsPackages = [
+        pkgs.nemo
+        pkgs.gcr
+        pkgs.libcryptui
+        cfg.seahorse.package
+      ];
     in
     {
       options.programs.nemo.extended = {
@@ -40,11 +62,49 @@ let
           description = "Whether to enable nemo.";
         };
 
-        package = lib.mkPackageOption pkgs "nemo" { };
+        package = lib.mkPackageOption pkgs "nemo-with-extensions" { };
+
+        preview = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether to enable Nemo quick preview integration.";
+          };
+
+          package = lib.mkPackageOption pkgs "nemo-preview" { };
+        };
+
+        seahorse = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = true;
+            description = "Whether to enable Nemo Seahorse encryption and signing integration.";
+          };
+
+          package = lib.mkPackageOption pkgs "nemo-seahorse" { };
+        };
       };
 
       config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
+        environment.systemPackages = [
+          configuredPackage
+          pkgs.ffmpegthumbnailer
+          pkgs.gst-thumbnailers
+          pkgs.xapp-thumbnailers
+        ];
+
+        services = {
+          dbus.packages = [
+            configuredPackage
+          ]
+          ++ lib.optionals cfg.seahorse.enable [
+            pkgs.libcryptui
+          ];
+
+          desktopManager.gnome.extraGSettingsOverridePackages = lib.optionals cfg.seahorse.enable seahorseGSettingsPackages;
+
+          xserver.desktopManager.cinnamon.extraGSettingsOverridePackages = lib.optionals cfg.seahorse.enable seahorseGSettingsPackages;
+        };
       };
     };
 in

--- a/modules/apps/nemo.nix
+++ b/modules/apps/nemo.nix
@@ -7,6 +7,7 @@
 
   Summary:
     * Provides a feature-rich file manager supporting SMB/NFS/GVFS mounts, context-menu extensions, bulk rename, and media previews.
+    * Enables the Mint-default Nemo extensions explicitly instead of relying on wrapper defaults.
     * Installs video and XApp thumbnail generators so XDG thumbnail lookup can generate previews for common media formats.
     * Enables Nemo quick previews and Seahorse encryption/signing integration by default.
     * Integrates Cinnamon desktop conventions while remaining usable in other desktop environments with underlying GNOME services.
@@ -33,22 +34,45 @@ let
     }:
     let
       cfg = config.programs.nemo.extended;
-      nemoExtensionPackages =
-        lib.optional cfg.preview.enable cfg.preview.package
-        ++ lib.optional cfg.seahorse.enable cfg.seahorse.package;
+      mkExtensionOptions = packageName: description: {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether to enable ${description}.";
+        };
+
+        package = lib.mkPackageOption pkgs packageName { };
+      };
+
+      configuredExtensions = [
+        cfg.folderColorSwitcher
+        cfg.emblems
+        cfg.fileRoller
+        cfg.python
+        cfg.preview
+        cfg.seahorse
+      ];
+
+      nemoExtensionPackages = lib.concatMap (
+        extension: lib.optional extension.enable extension.package
+      ) configuredExtensions;
+
+      canWrapPackage = cfg.package ? extensiondir && cfg.package ? version;
 
       configuredPackage =
         if nemoExtensionPackages == [ ] then
           cfg.package
-        else if cfg.package ? override then
-          cfg.package.override {
+        else if canWrapPackage then
+          pkgs.nemo-with-extensions.override {
+            nemo = cfg.package;
             extensions = nemoExtensionPackages;
+            useDefaultExtensions = false;
           }
         else
           cfg.package;
 
       seahorseGSettingsPackages = [
-        pkgs.nemo
+        cfg.package
         pkgs.gcr
         pkgs.libcryptui
         cfg.seahorse.package
@@ -62,34 +86,26 @@ let
           description = "Whether to enable nemo.";
         };
 
-        package = lib.mkPackageOption pkgs "nemo-with-extensions" { };
+        package = lib.mkPackageOption pkgs "nemo" { };
 
-        preview = {
-          enable = lib.mkOption {
-            type = lib.types.bool;
-            default = true;
-            description = "Whether to enable Nemo quick preview integration.";
-          };
+        folderColorSwitcher = mkExtensionOptions "folder-color-switcher" "Nemo folder color integration";
 
-          package = lib.mkPackageOption pkgs "nemo-preview" { };
-        };
+        emblems = mkExtensionOptions "nemo-emblems" "Nemo emblem integration";
 
-        seahorse = {
-          enable = lib.mkOption {
-            type = lib.types.bool;
-            default = true;
-            description = "Whether to enable Nemo Seahorse encryption and signing integration.";
-          };
+        fileRoller = mkExtensionOptions "nemo-fileroller" "Nemo archive integration";
 
-          package = lib.mkPackageOption pkgs "nemo-seahorse" { };
-        };
+        python = mkExtensionOptions "nemo-python" "Nemo Python extension loading support";
+
+        preview = mkExtensionOptions "nemo-preview" "Nemo quick preview integration";
+
+        seahorse = mkExtensionOptions "nemo-seahorse" "Nemo Seahorse encryption and signing integration";
       };
 
       config = lib.mkIf cfg.enable {
         assertions = [
           {
-            assertion = nemoExtensionPackages == [ ] || cfg.package ? override;
-            message = "programs.nemo.extended.package requires override support when preview or seahorse integration is enabled";
+            assertion = nemoExtensionPackages == [ ] || canWrapPackage;
+            message = "programs.nemo.extended.package requires version and extensiondir attributes when Nemo extensions are enabled";
           }
         ];
 

--- a/modules/apps/nemo.nix
+++ b/modules/apps/nemo.nix
@@ -111,6 +111,8 @@ let
 
         environment.systemPackages = [
           configuredPackage
+        ]
+        ++ lib.optionals cfg.thumbnailers.enable [
           pkgs.ffmpegthumbnailer
           pkgs.gst-thumbnailers
           pkgs.xapp-thumbnailers

--- a/modules/apps/nemo.nix
+++ b/modules/apps/nemo.nix
@@ -45,7 +45,7 @@ let
             extensions = nemoExtensionPackages;
           }
         else
-          throw "programs.nemo.extended.package requires override support when preview or seahorse integration is enabled";
+          cfg.package;
 
       seahorseGSettingsPackages = [
         pkgs.nemo
@@ -86,6 +86,13 @@ let
       };
 
       config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = nemoExtensionPackages == [ ] || cfg.package ? override;
+            message = "programs.nemo.extended.package requires override support when preview or seahorse integration is enabled";
+          }
+        ];
+
         environment.systemPackages = [
           configuredPackage
           pkgs.ffmpegthumbnailer

--- a/modules/apps/nemo.nix
+++ b/modules/apps/nemo.nix
@@ -8,7 +8,7 @@
   Summary:
     * Provides a feature-rich file manager supporting SMB/NFS/GVFS mounts, context-menu extensions, bulk rename, and media previews.
     * Enables the Mint-default Nemo extensions explicitly instead of relying on wrapper defaults.
-    * Installs video and XApp thumbnail generators so XDG thumbnail lookup can generate previews for common media formats.
+    * Installs optional video and XApp thumbnail generators so XDG thumbnail lookup can generate previews for common media formats.
     * Enables Nemo quick previews and Seahorse encryption/signing integration by default.
     * Integrates Cinnamon desktop conventions while remaining usable in other desktop environments with underlying GNOME services.
 
@@ -99,6 +99,12 @@ let
         preview = mkExtensionOptions "nemo-preview" "Nemo quick preview integration";
 
         seahorse = mkExtensionOptions "nemo-seahorse" "Nemo Seahorse encryption and signing integration";
+
+        thumbnailers.enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Whether to install video and XApp thumbnail generators for media previews.";
+        };
       };
 
       config = lib.mkIf cfg.enable {

--- a/modules/apps/nemo.nix
+++ b/modules/apps/nemo.nix
@@ -58,6 +58,8 @@ let
       ) configuredExtensions;
 
       canWrapPackage = cfg.package ? extensiondir && cfg.package ? version;
+      canExtendWrappedPackage =
+        cfg.package ? override && lib.hasPrefix "nemo-with-extensions-" (cfg.package.name or "");
 
       configuredPackage =
         if nemoExtensionPackages == [ ] then
@@ -68,6 +70,11 @@ let
             extensions = nemoExtensionPackages;
             useDefaultExtensions = false;
           }
+        else if canExtendWrappedPackage then
+          cfg.package.override (prev: {
+            extensions = lib.unique ((prev.extensions or [ ]) ++ nemoExtensionPackages);
+            useDefaultExtensions = false;
+          })
         else
           cfg.package;
 
@@ -110,8 +117,8 @@ let
       config = lib.mkIf cfg.enable {
         assertions = [
           {
-            assertion = nemoExtensionPackages == [ ] || canWrapPackage;
-            message = "programs.nemo.extended.package requires version and extensiondir attributes when Nemo extensions are enabled";
+            assertion = nemoExtensionPackages == [ ] || canWrapPackage || canExtendWrappedPackage;
+            message = "programs.nemo.extended.package requires version and extensiondir attributes or an overridable nemo-with-extensions package when Nemo extensions are enabled";
           }
         ];
 

--- a/modules/apps/wireshark.nix
+++ b/modules/apps/wireshark.nix
@@ -34,7 +34,7 @@ let
     }:
     let
       cfg = config.programs.wireshark.extended;
-      owner = metaOwner.username or (throw "Wireshark module: expected metaOwner.username to be defined");
+      owner = metaOwner.username or null;
     in
     {
       options.programs.wireshark.extended = {
@@ -47,19 +47,33 @@ let
         package = lib.mkPackageOption pkgs "wireshark" { };
       };
 
-      config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
-        users.groups.wireshark = { };
-        users.users.${owner}.extraGroups = lib.mkAfter [ "wireshark" ];
+      config = lib.mkIf cfg.enable (
+        lib.mkMerge [
+          {
+            assertions = [
+              {
+                assertion = owner != null;
+                message = "Wireshark module: expected metaOwner.username to be defined";
+              }
+            ];
 
-        security.wrappers.dumpcap = {
-          source = "${cfg.package}/bin/dumpcap";
-          capabilities = "cap_net_raw,cap_net_admin+ep";
-          owner = "root";
-          group = "wheel";
-          permissions = "u+rx,g+x";
-        };
-      };
+            environment.systemPackages = [ cfg.package ];
+            users.groups.wireshark = { };
+
+            security.wrappers.dumpcap = {
+              source = "${cfg.package}/bin/dumpcap";
+              capabilities = "cap_net_raw,cap_net_admin+ep";
+              owner = "root";
+              group = "wheel";
+              permissions = "u+rx,g+x";
+            };
+          }
+
+          (lib.mkIf (owner != null) {
+            users.users.${owner}.extraGroups = lib.mkAfter [ "wireshark" ];
+          })
+        ]
+      );
     };
 in
 {


### PR DESCRIPTION
## Summary
- Use regular `pkgs.nemo` as the Nemo package option and build the wrapper internally only when explicit extension options are enabled.
- Declare the Mint-default Nemo extensions directly: folder-color-switcher, nemo-emblems, nemo-fileroller, and nemo-python.
- Keep nemo-preview and nemo-seahorse as explicit default-on Nemo extension options with per-extension package overrides.
- Add ffmpegthumbnailer, gst-thumbnailers, and xapp-thumbnailers so XDG thumbnail lookup can generate media previews.
- Wire nemo-seahorse support with libcryptui D-Bus and GNOME/Cinnamon GSettings override packages.
- Move Nemo, Burp Suite Pro, Wireshark, and CeWL module invariants from direct throws into NixOS assertions.

## Test plan
- `nix fmt -- modules/apps/nemo.nix`
- `nix fmt -- modules/apps/nemo.nix modules/apps/burpsuitepro.nix modules/apps/wireshark.nix modules/apps/cewl.nix`
- `rg -n "throw" modules/apps/nemo.nix` confirmed no matches
- `rg -n "throw" modules/apps/nemo.nix modules/apps/burpsuitepro.nix modules/apps/wireshark.nix modules/apps/cewl.nix` confirmed no matches
- `nix eval --accept-flake-config --offline --raw .#nixosConfigurations.system76.config.programs.nemo.extended.package.name`
- `nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.programs.nemo.extended` filtered for Nemo extension defaults
- `nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.environment.systemPackages` filtered for affected apps
- `nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.assertions` filtered for false assertions
- `nix eval --accept-flake-config --offline --raw .#nixosConfigurations.system76.config.system.build.toplevel.drvPath`
- `nix eval --accept-flake-config --offline --impure --json --expr ...` for disabled Nemo extension override smoke test
- `nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.services.dbus.packages` filtered for Nemo and libcryptui packages
- `nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.services.desktopManager.gnome.extraGSettingsOverridePackages`
- `nix eval --accept-flake-config --offline --json .#nixosConfigurations.system76.config.services.xserver.desktopManager.cinnamon.extraGSettingsOverridePackages`
- `nix flake check --accept-flake-config --no-build --offline`
- `git push`