### PR TITLE
feat(xdg): route Thunderbird communication handlers

### DIFF
--- a/modules/hosts/common/default-apps.nix
+++ b/modules/hosts/common/default-apps.nix
@@ -73,14 +73,30 @@ let
       mkCategoryConfig =
         name: cat:
         lib.mkIf (cfg.${name} != null) (
+          let
+            appInfo = cat.desktopFiles.${cfg.${name}};
+            desktopFile = appInfo.desktop;
+            mimeDefaults =
+              if appInfo ? mimeTypes then
+                xdg.mime.mkDefaults appInfo.mimeTypes desktopFile
+              else
+                cat.mkMimeDefaults desktopFile;
+            addedAssociations =
+              if appInfo ? addedAssociations then
+                xdg.mime.mkDefaults appInfo.addedAssociations desktopFile
+              else
+                { };
+          in
           lib.mkMerge [
-            { xdg.mime.defaultApplications = cat.mkMimeDefaults cat.desktopFiles.${cfg.${name}}.desktop; }
+            { xdg.mime.defaultApplications = mimeDefaults; }
+            { xdg.mime.addedAssociations = addedAssociations; }
             (lib.optionalAttrs hasHomeManager {
               home-manager.sharedModules = [
                 {
                   xdg.mimeApps = {
                     enable = true;
-                    defaultApplications = cat.mkMimeDefaults cat.desktopFiles.${cfg.${name}}.desktop;
+                    defaultApplications = mimeDefaults;
+                    associations.added = addedAssociations;
                   };
                 }
               ];

--- a/modules/hosts/common/default-apps.nix
+++ b/modules/hosts/common/default-apps.nix
@@ -6,7 +6,7 @@
 
   Usage:
     host.defaults.browser = "librewolf";
-    host.defaults.mailClient = "thunderbird";
+    host.defaults.mailClient = "thunderbird"; # Email, calendar, feeds, and newsgroups.
     host.defaults.torrentClient = "qbittorrent";
     host.defaults.terminal = "kitty";
     host.defaults.fileManager = "nemo";

--- a/modules/xdg/mime.nix
+++ b/modules/xdg/mime.nix
@@ -33,24 +33,38 @@ let
     "x-scheme-handler/https"
   ];
 
-  # MIME types and URI schemes for mail, calendar, feed, and newsgroup clients.
+  # MIME types and URI schemes for plain mail clients.
   mailClientMimeTypes = [
-    "application/atom+xml"
-    "application/rdf+xml"
-    "application/rss+xml"
-    "message/news"
     "message/rfc822"
+    "x-scheme-handler/mailto"
+  ];
+
+  # MIME types and URI schemes for applications that manage calendars.
+  calendarMimeTypes = [
     "text/calendar"
     "text/x-vcalendar"
     "text/x-vcard"
-    "x-scheme-handler/feed"
-    "x-scheme-handler/mailto"
-    "x-scheme-handler/news"
-    "x-scheme-handler/nntp"
-    "x-scheme-handler/snews"
     "x-scheme-handler/webcal"
     "x-scheme-handler/webcals"
   ];
+
+  # MIME types and URI schemes for applications that manage feeds.
+  feedMimeTypes = [
+    "application/atom+xml"
+    "application/rdf+xml"
+    "application/rss+xml"
+    "x-scheme-handler/feed"
+  ];
+
+  # MIME types and URI schemes for applications that manage newsgroups.
+  newsMimeTypes = [
+    "message/news"
+    "x-scheme-handler/news"
+    "x-scheme-handler/nntp"
+    "x-scheme-handler/snews"
+  ];
+
+  thunderbirdMimeTypes = mailClientMimeTypes ++ calendarMimeTypes ++ feedMimeTypes ++ newsMimeTypes;
 
   # MIME types for BitTorrent clients
   torrentClientMimeTypes = [
@@ -271,6 +285,8 @@ let
       thunderbird = {
         desktop = "thunderbird.desktop";
         module = "thunderbird";
+        mimeTypes = thunderbirdMimeTypes;
+        addedAssociations = thunderbirdMimeTypes;
       };
     };
 
@@ -370,6 +386,10 @@ let
       mkDefaults
       browserMimeTypes
       mailClientMimeTypes
+      calendarMimeTypes
+      feedMimeTypes
+      newsMimeTypes
+      thunderbirdMimeTypes
       torrentClientMimeTypes
       terminalMimeTypes
       fileManagerMimeTypes
@@ -656,6 +676,34 @@ let
   };
 in
 {
+  perSystem =
+    { pkgs, ... }:
+    let
+      thunderbird = desktopFiles.mailClient.thunderbird;
+      thunderbirdMimeHandlersOk =
+        lib.assertMsg (
+          mailClientMimeTypes == [
+            "message/rfc822"
+            "x-scheme-handler/mailto"
+          ]
+        ) "generic mail client MIME defaults must stay mail-only"
+        && lib.assertMsg (
+          thunderbird.mimeTypes == thunderbirdMimeTypes
+        ) "Thunderbird must opt into mail, calendar, feed, and newsgroup MIME defaults"
+        && lib.assertMsg (
+          thunderbird.addedAssociations == thunderbirdMimeTypes
+        ) "Thunderbird must add associations for every defaulted MIME handler";
+    in
+    {
+      checks.xdg-thunderbird-mime-handlers =
+        if thunderbirdMimeHandlersOk then
+          pkgs.runCommandLocal "xdg-thunderbird-mime-handlers-ok" { } ''
+            echo "ok: Thunderbird MIME handlers are scoped and associated" > $out
+          ''
+        else
+          throw "unreachable";
+    };
+
   flake = {
     lib.xdg = {
       inherit

--- a/modules/xdg/mime.nix
+++ b/modules/xdg/mime.nix
@@ -33,10 +33,23 @@ let
     "x-scheme-handler/https"
   ];
 
-  # MIME types for mail clients
+  # MIME types and URI schemes for mail, calendar, feed, and newsgroup clients.
   mailClientMimeTypes = [
+    "application/atom+xml"
+    "application/rdf+xml"
+    "application/rss+xml"
+    "message/news"
     "message/rfc822"
+    "text/calendar"
+    "text/x-vcalendar"
+    "text/x-vcard"
+    "x-scheme-handler/feed"
     "x-scheme-handler/mailto"
+    "x-scheme-handler/news"
+    "x-scheme-handler/nntp"
+    "x-scheme-handler/snews"
+    "x-scheme-handler/webcal"
+    "x-scheme-handler/webcals"
   ];
 
   # MIME types for BitTorrent clients
@@ -400,8 +413,8 @@ let
       defaultValue = "thunderbird";
       example = "thunderbird";
       description = ''
-        Default mail client for this host.
-        Set to null to not configure a default mail client via XDG mimeapps.
+        Default mail, calendar, feed, and newsgroup client for this host.
+        Set to null to not configure these defaults via XDG mimeapps.
       '';
     };
 


### PR DESCRIPTION
## Summary

- Route the Thunderbird mail-client default through calendar, RSS/Atom feed, and newsgroup MIME or URI handlers.
- Keep `host.defaults.mailClient = "thunderbird"` as the single default-app knob for email, calendar, feeds, and news.

## Test plan

- `nix fmt -- modules/hosts/common/default-apps.nix modules/xdg/mime.nix`
- `nix-instantiate --parse modules/hosts/common/default-apps.nix`
- `nix-instantiate --parse modules/xdg/mime.nix`
- `nix eval --impure --json --expr '<xdg mailClient helper assertion>' | jq -e '<Thunderbird handler assertions>'`
- `nix eval --accept-flake-config --json '.#nixosConfigurations.$(hostname).config.xdg.mime.defaultApplications' | jq -e '<Thunderbird handler assertions>'`