### PR TITLE
feat(cloudflare-warp): managed Zero Trust enrollment

### DIFF
--- a/docs/cloudflare/README.md
+++ b/docs/cloudflare/README.md
@@ -15,6 +15,12 @@ Technical documentation for Cloudflare's developer platform services.
 | [ACME DNS-01](./acme-cloudflare-sample.md)          | Configure ACME certificates with DNS-01 |
 | [Cloudflare Tunnel](./cloudflared-tunnel-sample.md) | Configure `cloudflared` ingress locally |
 
+## Zero Trust
+
+| Topic           | Purpose                                           |
+| --------------- | ------------------------------------------------- |
+| [WARP](./warp/) | Declarative WARP / Zero Trust enrollment on NixOS |
+
 ## Planned Documentation
 
 - Workers

--- a/docs/cloudflare/warp/README.md
+++ b/docs/cloudflare/warp/README.md
@@ -46,7 +46,12 @@ is enabled it:
 | `system76` | `warp` (full tunnel) | `modules/system76/cloudflare-warp.nix` |
 
 The common baseline (`modules/hosts/common/apps-enable.nix`) defaults the app
-OFF; enrollment is a deliberate per-host opt-in.
+OFF; enrollment is a deliberate per-host opt-in. `system76` enables the wrapper
+directly. `tpnix` gates `enable` on `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady`
+(currently `false`, `modules/tpnix/policy.nix`), like its other sops consumers, so
+the wrapper stays off until tpnix has a runtime decryption key; without the gate,
+committing the secret would make tpnix declare `cloudflare-warp/*` secrets it cannot
+decrypt and fail activation.
 
 ## Security model
 

--- a/docs/cloudflare/warp/README.md
+++ b/docs/cloudflare/warp/README.md
@@ -1,0 +1,55 @@
+# Cloudflare WARP (Zero Trust)
+
+Declarative Cloudflare WARP enrollment for this NixOS configuration. The
+`programs.cloudflare-warp.extended` module runs the `warp-svc` daemon and enrolls
+a device into the Cloudflare Zero Trust organization non-interactively, using a
+service token delivered through a managed deployment file (`mdm.xml`).
+
+## Documents
+
+| Document                      | Purpose                                                    |
+| ----------------------------- | ---------------------------------------------------------- |
+| [Deployment](./deployment.md) | Operator runbook: dashboard prerequisites, secret, rollout |
+| [Reference](./reference.md)   | Module options, mdm.xml parameters, sops layout            |
+| [Operations](./operations.md) | Runtime verification, coexistence checks, troubleshooting  |
+
+## What the module does
+
+`modules/apps/cloudflare-warp.nix` is a thin wrapper over the upstream
+`services.cloudflare-warp` NixOS service. When `programs.cloudflare-warp.extended`
+is enabled it:
+
+1. Enables `services.cloudflare-warp`, which runs `warp-svc` as root with
+   `CAP_NET_ADMIN` and opens the WARP UDP port (2408 by default).
+2. Declares two sops secrets (`auth_client_id`, `auth_client_secret`) from
+   `secrets/cloudflare-warp.yaml`, guarded by `builtins.pathExists` so a missing
+   secret warns instead of failing evaluation.
+3. Renders `/var/lib/cloudflare-warp/mdm.xml` from non-secret options plus sops
+   placeholders, and installs it (mode 0600, root) via an `ExecStartPre` right
+   before `warp-svc` starts.
+4. Sets `networking.firewall.checkReversePath = "loose"` (the WARP interface
+   trips strict reverse-path filtering).
+5. Adds a best-effort `cloudflare-warp-connect` oneshot that waits for the daemon
+   and runs `warp-cli connect` on boot.
+
+`service_mode` is authoritative through `mdm.xml`; the module never calls
+`warp-cli mode`, so the managed config and the local client cannot fight.
+
+## Enrolled hosts
+
+| Host       | Service mode         | Enable file                            |
+| ---------- | -------------------- | -------------------------------------- |
+| `tpnix`    | `warp` (full tunnel) | `modules/tpnix/cloudflare-warp.nix`    |
+| `system76` | `warp` (full tunnel) | `modules/system76/cloudflare-warp.nix` |
+
+The common baseline (`modules/hosts/common/apps-enable.nix`) defaults the app
+OFF; enrollment is a deliberate per-host opt-in.
+
+## Security model
+
+- Credentials live only in `secrets/cloudflare-warp.yaml` (sops, age). The
+  rendered `mdm.xml` is produced from sops placeholders, so plaintext
+  credentials never enter the Nix store or git history.
+- `mdm.xml` is written to `/var/lib/cloudflare-warp/mdm.xml` as `0600 root:root`.
+- `secrets/` is a git submodule; the encrypted payload is committed there, the
+  Nix changes in the main repository.

--- a/docs/cloudflare/warp/README.md
+++ b/docs/cloudflare/warp/README.md
@@ -23,9 +23,10 @@ is enabled it:
 
 1. Enables `services.cloudflare-warp`, which runs `warp-svc` as root with
    `CAP_NET_ADMIN` and opens the WARP UDP port (2408 by default).
-2. Declares two sops secrets (`auth_client_id`, `auth_client_secret`) from
-   `secrets/cloudflare-warp.yaml`, guarded by `builtins.pathExists` so a missing
-   secret warns instead of failing evaluation.
+2. Declares three sops secrets (`organization`, `auth_client_id`,
+   `auth_client_secret`) from `secrets/cloudflare-warp.yaml`, guarded by
+   `builtins.pathExists` so a missing secret warns and runs `warp-svc`
+   un-enrolled instead of failing evaluation.
 3. Renders `/var/lib/cloudflare-warp/mdm.xml` from non-secret options plus sops
    placeholders, and installs it (mode 0600, root) via an `ExecStartPre` right
    before `warp-svc` starts.
@@ -49,9 +50,10 @@ OFF; enrollment is a deliberate per-host opt-in.
 
 ## Security model
 
-- Credentials live only in `secrets/cloudflare-warp.yaml` (sops, age). The
-  rendered `mdm.xml` is produced from sops placeholders, so plaintext
-  credentials never enter the Nix store or git history.
+- The team name (`organization`) and service-token credentials live only in
+  `secrets/cloudflare-warp.yaml` (sops, age). The rendered `mdm.xml` is produced
+  from sops placeholders, so neither the team name nor the credentials enter the
+  Nix store or git history.
 - `mdm.xml` is written to `/var/lib/cloudflare-warp/mdm.xml` as `0600 root:root`.
 - `secrets/` is a git submodule; the encrypted payload is committed there, the
   Nix changes in the main repository.

--- a/docs/cloudflare/warp/README.md
+++ b/docs/cloudflare/warp/README.md
@@ -11,7 +11,9 @@ service token delivered through a managed deployment file (`mdm.xml`).
 | ----------------------------- | ---------------------------------------------------------- |
 | [Deployment](./deployment.md) | Operator runbook: dashboard prerequisites, secret, rollout |
 | [Reference](./reference.md)   | Module options, mdm.xml parameters, sops layout            |
+| [Modes](./modes.md)           | WARP mode comparison, DNS tradeoffs, split tunnels         |
 | [Operations](./operations.md) | Runtime verification, coexistence checks, troubleshooting  |
+| [Cheatsheet](./cheatsheet.md) | `warp-cli`, `warp-diag`, and service inspection commands   |
 
 ## What the module does
 
@@ -53,3 +55,12 @@ OFF; enrollment is a deliberate per-host opt-in.
 - `mdm.xml` is written to `/var/lib/cloudflare-warp/mdm.xml` as `0600 root:root`.
 - `secrets/` is a git submodule; the encrypted payload is committed there, the
   Nix changes in the main repository.
+
+## References
+
+- [WARP client docs](https://developers.cloudflare.com/warp-client/)
+- [Get started on Linux](https://developers.cloudflare.com/warp-client/get-started/linux/)
+- [Deploy the client headless on Linux](https://developers.cloudflare.com/cloudflare-one/tutorials/deploy-client-headless-linux/)
+- [Managed deployment parameters](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/deployment/mdm-deployment/parameters/)
+- [Service tokens](https://developers.cloudflare.com/cloudflare-one/access-controls/service-auth/service-tokens/)
+- [NixOS option `services.cloudflare-warp`](https://search.nixos.org/options?query=services.cloudflare-warp)

--- a/docs/cloudflare/warp/cheatsheet.md
+++ b/docs/cloudflare/warp/cheatsheet.md
@@ -1,0 +1,66 @@
+# Running WARP CLI commands
+
+Use these commands after the host has been deployed with
+`programs.cloudflare-warp.extended.enable = true`. The module installs the
+headless WARP package, so `warp-cli`, `warp-svc`, `warp-dex`, and `warp-diag`
+are available on enrolled hosts.
+
+## Check runtime state
+
+```bash
+systemctl status cloudflare-warp.service
+systemctl status cloudflare-warp-connect.service
+ls -l /var/lib/cloudflare-warp/mdm.xml
+warp-cli registration show
+warp-cli status
+warp-cli settings
+warp-cli tunnel stats
+curl -s https://www.cloudflare.com/cdn-cgi/trace | grep -E '^warp='
+```
+
+A healthy full-mode deployment shows the daemon running, the connect oneshot as
+`active (exited)`, a `0600 root:root` `mdm.xml`, an enrolled Zero Trust
+registration, `warp-cli status` as connected, and `warp=on` in the Cloudflare
+trace output.
+
+## Control the tunnel
+
+```bash
+warp-cli --accept-tos connect
+warp-cli --accept-tos disconnect
+warp-cli status
+```
+
+`disconnect` is temporary when the managed `mdm.xml` allows it. If
+`switch_locked` is true, the client prevents local disconnects.
+
+## Inspect managed settings
+
+```bash
+warp-cli settings
+warp-cli registration show
+warp-cli tunnel stats
+```
+
+`mdm.xml` is authoritative for `service_mode`. Do not use `warp-cli mode` for
+durable mode changes on a managed host. Change
+`programs.cloudflare-warp.extended.serviceMode` and rebuild instead.
+
+## Collect diagnostics
+
+```bash
+sudo warp-diag
+sudo warp-diag feedback
+journalctl -u cloudflare-warp.service -b
+journalctl -u cloudflare-warp-connect.service -b
+```
+
+The diagnostics bundle includes client settings, status, and daemon logs. Search
+the daemon log for `error`, `failed`, and `DNS connectivity check` to separate
+DNS setup problems from tunnel problems.
+
+## References
+
+- [Troubleshooting WARP](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/troubleshooting/)
+- [WARP diagnostic logs](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/troubleshooting/warp-diag/)
+- [Firewall and network ports](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/deployment/firewall/)

--- a/docs/cloudflare/warp/deployment.md
+++ b/docs/cloudflare/warp/deployment.md
@@ -54,8 +54,16 @@ git -C secrets add cloudflare-warp.yaml
 
 Each host opts in through a small file that enables the wrapper in Full mode:
 
-- `modules/tpnix/cloudflare-warp.nix`
-- `modules/system76/cloudflare-warp.nix`
+- `modules/system76/cloudflare-warp.nix` sets `enable = true` directly; system76
+  has runtime SOPS decryption.
+- `modules/tpnix/cloudflare-warp.nix` sets `enable = sopsRuntimeReady`, gating on
+  `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady` (`modules/tpnix/policy.nix`) like
+  the other tpnix sops consumers (`duplicati.nix`, `printing.nix`, `fonts.nix`).
+  tpnix has no runtime decryption key yet, so the wrapper stays off until that flag
+  is `true`; committing the secret while it is `false` would make tpnix declare
+  `cloudflare-warp/*` secrets it cannot decrypt and fail activation.
+
+A SOPS-ready host enables directly:
 
 ```nix
 _: {
@@ -71,9 +79,31 @@ _: {
 }
 ```
 
+A host still gated by `sopsRuntimeReady` (tpnix) enables through the flag; flip it in
+`modules/tpnix/policy.nix` once the decryption key is in place:
+
+```nix
+{ config, ... }:
+let
+  inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
+in
+{
+  configurations.nixos.tpnix.module = {
+    programs.cloudflare-warp.extended = {
+      enable = sopsRuntimeReady;
+      serviceMode = "warp";
+      autoConnect = 0;
+      switchLocked = false;
+      connectOnBoot = true;
+    };
+  };
+}
+```
+
 The team name is not set here; it comes from the `organization` key in the sops
-secret. Until `secrets/cloudflare-warp.yaml` exists the host runs `warp-svc`
-un-enrolled and emits a build warning.
+secret. On a SOPS-ready host, until `secrets/cloudflare-warp.yaml` exists the host
+runs `warp-svc` un-enrolled and emits a build warning. A host still gated by
+`sopsRuntimeReady` stays off entirely until the flag is `true`.
 
 ## 4. Validate and deploy
 

--- a/docs/cloudflare/warp/deployment.md
+++ b/docs/cloudflare/warp/deployment.md
@@ -60,7 +60,7 @@ _: {
   configurations.nixos.<host>.module = {
     programs.cloudflare-warp.extended = {
       enable = true;
-      organization = "<your-team-name>";
+      organization = "my-team"; # your Zero Trust team name; null leaves warp-svc un-enrolled
       serviceMode = "warp";
       autoConnect = 0;
       switchLocked = false;

--- a/docs/cloudflare/warp/deployment.md
+++ b/docs/cloudflare/warp/deployment.md
@@ -1,0 +1,89 @@
+# WARP Zero Trust Deployment
+
+Operator runbook to enroll a host into Cloudflare Zero Trust with this
+configuration. Dashboard steps target an Enterprise Zero Trust account.
+
+## 1. Dashboard prerequisites (one time)
+
+1. **Team name.** Note the `<team>` in `<team>.cloudflareaccess.com`. This becomes
+   the `organization` option.
+2. **Service token.** Settings/Access > Service Auth > Create Service Token.
+   Capture the **Client ID** (ends in `.access`) and the **Client Secret** (shown
+   once). These become `auth_client_id` / `auth_client_secret`.
+3. **Device-enrollment permission.** Settings > WARP Client > Device enrollment
+   permissions > Manage. Add a rule whose action is **Service Auth**, including
+   the service token from step 2. Required for token enrollment; without it the
+   daemon enrolls then fails policy.
+4. **Device profile.** Settings > WARP Client > Device profiles > Default >
+   Service mode = **Gateway with WARP** so dashboard policy matches the local
+   `service_mode = warp`.
+5. **Split Tunnels (Exclude IPs).** Keep the default RFC1918 ranges excluded and
+   ADD Tailscale's `100.64.0.0/10` so the tailnet keeps working under full
+   tunnel. Confirm `10.0.0.0/8` (the LAN range used by the tpnix SSH firewall
+   rule) stays excluded.
+6. **Local Domain Fallback.** Add internal/dev domains (for example `local`,
+   `internal`, corporate AD) so they resolve outside Cloudflare DNS.
+
+## 2. Create the encrypted secret
+
+The secret lives in the `secrets/` submodule and is covered by the existing
+`.sops.yaml` catch-all rule.
+
+```bash
+sops secrets/cloudflare-warp.yaml
+```
+
+Enter the service-token values:
+
+```yaml
+auth_client_id: <client-id>.access
+auth_client_secret: <client-secret>
+```
+
+Verify and stage inside the submodule:
+
+```bash
+sops -d secrets/cloudflare-warp.yaml          # shows both keys
+git -C secrets add cloudflare-warp.yaml
+```
+
+## 3. Enable the host
+
+Each host opts in through a small file that sets the `organization` (team name)
+and Full mode:
+
+- `modules/tpnix/cloudflare-warp.nix`
+- `modules/system76/cloudflare-warp.nix`
+
+```nix
+_: {
+  configurations.nixos.<host>.module = {
+    programs.cloudflare-warp.extended = {
+      enable = true;
+      organization = "<your-team-name>";
+      serviceMode = "warp";
+      autoConnect = 0;
+      switchLocked = false;
+      connectOnBoot = true;
+    };
+  };
+}
+```
+
+## 4. Validate and deploy
+
+```bash
+nix fmt
+nix flake check --accept-flake-config --no-build --offline
+nix build .#nixosConfigurations.<host>.config.system.build.toplevel --no-link
+sudo nixos-rebuild switch --flake .#<host>
+```
+
+After switch, follow [Operations](./operations.md) to confirm enrollment,
+connection, and coexistence with Tailscale and DNS.
+
+## 5. Commit
+
+The encrypted secret is committed inside the submodule; the Nix changes in the
+main repository. Keep them as separate commits, then update the submodule pointer
+in the main repo.

--- a/docs/cloudflare/warp/deployment.md
+++ b/docs/cloudflare/warp/deployment.md
@@ -6,7 +6,8 @@ configuration. Dashboard steps target an Enterprise Zero Trust account.
 ## 1. Dashboard prerequisites (one time)
 
 1. **Team name.** Note the `<team>` in `<team>.cloudflareaccess.com`. This becomes
-   the `organization` option.
+   the `organization` key in the sops secret (step 2). Use the bare team name,
+   not the full hostname.
 2. **Service token.** Settings/Access > Service Auth > Create Service Token.
    Capture the **Client ID** (ends in `.access`) and the **Client Secret** (shown
    once). These become `auth_client_id` / `auth_client_secret`.
@@ -27,15 +28,17 @@ configuration. Dashboard steps target an Enterprise Zero Trust account.
 ## 2. Create the encrypted secret
 
 The secret lives in the `secrets/` submodule and is covered by the existing
-`.sops.yaml` catch-all rule.
+`.sops.yaml` catch-all rule. Copy `secrets/cloudflare-warp.yaml.example` for the
+expected key layout.
 
 ```bash
 sops secrets/cloudflare-warp.yaml
 ```
 
-Enter the service-token values:
+Enter the team name and the service-token values:
 
 ```yaml
+organization: <team>
 auth_client_id: <client-id>.access
 auth_client_secret: <client-secret>
 ```
@@ -43,14 +46,13 @@ auth_client_secret: <client-secret>
 Verify and stage inside the submodule:
 
 ```bash
-sops -d secrets/cloudflare-warp.yaml          # shows both keys
+sops -d secrets/cloudflare-warp.yaml          # shows all three keys
 git -C secrets add cloudflare-warp.yaml
 ```
 
 ## 3. Enable the host
 
-Each host opts in through a small file that sets the `organization` (team name)
-and Full mode:
+Each host opts in through a small file that enables the wrapper in Full mode:
 
 - `modules/tpnix/cloudflare-warp.nix`
 - `modules/system76/cloudflare-warp.nix`
@@ -60,7 +62,6 @@ _: {
   configurations.nixos.<host>.module = {
     programs.cloudflare-warp.extended = {
       enable = true;
-      organization = "my-team"; # your Zero Trust team name; null leaves warp-svc un-enrolled
       serviceMode = "warp";
       autoConnect = 0;
       switchLocked = false;
@@ -69,6 +70,10 @@ _: {
   };
 }
 ```
+
+The team name is not set here; it comes from the `organization` key in the sops
+secret. Until `secrets/cloudflare-warp.yaml` exists the host runs `warp-svc`
+un-enrolled and emits a build warning.
 
 ## 4. Validate and deploy
 

--- a/docs/cloudflare/warp/modes.md
+++ b/docs/cloudflare/warp/modes.md
@@ -1,0 +1,64 @@
+# Choosing a WARP mode
+
+Choose the WARP mode before changing host configuration. The mode controls which
+Zero Trust features reach the device because each mode combines DNS, tunneling,
+and posture collection differently.
+
+This repository enables `Gateway with WARP` by default for enrolled hosts. That
+maps to `service_mode = "warp"` in `mdm.xml` and keeps DNS filtering, HTTP
+filtering, device posture, and domain-based split tunneling active.
+
+## Compare the client modes
+
+| Dashboard mode                           | `service_mode` | `warp-cli mode` | Traffic handled           | Gateway DNS | HTTP filtering | Posture |
+| ---------------------------------------- | -------------- | --------------- | ------------------------- | ----------- | -------------- | ------- |
+| Gateway with WARP                        | `warp`         | `warp+doh`      | All traffic and DNS       | Yes         | Yes            | Yes     |
+| Gateway with DoH                         | `1dot1`        | `doh`           | DNS only                  | Yes         | No             | No      |
+| Secure Web Gateway without DNS filtering | `tunnelonly`   | `tunnel_only`   | All traffic, OS keeps DNS | No          | Yes            | Yes     |
+| Proxy                                    | `proxy`        | `proxy`         | `127.0.0.1:40000` only    | No          | Yes            | No      |
+| Device Information Only                  | `postureonly`  | n/a             | None                      | No          | No             | Yes     |
+
+`warp-cli settings` reports the same modes as `WarpWithDnsOverHttps`,
+`DnsOverHttps`, `TunnelOnly`, `WarpProxy`, and `PostureOnly`.
+
+## Prefer full mode for enrolled hosts
+
+Use `Gateway with WARP` unless a host must keep an independent DNS resolver.
+Full mode makes WARP the system resolver, so Gateway DNS policies can block
+malware, phishing, and content categories before a connection starts.
+
+Full mode also preserves domain-based split tunneling because the client owns
+resolution. Internal names still work when their suffixes are configured in
+Local Domain Fallback.
+
+Use `tunnelonly` only when Cloudflare cannot control DNS on the device. It keeps
+the tunnel, HTTP filtering, network policies, and posture checks, but it removes
+Gateway DNS filtering, DNS query logs, and domain-based split tunneling.
+
+## Avoid local DNS resolver conflicts
+
+Do not run a local resolver on `127.0.0.1:53` while using full mode. If a host
+enables `services.dnscrypt-proxy` or imports a module that provides a competing
+local resolver, switch WARP to `tunnelonly` or disable the local resolver.
+
+The `tpnix` and `system76` hosts use NetworkManager with DHCP, and the unused
+`flake.nixosModules.workstation` module owns the `services.dnscrypt-proxy`
+definition. Full mode is the expected setting for the current enrolled hosts.
+
+## Configure split tunnels
+
+Configure split tunnels in the Zero Trust device profile. Exclude mode sends all
+traffic through WARP except listed IPs and domains. Include mode sends only
+listed IPs and domains through WARP.
+
+Keep the default RFC1918 exclusions so local networks stay reachable. Also
+exclude Tailscale's `100.64.0.0/10` range on hosts that use the tailnet.
+
+`tunnelonly` and `postureonly` disable domain-based split tunneling. In those
+modes, split only by IP or CIDR.
+
+## References
+
+- [WARP modes](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-modes/)
+- [Split tunnels](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/split-tunnels/)
+- [Local Domain Fallback](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/local-domains/)

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -1,0 +1,64 @@
+# WARP Operations
+
+Runtime verification, coexistence checks, and troubleshooting after
+`nixos-rebuild switch` on an enrolled host.
+
+## Verify the daemon and enrollment
+
+```bash
+systemctl status cloudflare-warp.service          # warp-svc running
+systemctl status cloudflare-warp-connect.service  # oneshot succeeded (active/exited)
+ls -l /var/lib/cloudflare-warp/mdm.xml            # 0600 root:root, present
+warp-cli registration show                        # enrolled into <team> (non_identity@<team>...)
+warp-cli status                                   # Connected
+```
+
+The `cloudflare-warp-connect` oneshot polls the daemon for up to 30 seconds
+before it issues `warp-cli connect`, so on a fresh boot the unit can take that
+long to reach `active (exited)`.
+
+Confirm WARP is carrying traffic:
+
+```bash
+curl -s https://www.cloudflare.com/cdn-cgi/trace | grep -E '^warp='   # warp=on
+```
+
+## Zero Trust dashboard checks
+
+- The device appears under Team & Resources > Devices.
+- Gateway DNS/HTTP logs show this device's queries (confirms Full mode + Gateway
+  DNS).
+
+## Coexistence checks
+
+- `tailscale status` is still reachable (confirms the `100.64.0.0/10`
+  split-tunnel exclude).
+- Internal / `.local` names resolve (confirms Local Domain Fallback).
+
+## Reapplying managed config
+
+The `cloudflare-warp.service` carries a `restartTriggers` hash of the non-secret
+mdm fields (`organization`, `serviceMode`, `autoConnect`, `switchLocked`).
+Changing any of them and rebuilding restarts `warp-svc`, which re-reads
+`mdm.xml`. Rotating the service token (the sops secret) re-renders the file on
+the next activation.
+
+## Troubleshooting
+
+- **Enrollment fails / device shows then drops.** The service token likely lacks
+  device-enrollment permission. Add a Service Auth rule referencing the token
+  (Deployment, step 3). Collect a diagnostics bundle: `sudo warp-diag`.
+- **mdm.xml missing at boot (race).** `mdm.xml` is installed by an `ExecStartPre`
+  that copies the sops-rendered template. The template is rendered during
+  activation, before `multi-user.target`, and `warp-svc` has `Restart=always`, so
+  a transient miss self-heals. If a cold-boot race is observed, order
+  `cloudflare-warp.service` after the sops template unit (add `after`/`wants` on
+  the sops setup unit) and rebuild.
+- **No connectivity with strict rp_filter.** The module sets
+  `networking.firewall.checkReversePath = "loose"` by default. If a host firewall
+  module forces `strict`, the `CloudflareWARP` interface drops return traffic.
+- **DNS resolver conflict.** Full mode (`warp` / `1dot1`) makes WARP the DNS
+  resolver. Do not also enable `services.dnscrypt-proxy` (or import
+  `flake.nixosModules.workstation`); the module warns if you do.
+- **General diagnostics.** `sudo warp-diag` writes a zip with logs and settings;
+  `sudo warp-diag feedback` is the same bundle framed for a support ticket.

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -38,10 +38,11 @@ curl -s https://www.cloudflare.com/cdn-cgi/trace | grep -E '^warp='   # warp=on
 ## Reapplying managed config
 
 The `cloudflare-warp.service` carries a `restartTriggers` hash of the non-secret
-mdm fields (`organization`, `serviceMode`, `autoConnect`, `switchLocked`).
-Changing any of them and rebuilding restarts `warp-svc`, which re-reads
-`mdm.xml`. Rotating the service token (the sops secret) re-renders the file on
-the next activation.
+mdm fields (`serviceMode`, `autoConnect`, `switchLocked`). Changing any of them
+and rebuilding restarts `warp-svc`, which re-reads `mdm.xml`. The team name
+(`organization`) and the service token live in the sops secret; rotating either
+re-renders the `cloudflare-warp-mdm` template, whose `restartUnits` restarts
+`warp-svc` on the next activation.
 
 ## Troubleshooting
 
@@ -49,11 +50,12 @@ the next activation.
   device-enrollment permission. Add a Service Auth rule referencing the token
   (Deployment, step 3). Collect a diagnostics bundle: `sudo warp-diag`.
 - **mdm.xml missing at boot (race).** `mdm.xml` is installed by an `ExecStartPre`
-  that copies the sops-rendered template. The template is rendered during
-  activation, before `multi-user.target`, and `warp-svc` has `Restart=always`, so
-  a transient miss self-heals. If a cold-boot race is observed, order
-  `cloudflare-warp.service` after the sops template unit (add `after`/`wants` on
-  the sops setup unit) and rebuild.
+  that copies the sops-rendered template. Ordering is wired into the module:
+  `cloudflare-warp.service` carries `after`/`requires` on the sops secret-install
+  dependency (`config.flake.lib.security.sopsInstallSecretsDeps`), so on
+  systemd-activation hosts the rendered template is present before `warp-svc`
+  starts. Activation-script hosts decrypt secrets before any unit ordering, and
+  `warp-svc` has `Restart=always`, so a transient miss self-heals either way.
 - **No connectivity with strict rp_filter.** The module sets
   `networking.firewall.checkReversePath = "loose"` by default. If a host firewall
   module forces `strict`, the `CloudflareWARP` interface drops return traffic.

--- a/docs/cloudflare/warp/reference.md
+++ b/docs/cloudflare/warp/reference.md
@@ -1,0 +1,80 @@
+# WARP Module Reference
+
+## Module options (`programs.cloudflare-warp.extended`)
+
+| Option          | Type            | Default                                              | Description                                                                      |
+| --------------- | --------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `enable`        | bool            | `false`                                              | Run `warp-svc` and enroll into Zero Trust.                                       |
+| `package`       | package         | `pkgs.cloudflare-warp.override { headless = true; }` | WARP package; headless ships `warp-cli`/`warp-svc`/`warp-dex`/`warp-diag`.       |
+| `organization`  | nullable string | `null`                                               | Zero Trust team name; `null` runs `warp-svc` without managed enrollment.         |
+| `serviceMode`   | enum            | `"warp"`                                             | `mdm.xml` `service_mode`: `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly`. |
+| `autoConnect`   | int 0-1440      | `0`                                                  | `mdm.xml` `auto_connect` minutes before reconnect after a manual disconnect.     |
+| `switchLocked`  | bool            | `false`                                              | `mdm.xml` `switch_locked`; when true the user cannot disconnect.                 |
+| `connectOnBoot` | bool            | `true`                                               | Best-effort oneshot `warp-cli connect` after the daemon starts.                  |
+| `openFirewall`  | bool            | `true`                                               | Open the WARP UDP port.                                                          |
+| `udpPort`       | port            | `2408`                                               | WARP UDP port to open.                                                           |
+
+## mdm.xml parameters
+
+Linux reads the managed deployment file at `/var/lib/cloudflare-warp/mdm.xml`.
+The file is a bare `<dict>` plist fragment: no `<?xml ...?>` declaration, no
+DOCTYPE, and no `<plist>` wrapper. The module emits these keys:
+
+| Key                  | Type    | Values / format                                       | Source         |
+| -------------------- | ------- | ----------------------------------------------------- | -------------- |
+| `organization`       | string  | Zero Trust team name                                  | `organization` |
+| `auth_client_id`     | string  | Service-token Client ID (`...access`)                 | sops secret    |
+| `auth_client_secret` | string  | Service-token Client Secret                           | sops secret    |
+| `service_mode`       | string  | `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly` | `serviceMode`  |
+| `auto_connect`       | integer | `0`-`1440` (minutes)                                  | `autoConnect`  |
+| `switch_locked`      | boolean | `<true/>` / `<false/>`                                | `switchLocked` |
+
+Other Cloudflare-documented keys not emitted by this module (add to `mdmContent`
+in `modules/apps/cloudflare-warp.nix` if needed): `support_url`,
+`warp_tunnel_protocol` (`masque` or `wireguard`), `enable_post_quantum`,
+`gateway_unique_id`, `display_name`. `unique_client_id` is iOS/Android/ChromeOS
+only and is not valid on Linux.
+
+Rendered example (placeholders shown; real values are injected by sops):
+
+```xml
+<dict>
+  <key>organization</key>
+  <string>my-team</string>
+  <key>auth_client_id</key>
+  <string>REDACTED.access</string>
+  <key>auth_client_secret</key>
+  <string>REDACTED</string>
+  <key>service_mode</key>
+  <string>warp</string>
+  <key>auto_connect</key>
+  <integer>0</integer>
+  <key>switch_locked</key>
+  <false/>
+</dict>
+```
+
+## sops layout
+
+| Item                   | Value                                                                     |
+| ---------------------- | ------------------------------------------------------------------------- |
+| Encrypted file         | `secrets/cloudflare-warp.yaml`                                            |
+| Keys                   | `auth_client_id`, `auth_client_secret`                                    |
+| Secret names           | `cloudflare-warp/auth_client_id`, `cloudflare-warp/auth_client_secret`    |
+| Template               | `sops.templates."cloudflare-warp-mdm"` (mode 0600)                        |
+| Rendered template path | `config.sops.templates."cloudflare-warp-mdm".path` (under `/run/secrets`) |
+| Installed runtime file | `/var/lib/cloudflare-warp/mdm.xml` (0600 root, via ExecStartPre)          |
+| `.sops.yaml` rule      | Covered by the existing catch-all (no policy change needed)               |
+
+## Keeping the team name private
+
+`organization` is not a credential, but it identifies the Zero Trust tenant, and
+this repository is public. To keep it out of git, add it to the sops secret and
+render it through a placeholder instead of the plaintext option:
+
+1. Add `organization: <team>` to `secrets/cloudflare-warp.yaml`.
+2. Declare `sops.secrets."cloudflare-warp/organization"`.
+3. In `mdmContent`, replace `<string>${cfg.organization}</string>` with
+   `<string>${config.sops.placeholder."cloudflare-warp/organization"}</string>`
+   and drop the `organization` per-host option (or keep it only as a non-secret
+   fallback).

--- a/docs/cloudflare/warp/reference.md
+++ b/docs/cloudflare/warp/reference.md
@@ -2,17 +2,16 @@
 
 ## Module options (`programs.cloudflare-warp.extended`)
 
-| Option          | Type            | Default                                              | Description                                                                      |
-| --------------- | --------------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
-| `enable`        | bool            | `false`                                              | Run `warp-svc` and enroll into Zero Trust.                                       |
-| `package`       | package         | `pkgs.cloudflare-warp.override { headless = true; }` | WARP package; headless ships `warp-cli`/`warp-svc`/`warp-dex`/`warp-diag`.       |
-| `organization`  | nullable string | `null`                                               | Zero Trust team name; `null` runs `warp-svc` without managed enrollment.         |
-| `serviceMode`   | enum            | `"warp"`                                             | `mdm.xml` `service_mode`: `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly`. |
-| `autoConnect`   | int 0-1440      | `0`                                                  | `mdm.xml` `auto_connect` minutes before reconnect after a manual disconnect.     |
-| `switchLocked`  | bool            | `false`                                              | `mdm.xml` `switch_locked`; when true the user cannot disconnect.                 |
-| `connectOnBoot` | bool            | `true`                                               | Best-effort oneshot `warp-cli connect` after the daemon starts.                  |
-| `openFirewall`  | bool            | `true`                                               | Open the WARP UDP port.                                                          |
-| `udpPort`       | port            | `2408`                                               | WARP UDP port to open.                                                           |
+| Option          | Type       | Default                                              | Description                                                                      |
+| --------------- | ---------- | ---------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `enable`        | bool       | `false`                                              | Run `warp-svc` and enroll into Zero Trust.                                       |
+| `package`       | package    | `pkgs.cloudflare-warp.override { headless = true; }` | WARP package; headless ships `warp-cli`/`warp-svc`/`warp-dex`/`warp-diag`.       |
+| `serviceMode`   | enum       | `"warp"`                                             | `mdm.xml` `service_mode`: `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly`. |
+| `autoConnect`   | int 0-1440 | `0`                                                  | `mdm.xml` `auto_connect` minutes before reconnect after a manual disconnect.     |
+| `switchLocked`  | bool       | `false`                                              | `mdm.xml` `switch_locked`; when true the user cannot disconnect.                 |
+| `connectOnBoot` | bool       | `true`                                               | Best-effort oneshot `warp-cli connect` after the daemon starts.                  |
+| `openFirewall`  | bool       | `true`                                               | Open the WARP UDP port.                                                          |
+| `udpPort`       | port       | `2408`                                               | WARP UDP port to open.                                                           |
 
 ## mdm.xml parameters
 
@@ -22,7 +21,7 @@ DOCTYPE, and no `<plist>` wrapper. The module emits these keys:
 
 | Key                  | Type    | Values / format                                       | Source         |
 | -------------------- | ------- | ----------------------------------------------------- | -------------- |
-| `organization`       | string  | Zero Trust team name                                  | `organization` |
+| `organization`       | string  | Zero Trust team name                                  | sops secret    |
 | `auth_client_id`     | string  | Service-token Client ID (`...access`)                 | sops secret    |
 | `auth_client_secret` | string  | Service-token Client Secret                           | sops secret    |
 | `service_mode`       | string  | `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly` | `serviceMode`  |
@@ -40,7 +39,7 @@ Rendered example (placeholders shown; real values are injected by sops):
 ```xml
 <dict>
   <key>organization</key>
-  <string>my-team</string>
+  <string>REDACTED</string>
   <key>auth_client_id</key>
   <string>REDACTED.access</string>
   <key>auth_client_secret</key>
@@ -56,25 +55,26 @@ Rendered example (placeholders shown; real values are injected by sops):
 
 ## sops layout
 
-| Item                   | Value                                                                     |
-| ---------------------- | ------------------------------------------------------------------------- |
-| Encrypted file         | `secrets/cloudflare-warp.yaml`                                            |
-| Keys                   | `auth_client_id`, `auth_client_secret`                                    |
-| Secret names           | `cloudflare-warp/auth_client_id`, `cloudflare-warp/auth_client_secret`    |
-| Template               | `sops.templates."cloudflare-warp-mdm"` (mode 0600)                        |
-| Rendered template path | `config.sops.templates."cloudflare-warp-mdm".path` (under `/run/secrets`) |
-| Installed runtime file | `/var/lib/cloudflare-warp/mdm.xml` (0600 root, via ExecStartPre)          |
-| `.sops.yaml` rule      | Covered by the existing catch-all (no policy change needed)               |
+| Item                   | Value                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| Encrypted file         | `secrets/cloudflare-warp.yaml`                                                                         |
+| Keys                   | `organization`, `auth_client_id`, `auth_client_secret`                                                 |
+| Secret names           | `cloudflare-warp/organization`, `cloudflare-warp/auth_client_id`, `cloudflare-warp/auth_client_secret` |
+| Template               | `sops.templates."cloudflare-warp-mdm"` (mode 0600)                                                     |
+| Rendered template path | `config.sops.templates."cloudflare-warp-mdm".path` (under `/run/secrets`)                              |
+| Installed runtime file | `/var/lib/cloudflare-warp/mdm.xml` (0600 root, via ExecStartPre)                                       |
+| `.sops.yaml` rule      | Covered by the existing catch-all (no policy change needed)                                            |
 
 ## Keeping the team name private
 
 `organization` is not a credential, but it identifies the Zero Trust tenant, and
-this repository is public. To keep it out of git, add it to the sops secret and
-render it through a placeholder instead of the plaintext option:
+this repository is public, so the team name is sourced from sops rather than Nix
+code:
 
-1. Add `organization: <team>` to `secrets/cloudflare-warp.yaml`.
-2. Declare `sops.secrets."cloudflare-warp/organization"`.
-3. In `mdmContent`, replace `<string>${cfg.organization}</string>` with
-   `<string>${config.sops.placeholder."cloudflare-warp/organization"}</string>`
-   and drop the `organization` per-host option (or keep it only as a non-secret
-   fallback).
+- `organization` is a key in `secrets/cloudflare-warp.yaml`, declared as
+  `sops.secrets."cloudflare-warp/organization"`.
+- `mdmContent` renders it through
+  `<string>${config.sops.placeholder."cloudflare-warp/organization"}</string>`,
+  so the team name never enters the Nix store or git history.
+- There is no per-host `organization` option; a host enrolls by providing the
+  secret. Without the secret the host runs `warp-svc` un-enrolled and warns.

--- a/docs/cloudflare/warp/reference.md
+++ b/docs/cloudflare/warp/reference.md
@@ -77,4 +77,6 @@ code:
   `<string>${config.sops.placeholder."cloudflare-warp/organization"}</string>`,
   so the team name never enters the Nix store or git history.
 - There is no per-host `organization` option; a host enrolls by providing the
-  secret. Without the secret the host runs `warp-svc` un-enrolled and warns.
+  secret (and, where enablement is gated on `sopsRuntimeReady` such as tpnix, once
+  that flag is `true`). On an enabled host without the secret, `warp-svc` runs
+  un-enrolled and warns; a host still gated by `sopsRuntimeReady` stays off entirely.

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,15 +33,17 @@
 - [cloudflare/cloudflared-tunnel-sample.md](cloudflare/cloudflared-tunnel-sample.md)
   - Sample NixOS configuration for Cloudflare Tunnel (cloudflared) with ingress rules and credential setup.
 - [cloudflare/warp/README.md](cloudflare/warp/README.md)
-  - Overview and reading order for running Cloudflare WARP (Zero Trust device client) on NixOS.
-- [cloudflare/warp/warp-modes.md](cloudflare/warp/warp-modes.md)
-  - Comparison of the five WARP modes and the full versus traffic-only DNS tradeoff.
-- [cloudflare/warp/zero-trust-enrollment.md](cloudflare/warp/zero-trust-enrollment.md)
-  - Non-interactive Zero Trust enrollment with a service token and mdm.xml parameters.
-- [cloudflare/warp/nixos-setup.md](cloudflare/warp/nixos-setup.md)
-  - Working NixOS recipe using services.cloudflare-warp and a sops-rendered mdm.xml.
+  - Index for declarative Cloudflare WARP and Zero Trust enrollment on NixOS.
+- [cloudflare/warp/deployment.md](cloudflare/warp/deployment.md)
+  - Operator runbook for WARP dashboard prerequisites, service-token secrets, host rollout, and validation.
+- [cloudflare/warp/reference.md](cloudflare/warp/reference.md)
+  - Reference for `programs.cloudflare-warp.extended` options, `mdm.xml` parameters, and sops layout.
+- [cloudflare/warp/modes.md](cloudflare/warp/modes.md)
+  - Compact comparison of WARP modes, DNS ownership tradeoffs, and split-tunnel behavior.
 - [cloudflare/warp/operations.md](cloudflare/warp/operations.md)
-  - Verification checks, warp-cli cheat sheet, warp-diag, and common Linux failure modes.
+  - Runtime verification, coexistence checks, and troubleshooting for enrolled WARP hosts.
+- [cloudflare/warp/cheatsheet.md](cloudflare/warp/cheatsheet.md)
+  - Command reference for `warp-cli`, `warp-diag`, and WARP-related systemd services.
 - [cloudflare/containers/README.md](cloudflare/containers/README.md)
   - Technical documentation index for Cloudflare Containers.
 - [cloudflare/containers/architecture.md](cloudflare/containers/architecture.md)

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -12,8 +12,7 @@
     * Renders /var/lib/cloudflare-warp/mdm.xml from sops-backed credentials, store-safe.
 
   Options:
-    enable: Run warp-svc plus managed Zero Trust enrollment.
-    organization: Zero Trust team name (the <team> in <team>.cloudflareaccess.com); null disables managed enrollment.
+    enable: Run warp-svc; managed Zero Trust enrollment activates when secrets/cloudflare-warp.yaml exists.
     serviceMode: mdm.xml service_mode (warp | tunnelonly | 1dot1 | proxy | postureonly).
     autoConnect: mdm.xml auto_connect minutes (0-1440); 0 keeps the client off after a manual disconnect.
     switchLocked: mdm.xml switch_locked; when true the user cannot disconnect.
@@ -21,7 +20,7 @@
 
   Notes:
     * service_mode is authoritative via mdm.xml; the module never calls `warp-cli mode`.
-    * Secrets (auth_client_id/auth_client_secret) live in secrets/cloudflare-warp.yaml (sops).
+    * Secrets (organization/auth_client_id/auth_client_secret) live in secrets/cloudflare-warp.yaml (sops).
     * Sets networking.firewall.checkReversePath = "loose" (mkDefault); the WARP interface trips strict rp_filter.
     * Pairs with per-host enablement in modules/tpnix/cloudflare-warp.nix and modules/system76/cloudflare-warp.nix.
 */
@@ -40,7 +39,14 @@ let
       rootDir = config.services.cloudflare-warp.rootDir;
       secretsFile = "${secretsRoot}/cloudflare-warp.yaml";
       haveSecrets = builtins.pathExists secretsFile;
-      enrolling = cfg.organization != null && haveSecrets;
+      enrolling = haveSecrets;
+
+      # Logged by the connect-on-boot oneshot when the device has no managed
+      # mdm.xml, so the journal explains why `warp-cli connect` only reaches
+      # consumer WARP instead of the Zero Trust org.
+      unenrolledNotice = lib.optionalString (!enrolling) ''
+        echo "cloudflare-warp-connect: device is UN-ENROLLED (no managed mdm.xml); connecting to consumer WARP only. Create secrets/cloudflare-warp.yaml to enroll."
+      '';
 
       # Linux mdm.xml is a bare <dict> plist fragment (no XML declaration, no
       # <plist> wrapper). Secret values are injected through sops placeholders so
@@ -48,7 +54,7 @@ let
       mdmContent = ''
         <dict>
           <key>organization</key>
-          <string>${cfg.organization}</string>
+          <string>${config.sops.placeholder."cloudflare-warp/organization"}</string>
           <key>auth_client_id</key>
           <string>${config.sops.placeholder."cloudflare-warp/auth_client_id"}</string>
           <key>auth_client_secret</key>
@@ -77,20 +83,6 @@ let
           description = ''
             Cloudflare WARP package. Defaults to the headless build, which ships
             warp-cli, warp-svc, warp-dex, and warp-diag and omits the GUI taskbar.
-          '';
-        };
-
-        organization = lib.mkOption {
-          # Zero Trust team names are [A-Za-z0-9-]+. Constraining the type makes a
-          # bad value (placeholder, whitespace, XML metacharacters) fail at eval
-          # instead of rendering an unparsable mdm.xml that warp-svc rejects at
-          # startup. cfg.organization is interpolated raw into the plist body.
-          type = lib.types.nullOr (lib.types.strMatching "[A-Za-z0-9-]+");
-          default = null;
-          example = "my-team";
-          description = ''
-            Cloudflare Zero Trust team name (the <team> in <team>.cloudflareaccess.com).
-            When null, the module runs warp-svc without managed enrollment.
           '';
         };
 
@@ -169,14 +161,14 @@ let
                   but services.dnscrypt-proxy is enabled (binds 127.0.0.1:53). Use serviceMode
                   "tunnelonly"/"proxy" or disable dnscrypt-proxy.
                 ''
-              ++ lib.optional (cfg.organization != null && !haveSecrets) ''
+              ++ lib.optional (!haveSecrets) ''
                 programs.cloudflare-warp.extended: ${secretsFile} is missing; running warp-svc
-                WITHOUT managed enrollment. Create the sops secret (see
+                WITHOUT managed enrollment (degraded). Create the sops secret (see
                 docs/cloudflare/warp/deployment.md) and rebuild.
               '';
           }
 
-          # When not enrolling (organization unset, or the sops secret is absent),
+          # When not enrolling (the sops secret is absent),
           # remove any mdm.xml left by a previous enrollment. mdm.xml is
           # authoritative for service_mode and caches the service token, so a stale
           # file would keep warp-svc in managed mode instead of degrading to the
@@ -189,15 +181,22 @@ let
 
           (lib.mkIf enrolling {
             sops = {
-              secrets."cloudflare-warp/auth_client_id" = {
-                sopsFile = secretsFile;
-                key = "auth_client_id";
-                mode = "0400";
-              };
-              secrets."cloudflare-warp/auth_client_secret" = {
-                sopsFile = secretsFile;
-                key = "auth_client_secret";
-                mode = "0400";
+              secrets = {
+                "cloudflare-warp/organization" = {
+                  sopsFile = secretsFile;
+                  key = "organization";
+                  mode = "0400";
+                };
+                "cloudflare-warp/auth_client_id" = {
+                  sopsFile = secretsFile;
+                  key = "auth_client_id";
+                  mode = "0400";
+                };
+                "cloudflare-warp/auth_client_secret" = {
+                  sopsFile = secretsFile;
+                  key = "auth_client_secret";
+                  mode = "0400";
+                };
               };
               templates."cloudflare-warp-mdm" = {
                 content = mdmContent;
@@ -224,7 +223,6 @@ let
               restartTriggers = [
                 (builtins.toJSON {
                   inherit (cfg)
-                    organization
                     serviceMode
                     autoConnect
                     switchLocked
@@ -252,11 +250,12 @@ let
                   fi
                   sleep 1
                 done
-
-                # Managed enrollment (mdm.xml service token) registers the device and
-                # accepts ToS, so no interactive `warp-cli registration new` is needed.
-                # This connect is best-effort: log the outcome and exit 0 so a user who
-                # legitimately keeps WARP off does not leave the unit failed.
+                ${unenrolledNotice}
+                # When enrolling, mdm.xml (service token) has already registered the
+                # device and accepted ToS, so no interactive `warp-cli registration
+                # new` is needed. This connect is best-effort either way: log the
+                # outcome and exit 0 so a user who legitimately keeps WARP off does
+                # not leave the unit failed.
                 if ${cfg.package}/bin/warp-cli connect; then
                   echo "cloudflare-warp-connect: connect requested"
                 else

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -246,7 +246,7 @@ let
               };
               script = ''
                 # Wait for the warp-svc IPC socket to answer before connecting.
-                for _ in $(seq 1 30); do
+                for _ in {1..30}; do
                   if ${cfg.package}/bin/warp-cli status >/dev/null 2>&1; then
                     break
                   fi

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -24,8 +24,9 @@
     * Sets networking.firewall.checkReversePath = "loose" (mkDefault); the WARP interface trips strict rp_filter.
     * Pairs with per-host enablement in modules/tpnix/cloudflare-warp.nix and modules/system76/cloudflare-warp.nix.
 */
-_:
+{ config, ... }:
 let
+  inherit (config.flake.lib.security) sopsInstallSecretsDeps;
   CloudflareWarpModule =
     {
       config,
@@ -40,6 +41,10 @@ let
       secretsFile = "${secretsRoot}/cloudflare-warp.yaml";
       haveSecrets = builtins.pathExists secretsFile;
       enrolling = haveSecrets;
+      # Gate the sops-install-secrets.service dependency on
+      # sops.useSystemdActivation: the unit only exists in that mode (issue #37);
+      # activation-script hosts decrypt before any unit ordering, so this is [].
+      installSecretsDeps = sopsInstallSecretsDeps config;
 
       # Logged by the connect-on-boot oneshot when the device has no managed
       # mdm.xml, so the journal explains why `warp-cli connect` only reaches
@@ -214,6 +219,11 @@ let
             # rootDir already exists from the upstream tmpfiles rule, and the sops
             # template is rendered during activation (before multi-user.target).
             systemd.services.cloudflare-warp = {
+              # Order warp-svc after sops installs the secret/template so the
+              # ExecStartPre install of mdm.xml sees the rendered file. No-op on
+              # activation-script hosts (installSecretsDeps = []).
+              after = installSecretsDeps;
+              requires = installSecretsDeps;
               serviceConfig.ExecStartPre = [
                 "${pkgs.coreutils}/bin/install -D -m0600 -o root -g root ${
                   config.sops.templates."cloudflare-warp-mdm".path

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -202,6 +202,12 @@ let
               templates."cloudflare-warp-mdm" = {
                 content = mdmContent;
                 mode = "0600";
+                # restartTriggers below only hash non-secret fields. Rotating
+                # auth_client_id/auth_client_secret re-renders this template but
+                # would not restart warp-svc, so the daemon would keep the old
+                # token until reboot. Restart on rotation (matches the repo
+                # pattern in usbguard.nix and duplicati-r2.nix).
+                restartUnits = [ "cloudflare-warp.service" ];
               };
             };
 

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -176,6 +176,17 @@ let
               '';
           }
 
+          # When not enrolling (organization unset, or the sops secret is absent),
+          # remove any mdm.xml left by a previous enrollment. mdm.xml is
+          # authoritative for service_mode and caches the service token, so a stale
+          # file would keep warp-svc in managed mode instead of degrading to the
+          # un-enrolled daemon. rootDir is the upstream StateDirectory.
+          (lib.mkIf (!enrolling) {
+            systemd.services.cloudflare-warp.serviceConfig.ExecStartPre = [
+              "${pkgs.coreutils}/bin/rm -f ${rootDir}/mdm.xml"
+            ];
+          })
+
           (lib.mkIf enrolling {
             sops = {
               secrets."cloudflare-warp/auth_client_id" = {

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -1,19 +1,29 @@
 /*
   Package: cloudflare-warp
-  Variant: headless (warp-cli + warp-svc; no GUI taskbar, no XDG autostart)
-  Description: Cloudflare WARP client delivering encrypted consumer VPN and Zero Trust connectivity.
+  Variant: headless (warp-cli + warp-svc + warp-dex + warp-diag; no GUI taskbar)
+  Description: Cloudflare WARP client delivering encrypted VPN and Zero Trust connectivity.
   Homepage: https://developers.cloudflare.com/warp-client/
-  Documentation: https://developers.cloudflare.com/warp-client/get-started/linux/
+  Documentation: https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/
   Repository: https://github.com/cloudflare/warp
 
   Summary:
-    * Secures device traffic using WireGuard-based tunnels through Cloudflare's global edge network.
-    * Integrates with Cloudflare Zero Trust policies for split tunneling, device posture, and secure web gateway enforcement.
+    * Drives upstream services.cloudflare-warp to run warp-svc and enroll the device into
+      Cloudflare Zero Trust non-interactively via a service token in managed (mdm.xml) mode.
+    * Renders /var/lib/cloudflare-warp/mdm.xml from sops-backed credentials, store-safe.
 
   Options:
-    --accept-tos: Accept Cloudflare's Terms of Service non-interactively when registering with `warp-cli register --accept-tos`.
-    --warp: Select the full WARP mode using `warp-cli mode --warp` instead of the default Gateway-only mode.
-    --add --ip <cidr>: Extend split tunneling by combining `warp-cli split-tunnel --add --ip <cidr>`.
+    enable: Run warp-svc plus managed Zero Trust enrollment.
+    organization: Zero Trust team name (the <team> in <team>.cloudflareaccess.com); null disables managed enrollment.
+    serviceMode: mdm.xml service_mode (warp | tunnelonly | 1dot1 | proxy | postureonly).
+    autoConnect: mdm.xml auto_connect minutes (0-1440); 0 keeps the client off after a manual disconnect.
+    switchLocked: mdm.xml switch_locked; when true the user cannot disconnect.
+    connectOnBoot: run a best-effort oneshot `warp-cli connect` after the daemon starts.
+
+  Notes:
+    * service_mode is authoritative via mdm.xml; the module never calls `warp-cli mode`.
+    * Secrets (auth_client_id/auth_client_secret) live in secrets/cloudflare-warp.yaml (sops).
+    * Sets networking.firewall.checkReversePath = "loose" (mkDefault); the WARP interface trips strict rp_filter.
+    * Pairs with per-host enablement in modules/tpnix/cloudflare-warp.nix and modules/system76/cloudflare-warp.nix.
 */
 _:
 let
@@ -22,17 +32,42 @@ let
       config,
       lib,
       pkgs,
+      secretsRoot,
       ...
     }:
     let
-      cfg = config.programs."cloudflare-warp".extended;
+      cfg = config.programs.cloudflare-warp.extended;
+      rootDir = config.services.cloudflare-warp.rootDir;
+      secretsFile = "${secretsRoot}/cloudflare-warp.yaml";
+      haveSecrets = builtins.pathExists secretsFile;
+      enrolling = cfg.organization != null && haveSecrets;
+
+      # Linux mdm.xml is a bare <dict> plist fragment (no XML declaration, no
+      # <plist> wrapper). Secret values are injected through sops placeholders so
+      # the rendered file never enters the Nix store.
+      mdmContent = ''
+        <dict>
+          <key>organization</key>
+          <string>${cfg.organization}</string>
+          <key>auth_client_id</key>
+          <string>${config.sops.placeholder."cloudflare-warp/auth_client_id"}</string>
+          <key>auth_client_secret</key>
+          <string>${config.sops.placeholder."cloudflare-warp/auth_client_secret"}</string>
+          <key>service_mode</key>
+          <string>${cfg.serviceMode}</string>
+          <key>auto_connect</key>
+          <integer>${toString cfg.autoConnect}</integer>
+          <key>switch_locked</key>
+          ${if cfg.switchLocked then "<true/>" else "<false/>"}
+        </dict>
+      '';
     in
     {
       options.programs.cloudflare-warp.extended = {
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Whether to enable cloudflare-warp.";
+          description = "Whether to run warp-svc and enroll into Cloudflare Zero Trust.";
         };
 
         package = lib.mkOption {
@@ -40,19 +75,178 @@ let
           default = pkgs.cloudflare-warp.override { headless = true; };
           defaultText = lib.literalExpression "pkgs.cloudflare-warp.override { headless = true; }";
           description = ''
-            Cloudflare WARP package. Defaults to the headless build, which
-            ships `warp-cli`, `warp-svc`, `warp-dex`, and `warp-diag` and
-            omits the GUI taskbar,
-            `etc/xdg/autostart/com.cloudflare.WarpTaskbar.desktop`, and the
-            `share/systemd/user/warp-taskbar.service` user unit. Set to
-            `pkgs.cloudflare-warp` to install the GUI variant.
+            Cloudflare WARP package. Defaults to the headless build, which ships
+            warp-cli, warp-svc, warp-dex, and warp-diag and omits the GUI taskbar.
           '';
+        };
+
+        organization = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          example = "my-team";
+          description = ''
+            Cloudflare Zero Trust team name (the <team> in <team>.cloudflareaccess.com).
+            When null, the module runs warp-svc without managed enrollment.
+          '';
+        };
+
+        serviceMode = lib.mkOption {
+          type = lib.types.enum [
+            "warp"
+            "tunnelonly"
+            "1dot1"
+            "proxy"
+            "postureonly"
+          ];
+          default = "warp";
+          description = ''
+            mdm.xml service_mode. "warp" is Full / Gateway with WARP (full tunnel
+            plus Gateway DNS/HTTP filtering).
+          '';
+        };
+
+        autoConnect = lib.mkOption {
+          type = lib.types.ints.between 0 1440;
+          default = 0;
+          description = ''
+            mdm.xml auto_connect: minutes before the client reconnects after a manual
+            disconnect. 0 keeps it off until the user reconnects.
+          '';
+        };
+
+        switchLocked = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "mdm.xml switch_locked; when true the user cannot disconnect WARP.";
+        };
+
+        connectOnBoot = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Run a best-effort oneshot `warp-cli connect` after the daemon starts.";
+        };
+
+        openFirewall = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Open the WARP UDP port in the firewall.";
+        };
+
+        udpPort = lib.mkOption {
+          type = lib.types.port;
+          default = 2408;
+          description = "WARP UDP port to open when openFirewall is true.";
         };
       };
 
-      config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
-      };
+      config = lib.mkIf cfg.enable (
+        lib.mkMerge [
+          {
+            services.cloudflare-warp = {
+              enable = true;
+              inherit (cfg) package udpPort openFirewall;
+            };
+
+            # WARP's CloudflareWARP interface trips strict reverse-path filtering.
+            # mkDefault so a host firewall module can still override it.
+            networking.firewall.checkReversePath = lib.mkDefault "loose";
+
+            warnings =
+              lib.optional
+                (
+                  config.services.dnscrypt-proxy.enable
+                  && builtins.elem cfg.serviceMode [
+                    "warp"
+                    "1dot1"
+                  ]
+                )
+                ''
+                  programs.cloudflare-warp.extended.serviceMode "${cfg.serviceMode}" takes over DNS,
+                  but services.dnscrypt-proxy is enabled (binds 127.0.0.1:53). Use serviceMode
+                  "tunnelonly"/"proxy" or disable dnscrypt-proxy.
+                ''
+              ++ lib.optional (cfg.organization != null && !haveSecrets) ''
+                programs.cloudflare-warp.extended: ${secretsFile} is missing; running warp-svc
+                WITHOUT managed enrollment. Create the sops secret (see
+                docs/cloudflare/warp/deployment.md) and rebuild.
+              '';
+          }
+
+          (lib.mkIf enrolling {
+            sops = {
+              secrets."cloudflare-warp/auth_client_id" = {
+                sopsFile = secretsFile;
+                key = "auth_client_id";
+                mode = "0400";
+              };
+              secrets."cloudflare-warp/auth_client_secret" = {
+                sopsFile = secretsFile;
+                key = "auth_client_secret";
+                mode = "0400";
+              };
+              templates."cloudflare-warp-mdm" = {
+                content = mdmContent;
+                mode = "0600";
+              };
+            };
+
+            # Install the rendered mdm.xml into rootDir right before warp-svc starts.
+            # rootDir already exists from the upstream tmpfiles rule, and the sops
+            # template is rendered during activation (before multi-user.target).
+            systemd.services.cloudflare-warp = {
+              serviceConfig.ExecStartPre = [
+                "${pkgs.coreutils}/bin/install -D -m0600 -o root -g root ${
+                  config.sops.templates."cloudflare-warp-mdm".path
+                } ${rootDir}/mdm.xml"
+              ];
+              # Re-apply managed config when any non-secret mdm field changes.
+              restartTriggers = [
+                (builtins.toJSON {
+                  inherit (cfg)
+                    organization
+                    serviceMode
+                    autoConnect
+                    switchLocked
+                    ;
+                })
+              ];
+            };
+          })
+
+          (lib.mkIf cfg.connectOnBoot {
+            systemd.services.cloudflare-warp-connect = {
+              description = "Cloudflare WARP connect on boot";
+              after = [ "cloudflare-warp.service" ];
+              requires = [ "cloudflare-warp.service" ];
+              wantedBy = [ "multi-user.target" ];
+              serviceConfig = {
+                Type = "oneshot";
+                RemainAfterExit = true;
+              };
+              script = ''
+                # Wait for the warp-svc IPC socket to answer before connecting.
+                for _ in $(seq 1 30); do
+                  if ${cfg.package}/bin/warp-cli status >/dev/null 2>&1; then
+                    break
+                  fi
+                  sleep 1
+                done
+
+                # Managed enrollment (mdm.xml service token) registers the device and
+                # accepts ToS, so no interactive `warp-cli registration new` is needed.
+                # This connect is best-effort: log the outcome and exit 0 so a user who
+                # legitimately keeps WARP off does not leave the unit failed.
+                if ${cfg.package}/bin/warp-cli connect; then
+                  echo "cloudflare-warp-connect: connect requested"
+                else
+                  echo "cloudflare-warp-connect: connect returned non-zero (already connected or daemon still settling)"
+                fi
+                ${cfg.package}/bin/warp-cli status || echo "cloudflare-warp-connect: status unavailable"
+              '';
+            };
+          })
+        ]
+      );
     };
 in
 {

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -81,7 +81,11 @@ let
         };
 
         organization = lib.mkOption {
-          type = lib.types.nullOr lib.types.str;
+          # Zero Trust team names are [A-Za-z0-9-]+. Constraining the type makes a
+          # bad value (placeholder, whitespace, XML metacharacters) fail at eval
+          # instead of rendering an unparsable mdm.xml that warp-svc rejects at
+          # startup. cfg.organization is interpolated raw into the plist body.
+          type = lib.types.nullOr (lib.types.strMatching "[A-Za-z0-9-]+");
           default = null;
           example = "my-team";
           description = ''

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -266,7 +266,7 @@ let
                 # new` is needed. This connect is best-effort either way: log the
                 # outcome and exit 0 so a user who legitimately keeps WARP off does
                 # not leave the unit failed.
-                if ${cfg.package}/bin/warp-cli connect; then
+                if ${cfg.package}/bin/warp-cli --accept-tos connect; then
                   echo "cloudflare-warp-connect: connect requested"
                 else
                   echo "cloudflare-warp-connect: connect returned non-zero (already connected or daemon still settling)"

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -95,7 +95,7 @@ let
       "cloudflare-go-sdk".extended.enable = lib.mkOverride 1100 false;
       "cloudflare-python-sdk".extended.enable = lib.mkOverride 1100 false;
       "cloudflare-rs-sdk".extended.enable = lib.mkOverride 1100 false;
-      "cloudflare-warp".extended.enable = lib.mkOverride 1100 true;
+      "cloudflare-warp".extended.enable = lib.mkOverride 1100 false;
       cloudflared.extended.enable = lib.mkOverride 1100 true;
       cmake.extended.enable = lib.mkOverride 1100 true;
       codeburn.extended.enable = lib.mkOverride 1100 false;

--- a/modules/hosts/common/usbguard.nix
+++ b/modules/hosts/common/usbguard.nix
@@ -63,7 +63,8 @@ let
           };
 
           systemd.services.usbguard = {
-            after = lib.mkIf (installSecretsDeps != [ ]) (lib.mkAfter installSecretsDeps);
+            after = installSecretsDeps;
+            requires = installSecretsDeps;
             preStart = lib.mkAfter ''
               install -D -m 0600 /dev/null ${runtimeRuleFile}
               cat ${baseRulesFile} > ${runtimeRuleFile}

--- a/modules/system76/cloudflare-warp.nix
+++ b/modules/system76/cloudflare-warp.nix
@@ -1,0 +1,24 @@
+/*
+  Per-host Cloudflare WARP (Zero Trust) enrollment for system76.
+
+  Enables the programs.cloudflare-warp.extended wrapper in Full mode
+  ("Gateway with WARP"). Credentials come from secrets/cloudflare-warp.yaml
+  (sops); see docs/cloudflare/warp/deployment.md for the dashboard prerequisites.
+
+  Note: organization (the Zero Trust team name) is not a credential but is
+  identifying, and this repository is public. To keep it out of git, move it into
+  the sops secret and render it through an mdm placeholder; see
+  docs/cloudflare/warp/reference.md.
+*/
+_: {
+  configurations.nixos.system76.module = {
+    programs.cloudflare-warp.extended = {
+      enable = true;
+      organization = "<your-team-name>";
+      serviceMode = "warp";
+      autoConnect = 0;
+      switchLocked = false;
+      connectOnBoot = true;
+    };
+  };
+}

--- a/modules/system76/cloudflare-warp.nix
+++ b/modules/system76/cloudflare-warp.nix
@@ -14,7 +14,10 @@ _: {
   configurations.nixos.system76.module = {
     programs.cloudflare-warp.extended = {
       enable = true;
-      organization = "<your-team-name>";
+      # null keeps warp-svc un-enrolled (the documented sentinel). Set the real
+      # Zero Trust team name to turn on managed enrollment; a placeholder or any
+      # non-team-name string now fails at eval (strMatching in the wrapper).
+      organization = null;
       serviceMode = "warp";
       autoConnect = 0;
       switchLocked = false;

--- a/modules/system76/cloudflare-warp.nix
+++ b/modules/system76/cloudflare-warp.nix
@@ -5,19 +5,14 @@
   ("Gateway with WARP"). Credentials come from secrets/cloudflare-warp.yaml
   (sops); see docs/cloudflare/warp/deployment.md for the dashboard prerequisites.
 
-  Note: organization (the Zero Trust team name) is not a credential but is
-  identifying, and this repository is public. To keep it out of git, move it into
-  the sops secret and render it through an mdm placeholder; see
-  docs/cloudflare/warp/reference.md.
+  Note: the Zero Trust team name (organization) is identifying, and this repository
+  is public, so it lives in secrets/cloudflare-warp.yaml (sops) and is rendered into
+  mdm.xml through a placeholder; see docs/cloudflare/warp/reference.md.
 */
 _: {
   configurations.nixos.system76.module = {
     programs.cloudflare-warp.extended = {
       enable = true;
-      # null keeps warp-svc un-enrolled (the documented sentinel). Set the real
-      # Zero Trust team name to turn on managed enrollment; a placeholder or any
-      # non-team-name string now fails at eval (strMatching in the wrapper).
-      organization = null;
       serviceMode = "warp";
       autoConnect = 0;
       switchLocked = false;

--- a/modules/system76/services.nix
+++ b/modules/system76/services.nix
@@ -115,11 +115,6 @@ in
 
         cloudflared.enable = true;
 
-        cloudflare-warp = {
-          enable = true;
-          package = pkgs.cloudflare-warp.override { headless = true; };
-        };
-
         printing = {
           enable = lib.mkForce false;
           drivers = with pkgs; [

--- a/modules/tpnix/cloudflare-warp.nix
+++ b/modules/tpnix/cloudflare-warp.nix
@@ -14,7 +14,10 @@ _: {
   configurations.nixos.tpnix.module = {
     programs.cloudflare-warp.extended = {
       enable = true;
-      organization = "<your-team-name>";
+      # null keeps warp-svc un-enrolled (the documented sentinel). Set the real
+      # Zero Trust team name to turn on managed enrollment; a placeholder or any
+      # non-team-name string now fails at eval (strMatching in the wrapper).
+      organization = null;
       serviceMode = "warp";
       autoConnect = 0;
       switchLocked = false;

--- a/modules/tpnix/cloudflare-warp.nix
+++ b/modules/tpnix/cloudflare-warp.nix
@@ -5,14 +5,26 @@
   ("Gateway with WARP"). Credentials come from secrets/cloudflare-warp.yaml
   (sops); see docs/cloudflare/warp/deployment.md for the dashboard prerequisites.
 
+  Gated on tpnix's sopsRuntimeReady flag (modules/tpnix/policy.nix), matching the
+  other tpnix sops consumers (duplicati.nix, printing.nix, fonts.nix). tpnix has no
+  runtime SOPS decryption key yet, so with the flag false the wrapper stays off;
+  otherwise committing secrets/cloudflare-warp.yaml would make enrolling declare
+  sops.secrets."cloudflare-warp/*" and the cloudflare-warp-mdm template, and
+  sops-install-secrets/activation would fail on the un-decryptable payload instead of
+  the intended un-enrolled fallback. Flip the flag to true once tpnix can decrypt.
+
   Note: the Zero Trust team name (organization) is identifying, and this repository
   is public, so it lives in secrets/cloudflare-warp.yaml (sops) and is rendered into
   mdm.xml through a placeholder; see docs/cloudflare/warp/reference.md.
 */
-_: {
+{ config, ... }:
+let
+  inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
+in
+{
   configurations.nixos.tpnix.module = {
     programs.cloudflare-warp.extended = {
-      enable = true;
+      enable = sopsRuntimeReady;
       serviceMode = "warp";
       autoConnect = 0;
       switchLocked = false;

--- a/modules/tpnix/cloudflare-warp.nix
+++ b/modules/tpnix/cloudflare-warp.nix
@@ -1,0 +1,24 @@
+/*
+  Per-host Cloudflare WARP (Zero Trust) enrollment for tpnix.
+
+  Enables the programs.cloudflare-warp.extended wrapper in Full mode
+  ("Gateway with WARP"). Credentials come from secrets/cloudflare-warp.yaml
+  (sops); see docs/cloudflare/warp/deployment.md for the dashboard prerequisites.
+
+  Note: organization (the Zero Trust team name) is not a credential but is
+  identifying, and this repository is public. To keep it out of git, move it into
+  the sops secret and render it through an mdm placeholder; see
+  docs/cloudflare/warp/reference.md.
+*/
+_: {
+  configurations.nixos.tpnix.module = {
+    programs.cloudflare-warp.extended = {
+      enable = true;
+      organization = "<your-team-name>";
+      serviceMode = "warp";
+      autoConnect = 0;
+      switchLocked = false;
+      connectOnBoot = true;
+    };
+  };
+}

--- a/modules/tpnix/cloudflare-warp.nix
+++ b/modules/tpnix/cloudflare-warp.nix
@@ -5,19 +5,14 @@
   ("Gateway with WARP"). Credentials come from secrets/cloudflare-warp.yaml
   (sops); see docs/cloudflare/warp/deployment.md for the dashboard prerequisites.
 
-  Note: organization (the Zero Trust team name) is not a credential but is
-  identifying, and this repository is public. To keep it out of git, move it into
-  the sops secret and render it through an mdm placeholder; see
-  docs/cloudflare/warp/reference.md.
+  Note: the Zero Trust team name (organization) is identifying, and this repository
+  is public, so it lives in secrets/cloudflare-warp.yaml (sops) and is rendered into
+  mdm.xml through a placeholder; see docs/cloudflare/warp/reference.md.
 */
 _: {
   configurations.nixos.tpnix.module = {
     programs.cloudflare-warp.extended = {
       enable = true;
-      # null keeps warp-svc un-enrolled (the documented sentinel). Set the real
-      # Zero Trust team name to turn on managed enrollment; a placeholder or any
-      # non-team-name string now fails at eval (strMatching in the wrapper).
-      organization = null;
       serviceMode = "warp";
       autoConnect = 0;
       switchLocked = false;


### PR DESCRIPTION
## Summary

Refactor `programs.cloudflare-warp.extended` from a package-only app module into a
wrapper over upstream `services.cloudflare-warp` that:

- runs `warp-svc` and enrolls `tpnix` and `system76` into Cloudflare Zero Trust
  non-interactively via a sops-backed service token in Full mode (`service_mode warp`);
- renders a store-safe `/var/lib/cloudflare-warp/mdm.xml` from sops placeholders and
  installs it (0600 root) via `ExecStartPre`;
- sources the Zero Trust team name (`organization`) from the sops secret instead of Nix
  code, rendered through a placeholder, so the team name stays out of this public repo;
- orders `cloudflare-warp.service` after the sops secret install (`after`/`requires` via
  `config.flake.lib.security.sopsInstallSecretsDeps`), matching the repo's other
  secret-consuming services (`duplicati-r2`, `fonts`, `usbguard`);
- when the secret is absent, keeps `warp-svc` enabled but degraded, emitting a build
  warning and an explicit UN-ENROLLED notice from the connect-on-boot oneshot;
- sets `networking.firewall.checkReversePath = "loose"` and adds a best-effort
  connect-on-boot oneshot;
- defaults the common baseline OFF so enrollment is a deliberate per-host opt-in;
- removes the redundant `services.cloudflare-warp` block from
  `modules/system76/services.nix` that double-defined `services.cloudflare-warp.package`
  against the refactored module (root-cause fix, not a mask).

Adds documentation under `docs/cloudflare/warp/` (overview, deployment runbook,
options/mdm reference, operations) and indexes it from `docs/cloudflare/README.md`.

`service_mode` is authoritative through `mdm.xml`; the module never calls `warp-cli mode`.

## Test plan

- `nix fmt`: clean.
- `nix flake check --accept-flake-config --no-build`: all checks passed; both host
  toplevels evaluate with the refactor and with the operator secret absent.
- Targeted eval on both hosts: the `cloudflare-warp-connect` script renders, and with the
  secret absent (`enrolling = builtins.pathExists ...` is false) it logs the explicit
  UN-ENROLLED notice and still runs `warp-cli connect` best-effort.
- Eval assertions on both hosts:
  - `programs.cloudflare-warp.extended.enable = true`, `serviceMode = "warp"`
  - `services.cloudflare-warp.enable = true`
  - `systemd.services.cloudflare-warp-connect.wantedBy = ["multi-user.target"]`
  - `networking.firewall.checkReversePath = "loose"`, UDP 2408 open
- Evaluates WITHOUT the operator secret present, degrading to an un-enrolled daemon with a
  build warning (the `enrolling` guard uses `builtins.pathExists`).

## Operator follow-ups (deploy-time, not merge blockers)

Intentional operator gates, working as designed:

1. Create `secrets/cloudflare-warp.yaml` from the committed
   `secrets/cloudflare-warp.yaml.example` (`organization`, `auth_client_id`,
   `auth_client_secret`), encrypt it with `sops`, commit it in the `secrets/` submodule,
   and bump the submodule pointer. `organization` is the bare Zero Trust team name. Until
   then both hosts run un-enrolled and emit a build warning.
2. Complete the dashboard prerequisites in `docs/cloudflare/warp/deployment.md`
   (service-token Service Auth enrollment rule, Default device profile = Gateway with WARP,
   Split Tunnels excluding `100.64.0.0/10` and `10.0.0.0/8`).
3. After `nixos-rebuild switch`, run the `docs/cloudflare/warp/operations.md` checks.