### PR TITLE
feat(tpnix): configure printing

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -32,6 +32,16 @@
   - Sample NixOS configuration for ACME certificate management using Cloudflare DNS-01 challenge.
 - [cloudflare/cloudflared-tunnel-sample.md](cloudflare/cloudflared-tunnel-sample.md)
   - Sample NixOS configuration for Cloudflare Tunnel (cloudflared) with ingress rules and credential setup.
+- [cloudflare/warp/README.md](cloudflare/warp/README.md)
+  - Overview and reading order for running Cloudflare WARP (Zero Trust device client) on NixOS.
+- [cloudflare/warp/warp-modes.md](cloudflare/warp/warp-modes.md)
+  - Comparison of the five WARP modes and the full versus traffic-only DNS tradeoff.
+- [cloudflare/warp/zero-trust-enrollment.md](cloudflare/warp/zero-trust-enrollment.md)
+  - Non-interactive Zero Trust enrollment with a service token and mdm.xml parameters.
+- [cloudflare/warp/nixos-setup.md](cloudflare/warp/nixos-setup.md)
+  - Working NixOS recipe using services.cloudflare-warp and a sops-rendered mdm.xml.
+- [cloudflare/warp/operations.md](cloudflare/warp/operations.md)
+  - Verification checks, warp-cli cheat sheet, warp-diag, and common Linux failure modes.
 - [cloudflare/containers/README.md](cloudflare/containers/README.md)
   - Technical documentation index for Cloudflare Containers.
 - [cloudflare/containers/architecture.md](cloudflare/containers/architecture.md)

--- a/docs/sops/README.md
+++ b/docs/sops/README.md
@@ -73,20 +73,81 @@ hardware-backed SSH keys can coexist without breaking SOPS.
 ## Adding a New Secret
 
 1. Confirm the recipient exists in `.sops.yaml` (regenerate via `nix develop -c write-files` if you just edited the policy module).
-2. Create or edit the encrypted file:
+2. Create or edit the encrypted file under `secrets/`:
    ```bash
-   sops secrets/<name>.yaml
+   sops secrets/<service>.yaml
    ```
-3. Declare the secret in a module:
+3. Use `secrets/service.yaml.example` as the plaintext template for ordinary
+   service credentials. Keep the actual secret file as a small YAML document
+   with flat, top-level `snake_case` keys. Do not add the `sops:` metadata block
+   manually; SOPS adds and maintains it after encryption.
+   ```yaml
+   # secrets/<service>.yaml
+   # Edit with: sops secrets/<service>.yaml
+   # Do not add the sops: metadata block manually. SOPS adds it after encryption.
+
+   api_token: "<secret>"
+   client_id: "<secret>"
+   client_secret: "<secret>"
+   ```
+4. Declare each consumed key explicitly in the owning module. Set `key` to the
+   YAML key name even when it would match today, because the runtime secret name
+   often uses slashes or hyphens while the YAML key should stay simple.
    ```nix
-   sops.secrets."<namespace>/<name>" = {
-     sopsFile = "${secretsRoot}/<name>.yaml";
-     mode = "0400";
-     owner = config.flake.lib.meta.owner.username;
-   };
+   {
+     config,
+     lib,
+     metaOwner,
+     secretsRoot,
+     ...
+   }:
+   let
+     serviceSecretFile = "${secretsRoot}/<service>.yaml";
+     serviceSecretExists = builtins.pathExists serviceSecretFile;
+     ownerName = metaOwner.username;
+   in
+   {
+     config = lib.mkIf serviceSecretExists {
+       sops.secrets."<service>/api-token" = {
+         sopsFile = serviceSecretFile;
+         format = "yaml";
+         key = "api_token";
+         path = "/run/secrets/<service>/api-token";
+         mode = "0400";
+         owner = ownerName;
+       };
+
+       sops.secrets."<service>/client-id" = {
+         sopsFile = serviceSecretFile;
+         format = "yaml";
+         key = "client_id";
+         path = "/run/secrets/<service>/client-id";
+         mode = "0400";
+         owner = ownerName;
+       };
+
+       sops.secrets."<service>/client-secret" = {
+         sopsFile = serviceSecretFile;
+         format = "yaml";
+         key = "client_secret";
+         path = "/run/secrets/<service>/client-secret";
+         mode = "0400";
+         owner = ownerName;
+       };
+     };
+   }
    ```
-4. Reference the runtime material via `.path` or a template. Never read secrets at evaluation time.
-5. Run the validation suite (see [`docs/architecture/06-reference.md`](../architecture/06-reference.md#validation)).
+5. For Home Manager modules, use the same YAML shape and explicit `key`
+   selectors. Set `path` under the user's home directory and omit `owner`
+   unless the local module needs a non-default owner.
+6. Reference the runtime material via `.path`, `config.sops.placeholder`, or a
+   `sops.templates` output. Never read decrypted secret values at evaluation
+   time.
+7. Use nested YAML only when the owning module intentionally expects a
+   slash-separated selector such as `duplicati-r2/AWS_ACCESS_KEY_ID`. Use
+   `key = ""` only when the consumer needs the whole decrypted YAML file instead
+   of one key.
+8. Run the validation suite (see [`docs/architecture/06-reference.md`](../architecture/06-reference.md#validation)).
 
 ## Example: GitHub Token for `act`
 

--- a/modules/tpnix/power.nix
+++ b/modules/tpnix/power.nix
@@ -91,7 +91,6 @@
           '';
         };
 
-        printing.enable = lib.mkForce false;
         fstrim.enable = true;
       };
 

--- a/modules/tpnix/printing.nix
+++ b/modules/tpnix/printing.nix
@@ -1,0 +1,77 @@
+{
+  config,
+  lib,
+  secretsRoot,
+  ...
+}:
+let
+  printerSecretFile = "${secretsRoot}/tpnix.yaml";
+  printerSecretExists = builtins.pathExists printerSecretFile;
+  printerSecretName = "tpnix/printing/m604-device-uri";
+  printerSecretPath = "/run/secrets/${printerSecretName}";
+  printerServiceName = "ensure-tpnix-printer-m604";
+  inherit (config.flake.lib.security) sopsInstallSecretsDeps;
+in
+{
+  configurations.nixos.tpnix.module =
+    { config, pkgs, ... }:
+    let
+      installSecretsDeps = sopsInstallSecretsDeps config;
+      stopCups = lib.optionalString (
+        config.services.printing.startWhenNeeded && !config.services.printing.stateless
+      ) "${pkgs.systemd}/bin/systemctl stop cups.service";
+    in
+    {
+      config = lib.mkMerge [
+        (lib.mkIf printerSecretExists {
+          sops.secrets.${printerSecretName} = {
+            sopsFile = printerSecretFile;
+            format = "yaml";
+            key = "m604_device_uri";
+            path = printerSecretPath;
+            owner = "root";
+            group = "root";
+            mode = "0400";
+            restartUnits = [ "${printerServiceName}.service" ];
+          };
+
+          systemd.services.${printerServiceName} = {
+            description = "Ensure tpnix M604 CUPS printer";
+            wantedBy = [ "multi-user.target" ];
+            wants = [ "cups.service" ];
+            after = [ "cups.service" ] ++ installSecretsDeps;
+            requires = installSecretsDeps;
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+            };
+            script = ''
+              set -euo pipefail
+
+              device_uri="$(${pkgs.coreutils}/bin/cat ${lib.escapeShellArg printerSecretPath})"
+              if [ -z "$device_uri" ]; then
+                echo "M604 printer device URI secret is empty" >&2
+                exit 1
+              fi
+
+              ${pkgs.cups}/bin/lpadmin \
+                -p ${lib.escapeShellArg "M604"} \
+                -v "$device_uri" \
+                -m ${lib.escapeShellArg "gutenprint.5.3://pcl-g_5e/expert"} \
+                -D ${lib.escapeShellArg "HP LaserJet M604"} \
+                -o ${lib.escapeShellArg "PageSize=A4"} \
+                -E
+              ${pkgs.cups}/bin/lpadmin -d ${lib.escapeShellArg "M604"}
+              ${stopCups}
+            '';
+          };
+        })
+
+        (lib.mkIf (!printerSecretExists) {
+          warnings = [
+            "tpnix M604 printer is skipped because ${printerSecretFile} is missing."
+          ];
+        })
+      ];
+    };
+}

--- a/modules/tpnix/printing.nix
+++ b/modules/tpnix/printing.nix
@@ -10,7 +10,9 @@ let
   printerSecretName = "tpnix/printing/m604-device-uri";
   printerSecretPath = "/run/secrets/${printerSecretName}";
   printerServiceName = "ensure-tpnix-printer-m604";
+  inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
   inherit (config.flake.lib.security) sopsInstallSecretsDeps;
+  printerSecretsReady = sopsRuntimeReady && printerSecretExists;
 in
 {
   configurations.nixos.tpnix.module =
@@ -23,7 +25,7 @@ in
     in
     {
       config = lib.mkMerge [
-        (lib.mkIf printerSecretExists {
+        (lib.mkIf printerSecretsReady {
           sops.secrets.${printerSecretName} = {
             sopsFile = printerSecretFile;
             format = "yaml";
@@ -67,9 +69,9 @@ in
           };
         })
 
-        (lib.mkIf (!printerSecretExists) {
+        (lib.mkIf (!printerSecretsReady) {
           warnings = [
-            "tpnix M604 printer is skipped because ${printerSecretFile} is missing."
+            "M604 printer queue is disabled on tpnix until SOPS decryption keys are configured."
           ];
         })
       ];

--- a/modules/tpnix/services.nix
+++ b/modules/tpnix/services.nix
@@ -32,10 +32,10 @@ _: {
         cloudflared.enable = lib.mkForce false;
 
         printing = {
-          enable = lib.mkForce false;
+          enable = true;
           drivers = with pkgs; [
             gutenprint
-            # hplip  # Requires unfree license
+            hplip
             brlaser
           ];
         };


### PR DESCRIPTION
## Summary

- enable CUPS printing on tpnix with gutenprint, hplip, and brlaser drivers
- add a tpnix-only SOPS-backed service that provisions the M604 CUPS queue from m604_device_uri
- expand the SOPS guide with the flat YAML and explicit key selector pattern used by the printer secret
- preserve the unstaged Cloudflare WARP docs index entries as a separate commit from the tpnix change

## Notes

The source checkout also had unstaged docs/index.md entries for Cloudflare WARP pages. Those entries were moved to
this branch as requested, but the referenced docs/cloudflare/warp files are not present on main in this branch.

## Test plan

- nix fmt docs/index.md docs/sops/README.md modules/tpnix/power.nix modules/tpnix/services.nix modules/tpnix/printing.nix
- nix-instantiate --parse modules/tpnix/printing.nix modules/tpnix/services.nix modules/tpnix/power.nix
- git diff --cached --check
- git diff --check main..HEAD
- git diff --check -- docs/index.md
- nix eval --accept-flake-config --offline --no-write-lock-file --json .#nixosConfigurations.tpnix.config.services.printing.enable
- nix eval --accept-flake-config --offline --no-write-lock-file --raw '.#nixosConfigurations.tpnix.config.systemd.services."ensure-tpnix-printer-m604".description'
- nix eval --accept-flake-config --offline --no-write-lock-file --raw '.#nixosConfigurations.tpnix.config.sops.secrets."tpnix/printing/m604-device-uri".key'
- nix eval --accept-flake-config --offline --no-write-lock-file --json '.#nixosConfigurations.tpnix.config.services.printing.drivers' --apply 'map (pkg: pkg.pname or pkg.name or "unknown")'
- nix flake check --accept-flake-config --no-build --offline
- push hooks: apps-catalog-sync, flake-checker, gitleaks, managed-files-drift