### PR TITLE
feat(agents): add Claude Code launch wrapper

### DIFF
--- a/modules/agents/_rm-shim.nix
+++ b/modules/agents/_rm-shim.nix
@@ -1,0 +1,66 @@
+# Shared rm -> rip shim for terminal coding agents.
+#
+# Both the codex and claude-code shell wrappers rewrite bare `rm` to a
+# recoverable, rip-backed deletion. Keeping the shim here is the single source
+# of truth so the two agents cannot drift on deletion semantics.
+{ lib, pkgs }:
+# Translate common rm flags into rip so agents default to recoverable deletions.
+pkgs.writeShellScriptBin "rm" ''
+  set -euo pipefail
+
+  force=0
+  operands=()
+
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --)
+        shift
+        while [ "$#" -gt 0 ]; do
+          operands+=("$1")
+          shift
+        done
+        break
+        ;;
+      -f|--force)
+        force=1
+        shift
+        ;;
+      -r|-R|--recursive)
+        shift
+        ;;
+      -[!-]*)
+        bundle="''${1#-}"
+        unsupported="''${bundle//[fRr]/}"
+        if [ -n "$unsupported" ]; then
+          echo "rm shim: unsupported rm option '$1'; use rip directly for nonstandard flags" >&2
+          exit 2
+        fi
+        case "$bundle" in
+          *f*)
+            force=1
+            ;;
+        esac
+        shift
+        ;;
+      --*)
+        echo "rm shim: unsupported rm option '$1'; use rip directly for nonstandard flags" >&2
+        exit 2
+        ;;
+      *)
+        operands+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  cmd=(${lib.getExe' pkgs.trash-cli "trash-put"})
+  if [ "$force" -eq 1 ]; then
+    cmd+=(-f)
+  fi
+
+  if [ "''${#operands[@]}" -eq 0 ]; then
+    exec "''${cmd[@]}"
+  fi
+
+  exec "''${cmd[@]}" -- "''${operands[@]}"
+''

--- a/modules/agents/_rm-shim.nix
+++ b/modules/agents/_rm-shim.nix
@@ -1,10 +1,6 @@
-# Shared rm -> rip shim for terminal coding agents.
-#
-# Both the codex and claude-code shell wrappers rewrite bare `rm` to a
-# recoverable, rip-backed deletion. Keeping the shim here is the single source
-# of truth so the two agents cannot drift on deletion semantics.
+# Shared rm -> rip shim: the codex and claude-code wrappers both route bare `rm`
+# through it so deletions stay recoverable.
 { lib, pkgs }:
-# Translate common rm flags into rip so agents default to recoverable deletions.
 pkgs.writeShellScriptBin "rm" ''
   set -euo pipefail
 

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -6,22 +6,15 @@
   mcpServers) are injected by _settings.nix; this attrset only carries the
   static portion shared across hosts.
 */
+let
+  claudeEnv = import ./_env.nix;
+in
 {
   claudeSettingsBase = {
     cleanupPeriodDays = 30;
-    env = {
-      # Duplicates of postFixup in modules/apps/claude-code.nix (belt-and-suspenders)
-      DISABLE_AUTOUPDATER = "1";
-      CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
-      DISABLE_NON_ESSENTIAL_MODEL_CALLS = "1";
-      DISABLE_TELEMETRY = "1";
-      DISABLE_INSTALLATION_CHECKS = "1";
-      # Runtime settings (not in postFixup)
-      CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "1";
-      BASH_DEFAULT_TIMEOUT_MS = "240000";
-      BASH_MAX_TIMEOUT_MS = "4800000";
-      # MAX_THINKING_TOKENS = "32768";
-    };
+    # Disables + bash knobs from the shared source
+    # (modules/agents/claude-code/_env.nix).
+    env = claudeEnv.settings;
     includeCoAuthoredBy = false;
     permissions = {
       allow = [

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -1,0 +1,54 @@
+/*
+  Single source of truth for the Claude Code environment variables that were
+  otherwise hand-duplicated across the binary postFixup, settings.json, the
+  Home Manager session variables, and the launch wrapper. Each consumer pulls
+  exactly the subset it needs:
+
+    * binary    baked into the Nix binary via wrapProgram (postFixup in
+                modules/apps/claude-code.nix) so a bare `claude` that bypasses
+                the ~/.local/bin wrapper still gets the privacy/update disables.
+    * settings  ~/.claude/settings.json `env`, read by Claude at runtime
+                regardless of launch path (binary disables + bash knobs).
+    * all       full shell environment exported by the wrapper and the Home
+                Manager session variables.
+
+  Keeping the layers as one expression makes the belt-and-suspenders coverage
+  explicit and removes the drift risk between sites.
+*/
+let
+  # Privacy/telemetry/update disables baked into the binary.
+  binary = {
+    DISABLE_AUTOUPDATER = "1";
+    CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
+    DISABLE_NON_ESSENTIAL_MODEL_CALLS = "1";
+    DISABLE_TELEMETRY = "1";
+    DISABLE_INSTALLATION_CHECKS = "1";
+  };
+
+  # Bash tool knobs Claude also reads from settings.json `env`.
+  bashRuntime = {
+    CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "1";
+    BASH_DEFAULT_TIMEOUT_MS = "240000";
+    BASH_MAX_TIMEOUT_MS = "4800000";
+  };
+
+  # Shell-level vars not needed in settings.json.
+  shellOnly = {
+    CLAUDE_CODE_ENABLE_TELEMETRY = "0";
+    DISABLE_ERROR_REPORTING = "1";
+    BASH_MAX_OUTPUT_LENGTH = "1024";
+    CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "0";
+    CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL = "1";
+    DISABLE_BUG_COMMAND = "1";
+    USE_BUILTIN_RIPGREP = "0";
+  };
+
+  # Optional knobs left unset by default (enable by adding to a group above):
+  #   ANTHROPIC_MODEL, MAX_THINKING_TOKENS = "32768",
+  #   CLAUDE_CODE_MAX_OUTPUT_TOKENS, MAX_MCP_OUTPUT_TOKENS = "32000"
+in
+{
+  inherit binary;
+  settings = binary // bashRuntime;
+  all = binary // bashRuntime // shellOnly;
+}

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -6,6 +6,14 @@
   ~/.local/bin ahead of the bun global bin on home.sessionPath (lib.mkBefore),
   so it wins PATH resolution over an external bun global binary at
   $XDG_DATA_HOME/bun/bin/claude.
+
+  Like the codex wrapper it: corrals temp files under /tmp/agents, and forces a
+  controlled bash for the agent's shell tool (rip-backed rm + direnv) instead of
+  the user's login shell. Codex injects that bash by overriding the passwd shell
+  field through nss_wrapper because it execs the login shell; Claude Code instead
+  resolves its shell from CLAUDE_CODE_SHELL (it accepts a path containing
+  bash/zsh that is executable), so the wrapper points that variable at the shim
+  rather than carrying the nss_wrapper/LD_PRELOAD machinery.
 */
 {
   lib,
@@ -18,6 +26,50 @@
   greptileApiKeyPath,
 }:
 let
+  # rm -> rip shim shared with the codex wrapper (modules/agents/_rm-shim.nix).
+  rmShim = import ../_rm-shim.nix { inherit lib pkgs; };
+
+  # Controlled bash for Claude's shell tool. Puts the rip-backed `rm` shim first
+  # on PATH so bare `rm` stays recoverable for every command and subprocess in
+  # any invocation form (-c, -lc, -i, -s, stdin, sourced snapshot), not just the
+  # `bash -c` path Claude happens to use today. It also mirrors interactive
+  # direnv for `bash -c`/`-lc` commands, then hands off to real bash. This is the
+  # codex bash wrapper minus the nss_wrapper LD_PRELOAD restore (Claude never
+  # sets that preload). Kept named `bash` so the CLAUDE_CODE_SHELL check accepts
+  # it.
+  claudeBashWrapper = pkgs.writeShellScriptBin "bash" ''
+    set -euo pipefail
+
+    direnvBin=${lib.getExe pkgs.direnv}
+    realBash=${lib.getExe pkgs.bashInteractive}
+    rmShimPath=${rmShim}/bin/rm
+
+    # The shim dir holds only `rm`, so prepending it shadows nothing else. This
+    # is the layer that cannot be bypassed by how the shell is launched; the -c
+    # branch below additionally defines an `rm` function as defense in depth.
+    export PATH=${rmShim}/bin''${PATH:+:$PATH}
+
+    if [ "$#" -ge 2 ] && { [ "$1" = "-c" ] || [ "$1" = "-lc" ]; }; then
+      shellFlag="$1"
+      wrappedCommand="$2"
+      shift 2
+
+      export CLAUDE_WRAPPED_COMMAND="$wrappedCommand"
+      exec "$realBash" "$shellFlag" '
+        # Mirror interactive direnv behavior for non-interactive shell commands.
+        if direnvExports="$("'"$direnvBin"'" export bash 2>/dev/null)"; then
+          eval "$direnvExports"
+        fi
+        rm() {
+          "'"$rmShimPath"'" "$@"
+        }
+        eval "$CLAUDE_WRAPPED_COMMAND"
+      ' "$@"
+    fi
+
+    exec "$realBash" "$@"
+  '';
+
   targetScript =
     if installMethods.bun.enable then
       ''
@@ -62,6 +114,22 @@ let
     export DISABLE_BUG_COMMAND=1
     export USE_BUILTIN_RIPGREP=0
 
+    # Corral agent temp files under a shared root, matching the codex wrapper.
+    tmpDir="/tmp/agents"
+    mkdir -p "$tmpDir"
+    export TMPDIR="$tmpDir"
+
+    # Resolve bare `rm` to the rip-backed shim for Claude and every process it
+    # spawns, including a fallback shell if CLAUDE_CODE_SHELL is ever rejected,
+    # so the safeguard does not depend on the shell launch path. The controlled
+    # bash shim re-asserts this on its own PATH as well.
+    export PATH=${rmShim}/bin''${PATH:+:$PATH}
+
+    # Force Claude's shell tool onto the controlled bash shim (direnv mirror +
+    # rip-backed rm): the CLAUDE_CODE_SHELL analogue of the codex passwd-shell
+    # override.
+    export CLAUDE_CODE_SHELL=${lib.escapeShellArg "${claudeBashWrapper}/bin/bash"}
+
     ${greptileEnv}
     ${targetScript}
 
@@ -73,8 +141,8 @@ let
     exec "$target" "$@"
   '';
 
-  claudeWrapperScript = pkgs.writeShellScript "claude" wrapperBody;
+  claudeWrapped = pkgs.writeShellScriptBin "claude" wrapperBody;
 in
 {
-  inherit claudeWrapperScript;
+  inherit claudeWrapped;
 }

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -16,8 +16,6 @@
   greptileApiKeyPath,
 }:
 let
-  coreutilsTr = lib.getExe' pkgs.coreutils "tr";
-
   targetScript =
     if installMethods.bun.enable then
       ''
@@ -35,7 +33,9 @@ let
   greptileEnv = lib.optionalString greptilePluginRequested ''
     secret_path="''${GREPTILE_API_KEY_FILE:-${greptileApiKeyPath}}"
     if [ -r "$secret_path" ] && [ -s "$secret_path" ]; then
-      if secret_value="$(${coreutilsTr} -d '\r\n' < "$secret_path")" && [ -n "$secret_value" ]; then
+      secret_value=$(< "$secret_path")
+      secret_value="''${secret_value//[$'\r\n']/}"
+      if [ -n "$secret_value" ]; then
         export GREPTILE_API_KEY="$secret_value"
       fi
     fi

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -1,19 +1,9 @@
 /*
-  Runtime wrapper for Claude Code.
+  Launch wrapper for Claude Code: launch-time env, target-binary selection, and
+  routing the shell tool through a controlled bash.
 
-  The wrapper owns launch-time environment and target selection. It is installed
-  into ~/.local/bin/claude from home-manager.nix, which also prepends
-  ~/.local/bin ahead of the bun global bin on home.sessionPath (lib.mkBefore),
-  so it wins PATH resolution over an external bun global binary at
-  $XDG_DATA_HOME/bun/bin/claude.
-
-  Like the codex wrapper it: corrals temp files under /tmp/agents, and forces a
-  controlled bash for the agent's shell tool (rip-backed rm + direnv) instead of
-  the user's login shell. Codex injects that bash by overriding the passwd shell
-  field through nss_wrapper because it execs the login shell; Claude Code instead
-  resolves its shell from CLAUDE_CODE_SHELL (it accepts a path containing
-  bash/zsh that is executable), so the wrapper points that variable at the shim
-  rather than carrying the nss_wrapper/LD_PRELOAD machinery.
+  Unlike codex (which overrides the passwd shell via nss_wrapper), Claude Code
+  takes its shell from CLAUDE_CODE_SHELL, so the wrapper sets that variable.
 */
 {
   lib,
@@ -26,17 +16,10 @@
   greptileApiKeyPath,
 }:
 let
-  # rm -> rip shim shared with the codex wrapper (modules/agents/_rm-shim.nix).
   rmShim = import ../_rm-shim.nix { inherit lib pkgs; };
 
-  # Controlled bash for Claude's shell tool. Puts the rip-backed `rm` shim first
-  # on PATH so bare `rm` stays recoverable for every command and subprocess in
-  # any invocation form (-c, -lc, -i, -s, stdin, sourced snapshot), not just the
-  # `bash -c` path Claude happens to use today. It also mirrors interactive
-  # direnv for `bash -c`/`-lc` commands, then hands off to real bash. This is the
-  # codex bash wrapper minus the nss_wrapper LD_PRELOAD restore (Claude never
-  # sets that preload). Kept named `bash` so the CLAUDE_CODE_SHELL check accepts
-  # it.
+  # Claude runs its shell tool through this via CLAUDE_CODE_SHELL, which requires
+  # the path to contain "bash" or "zsh", hence the `bash` name.
   claudeBashWrapper = pkgs.writeShellScriptBin "bash" ''
     set -euo pipefail
 
@@ -44,9 +27,8 @@ let
     realBash=${lib.getExe pkgs.bashInteractive}
     rmShimPath=${rmShim}/bin/rm
 
-    # The shim dir holds only `rm`, so prepending it shadows nothing else. This
-    # is the layer that cannot be bypassed by how the shell is launched; the -c
-    # branch below additionally defines an `rm` function as defense in depth.
+    # Only `rm` lives in this dir, so prepending shadows nothing else; on PATH so
+    # bare `rm` is shimmed for every shell invocation form, not just -c below.
     export PATH=${rmShim}/bin''${PATH:+:$PATH}
 
     if [ "$#" -ge 2 ] && { [ "$1" = "-c" ] || [ "$1" = "-lc" ]; }; then
@@ -56,7 +38,7 @@ let
 
       export CLAUDE_WRAPPED_COMMAND="$wrappedCommand"
       exec "$realBash" "$shellFlag" '
-        # Mirror interactive direnv behavior for non-interactive shell commands.
+        # Load direnv as an interactive shell would.
         if direnvExports="$("'"$direnvBin"'" export bash 2>/dev/null)"; then
           eval "$direnvExports"
         fi
@@ -114,20 +96,15 @@ let
     export DISABLE_BUG_COMMAND=1
     export USE_BUILTIN_RIPGREP=0
 
-    # Corral agent temp files under a shared root, matching the codex wrapper.
+    # Shared scratch root for agent temp files.
     tmpDir="/tmp/agents"
     mkdir -p "$tmpDir"
     export TMPDIR="$tmpDir"
 
-    # Resolve bare `rm` to the rip-backed shim for Claude and every process it
-    # spawns, including a fallback shell if CLAUDE_CODE_SHELL is ever rejected,
-    # so the safeguard does not depend on the shell launch path. The controlled
-    # bash shim re-asserts this on its own PATH as well.
+    # Covers Claude itself and any fallback shell (if CLAUDE_CODE_SHELL is
+    # rejected); the controlled bash re-asserts the same prepend.
     export PATH=${rmShim}/bin''${PATH:+:$PATH}
 
-    # Force Claude's shell tool onto the controlled bash shim (direnv mirror +
-    # rip-backed rm): the CLAUDE_CODE_SHELL analogue of the codex passwd-shell
-    # override.
     export CLAUDE_CODE_SHELL=${lib.escapeShellArg "${claudeBashWrapper}/bin/bash"}
 
     ${greptileEnv}

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -1,0 +1,82 @@
+/*
+  Runtime wrapper for Claude Code.
+
+  The wrapper owns launch-time environment and target selection. It is installed
+  into ~/.local/bin/claude from home-manager.nix so it wins over an external
+  bun global binary at $XDG_DATA_HOME/bun/bin/claude.
+*/
+{
+  lib,
+  pkgs,
+  claudePkg,
+  bunInstallDir,
+  externalBinary,
+  installMethods,
+  greptilePluginRequested,
+  greptileApiKeyPath,
+}:
+let
+  coreutilsTr = lib.getExe' pkgs.coreutils "tr";
+
+  targetScript =
+    if installMethods.bun.enable then
+      ''
+        target=${lib.escapeShellArg "${bunInstallDir}/bin/claude"}
+      ''
+    else if installMethods.nix.enable then
+      ''
+        target=${lib.escapeShellArg "${claudePkg}/bin/claude"}
+      ''
+    else
+      ''
+        target=${lib.escapeShellArg externalBinary}
+      '';
+
+  greptileEnv = lib.optionalString greptilePluginRequested ''
+    secret_path="''${GREPTILE_API_KEY_FILE:-${greptileApiKeyPath}}"
+    if [ -r "$secret_path" ] && [ -s "$secret_path" ]; then
+      if secret_value="$(${coreutilsTr} -d '\r\n' < "$secret_path")" && [ -n "$secret_value" ]; then
+        export GREPTILE_API_KEY="$secret_value"
+      fi
+    fi
+  '';
+
+  wrapperBody = ''
+    set -euo pipefail
+
+    export DISABLE_AUTOUPDATER=1
+    export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+    export DISABLE_NON_ESSENTIAL_MODEL_CALLS=1
+    export DISABLE_TELEMETRY=1
+    export DISABLE_INSTALLATION_CHECKS=1
+    export CLAUDE_CODE_ENABLE_TELEMETRY=0
+    export DISABLE_ERROR_REPORTING=1
+    export CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1
+    export BASH_DEFAULT_TIMEOUT_MS=240000
+    export BASH_MAX_TIMEOUT_MS=4800000
+    export BASH_MAX_OUTPUT_LENGTH=1024
+    export CLAUDE_CODE_DISABLE_TERMINAL_TITLE=0
+    export CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL=1
+    export DISABLE_BUG_COMMAND=1
+    export USE_BUILTIN_RIPGREP=0
+
+    ${greptileEnv}
+    ${targetScript}
+
+    if [ ! -x "$target" ]; then
+      echo "claude-wrapper: ERROR: Claude Code binary not found or not executable at $target" >&2
+      exit 127
+    fi
+
+    exec "$target" "$@"
+  '';
+
+  claudeWrapperScript = pkgs.writeShellScript "claude" wrapperBody;
+  claudeWrapped = pkgs.writeShellScriptBin "claude" wrapperBody;
+in
+{
+  inherit
+    claudeWrapped
+    claudeWrapperScript
+    ;
+}

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -72,11 +72,7 @@ let
   '';
 
   claudeWrapperScript = pkgs.writeShellScript "claude" wrapperBody;
-  claudeWrapped = pkgs.writeShellScriptBin "claude" wrapperBody;
 in
 {
-  inherit
-    claudeWrapped
-    claudeWrapperScript
-    ;
+  inherit claudeWrapperScript;
 }

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -42,6 +42,10 @@ let
         if direnvExports="$("'"$direnvBin"'" export bash 2>/dev/null)"; then
           eval "$direnvExports"
         fi
+        # direnv (e.g. nix-direnv use-flake) can prepend dev-shell bins and
+        # push the shim down PATH; re-prepend it so command rm, find -exec rm,
+        # xargs rm, and nested shells resolve the shim, not coreutils rm.
+        export PATH=${rmShim}/bin''${PATH:+:$PATH}
         rm() {
           "'"$rmShimPath"'" "$@"
         }

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -18,6 +18,14 @@
 let
   rmShim = import ../_rm-shim.nix { inherit lib pkgs; };
 
+  # Full env from the shared source (modules/agents/claude-code/_env.nix),
+  # rendered as shell exports; belt-and-suspenders with home.sessionVariables,
+  # the binary postFixup, and settings.json `env`.
+  claudeEnv = import ./_env.nix;
+  envExports = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") claudeEnv.all
+  );
+
   # Claude runs its shell tool through this via CLAUDE_CODE_SHELL, which requires
   # the path to contain "bash" or "zsh", hence the `bash` name.
   claudeBashWrapper = pkgs.writeShellScriptBin "bash" ''
@@ -84,21 +92,7 @@ let
   wrapperBody = ''
     set -euo pipefail
 
-    export DISABLE_AUTOUPDATER=1
-    export CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
-    export DISABLE_NON_ESSENTIAL_MODEL_CALLS=1
-    export DISABLE_TELEMETRY=1
-    export DISABLE_INSTALLATION_CHECKS=1
-    export CLAUDE_CODE_ENABLE_TELEMETRY=0
-    export DISABLE_ERROR_REPORTING=1
-    export CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR=1
-    export BASH_DEFAULT_TIMEOUT_MS=240000
-    export BASH_MAX_TIMEOUT_MS=4800000
-    export BASH_MAX_OUTPUT_LENGTH=1024
-    export CLAUDE_CODE_DISABLE_TERMINAL_TITLE=0
-    export CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL=1
-    export DISABLE_BUG_COMMAND=1
-    export USE_BUILTIN_RIPGREP=0
+    ${envExports}
 
     # Shared scratch root for agent temp files.
     tmpDir="/tmp/agents"

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -2,8 +2,10 @@
   Runtime wrapper for Claude Code.
 
   The wrapper owns launch-time environment and target selection. It is installed
-  into ~/.local/bin/claude from home-manager.nix so it wins over an external
-  bun global binary at $XDG_DATA_HOME/bun/bin/claude.
+  into ~/.local/bin/claude from home-manager.nix, which also prepends
+  ~/.local/bin ahead of the bun global bin on home.sessionPath (lib.mkBefore),
+  so it wins PATH resolution over an external bun global binary at
+  $XDG_DATA_HOME/bun/bin/claude.
 */
 {
   lib,

--- a/modules/agents/claude-code/home-manager.nix
+++ b/modules/agents/claude-code/home-manager.nix
@@ -54,6 +54,7 @@ _: {
       } osConfig;
 
       defaults = import ./_default-settings.nix;
+      claudeEnv = import ./_env.nix;
       plugins = import ./_plugins.nix { inherit lib osConfig; };
       inherit (plugins) greptilePluginRequested;
 
@@ -159,29 +160,9 @@ _: {
           # ~/.local/bin ahead of it so the wrapper shadows a bun-global claude.
           sessionPath = lib.mkBefore [ "${config.home.homeDirectory}/.local/bin" ];
 
-          sessionVariables = {
-            # Duplicates of postFixup in modules/apps/claude-code.nix (belt-and-suspenders)
-            DISABLE_AUTOUPDATER = "1";
-            CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
-            DISABLE_NON_ESSENTIAL_MODEL_CALLS = "1";
-            DISABLE_TELEMETRY = "1";
-            DISABLE_INSTALLATION_CHECKS = "1";
-            # Runtime settings (not in postFixup)
-            # ANTHROPIC_MODEL = defaultModel;
-            CLAUDE_CODE_ENABLE_TELEMETRY = "0";
-            DISABLE_ERROR_REPORTING = "1";
-            CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "1";
-            BASH_DEFAULT_TIMEOUT_MS = "240000";
-            BASH_MAX_TIMEOUT_MS = "4800000";
-            BASH_MAX_OUTPUT_LENGTH = "1024";
-            # MAX_THINKING_TOKENS = "32768";
-            # CLAUDE_CODE_MAX_OUTPUT_TOKENS = "UNKNOWN";
-            # MAX_MCP_OUTPUT_TOKENS = "32000";
-            CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "0";
-            CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL = "1";
-            DISABLE_BUG_COMMAND = "1";
-            USE_BUILTIN_RIPGREP = "0";
-          };
+          # Full env from the shared source (modules/agents/claude-code/_env.nix);
+          # belt-and-suspenders with the binary postFixup and settings.json `env`.
+          sessionVariables = claudeEnv.all;
         };
       };
     };

--- a/modules/agents/claude-code/home-manager.nix
+++ b/modules/agents/claude-code/home-manager.nix
@@ -27,6 +27,7 @@
         _plugins.nix           enabledPlugins composition from osConfig
         _settings.nix          merges defaults + plugins + mcpServers
         _activation.nix        activation snippets (jq merge + optional bun install)
+        _wrapper.nix           shell launcher environment and binary selection
 */
 
 _: {
@@ -41,6 +42,16 @@ _: {
     }:
     let
       nixosEnabled = lib.attrByPath [ "programs" "claude-code" "extended" "enable" ] false osConfig;
+      claudePkg = lib.attrByPath [
+        "programs"
+        "claude-code"
+        "extended"
+        "package"
+      ] pkgs.claude-code osConfig;
+      installMethods = lib.attrByPath [ "programs" "claude-code" "extended" "installMethods" ] {
+        nix.enable = false;
+        bun.enable = false;
+      } osConfig;
 
       defaults = import ./_default-settings.nix;
       plugins = import ./_plugins.nix { inherit lib osConfig; };
@@ -56,6 +67,18 @@ _: {
 
       greptileApiKeyPath = "${config.xdg.dataHome}/greptile/api-key";
       greptileHeadersHelperPath = "${config.home.homeDirectory}/.local/bin/claude-greptile-mcp-headers";
+      bunInstallDir = "${config.xdg.dataHome}/bun";
+      configuredExternalBinary = lib.attrByPath [
+        "programs"
+        "claude-code"
+        "extended"
+        "externalBinary"
+      ] null osConfig;
+      externalBinary =
+        if configuredExternalBinary == null then
+          "${bunInstallDir}/bin/claude"
+        else
+          configuredExternalBinary;
 
       activation = import ./_activation.nix {
         inherit
@@ -70,14 +93,18 @@ _: {
         inherit (plugins) greptilePluginKey greptilePluginRequested;
       };
 
-      bunInstallEnabled = lib.attrByPath [
-        "programs"
-        "claude-code"
-        "extended"
-        "installMethods"
-        "bun"
-        "enable"
-      ] false osConfig;
+      claudeRuntime = import ./_wrapper.nix {
+        inherit
+          lib
+          pkgs
+          claudePkg
+          bunInstallDir
+          externalBinary
+          installMethods
+          greptilePluginRequested
+          greptileApiKeyPath
+          ;
+      };
 
       # ── Commit Skill ──────────────────────────────────────────────────────
       claudeInstructions = agents.systemPrompt.render {
@@ -93,6 +120,11 @@ _: {
 
             ".claude/skills/commit/SKILL.md" = {
               text = commitSkillMd;
+            };
+
+            ".local/bin/claude" = {
+              source = claudeRuntime.claudeWrapperScript;
+              executable = true;
             };
           }
           // lib.optionalAttrs greptilePluginRequested {
@@ -117,32 +149,6 @@ _: {
                 ${pkgs.jq}/bin/jq -n --arg authorization "Bearer $secret_value" '{
                   Authorization: $authorization
                 }'
-              '';
-            };
-          }
-          // lib.optionalAttrs bunInstallEnabled {
-            ".local/bin/claude" = {
-              executable = true;
-              text = ''
-                #!${pkgs.bash}/bin/bash
-                set -euo pipefail
-
-                ${lib.optionalString greptilePluginRequested ''
-                  secret_path="''${GREPTILE_API_KEY_FILE:-${greptileApiKeyPath}}"
-                  if [ -r "$secret_path" ] && [ -s "$secret_path" ]; then
-                    if secret_value="$(${pkgs.coreutils}/bin/tr -d '\r\n' < "$secret_path")" && [ -n "$secret_value" ]; then
-                      export GREPTILE_API_KEY="$secret_value"
-                    fi
-                  fi
-                ''}
-
-                bun_claude="$HOME/.local/share/bun/bin/claude"
-                if [ -x "$bun_claude" ]; then
-                  exec "$bun_claude" "$@"
-                fi
-
-                echo "ERROR: Claude Code bun install not found at $bun_claude" >&2
-                exit 127
               '';
             };
           };

--- a/modules/agents/claude-code/home-manager.nix
+++ b/modules/agents/claude-code/home-manager.nix
@@ -123,7 +123,7 @@ _: {
             };
 
             ".local/bin/claude" = {
-              source = claudeRuntime.claudeWrapperScript;
+              source = lib.getExe claudeRuntime.claudeWrapped;
               executable = true;
             };
           }

--- a/modules/agents/claude-code/home-manager.nix
+++ b/modules/agents/claude-code/home-manager.nix
@@ -155,6 +155,12 @@ _: {
 
           inherit activation;
 
+          # Prepend ~/.local/bin so the wrapper at ~/.local/bin/claude wins PATH
+          # resolution over an external bun-global claude. bun (modules/hm-apps/bun.nix)
+          # puts its bin on home.sessionPath, which is prepended to PATH in list
+          # order; lib.mkBefore orders this entry ahead of bun's so the wrapper wins.
+          sessionPath = lib.mkBefore [ "${config.home.homeDirectory}/.local/bin" ];
+
           sessionVariables = {
             # Duplicates of postFixup in modules/apps/claude-code.nix (belt-and-suspenders)
             DISABLE_AUTOUPDATER = "1";

--- a/modules/agents/claude-code/home-manager.nix
+++ b/modules/agents/claude-code/home-manager.nix
@@ -155,10 +155,8 @@ _: {
 
           inherit activation;
 
-          # Prepend ~/.local/bin so the wrapper at ~/.local/bin/claude wins PATH
-          # resolution over an external bun-global claude. bun (modules/hm-apps/bun.nix)
-          # puts its bin on home.sessionPath, which is prepended to PATH in list
-          # order; lib.mkBefore orders this entry ahead of bun's so the wrapper wins.
+          # bun puts its global bin on home.sessionPath; mkBefore orders
+          # ~/.local/bin ahead of it so the wrapper shadows a bun-global claude.
           sessionPath = lib.mkBefore [ "${config.home.homeDirectory}/.local/bin" ];
 
           sessionVariables = {

--- a/modules/agents/codex/_exec-policy.nix
+++ b/modules/agents/codex/_exec-policy.nix
@@ -22,8 +22,12 @@ let
 
   rmShim = import ../_rm-shim.nix { inherit lib pkgs; };
 
-  # Scope recoverable bare `rm` rewrites to the top-level Codex shell command
-  # instead of mutating PATH for every subprocess those commands spawn.
+  # Route bare `rm` through the rip-backed shim (PATH prepend plus a top-level
+  # rm() function) so `find -exec rm`, `xargs rm`, and nested shells inside a
+  # Codex session trash deletions instead of running coreutils rm. Mirrors the
+  # claude-code wrapper: the bwrap workspace-write sandbox bounds the blast
+  # radius, but the workspace is the user's work, so the shim is what keeps
+  # those deletions recoverable.
   #
   # Keep the wrapper executable named `bash` so Codex continues to classify
   # `bash -lc ...` invocations as shell commands and applies execpolicy to the
@@ -34,6 +38,10 @@ let
     direnvBin=${lib.getExe pkgs.direnv}
     realBash=${lib.getExe pkgs.bashInteractive}
     rmShimPath=${rmShim}/bin/rm
+
+    # Only `rm` lives in this dir, so prepending shadows nothing else; on PATH so
+    # bare `rm` is shimmed for every shell invocation form, not just -c below.
+    export PATH=${rmShim}/bin''${PATH:+:$PATH}
 
     restoreCodexShellEnv() {
       if [ -n "''${CODEX_ORIGINAL_LD_PRELOAD-}" ]; then
@@ -56,6 +64,10 @@ let
         if direnvExports="$("'"$direnvBin"'" export bash 2>/dev/null)"; then
           eval "$direnvExports"
         fi
+        # direnv (e.g. nix-direnv use-flake) can prepend dev-shell bins and
+        # push the shim down PATH; re-prepend it so command rm, find -exec rm,
+        # xargs rm, and nested shells resolve the shim, not coreutils rm.
+        export PATH=${rmShim}/bin''${PATH:+:$PATH}
         rm() {
           "'"$rmShimPath"'" "$@"
         }

--- a/modules/agents/codex/_exec-policy.nix
+++ b/modules/agents/codex/_exec-policy.nix
@@ -20,7 +20,6 @@ let
     }:
     "host_executable(name=${builtins.toJSON name}, paths=${builtins.toJSON paths})";
 
-  # rm -> rip shim shared with the other agent wrappers (modules/agents/_rm-shim.nix).
   rmShim = import ../_rm-shim.nix { inherit lib pkgs; };
 
   # Scope recoverable bare `rm` rewrites to the top-level Codex shell command

--- a/modules/agents/codex/_exec-policy.nix
+++ b/modules/agents/codex/_exec-policy.nix
@@ -20,66 +20,8 @@ let
     }:
     "host_executable(name=${builtins.toJSON name}, paths=${builtins.toJSON paths})";
 
-  # Translate common rm flags into rip so Codex defaults to recoverable deletions.
-  rmShim = pkgs.writeShellScriptBin "rm" ''
-    set -euo pipefail
-
-    force=0
-    operands=()
-
-    while [ "$#" -gt 0 ]; do
-      case "$1" in
-        --)
-          shift
-          while [ "$#" -gt 0 ]; do
-            operands+=("$1")
-            shift
-          done
-          break
-          ;;
-        -f|--force)
-          force=1
-          shift
-          ;;
-        -r|-R|--recursive)
-          shift
-          ;;
-        -[!-]*)
-          bundle="''${1#-}"
-          unsupported="''${bundle//[fRr]/}"
-          if [ -n "$unsupported" ]; then
-            echo "rm shim: unsupported rm option '$1'; use rip directly for nonstandard flags" >&2
-            exit 2
-          fi
-          case "$bundle" in
-            *f*)
-              force=1
-              ;;
-          esac
-          shift
-          ;;
-        --*)
-          echo "rm shim: unsupported rm option '$1'; use rip directly for nonstandard flags" >&2
-          exit 2
-          ;;
-        *)
-          operands+=("$1")
-          shift
-          ;;
-      esac
-    done
-
-    cmd=(${lib.getExe' pkgs.trash-cli "trash-put"})
-    if [ "$force" -eq 1 ]; then
-      cmd+=(-f)
-    fi
-
-    if [ "''${#operands[@]}" -eq 0 ]; then
-      exec "''${cmd[@]}"
-    fi
-
-    exec "''${cmd[@]}" -- "''${operands[@]}"
-  '';
+  # rm -> rip shim shared with the other agent wrappers (modules/agents/_rm-shim.nix).
+  rmShim = import ../_rm-shim.nix { inherit lib pkgs; };
 
   # Scope recoverable bare `rm` rewrites to the top-level Codex shell command
   # instead of mutating PATH for every subprocess those commands spawn.

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -82,6 +82,17 @@ in
           description = "Claude Code package used when installMethods.nix.enable is true.";
         };
 
+        externalBinary = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = null;
+          description = ''
+            Absolute runtime path used by the Home Manager `~/.local/bin/claude`
+            wrapper when both `installMethods.nix.enable` and
+            `installMethods.bun.enable` are false. When null, the wrapper
+            delegates to the Home Manager bun global path under XDG data home.
+          '';
+        };
+
         installMethods = {
           nix.enable = lib.mkOption {
             type = lib.types.bool;

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -89,7 +89,8 @@ in
             Absolute runtime path used by the Home Manager `~/.local/bin/claude`
             wrapper when both `installMethods.nix.enable` and
             `installMethods.bun.enable` are false. When null, the wrapper
-            delegates to the Home Manager bun global path under XDG data home.
+            delegates to the Home Manager bun global path under XDG data home,
+            so `programs.bun.extended.enable` must be true.
           '';
         };
 
@@ -186,6 +187,8 @@ in
                   malformedKeys = lib.filter (k: builtins.match ".+@.+" k == null) extraKeys;
                   lspKeysWithMarket = map (k: "${k}@claude-plugins-official") (lib.attrNames cfg.lspPlugins);
                   lspCollisions = lib.intersectLists extraKeys lspKeysWithMarket;
+                  delegatesToBunGlobal =
+                    (!cfg.installMethods.nix.enable) && (!cfg.installMethods.bun.enable) && cfg.externalBinary == null;
                 in
                 [
                   {
@@ -196,6 +199,16 @@ in
                       apps-enable.nix (e.g. modules/tpnix/apps-enable.nix:32 or
                       modules/system76/apps-enable.nix:47) before enabling the bun
                       install method for claude-code.
+                    '';
+                  }
+                  {
+                    assertion = (!delegatesToBunGlobal) || config.programs.bun.extended.enable;
+                    message = ''
+                      programs.claude-code.extended.externalBinary = null with both
+                      claude-code install methods disabled delegates to the Home Manager
+                      bun global path. Enable programs.bun.extended.enable, set
+                      programs.claude-code.extended.externalBinary to an absolute path,
+                      or enable one of the claude-code install methods.
                     '';
                   }
                   {

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -52,14 +52,17 @@ in
 
       basePackage = inputs.llm-agents.packages.${pkgs.stdenv.hostPlatform.system}.claude-code;
 
+      # Privacy/update disables baked into the binary so a bare `claude` that
+      # bypasses the ~/.local/bin wrapper still gets them. Shared source:
+      # modules/agents/claude-code/_env.nix (also feeds settings.json + wrapper).
+      claudeEnv = import ../agents/claude-code/_env.nix;
+      binaryEnvFlags = lib.concatStringsSep " " (
+        lib.mapAttrsToList (name: value: "--set ${name} ${lib.escapeShellArg value}") claudeEnv.binary
+      );
+
       wrappedPackage = basePackage.overrideAttrs (old: {
         postFixup = (old.postFixup or "") + ''
-          wrapProgram $out/bin/claude \
-            --set DISABLE_AUTOUPDATER 1 \
-            --set CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC 1 \
-            --set DISABLE_NON_ESSENTIAL_MODEL_CALLS 1 \
-            --set DISABLE_TELEMETRY 1 \
-            --set DISABLE_INSTALLATION_CHECKS 1
+          wrapProgram $out/bin/claude ${binaryEnvFlags}
         '';
       });
     in

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -78,8 +78,9 @@ let
       charles.extended.enable = lib.mkOverride 1100 true;
       circumflex.extended.enable = lib.mkOverride 1100 true;
       clangd.extended.enable = lib.mkOverride 1100 false;
-      # Both install methods off: binary managed outside Nix via externalBinary;
-      # the wrapper, settings, skills, and MCP merge still apply.
+      # Both install methods off: delegate to the bun global path by default;
+      # set externalBinary for a non-bun external binary.
+      # The wrapper, settings, skills, and MCP merge still apply.
       "claude-code".extended.enable = lib.mkOverride 1100 true;
       "claude-code".extended.installMethods.nix.enable = lib.mkOverride 1100 false;
       "claude-code".extended.installMethods.bun.enable = lib.mkOverride 1100 false;

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -78,13 +78,8 @@ let
       charles.extended.enable = lib.mkOverride 1100 true;
       circumflex.extended.enable = lib.mkOverride 1100 true;
       clangd.extended.enable = lib.mkOverride 1100 false;
-      # Both install methods disabled: the claude-code binary is managed
-      # outside Nix on this host. Home Manager still installs ~/.local/bin/claude
-      # as a wrapper, applies settings, skills, and MCP merge, then delegates to
-      # programs.claude-code.extended.externalBinary. To switch back to a
-      # Nix-managed binary, set installMethods.nix.enable = true; for
-      # bun-managed, set installMethods.bun.enable = true and
-      # programs.bun.extended.enable = true.
+      # Both install methods off: binary managed outside Nix via externalBinary;
+      # the wrapper, settings, skills, and MCP merge still apply.
       "claude-code".extended.enable = lib.mkOverride 1100 true;
       "claude-code".extended.installMethods.nix.enable = lib.mkOverride 1100 false;
       "claude-code".extended.installMethods.bun.enable = lib.mkOverride 1100 false;

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -79,10 +79,12 @@ let
       circumflex.extended.enable = lib.mkOverride 1100 true;
       clangd.extended.enable = lib.mkOverride 1100 false;
       # Both install methods disabled: the claude-code binary is managed
-      # outside Nix on this host. Home Manager still applies settings,
-      # skills, and MCP merge. To switch back to a Nix-managed binary, set
-      # installMethods.nix.enable = true; for bun-managed, set
-      # installMethods.bun.enable = true and programs.bun.extended.enable = true.
+      # outside Nix on this host. Home Manager still installs ~/.local/bin/claude
+      # as a wrapper, applies settings, skills, and MCP merge, then delegates to
+      # programs.claude-code.extended.externalBinary. To switch back to a
+      # Nix-managed binary, set installMethods.nix.enable = true; for
+      # bun-managed, set installMethods.bun.enable = true and
+      # programs.bun.extended.enable = true.
       "claude-code".extended.enable = lib.mkOverride 1100 true;
       "claude-code".extended.installMethods.nix.enable = lib.mkOverride 1100 false;
       "claude-code".extended.installMethods.bun.enable = lib.mkOverride 1100 false;


### PR DESCRIPTION
## Summary

Claude Code settings were already managed by Home Manager, but the launcher path and shell-tool behavior were not owned consistently. This PR adds a Home Manager installed `~/.local/bin/claude` wrapper that owns launch-time environment, target-binary selection, and shell-tool routing.

The wrapper now:

- selects the bun global, Nix package, or explicit `programs.claude-code.extended.externalBinary` target without relying on PATH recursion;
- puts `~/.local/bin` ahead of the bun global bin so the wrapper wins command resolution;
- sets Claude Code telemetry, updater, timeout, ripgrep, temp-directory, and Greptile key environment at launch;
- routes `CLAUDE_CODE_SHELL` through a controlled bash that mirrors direnv and keeps the shared recoverable `rm` shim first on PATH, including after direnv rewrites PATH;
- shares the `rm` to `rip` shim with the Codex wrapper instead of carrying duplicate shell snippets;
- keeps `externalBinary = null` as the documented default bun-global delegation, but now asserts that `programs.bun.extended.enable` is true when both Claude install methods are disabled and no explicit external binary is set.

## Test plan

- `nix fmt -- modules/apps/claude-code.nix modules/hosts/common/apps-enable.nix`
- `nix-instantiate --parse modules/apps/claude-code.nix`
- `nix-instantiate --parse modules/hosts/common/apps-enable.nix`
- `nix eval --impure --accept-flake-config --offline` host baseline checks for `tpnix` and `system76`
- `nix eval --impure --accept-flake-config --offline` forced invalid assertion probe with bun disabled, both Claude install methods disabled, and `externalBinary = null`
- `git diff --check`
- `nix flake check --accept-flake-config --no-build --offline`
- Prior wrapper validation on this PR: build the rendered Home Manager `~/.local/bin/claude` source, run `bash -n` on the rendered wrapper and `CLAUDE_CODE_SHELL`, and verify `type -P rm` still resolves the shim after a simulated direnv PATH prepend