### PR TITLE
feat(nixpkgs): point nixpkgs registry alias at my fork

### DIFF
--- a/modules/base/nixpkgs.nix
+++ b/modules/base/nixpkgs.nix
@@ -2,9 +2,29 @@
   flake.nixosModules.base =
     { config, lib, ... }:
     {
-      nix.channel.enable = false;
-      nix.nixPath = lib.mkDefault [
-        "nixpkgs=${config.nixpkgs.flake.source}"
-      ];
+      nix = {
+        channel.enable = false;
+        nixPath = lib.mkDefault [
+          "nixpkgs=${config.nixpkgs.flake.source}"
+        ];
+
+        # Resolve the `nixpkgs` registry alias (`nix run nixpkgs#pkg`,
+        # `nix shell nixpkgs#pkg`, ...) to the personal fork instead of the
+        # store-path pin that nixpkgs.flake.setFlakeRegistry installs by default.
+        registry.nixpkgs.to = {
+          type = "github";
+          owner = "Bad3r";
+          repo = "nixpkgs";
+        };
+      };
+
+      # setNixPath is disabled alongside setFlakeRegistry: nixpkgs-flake asserts
+      # `setNixPath -> setFlakeRegistry`, so leaving setNixPath at its default
+      # (true) while setFlakeRegistry is false fails evaluation. The nix.nixPath
+      # entry above keeps `<nixpkgs>` pinned to the system's own nixpkgs source.
+      nixpkgs.flake = {
+        setFlakeRegistry = false;
+        setNixPath = false;
+      };
     };
 }


### PR DESCRIPTION
## Summary

Redirect the `nixpkgs` flake registry alias to `github:Bad3r/nixpkgs` so CLI
lookups such as `nix run nixpkgs#pkg` and `nix shell nixpkgs#pkg` resolve against
the personal fork instead of the system store-path pin.

- `nix.registry.nixpkgs.to` now targets `github:Bad3r/nixpkgs`.
- `nixpkgs.flake.setFlakeRegistry = false` drops the default path pin that would
  otherwise collide with the explicit github target.
- `nixpkgs.flake.setNixPath = false` is required by the upstream assertion
  `setNixPath -> setFlakeRegistry` in `nixos/modules/misc/nixpkgs-flake.nix`;
  disabling only `setFlakeRegistry` fails evaluation. The existing `nix.nixPath`
  entry keeps `<nixpkgs>` pinned to the system's own nixpkgs source.

This applies to every host (the change lives in `flake.nixosModules.base`).

## Test plan

- `nix fmt modules/base/nixpkgs.nix` (0 changed)
- `statix check modules/base/nixpkgs.nix` (clean); full pre-commit suite passed
- `nix eval .#nixosConfigurations.{system76,tpnix}.config.nix.registry.nixpkgs.to`
  -> `{ owner = "Bad3r"; repo = "nixpkgs"; type = "github"; }`
- `nix eval .#nixosConfigurations.system76.config.system.build.toplevel.drvPath`
  succeeds, confirming the `setNixPath -> setFlakeRegistry` assertion holds
- rendered `/etc/nix/registry.json` maps indirect `nixpkgs` to
  `github:Bad3r/nixpkgs`