### PR TITLE
chore(packages): update pnpm packages and wakaru Rust release

### DIFF
--- a/packages/tweakcc/hashes.json
+++ b/packages/tweakcc/hashes.json
@@ -2,5 +2,5 @@
 	"version": "unstable-2026-06-27",
 	"srcRev": "1e03321d1fa8ea6dbb24446975cd9bd82f7ecf81",
 	"srcHash": "sha256-WZQ2nL/Ds3+ImjDlrd/4M+f7K3c6bUSZ2R47Z+ElcLk=",
-	"pnpmDepsHash": "sha256-3GMZkEGHmiuwpO4JjGfSvKGupJHjOx7QcY6RjCAEmtM="
+	"pnpmDepsHash": "sha256-v/uIpSJEl7q79PVsCkfiQU2brxuKNTHy5P/+Jp4/mJA="
 }

--- a/packages/tweakcc/package.nix
+++ b/packages/tweakcc/package.nix
@@ -3,7 +3,7 @@
   stdenv,
   fetchFromGitHub,
   nodejs_22,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeWrapper,
@@ -26,7 +26,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     nodejs_22
-    pnpm_9
+    pnpm_10
     pnpmConfigHook
     makeWrapper
     autoPatchelfHook
@@ -46,7 +46,7 @@ stdenv.mkDerivation (finalAttrs: {
       src
       postPatch
       ;
-    pnpm = pnpm_9;
+    pnpm = pnpm_10;
     fetcherVersion = 3;
     hash = pin.pnpmDepsHash;
   };

--- a/packages/wakaru/default.nix
+++ b/packages/wakaru/default.nix
@@ -1,83 +1,42 @@
 {
   lib,
-  stdenv,
+  rustPlatform,
   fetchFromGitHub,
-  nodejs_22,
-  pnpm_9,
-  fetchPnpmDeps,
-  pnpmConfigHook,
-  makeWrapper,
 }:
 
 let
   pin = lib.importJSON ./hashes.json;
 in
-stdenv.mkDerivation (finalAttrs: {
+rustPlatform.buildRustPackage rec {
   pname = "wakaru";
   inherit (pin) version;
 
   src = fetchFromGitHub {
     owner = "pionxzh";
     repo = "wakaru";
-    rev = "cli-v${pin.version}";
+    rev = "v${version}";
     hash = pin.srcHash;
   };
 
-  nativeBuildInputs = [
-    nodejs_22
-    pnpm_9
-    pnpmConfigHook
-    makeWrapper
+  inherit (pin) cargoHash;
+
+  cargoBuildFlags = [
+    "-p"
+    "wakaru-cli"
   ];
-
-  # Filter to CLI package and dependencies only, excluding playground/ide with missing npm packages
-  pnpmWorkspaces = [ "@wakaru/cli..." ];
-
-  pnpmDeps = fetchPnpmDeps {
-    inherit (finalAttrs)
-      pname
-      version
-      src
-      pnpmWorkspaces
-      ;
-    pnpm = pnpm_9;
-    fetcherVersion = 3;
-    hash = pin.pnpmDepsHash;
-  };
-
-  buildPhase = ''
-    runHook preBuild
-
-    pnpm --filter "@wakaru/cli..." build
-
-    runHook postBuild
-  '';
-
-  # NOTE: Copies entire pnpm workspace to preserve symlink structure for runtime.
-  # This includes dev dependencies which bloats the closure. The alternative
-  # (hoisted reinstall) fails because transitive dependencies are missing.
-  # Trade-off: larger size but correct behavior.
-  installPhase = ''
-    runHook preInstall
-
-    mkdir -p $out/lib/wakaru $out/bin
-
-    cp -r . $out/lib/wakaru/
-
-    makeWrapper ${nodejs_22}/bin/node $out/bin/wakaru \
-      --add-flags "--max-old-space-size=8192" \
-      --add-flags "$out/lib/wakaru/packages/cli/dist/cli.cjs"
-
-    runHook postInstall
-  '';
+  cargoTestFlags = [
+    "-p"
+    "wakaru-cli"
+  ];
 
   passthru.updateScript = ./update.py;
 
   meta = {
-    description = "Javascript decompiler for modern frontend";
+    description = "Fast JavaScript decompiler and bundle splitter";
     homepage = "https://github.com/pionxzh/wakaru";
-    license = lib.licenses.mit;
+    changelog = "https://github.com/pionxzh/wakaru/releases/tag/v${version}";
+    license = lib.licenses.asl20;
     mainProgram = "wakaru";
     platforms = lib.platforms.linux;
   };
-})
+}

--- a/packages/wakaru/hashes.json
+++ b/packages/wakaru/hashes.json
@@ -1,5 +1,5 @@
 {
-	"version": "0.0.10",
-	"srcHash": "sha256-bWApVN11HZy88xHbB2fQdk4quiyKsn6oyHa91Unxjds=",
-	"pnpmDepsHash": "sha256-y8I+nudfmsecpou9f6C23x6DVre9YXgybhMchILcBmo="
+	"version": "1.6.0",
+	"srcHash": "sha256-zz//ATq3q2546EshIamK97w+ZB3lITe8h32u2xs0SBA=",
+	"cargoHash": "sha256-dGCElfhn71UG1BeTbxQ3Cb84Het8JdQHUC3ykNr+RCk="
 }

--- a/packages/wakaru/update.py
+++ b/packages/wakaru/update.py
@@ -12,7 +12,7 @@ from typing import Any, cast
 PACKAGE_NAME = "wakaru"
 OWNER = "pionxzh"
 REPO = "wakaru"
-TAG_PATTERN = r"^cli-v(?P<version>\d+\.\d+\.\d+)$"
+TAG_PATTERN = r"^v(?P<version>\d+\.\d+\.\d+)$"
 
 
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
@@ -35,7 +35,7 @@ from updater import (  # noqa: E402
 
 
 def latest_version() -> str:
-    """Fetch the highest stable wakaru CLI tag."""
+    """Fetch the highest stable wakaru Rust release tag."""
     return fetch_github_latest_tag(OWNER, REPO, TAG_PATTERN)
 
 
@@ -56,7 +56,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def main() -> None:
-    """Update wakaru to the latest CLI tag."""
+    """Update wakaru to the latest stable Rust release."""
     args = parse_args()
     data = load_hashes(HASHES_FILE)
     current = cast("str", data["version"])
@@ -64,7 +64,7 @@ def main() -> None:
 
     print(f"Current: {current}")
     print(f"Latest:  {latest}")
-    print(f"Tag:     cli-v{latest}")
+    print(f"Tag:     v{latest}")
 
     if args.check_release:
         print("Release metadata is valid")
@@ -76,18 +76,18 @@ def main() -> None:
 
     print("Calculating source hash...")
     src_hash = calculate_url_hash(
-        f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/cli-v{latest}.tar.gz",
+        f"https://github.com/{OWNER}/{REPO}/archive/refs/tags/v{latest}.tar.gz",
         unpack=True,
     )
 
     new_data: dict[str, Any] = {
         "version": latest,
         "srcHash": src_hash,
-        "pnpmDepsHash": data.get("pnpmDepsHash", ""),
+        "cargoHash": data.get("cargoHash", ""),
     }
-    new_data["pnpmDepsHash"] = calculate_dependency_hash(
+    new_data["cargoHash"] = calculate_dependency_hash(
         PACKAGE_ATTR,
-        "pnpmDepsHash",
+        "cargoHash",
         HASHES_FILE,
         new_data,
     )

--- a/packages/webcrack/default.nix
+++ b/packages/webcrack/default.nix
@@ -6,7 +6,7 @@
   stdenv,
   fetchFromGitHub,
   nodejs_22,
-  pnpm_9,
+  pnpm_10,
   fetchPnpmDeps,
   pnpmConfigHook,
   makeWrapper,
@@ -89,7 +89,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   nativeBuildInputs = [
     nodejs_22
-    pnpm_9
+    pnpm_10
     pnpmConfigHook
     makeWrapper
     autoPatchelfHook
@@ -122,7 +122,7 @@ stdenv.mkDerivation (finalAttrs: {
 
   pnpmDeps = fetchPnpmDeps {
     inherit (finalAttrs) pname version src;
-    pnpm = pnpm_9;
+    pnpm = pnpm_10;
     fetcherVersion = 3;
     hash = pin.pnpmDepsHash;
   };

--- a/packages/webcrack/hashes.json
+++ b/packages/webcrack/hashes.json
@@ -1,7 +1,7 @@
 {
 	"version": "2.16.0",
 	"srcHash": "sha256-IalU/wio1cNCr6K7Pa1neHVpnO2md4Ey6YmtReE3r+8=",
-	"pnpmDepsHash": "sha256-Uo9LR49yhPan88WpSm0t7BVO4qW4nGlZ14cX6ImLMQ8=",
+	"pnpmDepsHash": "sha256-l2thuPuhasRDMHnftVV/onSxK2qRwbwR51xgVzAxv4w=",
 	"isolatedVmVersion": "6.1.2",
 	"isolatedVmIntegrity": "sha512-GGfsHqtlZiiurZaxB/3kY7LLAXR3sgzDul0fom4cSyBjx6ZbjpTrFWiH3z/nUfLJGJ8PIq9LQmQFiAxu24+I7A==",
 	"simdutfVersion": "6.5.0",


### PR DESCRIPTION
## Summary

- Package wakaru from the upstream Rust release line at v1.6.0 instead of the old cli-v0.0.x pnpm workspace.
- Update wakaru's updater to follow v* release tags and regenerate cargoHash through the shared updater dummy-hash path.
- Move webcrack and tweakcc from pnpm_9 to pnpm_10 and refresh their pnpm dependency hashes.

## Test plan

- nix fmt
- git diff --check
- nix-instantiate --parse packages/wakaru/default.nix packages/webcrack/default.nix packages/tweakcc/package.nix
- packages/wakaru/update.py --check-release
- packages/webcrack/update.py --check-release
- ./update.py --check-release from packages/wakaru
- packages/wakaru/update.py migration from old pnpm-era hashes.json
- nix build --accept-flake-config --no-write-lock-file --no-link --print-out-paths .#nixosConfigurations.tpnix.pkgs.wakaru .#nixosConfigurations.tpnix.pkgs.webcrack .#nixosConfigurations.tpnix.pkgs.tweakcc
- /nix/store/16pr44x3b1lrx8c4j2wmnyjpp4ns3qig-wakaru-1.6.0/bin/wakaru --version
- /nix/store/y9lgf494b5daz8xb0m41bkvfs5sv1d3s-webcrack-2.16.0/bin/webcrack --help
- /nix/store/cw4i46wbkjavlnhi178i3lphd9zlryyp-tweakcc-unstable-2026-06-27/bin/tweakcc --help