### PR TITLE
feat(networking): disable IPv6 host-wide

### DIFF
--- a/modules/hosts/common/disable-ipv6.nix
+++ b/modules/hosts/common/disable-ipv6.nix
@@ -1,4 +1,4 @@
-_:
+{ lib, ... }:
 let
   # The default route on these hosts is an IPv4-only ProtonVPN WireGuard tunnel
   # that sinks every IPv6 destination into its ipv6leakintrf0 blackhole. With
@@ -8,7 +8,7 @@ let
   # addresses in play. enableIPv6 = false sets
   # net.ipv6.conf.{all,default}.disable_ipv6 = true.
   body = {
-    networking.enableIPv6 = false;
+    networking.enableIPv6 = lib.mkDefault false;
   };
 in
 {

--- a/modules/hosts/common/disable-ipv6.nix
+++ b/modules/hosts/common/disable-ipv6.nix
@@ -1,0 +1,16 @@
+_:
+let
+  # The default route on these hosts is an IPv4-only ProtonVPN WireGuard tunnel
+  # that sinks every IPv6 destination into its ipv6leakintrf0 blackhole. With
+  # IPv6 left on, resolvers still hand out AAAA records, so Nix substituter
+  # fetches and Tailscale open IPv6 sockets that never complete the handshake
+  # and stall until connect-timeout. Disabling IPv6 keeps only reachable IPv4
+  # addresses in play. enableIPv6 = false sets
+  # net.ipv6.conf.{all,default}.disable_ipv6 = true.
+  body = {
+    networking.enableIPv6 = false;
+  };
+in
+{
+  flake.nixosModules.hosts-common.imports = [ body ];
+}


### PR DESCRIPTION
## Summary

The default route on `tpnix` and `system76` is an IPv4-only ProtonVPN WireGuard tunnel (`proton0`) that routes every IPv6 destination into an `ipv6leakintrf0` blackhole. With IPv6 enabled, DNS still returned AAAA records, so Nix substituter fetches (and the Tailscale daemon) opened IPv6 sockets that never completed the TCP handshake, each stalling for `connect-timeout` (30s) then retrying `download-attempts` (5) times. A running `nh os` build sat at 1872 queued / 0 completed downloads with near-zero CPU, which presents as a hung "Building NixOS configuration".

Adds `modules/hosts/common/disable-ipv6.nix` setting `networking.enableIPv6 = false`, which nixpkgs implements as `net.ipv6.conf.{all,default}.disable_ipv6 = true` (`nixos/modules/tasks/network-interfaces.nix`). IPv4 reachability to all binary caches was verified working; only IPv6 was dead. Applies to every host through the `hosts-common` aggregate.

## Test plan

- `nix eval .#nixosConfigurations.tpnix.config.networking.enableIPv6` -> `false`
- `nix eval .#nixosConfigurations.system76.config.networking.enableIPv6` -> `false`
- `nix fmt` -> 0 files changed
- pre-commit hooks pass (deadnix, statix, nix-parse, treefmt, typos)