### PR TITLE
fix(claude-code): handle login flag passed as a separate shell arg

### DIFF
--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -39,13 +39,48 @@ let
     # bare `rm` is shimmed for every shell invocation form, not just -c below.
     export PATH=${rmShim}/bin''${PATH:+:$PATH}
 
-    if [ "$#" -ge 2 ] && { [ "$1" = "-c" ] || [ "$1" = "-lc" ]; }; then
-      shellFlag="$1"
-      wrappedCommand="$2"
-      shift 2
+    # Claude Code runs its shell tool as `bash [OPTS] <command> [ARG...]`. OPTS is
+    # any order/mix of short flags (-c, -l, -i, or bundles like -lc) and long
+    # flags; newer Claude Code passes login as a separate flag, e.g.
+    # `-c -l <command>`, so the command is not always $2. Scan past every option
+    # word to find the first operand. A short flag bundle containing `c` selects
+    # command mode; long flags (--login, --norc) never do, even when they contain
+    # a "c". Non-command invocations (interactive/login shell, no `-c`) are exec'd
+    # through untouched.
+    originalArgs=("$@")
+    options=()
+    haveCommand=0
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --)
+          options+=("$1")
+          shift
+          break
+          ;;
+        --*)
+          options+=("$1")
+          shift
+          ;;
+        -*c*)
+          haveCommand=1
+          options+=("$1")
+          shift
+          ;;
+        -?*)
+          options+=("$1")
+          shift
+          ;;
+        *)
+          break
+          ;;
+      esac
+    done
 
-      export CLAUDE_WRAPPED_COMMAND="$wrappedCommand"
-      exec "$realBash" "$shellFlag" '
+    if [ "$haveCommand" -eq 1 ] && [ "$#" -ge 1 ]; then
+      export CLAUDE_WRAPPED_COMMAND="$1"
+      shift
+
+      exec "$realBash" "''${options[@]}" '
         # Load direnv as an interactive shell would.
         if direnvExports="$("'"$direnvBin"'" export bash 2>/dev/null)"; then
           eval "$direnvExports"
@@ -61,7 +96,7 @@ let
       ' "$@"
     fi
 
-    exec "$realBash" "$@"
+    exec "$realBash" "''${originalArgs[@]}"
   '';
 
   targetScript =


### PR DESCRIPTION
## Summary

Claude Code invokes `CLAUDE_CODE_SHELL` as `bash -c -l '<command>'`, passing the login flag `-l` as its own
argument. The launch wrapper (`modules/agents/claude-code/_wrapper.nix`) only recognized `-c`/`-lc` as `$1` and
assumed the command string was always `$2`, so it captured `-l` as the command. `eval "-l"` then failed with
`eval: -l: invalid option` at the wrapper's final eval, and the real command (which bash placed in `$0`) never ran.
This broke every Bash tool invocation.

The fix replaces the fixed `$1`/`$2` assumption with a loop that scans past every option word (any order or mix of
`-c`, `-l`, `-i`, bundles like `-lc`, and long flags), selects command mode when a short bundle contains `c`, then
takes the first operand as the command and preserves trailing positional args. Non-command (interactive/login)
invocations exec through untouched. The two new array expansions use `''${...}` Nix escaping so they reach the shell
instead of being interpolated by Nix.

## Test plan

Verified against the rebuilt, switched wrapper:

- `-c -l` (previously broken), `-c`, `-lc`, and `-l -c` all execute commands.
- Trailing positional args (`$0`/`$1`/`$2`) are preserved.
- The `rm` safety shim is active inside wrapped commands (`rm is a function`, PATH head is the rm-shim store path).
- Non-command passthrough (`--version`) execs real bash.
- `nix fmt` reports 0 changed; pre-commit hooks (deadnix, nix-parse, statix, treefmt, typos) pass.