### PR TITLE
fix(forks): disable inherited workflows and dependabot updates on forks

### DIFF
--- a/docs/reference/fork-sync-automation.md
+++ b/docs/reference/fork-sync-automation.md
@@ -41,6 +41,30 @@ conflict-recovery path.
   without repository activity. If GitHub sends such a notice, re-enable with
   `gh workflow enable sync-upstream.yml -R <owner>/<repo>`.
 
+## Fork Hygiene
+
+`sync-upstream` is the only active workflow on each covered fork. Workflow
+files inherited from upstream stay in the tree but are disabled server side,
+and Dependabot security updates are off:
+
+- Upstream deploy workflows fail on a fork. The home-manager `GitHub Pages`
+  workflow gets a 403 pushing `gh-pages` as `github-actions[bot]`, and the
+  stylix `Documentation` workflow gets a 404 from `actions/deploy-pages`
+  because the fork has no Pages environment.
+- Guarded upstream workflows (nixpkgs `Bot`, `Periodic Merges`, `Teams`)
+  skip on forks but keep logging scheduled runs.
+- Dependabot security updates attempt update jobs against manifests the fork
+  never edits and fail; upstream fixes arrive through the sync instead.
+  Vulnerability alerts stay enabled. The `Dependabot Updates` and
+  `Dependency Graph` entries in the Actions tab are dynamic system workflows
+  and cannot be disabled by workflow id.
+
+The installer applies this hygiene. Pushes made by the sync workflow itself
+use `GITHUB_TOKEN` and trigger no other workflows; the hygiene matters for
+manual pushes such as cherry-picks. Re-enable a specific workflow with
+`gh workflow enable <id> -R <owner>/<repo>` (find ids with
+`gh workflow list --all -R <owner>/<repo>`).
+
 ## Manual Operations
 
 Dispatch and watch a sync run:
@@ -67,6 +91,7 @@ scripts/install-fork-sync-workflow.sh /data/Projects/igit/<clone>
 ```
 
 The installer writes the canonical workflow, commits and pushes it, enables
-GitHub Actions when disabled, and dispatches a verification run. The
+GitHub Actions when disabled, disables inherited upstream workflows and
+Dependabot security updates, and dispatches a verification run. The
 canonical workflow content lives in the installer heredoc; keep changes to
 the workflow and the installer in one commit.

--- a/scripts/install-fork-sync-workflow.sh
+++ b/scripts/install-fork-sync-workflow.sh
@@ -144,6 +144,24 @@ Validation: nix run nixpkgs#actionlint -- .github/workflows/sync-upstream.yml'
   git -C "${clone_path}" push origin "${branch}"
 fi
 
+# Inherited upstream workflows only fail on a fork (Pages deploys hit 403
+# or 404 without the upstream environment) or accumulate skipped runs, and
+# Dependabot security updates fail against manifests the fork never edits;
+# upstream fixes arrive through the sync instead. Keep sync-upstream as the
+# only active workflow. Re-enable a workflow later with:
+# gh workflow enable <id> -R <owner>/<repo>
+gh workflow list --all -R "${repo}" --json id,name,state,path \
+  --jq '.[] | select(.state == "active")
+    | select(.path | startswith(".github/workflows/"))
+    | select(.path != ".github/workflows/sync-upstream.yml")
+    | "\(.id)\t\(.name)"' |
+  while IFS=$'\t' read -r workflow_id workflow_name; do
+    gh workflow disable "${workflow_id}" -R "${repo}"
+    printf 'Disabled inherited workflow: %s\n' "${workflow_name}"
+  done
+gh api --method DELETE "repos/${repo}/automated-security-fixes" >/dev/null
+printf 'Disabled Dependabot security updates on %s\n' "${repo}"
+
 for _ in 1 2 3 4 5; do
   if gh workflow run "${workflow_file_name}" -R "${repo}" --ref "${branch}" 2>/dev/null; then
     printf 'Dispatched verification run. Watch with: gh run list --workflow=%s -R %s\n' \


### PR DESCRIPTION
## Summary

Follow-up to #323. Enabling fork Actions surfaced failing inherited runs:

- Bad3r/home-manager `GitHub Pages`: 403 pushing `gh-pages` as `github-actions[bot]` on every push to master.
- Bad3r/stylix `Documentation`: 404 from `actions/deploy-pages` because the fork has no Pages environment.
- Bad3r/llm-agents.nix and Bad3r/nixpkgs `Dependabot Updates`: security-update jobs failing against manifests the forks never edit (llm-agents.nix had ~20 failures since 2026-06-13, predating #323).

Applied on all four forks (live, via `gh`): every inherited workflow disabled server side with `sync-upstream` left as the only active workflow, and `dependabot_security_updates` disabled while vulnerability alerts stay enabled. Upstream fixes reach the forks through the scheduled sync.

This PR encodes that hygiene in `scripts/install-fork-sync-workflow.sh` for future forks and documents it in `docs/reference/fork-sync-automation.md`, including how to re-enable an individual workflow.

## Test plan

- `nix run nixpkgs#shellcheck -- scripts/install-fork-sync-workflow.sh`: pass.
- `nix fmt`: clean.
- The disable loop and `DELETE /repos/{owner}/{repo}/automated-security-fixes` ran live against all four forks; verification shows `Sync Fork With Upstream` as the only active file-based workflow and `dependabot_security_updates: disabled` on each.
- Idempotency: repeated `DELETE automated-security-fixes` on an already-disabled repo returns success.