### PR TITLE
feat(hooks): add pre-commit-config-sync guard for generated hook state

### DIFF
--- a/docs/architecture/06-reference.md
+++ b/docs/architecture/06-reference.md
@@ -37,14 +37,15 @@ nix flake check --accept-flake-config --no-build --offline
 
 ## Troubleshooting
 
-| Scenario                         | Resolution                                                                                                                   |
-| -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Git hooks fail in a new worktree | Run `nix develop` (auto-sync runs in shellHook) or run `nix develop -c bash scripts/hooks/sync-pre-commit-hooks.sh` manually |
-| Missing app reference            | Use `config.flake.lib.nixos.hasApp "name"` or `nix eval --json .#nixosModules.apps --apply builtins.attrNames`               |
-| Helper assertion failures        | Run `nix flake check --accept-flake-config` and inspect `checks.<system>.helpers-exist`                                      |
-| Managed file drift               | Run `nix develop -c write-files` then `git diff`                                                                             |
-| Unfree package blocked           | Add to `config.nixpkgs.allowedUnfreePackages` in `modules/meta/nixpkgs-allowed-unfree.nix`                                   |
-| "Cannot coerce null to string"   | See [Two-Context Problem](02-module-authoring.md#the-two-context-problem)                                                    |
+| Scenario                                                | Resolution                                                                                                                   |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| Git hooks fail in a new worktree                        | Run `nix develop` (auto-sync runs in shellHook) or run `nix develop -c bash scripts/hooks/sync-pre-commit-hooks.sh` manually |
+| Commit fails with `hooks were refreshed; retry commit.` | The `pre-commit-config-sync` hook resynced generated hook state after a hook source change; rerun the same `git commit`      |
+| Missing app reference                                   | Use `config.flake.lib.nixos.hasApp "name"` or `nix eval --json .#nixosModules.apps --apply builtins.attrNames`               |
+| Helper assertion failures                               | Run `nix flake check --accept-flake-config` and inspect `checks.<system>.helpers-exist`                                      |
+| Managed file drift                                      | Run `nix develop -c write-files` then `git diff`                                                                             |
+| Unfree package blocked                                  | Add to `config.nixpkgs.allowedUnfreePackages` in `modules/meta/nixpkgs-allowed-unfree.nix`                                   |
+| "Cannot coerce null to string"                          | See [Two-Context Problem](02-module-authoring.md#the-two-context-problem)                                                    |
 
 ## Introspection
 

--- a/modules/devshell.nix
+++ b/modules/devshell.nix
@@ -111,6 +111,7 @@
               config.packages."hook-mcp-docs-sync"
               config.packages."hook-gitleaks"
               config.packages."hook-luacheck"
+              config.packages."hook-pre-commit-config-sync"
 
               age
               sops

--- a/modules/meta/hooks/pre-commit-config-sync.nix
+++ b/modules/meta/hooks/pre-commit-config-sync.nix
@@ -1,0 +1,85 @@
+_: {
+  perSystem =
+    { pkgs, ... }:
+    {
+      packages.hook-pre-commit-config-sync = pkgs.writeShellApplication {
+        name = "hook-pre-commit-config-sync";
+        runtimeInputs = [
+          pkgs.git
+          pkgs.nix
+          pkgs.coreutils
+        ];
+        text = # bash
+          ''
+            set -euo pipefail
+
+            root=$(git rev-parse --show-toplevel)
+            cd "$root"
+
+            # core.hooksPath points linked worktrees at the shared hooks
+            # directory, matching the config resolution order used by the
+            # installed pre-commit and pre-push scripts.
+            hooks_dir=$(git rev-parse --path-format=absolute --git-path hooks)
+
+            # Only files consumed by the in-flight pre-commit run force a
+            # retry. Auxiliary hooks such as post-checkout are refreshed by
+            # the same sync but never participate in the current commit.
+            targets=(
+              "$root/.pre-commit-config.yaml"
+              "$hooks_dir/pre-commit-config.yaml"
+              "$hooks_dir/pre-commit"
+              "$hooks_dir/pre-push"
+            )
+
+            digest() {
+              if [ -e "$1" ]; then
+                sha256sum "$1" | cut -d' ' -f1
+              else
+                echo absent
+              fi
+            }
+
+            declare -a before=()
+            for target in "''${targets[@]}"; do
+              before+=("$(digest "$target")")
+            done
+
+            # Re-entering the devshell runs the full existing sync pipeline:
+            # the git-hooks.nix installation script, then
+            # scripts/hooks/sync-pre-commit-hooks.sh and
+            # scripts/hooks/install-git-hooks.sh from the shellHook.
+            sync_log=$(mktemp -t pre-commit-config-sync.XXXXXX)
+            if ! nix develop --accept-flake-config --offline -c true >"$sync_log" 2>&1; then
+              {
+                echo "pre-commit-config-sync: offline hook sync failed."
+                echo "If updated inputs or tools are missing from the local store, realize them once with network access:"
+                echo "  nix develop --accept-flake-config -c true"
+                echo "then retry the commit."
+                echo "--- nix output (tail; full log: $sync_log) ---"
+                tail -n 40 "$sync_log"
+              } >&2
+              exit 1
+            fi
+            rm -f "$sync_log"
+
+            changed=0
+            for i in "''${!targets[@]}"; do
+              if [ "$(digest "''${targets[$i]}")" != "''${before[$i]}" ]; then
+                if [ "$changed" -eq 0 ]; then
+                  echo "pre-commit-config-sync: generated hook state was stale for this commit:" >&2
+                fi
+                changed=1
+                echo "  refreshed: ''${targets[$i]}" >&2
+              fi
+            done
+
+            # The running pre-commit process already parsed the old config,
+            # so continuing would validate this commit against stale hooks.
+            if [ "$changed" -ne 0 ]; then
+              echo "hooks were refreshed; retry commit." >&2
+              exit 1
+            fi
+          '';
+      };
+    };
+}

--- a/modules/meta/pre-commit.nix
+++ b/modules/meta/pre-commit.nix
@@ -173,6 +173,25 @@ _: {
                 "manual"
               ];
             };
+
+            pre-commit-config-sync = {
+              enable = true;
+              name = "pre-commit-config-sync";
+              description = "Refresh generated hook state offline when hook sources change.";
+              entry = "${config.packages.hook-pre-commit-config-sync}/bin/hook-pre-commit-config-sync";
+              pass_filenames = false;
+              files = builtins.concatStringsSep "|" [
+                "^(flake\\.nix"
+                "flake\\.lock"
+                "\\.githooks/"
+                "scripts/hooks/"
+                "modules/devshell\\.nix"
+                "modules/devshell/"
+                "modules/meta/pre-commit\\.nix"
+                "modules/meta/treefmt\\.nix"
+                "modules/meta/hooks/)"
+              ];
+            };
           };
         };
       };


### PR DESCRIPTION
## Summary

Implements #266: a file-triggered pre-commit guard that keeps generated hook state synchronized when hook-related sources change.

The new `pre-commit-config-sync` hook (`modules/meta/hooks/pre-commit-config-sync.nix`, wired through `modules/meta/pre-commit.nix`) runs only when staged files can change generated hook behavior. It checksums the four active hook files (worktree-local `.pre-commit-config.yaml`, the shared fallback config in the git hooks directory, and the installed `pre-commit` / `pre-push` scripts), re-runs the existing sync pipeline via `nix develop --accept-flake-config --offline -c true` (git-hooks.nix installation script plus `scripts/hooks/sync-pre-commit-hooks.sh` and `scripts/hooks/install-git-hooks.sh`), and fails the commit with the exact message `hooks were refreshed; retry commit.` when any checksum changed. The failure is required for correctness: the in-flight pre-commit process already parsed the old config, so continuing would validate the commit against stale hooks.

Deliberate deviations from the issue text (the issue predates recent repo evolution):

- `modules/development/formatter.nix` no longer exists; the trigger list uses `modules/meta/treefmt.nix`, which now owns treefmt and `formatter-toolchain`.
- `.githooks/` and `modules/devshell/` were added to the trigger scope. Auxiliary hooks such as `post-checkout` are refreshed by the same sync run but excluded from the retry checksums because they never participate in the in-flight commit.
- A failed offline realization (for example a `flake.lock` bump whose devshell closure is not yet in the local store) aborts the commit with guidance to run `nix develop --accept-flake-config -c true` once with network access, keeping the commit path offline-only.

Measured cost when triggered: 2.5 to 4.5 seconds; unrelated staged files skip the hook entirely (`files` regex, `pass_filenames = false`).

## Test plan

- [x] `nix fmt`
- [x] `nix flake check --accept-flake-config --no-build --offline`
- [x] `nix build --accept-flake-config --offline .#hook-pre-commit-config-sync`
- [x] Direct hook run in a fresh worktree: first run exits 1, prints the refreshed files, and ends with `hooks were refreshed; retry commit.`; second run exits 0 (idempotent, 2.6s)
- [x] `nix develop --accept-flake-config --offline -c pre-commit validate-config .pre-commit-config.yaml`
- [x] Trigger scoping through the framework: `pre-commit run pre-commit-config-sync --files docs/architecture/06-reference.md` is Skipped (no files to check); `--files modules/meta/pre-commit.nix` runs and Passes
- [x] The introduction commit itself ran the guard live (staged files match the trigger set) and passed