### PR TITLE
fix(r2): prevent r2-cloud and rclone config ownership conflict

### DIFF
--- a/docs/r2-cloud/home-manager-r2-cloud.md
+++ b/docs/r2-cloud/home-manager-r2-cloud.md
@@ -12,6 +12,8 @@ inputs for user `vx`.
 - `modules/system76/imports.nix`
 - `modules/home-manager/nixos.nix`
 - `modules/home/r2-secrets.nix`
+- `modules/hm-apps/rclone.nix`
+- `modules/home-manager/rclone-config-ownership.nix`
 
 ## Not Covered
 
@@ -54,6 +56,28 @@ Operational effect (when enabled):
 - wrapper reads credentials/account ID from rendered runtime secret paths
 - wrapper can source Worker share admin variables from `explorer.env`
 
+## `rclone.conf` Ownership
+
+`modules/hm-apps/rclone.nix` renders `~/.config/rclone/rclone.conf` from a
+Home Manager activation step whenever `programs.rclone.extended.enable` is
+true (the common-host default from `modules/hosts/common/apps-enable.nix`).
+While that option is set, the activation writer is the single owner of the
+file.
+
+`programs.r2-cloud.enableRcloneRemote` (upstream default: `true`) renders
+`programs.r2-cloud.rcloneConfigPath`, which defaults to the same file. Two
+writers for one path let one generation silently drop the other's remotes,
+such as `gdrive`. `modules/hm-apps/rclone.nix` therefore asserts that
+`programs.r2-cloud` either keeps `enableRcloneRemote = false` (the value set
+by `modules/lib/r2-runtime.nix`) or points `rcloneConfigPath` at a different
+file. A second assertion keeps upstream `programs.rclone.remotes` empty so
+the upstream rclone-config generator cannot become another writer.
+
+The boundary is regression-checked by
+`checks.<system>."home-manager/rclone-config-ownership"` from
+`modules/home-manager/rclone-config-ownership.nix`, which evaluates the safe
+split, the colliding combination, and a relocated `rcloneConfigPath`.
+
 ## Relationship to HM Env Template
 
 `modules/home/r2-secrets.nix` renders `~/.config/cloudflare/r2/env` when
@@ -72,4 +96,6 @@ Treat these as two valid credential surfaces:
 rg -n '"r2-flake"\.homeManagerModules\.default' modules/lib/r2-runtime.nix
 rg -n 'r2Secrets|cloudflare/r2/env' modules/home-manager/nixos.nix modules/home/r2-secrets.nix
 rg -n 'programs\.r2-cloud' modules/lib/r2-runtime.nix
+rg -n 'r2CloudClaimsRenderedConfig' modules/hm-apps/rclone.nix
+nix build --accept-flake-config --no-link '.#checks.x86_64-linux."home-manager/rclone-config-ownership"'
 ```

--- a/docs/r2-cloud/validation-and-drift-checks.md
+++ b/docs/r2-cloud/validation-and-drift-checks.md
@@ -47,12 +47,17 @@ Expected result:
 ```bash
 nix flake check --accept-flake-config --no-build --offline
 nix build .#nixosConfigurations.system76.config.system.build.toplevel
+# Focused rclone.conf ownership check (also part of nix flake check)
+nix build --accept-flake-config --no-link '.#checks.x86_64-linux."home-manager/rclone-config-ownership"'
 ```
 
 Expected result:
 
-- both commands exit `0`
+- all commands exit `0`
 - no missing-option/module import errors for `r2` surfaces
+- the ownership check proves `modules/hm-apps/rclone.nix` stays the single
+  writer of `~/.config/rclone/rclone.conf` and that a colliding
+  `programs.r2-cloud.enableRcloneRemote` fails evaluation
 
 ## Runtime Presence Checks (after switch/boot)
 
@@ -78,6 +83,12 @@ Expected result (on a host with the runtime enabled):
 
 - `inputs."r2-flake".*` gated imports removed from `modules/lib/r2-runtime.nix`
 - `programs.r2-cloud` assignment removed from `modules/lib/r2-runtime.nix`
+- `enableRcloneRemote = false` removed from `modules/lib/r2-runtime.nix`
+  (rejected at host evaluation by the `modules/hm-apps/rclone.nix` assertion
+  once a host policy re-enables the runtime)
+- the `rclone.conf` ownership assertions removed from
+  `modules/hm-apps/rclone.nix` (caught by
+  `checks.<system>."home-manager/rclone-config-ownership"`)
 - a host's `modules/<host>/r2-runtime.nix` no longer calls `mkHostR2Module`
 - `secrets/r2.yaml` creation rule removed from `modules/security/sops-policy.nix`
 - secret template paths changed without consumer path updates

--- a/docs/r2-cloud/validation-and-drift-checks.md
+++ b/docs/r2-cloud/validation-and-drift-checks.md
@@ -56,8 +56,9 @@ Expected result:
 - all commands exit `0`
 - no missing-option/module import errors for `r2` surfaces
 - the ownership check proves `modules/hm-apps/rclone.nix` stays the single
-  writer of `~/.config/rclone/rclone.conf` and that a colliding
-  `programs.r2-cloud.enableRcloneRemote` fails evaluation
+  writer of `~/.config/rclone/rclone.conf`, that a colliding
+  `programs.r2-cloud.enableRcloneRemote` fails evaluation, and that a
+  populated `programs.rclone.remotes` fails evaluation
 
 ## Runtime Presence Checks (after switch/boot)
 

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -27,11 +27,35 @@ _: {
       r2SecretsEnabled = lib.attrByPath [ "home" "r2Secrets" "enable" ] false config;
       r2EndpointAvailable = r2SecretsEnabled && r2SecretExists;
       renderedRcloneConfig = "${config.xdg.configHome}/rclone/rclone.conf";
+      # Ownership guard inputs. The r2-flake Home Manager module declares
+      # programs.r2-cloud only when a host policy imports it, so probe with
+      # attrByPath instead of reading undeclared options.
+      r2CloudCfg = lib.attrByPath [ "programs" "r2-cloud" ] { } config;
+      r2CloudRcloneConfigPath =
+        if r2CloudCfg ? rcloneConfigPath then toString r2CloudCfg.rcloneConfigPath else "";
+      r2CloudClaimsRenderedConfig =
+        (r2CloudCfg.enable or false)
+        && (r2CloudCfg.enableRcloneRemote or false)
+        && r2CloudRcloneConfigPath == renderedRcloneConfig;
     in
     {
       config = lib.mkIf nixosEnabled (
         lib.mkMerge [
           {
+            # This module is the single writer of renderedRcloneConfig while
+            # programs.rclone.extended.enable is set; other generators must
+            # target a different path (see docs/r2-cloud/home-manager-r2-cloud.md).
+            assertions = [
+              {
+                assertion = !r2CloudClaimsRenderedConfig;
+                message = "programs.rclone.extended.enable makes modules/hm-apps/rclone.nix the owner of ${renderedRcloneConfig}, but programs.r2-cloud.enableRcloneRemote also renders programs.r2-cloud.rcloneConfigPath = ${r2CloudRcloneConfigPath}. Set programs.r2-cloud.enableRcloneRemote = false (as modules/lib/r2-runtime.nix does) or point programs.r2-cloud.rcloneConfigPath at a different file.";
+              }
+              {
+                assertion = config.programs.rclone.remotes == { };
+                message = "programs.rclone.remotes would make the upstream Home Manager rclone-config generator a second writer of ${renderedRcloneConfig} next to the activation writer in modules/hm-apps/rclone.nix. Keep remotes empty or retire the activation writer first.";
+              }
+            ];
+
             programs.rclone = {
               enable = true;
             };

--- a/modules/home-manager/rclone-config-ownership.nix
+++ b/modules/home-manager/rclone-config-ownership.nix
@@ -9,13 +9,17 @@
 
   - the safe split keeps the repo activation writer as the only owner,
   - the colliding combination fails evaluation,
-  - a relocated programs.r2-cloud.rcloneConfigPath is accepted.
+  - a relocated programs.r2-cloud.rcloneConfigPath is accepted,
+  - a populated programs.rclone.remotes fails evaluation (this one is
+    independent of the r2-flake input, so it runs even when that input is
+    unavailable).
 
-  The three scenarios differ only in the enableRcloneRemote/rcloneConfigPath
-  values, so a failing colliding scenario is attributable to the ownership
-  assertion without matching on its message text. Home Manager gates config
-  access behind its own failed-assertion throw, which is why the colliding
-  scenario is probed with tryEval instead of reading config.assertions.
+  Each scenario differs from a passing baseline only in the
+  enableRcloneRemote/rcloneConfigPath/remotes values, so a failing scenario
+  is attributable to the ownership assertions without matching on message
+  text. Home Manager gates config access behind its own failed-assertion
+  throw, which is why the failing scenarios are probed with tryEval instead
+  of reading config.assertions.
 */
 {
   config,
@@ -110,7 +114,22 @@ in
         )
       ];
 
+      # Uses the upstream option shape (remotes.<name>.config, with the
+      # required "type" key) so the scenario is valid for the Home Manager
+      # rclone module and the only eval failure it can hit is the
+      # remotes-ownership assertion in modules/hm-apps/rclone.nix.
+      remotesConflict = mkRcloneHome [
+        {
+          programs.rclone.remotes.smoke.config = {
+            type = "s3";
+            provider = "Cloudflare";
+          };
+        }
+      ];
+
       collidingEval = builtins.tryEval collidingRemote.config.home.username;
+
+      remotesConflictEval = builtins.tryEval remotesConflict.config.home.username;
     in
     {
       checks."home-manager/rclone-config-ownership" =
@@ -129,6 +148,9 @@ in
         assert lib.assertMsg (
           (!r2HomeModuleAvailable) || relocatedRemote.config.home.activation ? configureRcloneConfig
         ) "relocated programs.r2-cloud.rcloneConfigPath lost the repo activation writer";
+        assert lib.assertMsg (
+          !remotesConflictEval.success
+        ) "non-empty programs.rclone.remotes colliding with the repo-owned rclone.conf was not rejected";
         pkgs.runCommand "rclone-config-ownership" { } "echo ok > $out";
     };
 }

--- a/modules/home-manager/rclone-config-ownership.nix
+++ b/modules/home-manager/rclone-config-ownership.nix
@@ -1,0 +1,134 @@
+/*
+  Check: rclone.conf ownership boundary (issue #121).
+
+  modules/hm-apps/rclone.nix owns ~/.config/rclone/rclone.conf whenever
+  programs.rclone.extended.enable is set. The r2-flake Home Manager module can
+  render the same path through programs.r2-cloud.enableRcloneRemote (upstream
+  default: true). These checks evaluate synthetic Home Manager configurations
+  to prove that:
+
+  - the safe split keeps the repo activation writer as the only owner,
+  - the colliding combination fails evaluation,
+  - a relocated programs.r2-cloud.rcloneConfigPath is accepted.
+
+  The three scenarios differ only in the enableRcloneRemote/rcloneConfigPath
+  values, so a failing colliding scenario is attributable to the ownership
+  assertion without matching on its message text. Home Manager gates config
+  access behind its own failed-assertion throw, which is why the colliding
+  scenario is probed with tryEval instead of reading config.assertions.
+*/
+{
+  config,
+  inputs,
+  lib,
+  secretsRoot,
+  ...
+}:
+let
+  r2HomeModuleAvailable = lib.hasAttrByPath [
+    "r2-flake"
+    "homeManagerModules"
+    "default"
+  ] inputs;
+  r2HomeModule = lib.getAttrFromPath [
+    "r2-flake"
+    "homeManagerModules"
+    "default"
+  ] inputs;
+in
+{
+  perSystem =
+    { pkgs, ... }:
+    let
+      mkRcloneHome =
+        scenarioModules:
+        inputs.home-manager.lib.homeManagerConfiguration {
+          inherit pkgs;
+          modules = [
+            {
+              home = {
+                username = "hm-smoke";
+                homeDirectory = "/tmp/hm-smoke";
+                stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
+                enableNixpkgsReleaseCheck = false;
+              };
+              programs.home-manager.enable = true;
+            }
+            inputs.sops-nix.homeManagerModules.sops
+            config.flake.homeManagerModules.apps.rclone
+          ]
+          ++ scenarioModules;
+          extraSpecialArgs = {
+            inherit secretsRoot;
+            # Mirrors the host shape from modules/apps/rclone.nix: extended
+            # rclone enabled with the gdrive env secret declared system-side.
+            osConfig = {
+              programs.rclone.extended.enable = true;
+              sops.secrets."rclone/gdrive-env".path = "/run/secrets/rclone/gdrive-env";
+            };
+          };
+        };
+
+      # Mirrors the host wiring in modules/lib/r2-runtime.nix.
+      safeSplit = mkRcloneHome (
+        lib.optionals r2HomeModuleAvailable [
+          r2HomeModule
+          {
+            programs.r2-cloud = {
+              enable = true;
+              accountId = "smoke-account-id";
+              enableRcloneRemote = false;
+            };
+          }
+        ]
+      );
+
+      # Leaves enableRcloneRemote at its upstream default (true), the exact
+      # drift the ownership assertion must reject.
+      collidingRemote = mkRcloneHome [
+        r2HomeModule
+        {
+          programs.r2-cloud = {
+            enable = true;
+            accountId = "smoke-account-id";
+          };
+        }
+      ];
+
+      relocatedRemote = mkRcloneHome [
+        r2HomeModule
+        (
+          { config, ... }:
+          {
+            programs.r2-cloud = {
+              enable = true;
+              accountId = "smoke-account-id";
+              enableRcloneRemote = true;
+              rcloneConfigPath = "${config.xdg.configHome}/rclone/r2-cloud.conf";
+            };
+          }
+        )
+      ];
+
+      collidingEval = builtins.tryEval collidingRemote.config.home.username;
+    in
+    {
+      checks."home-manager/rclone-config-ownership" =
+        assert lib.assertMsg (
+          safeSplit.config.home.activation ? configureRcloneConfig
+        ) "rclone.conf safe split lost the modules/hm-apps/rclone.nix activation writer";
+        assert lib.assertMsg (
+          !(safeSplit.config.xdg.configFile ? "rclone/rclone.conf")
+        ) "rclone.conf safe split unexpectedly manages rclone.conf through xdg.configFile";
+        assert lib.assertMsg (
+          (!r2HomeModuleAvailable) || !collidingEval.success
+        ) "programs.r2-cloud.enableRcloneRemote colliding with the repo-owned rclone.conf was not rejected";
+        assert lib.assertMsg (
+          (!r2HomeModuleAvailable) || relocatedRemote.config.xdg.configFile ? "rclone/r2-cloud.conf"
+        ) "relocated programs.r2-cloud.rcloneConfigPath did not render rclone/r2-cloud.conf";
+        assert lib.assertMsg (
+          (!r2HomeModuleAvailable) || relocatedRemote.config.home.activation ? configureRcloneConfig
+        ) "relocated programs.r2-cloud.rcloneConfigPath lost the repo activation writer";
+        pkgs.runCommand "rclone-config-ownership" { } "echo ok > $out";
+    };
+}

--- a/modules/lib/r2-runtime.nix
+++ b/modules/lib/r2-runtime.nix
@@ -110,6 +110,11 @@
             accountIdFile = "/run/secrets/r2/account-id";
             credentialsFile = "/run/secrets/r2/credentials.env";
             explorerEnvFile = "/run/secrets/r2/explorer.env";
+            # Upstream defaults this to true, which would register a second
+            # writer for ~/.config/rclone/rclone.conf. That file is owned by
+            # modules/hm-apps/rclone.nix while programs.rclone.extended.enable
+            # is set (the common-host default); its assertion rejects the
+            # colliding combination.
             enableRcloneRemote = false;
           };
 


### PR DESCRIPTION
## Summary

Resolves #121.

`modules/hm-apps/rclone.nix` renders `~/.config/rclone/rclone.conf` from `home.activation.configureRcloneConfig` whenever `programs.rclone.extended.enable` is set (the common-host default). The external `r2-flake` Home Manager module renders `programs.r2-cloud.rcloneConfigPath` (default: the same file) through `xdg.configFile` when `programs.r2-cloud.enableRcloneRemote` is set, and that option defaults to `true` upstream. The only protection was the hardcoded `enableRcloneRemote = false` in `modules/lib/r2-runtime.nix`; losing that line while re-enabling the R2 runtime would silently drop remotes such as `gdrive`.

Instead of the blanket "never combine" rule proposed in the issue, the guard is path-based, so `enableRcloneRemote = true` with a relocated `rcloneConfigPath` stays supported (issue acceptance criterion 4):

- `modules/hm-apps/rclone.nix` asserts, while it owns the file, that `programs.r2-cloud` does not render the same path, probing the possibly-undeclared option surface with `attrByPath`. A second assertion keeps upstream `programs.rclone.remotes` empty so the upstream `rclone-config` generator cannot become another writer of the same file.
- `modules/lib/r2-runtime.nix` keeps the safe split (`enableRcloneRemote = false`) and now documents why that value is load-bearing.
- New flake check `checks.<system>.\"home-manager/rclone-config-ownership\"` evaluates three synthetic Home Manager configurations against the real `r2-flake` module: the safe split (activation writer present, no `xdg.configFile` entry), the colliding combination (evaluation must fail), and a relocated `rcloneConfigPath` (must evaluate with both writers on separate files). The scenarios differ only in the colliding values, so a failure is attributable to the guard without matching message text. The check degrades gracefully if the `r2-flake` input is ever removed.
- `docs/r2-cloud/home-manager-r2-cloud.md` documents the ownership boundary; `docs/r2-cloud/validation-and-drift-checks.md` records the check and drift signals.

Possible upstream follow-up (separate repo): flip the `enableRcloneRemote` default to `false` in `Bad3r/nix-R2-CloudFlare-Flake`; the consumer-side guard here is needed regardless since `rcloneConfigPath` is user-configurable.

## Test plan

- `nix fmt` (no diffs)
- `nix build --accept-flake-config --no-link '.#checks.x86_64-linux."home-manager/rclone-config-ownership"'` passes
- Negative test: with the ownership assertion neutered, the check fails with `programs.r2-cloud.enableRcloneRemote colliding with the repo-owned rclone.conf was not rejected`
- `nix flake check --accept-flake-config --no-build --offline` passes (`all checks passed!`)