### PR TITLE
chore(agents): promote generated skill and durable rules into shared scopes

### DIFF
--- a/modules/agents/claude-code/home-manager.nix
+++ b/modules/agents/claude-code/home-manager.nix
@@ -107,11 +107,16 @@ _: {
           ;
       };
 
-      # ── Commit Skill ──────────────────────────────────────────────────────
       claudeInstructions = agents.systemPrompt.render {
         vars.questionTool = "AskUserQuestion";
       };
-      commitSkillMd = agents.skills.commit.claude;
+
+      # Install every compiled skill that ships a Claude profile at
+      # ~/.claude/skills/<name>/SKILL.md, keyed off the shared registry so new
+      # skills need no per-client wiring here.
+      claudeSkillFiles = lib.mapAttrs' (
+        name: skill: lib.nameValuePair ".claude/skills/${name}/SKILL.md" { text = skill.claude; }
+      ) (lib.filterAttrs (_name: skill: skill ? claude) agents.skills.list);
     in
     {
       config = lib.mkIf nixosEnabled {
@@ -119,15 +124,12 @@ _: {
           file = {
             ".claude/CLAUDE.md".text = claudeInstructions;
 
-            ".claude/skills/commit/SKILL.md" = {
-              text = commitSkillMd;
-            };
-
             ".local/bin/claude" = {
               source = lib.getExe claudeRuntime.claudeWrapped;
               executable = true;
             };
           }
+          // claudeSkillFiles
           // lib.optionalAttrs greptilePluginRequested {
             ".local/bin/claude-greptile-mcp-headers" = {
               executable = true;

--- a/modules/agents/codex/home-manager.nix
+++ b/modules/agents/codex/home-manager.nix
@@ -85,11 +85,17 @@ _: {
         ''
       ];
 
-      commitSkillDir = (agents.skills.commit.codex pkgs).dir;
       codexInstructions = agents.systemPrompt.render {
         vars.questionTool = "request_user_input";
         vars.shellRules = codexShellRules;
       };
+
+      # Install every compiled skill that ships a Codex profile under
+      # ~/.config/agents/skills/<name> (discovered by Codex at ~/.agents/skills),
+      # keyed off the shared registry so new skills need no per-client wiring.
+      codexSkillDirs = lib.mapAttrs' (
+        name: skill: lib.nameValuePair "agents/skills/${name}" { source = (skill.codex pkgs).dir; }
+      ) (lib.filterAttrs (_name: skill: skill ? codex) agents.skills.list);
     in
     {
       config = lib.mkIf nixosEnabled {
@@ -199,10 +205,9 @@ _: {
 
           # User-level Codex instructions under XDG config home
           "codex/AGENTS.md".text = codexInstructions;
-
-          # Commit skill (user-scoped, discovered by SkillsManager at ~/.agents/skills/)
-          "agents/skills/commit".source = commitSkillDir;
-        };
+        }
+        # Skills (user-scoped, discovered by SkillsManager at ~/.agents/skills/)
+        // codexSkillDirs;
       };
     };
 }

--- a/modules/agents/skills/commit.nix
+++ b/modules/agents/skills/commit.nix
@@ -48,9 +48,6 @@ let
     - Never run `git clean -fd`.
     - Never run `git add -A` or `git add .`; stage explicit file paths only.
     - Never run `git push --force` to `main` or `master`.
-    - Never use `--no-verify` or `--no-gpg-sign`.
-    - Never disable commit signing through any other mechanism either: no `-c commit.gpgsign=false`, no `GIT_CONFIG_PARAMETERS`, no git config edits. The shared system prompt's retry-once-unsigned fallback for unreachable signers does not apply inside this skill; if signing fails, stop and report the signer error.
-    - Never run `rm` or `rm -rf`; use recoverable deletion tool `rip` when deletion is required.
     - Treat `flake.lock` as protected and exclude it from transfer, staging, and cleanup unless the user explicitly requests it.
     - When moving edits to a new worktree with explicit file paths, only those paths must become clean in the invoking checkout before staging or commit continues.
     - If the required cleanup scope remains dirty after transfer, fail hard and report remaining paths.

--- a/modules/agents/skills/commit.nix
+++ b/modules/agents/skills/commit.nix
@@ -49,6 +49,7 @@ let
     - Never run `git add -A` or `git add .`; stage explicit file paths only.
     - Never run `git push --force` to `main` or `master`.
     - Never use `--no-verify` or `--no-gpg-sign`.
+    - Never disable commit signing through any other mechanism either: no `-c commit.gpgsign=false`, no `GIT_CONFIG_PARAMETERS`, no git config edits. The shared system prompt's retry-once-unsigned fallback for unreachable signers does not apply inside this skill; if signing fails, stop and report the signer error.
     - Never run `rm` or `rm -rf`; use recoverable deletion tool `rip` when deletion is required.
     - Treat `flake.lock` as protected and exclude it from transfer, staging, and cleanup unless the user explicitly requests it.
     - When moving edits to a new worktree with explicit file paths, only those paths must become clean in the invoking checkout before staging or commit continues.

--- a/modules/agents/skills/nixos-hm-post-switch-repair.nix
+++ b/modules/agents/skills/nixos-hm-post-switch-repair.nix
@@ -1,0 +1,137 @@
+_:
+let
+  skillBody = ''
+    ## When To Use
+
+    Use when a NixOS switch completed but user-level Home Manager artifacts are
+    stale or degraded in an integrated setup (Home Manager runs as a NixOS
+    module, not the standalone `home-manager` CLI).
+
+    Triggers:
+
+    - A `~/.config/*` symlink points at an old or missing `/nix/store/...`
+      generation.
+    - User systemd units report `Unit to trigger vanished` or fail after
+      `./build.sh`, `nh os switch`, or `nixos-rebuild switch`.
+    - The user asks for a real Home Manager activation on top of an integrated
+      Home Manager setup.
+
+    Non-goals:
+
+    - Standalone `home-manager` CLI workflows outside the integrated NixOS
+      module setup.
+    - System-level unit repairs unrelated to the user manager or Home Manager
+      generation links.
+
+    If the argument names a specific user unit, target that unit; otherwise
+    default to the unit named in the symptom the user reported.
+
+    ## Gather Context
+
+    1. Confirm the setup is integrated Home Manager (the generation is built by
+       the system switch, not by a separate `home-manager switch`).
+    2. Capture the active Home Manager generation root:
+
+    ```bash
+    readlink -f ~/.local/state/home-manager/gcroots/current-home
+    ```
+
+    3. Check the drifted symlink or unit state, for example:
+
+    ```bash
+    readlink ~/.config/<app>/<file>
+    systemctl --user status <unit>
+    ```
+
+    4. Only if the above is inconclusive, inspect the journal around the switch
+       window:
+
+    ```bash
+    journalctl --user -n 150 --no-pager
+    ```
+
+    ## Repair Procedure
+
+    1. Reapply the current Home Manager generation directly by running its
+       activation script:
+
+    ```bash
+    "$(readlink -f ~/.local/state/home-manager/gcroots/current-home)/activate"
+    ```
+
+    2. Refresh user-manager state after activation:
+
+    ```bash
+    systemctl --user daemon-reload
+    systemctl --user reset-failed
+    ```
+
+    3. If a timer or service was degraded or missing, re-enable it (substitute
+       the reported unit):
+
+    ```bash
+    systemctl --user enable --now <unit>
+    ```
+
+    4. If files keep drifting after activation, resolve the ownership conflict:
+       check whether a competing dotfile manager (for example Dotbot) owns the
+       same path, then remove or disable that entry so Home Manager is the sole
+       owner, and rerun the activation script.
+
+    ## Efficiency Plan
+
+    1. Inspect `current-home` and one failing artifact before any broader log
+       dive.
+    2. Run one activation pass, then one systemd recovery pass; only read deeper
+       logs if failures persist.
+    3. Stop once both the link target and the unit state verify cleanly.
+
+    ## Pitfalls And Fixes
+
+    - Symptom: a config file links to a nonexistent store path.
+      - Likely cause: a competing owner re-symlinked the directory after the
+        Home Manager run.
+      - Fix: remove the overlap and rerun Home Manager activation.
+
+    - Symptom: `<unit>: Unit to trigger vanished`.
+      - Likely cause: the user manager re-executed during the switch with an
+        incomplete Home Manager reactivation.
+      - Fix: activate Home Manager, `daemon-reload`, `reset-failed`, then enable
+        the unit.
+
+    - Symptom: invoking `nixos-activation.service` does nothing for user links.
+      - Likely cause: wrong activation layer (that service does not own
+        user-level Home Manager links).
+      - Fix: run the generated Home Manager `activate` script instead.
+
+    ## Verification Checklist
+
+    - The repaired symlink resolves into the active Home Manager generation when
+      Home Manager owns the path.
+    - `systemctl --user is-active <unit>` returns `active`.
+    - `systemctl --user is-failed` does not list the recovered units.
+  '';
+in
+{
+  flake.lib.agents._internal.skills.raw.nixos-hm-post-switch-repair = {
+    name = "nixos-hm-post-switch-repair";
+    title = "NixOS Home Manager Post-Switch Repair";
+    description = "Reapply integrated Home Manager activation and recover drifted user systemd units or symlinks after a NixOS switch.";
+    body = skillBody;
+
+    codex = {
+      openaiYaml.interface = {
+        display_name = "HM Post-Switch Repair";
+        short_description = "Recover user HM links and units after a NixOS switch";
+        default_prompt = "Reapply the integrated Home Manager generation and recover drifted user systemd units or symlinks after a NixOS switch.";
+      };
+    };
+
+    claude = {
+      frontmatter = {
+        "allowed-tools" = "Bash, Read, Grep";
+        "argument-hint" = "[optional target unit]";
+      };
+    };
+  };
+}

--- a/modules/agents/skills/nixos-hm-post-switch-repair.nix
+++ b/modules/agents/skills/nixos-hm-post-switch-repair.nix
@@ -59,11 +59,13 @@ let
     "$(readlink -f ~/.local/state/home-manager/gcroots/current-home)/activate"
     ```
 
-    2. Refresh user-manager state after activation:
+    2. Refresh user-manager state after activation. Scope `reset-failed` to the
+       repaired unit; a bare `reset-failed` clears the failed state of every
+       user unit and hides unrelated failures from later diagnostics:
 
     ```bash
     systemctl --user daemon-reload
-    systemctl --user reset-failed
+    systemctl --user reset-failed <unit>
     ```
 
     3. If a timer or service was degraded or missing, re-enable it (substitute
@@ -96,8 +98,8 @@ let
     - Symptom: `<unit>: Unit to trigger vanished`.
       - Likely cause: the user manager re-executed during the switch with an
         incomplete Home Manager reactivation.
-      - Fix: activate Home Manager, `daemon-reload`, `reset-failed`, then enable
-        the unit.
+      - Fix: activate Home Manager, `daemon-reload`, `reset-failed <unit>`, then
+        enable the unit.
 
     - Symptom: invoking `nixos-activation.service` does nothing for user links.
       - Likely cause: wrong activation layer (that service does not own

--- a/modules/agents/system-prompt.nix
+++ b/modules/agents/system-prompt.nix
@@ -98,7 +98,12 @@ let
         an established pattern.
       - Default to ASCII in file edits. Add non-ASCII only when the file already uses
         it or the content requires it.
-      - Comments should explain non-obvious constraints, not restate the code.
+      - Comments carry only context a reader cannot infer from the code. Do not
+        restate what the code does, narrate a change (`matching the X wrapper`,
+        `bring to parity`, `was previously Y`), or dump reasoning. Prefer one or
+        two dense lines and delete the rest.
+      - When the user asks for output inside a file, write the artifact to that file
+        instead of replying only in chat.
       - Update existing documentation locations when a change introduces a public API,
         option, CLI flag, environment variable, workflow, external requirement,
         behavior visible to callers, or a surprising design constraint.
@@ -230,6 +235,9 @@ let
       - Use Conventional Commits: `type(scope): summary`.
       - Keep one logical concern per commit.
       - Record validation commands used.
+      - Never add AI-assistance trailers such as `Assisted-by` or other
+        automated-authorship metadata. If a project policy requires disclosure,
+        surface the requirement and ask before adding any trailer.
 
       Commit bodies must add information beyond the subject. Lead with the concrete
       reason. Answer at least one of:
@@ -241,6 +249,12 @@ let
       Cite version numbers, symbol names, and error messages. Avoid adjectives like
       "compatible" and "latest". Wrap body text at 120 columns. Never open with
       "Update the X..." because the subject already says it.
+
+      Never disable commit signing in global or repository git config to work around
+      a signer that is unreachable in a non-interactive session. If a signed commit
+      fails only for that reason, retry once with signing disabled for that single
+      invocation (`git -c commit.gpgsign=false commit ...`) and state that you did so
+      in the report.
     '';
 
     github = _vars: ''


### PR DESCRIPTION
## Summary

Resolves the audit in #224. Audited every auto-generated agent memory and
skill across the Claude project memories, the Codex runtime memories tree,
and the Codex plugin caches, then promoted only the durable, generalizable
items into repo-owned scopes and left project-specific noise as runtime
memory.

Audit outcome:

- The only generated Codex skill still present under
  `${XDG_CONFIG_HOME}/codex/memories/skills/` is
  `nixos-hm-post-switch-repair`. The issue's original candidates
  (`blocked-upstream-issues`, `nixos-app-module-addition`,
  `nix-store-corruption-triage`, `statix-fix`) no longer exist, confirming
  the issue's own note that its list may be stale.
- The `openai-curated` plugin skills (`github`, `gh-fix-ci`,
  `gh-address-comments`, `yeet`) are OpenAI-authored vendor packages
  (`openai/plugins`, MIT), not memory-derived output, and are duplicated
  across the legacy `~/.codex` and XDG `~/.config/codex` caches. Left
  untouched: they are not repo-owned state.
- The Claude project memories and Codex `raw_memories.md` / `MEMORY.md`
  are runtime discovery state (darah engagement facts, host-specific
  config, individual PRs). Left as memory; not promotable.

Promotions:

- **Standalone skill (repo-managed):** `nixos-hm-post-switch-repair` moved
  into `flake.lib.agents._internal.skills.raw` following the `commit.nix`
  pattern, generalized away from host-specific kitty/Dotbot/tldr-update
  details. Ships both a Claude profile (`~/.claude/skills/<name>/SKILL.md`)
  and a Codex profile (`~/.config/agents/skills/<name>`, with
  `agents/openai.yaml`).
- **Registry-driven wiring:** both client Home Manager modules now iterate
  `agents.skills.list` instead of hardcoding the commit skill, so any
  future skill installs for both agents with no per-client edits. This is
  the enabling refactor requested by the issue ("promote through the
  existing skill registry").
- **Shared system prompt** (`modules/agents/system-prompt.nix`): no
  AI-assistance commit trailers (`Assisted-by`); a scoped, surfaced
  non-interactive signing-failure fallback that never persists signing
  config; file-artifact delivery; and a sharpened comment rule forbidding
  change-narration and reasoning dumps (PR #310 feedback).

Note: the ambient signing-failure fallback in the system prompt is
deliberately scoped and must be surfaced in the report; the explicit
`/commit` skill stays stricter (never drops signing silently).

## Test plan

- `nix fmt` on the four changed files: 0 changed.
- `nix-instantiate --parse` on all four files: OK.
- `nix eval .#lib.agents.skills.list --apply builtins.attrNames`:
  `[ "commit" "nixos-hm-post-switch-repair" ]`.
- Rendered both client profiles of the new skill (`.claude` SKILL.md,
  `.codex` `openai.yaml` interface) and the baseline
  `lib.agents.systemPrompt.default` (contains all promoted rules).
- `nix build` of the codex skill dir: emits `SKILL.md` +
  `agents/openai.yaml`.
- `nix eval` of `system76` and `tpnix`
  `config.system.build.toplevel.drvPath`: both evaluate (pre-existing r2
  warnings only).
- `nix flake check --accept-flake-config --no-build --offline`:
  all checks passed.