### PR TITLE
feat(scripts): automate pruning of stale local branches and worktrees

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,6 +159,12 @@ Rule: Use a dedicated worktree and PR for changes. Do not commit directly to `ma
     `working trees containing submodules cannot be moved or removed`; the helper
     refuses dirty, ignored, or locked worktrees before using `--force` for that
     Git guard.
+- Bulk cleanup of leftovers
+  - Command: `scripts/prune-stale-worktrees.sh` (dry-run), `--apply` to act
+  - Scope: branches whose upstream is gone plus their worktrees; a semimonthly
+    `worktree-prune` user timer runs the safe apply mode on shared hosts.
+  - Reference: `docs/reference/worktree-prune.md` for safety guarantees and
+    recovery through `refs/prune-backup/*`.
 
 Branch type should follow Conventional Commits prefixes.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,12 @@ This repo has an initialized `secrets/` submodule, so plain
 checks for dirty, ignored, and locked worktrees first, then uses `--force` only
 for that Git submodule guard.
 
+Leftover branches whose remote branch was deleted, and the worktrees backing
+them, are pruned by `scripts/prune-stale-worktrees.sh` (dry-run by default)
+and by a semimonthly `worktree-prune` user timer on shared hosts. See
+`docs/reference/worktree-prune.md` for flags, safety guarantees, and recovery
+through `refs/prune-backup/*`.
+
 Branch type should follow Conventional Commits prefixes. PR bodies should
 include:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -156,6 +156,8 @@
   - Quick reference for available MCP tools including context7, cfdocs, cfbrowser, and deepwiki.
 - [reference/useful-commands.md](reference/useful-commands.md)
   - Collection of handy general-purpose CLI commands not tied to NixOS or this repository.
+- [reference/worktree-prune.md](reference/worktree-prune.md)
+  - Pruning of local branches with gone upstreams and their worktrees, the scheduled cleanup timer, safety guarantees, and recovery paths.
 
 ## Security
 

--- a/docs/reference/worktree-prune.md
+++ b/docs/reference/worktree-prune.md
@@ -1,0 +1,128 @@
+# Stale Worktree And Branch Pruning
+
+`scripts/prune-stale-worktrees.sh` detects local branches whose upstream
+tracking branch is gone after `git fetch --all --prune`, removes the worktree
+backing each branch under the scanned roots, and deletes the local branch. A
+Home Manager timer (`modules/hm-apps/worktree-prune.nix`, enabled for shared
+hosts by `modules/hosts/common/worktree-prune.nix`) runs the safe apply mode
+twice a month. Issue tracking:
+`https://github.com/Bad3r/nixos/issues/201`.
+
+## Manual Use
+
+Dry-run report over `$HOME/trees` (default, changes nothing, exits 0):
+
+```sh
+scripts/prune-stale-worktrees.sh
+```
+
+Scan the primary checkout too, so branches without a remaining worktree are
+included, then apply:
+
+```sh
+scripts/prune-stale-worktrees.sh --repo "$HOME/nixos" --apply
+```
+
+The rebuilt user environment also installs the same script as
+`prune-stale-worktrees` on `PATH`.
+
+## Flags
+
+- `--apply`: perform safe deletions. Default is dry-run.
+- `--force`: additionally prune candidates with unpushed commits or a dirty
+  worktree. Implies `--apply`. Never used by the timer.
+- `--root DIR` (repeatable): worktree roots to scan. Default `$HOME/trees`.
+- `--repo DIR` (repeatable): repositories to scan even without a worktree
+  under the roots. Missing paths are reported and skipped.
+- `--include GLOB` / `--exclude GLOB` (repeatable): branch-name filters.
+- `--backup-retention-days N`: expiry for `refs/prune-backup/*` (default 90,
+  `0` disables expiry).
+- `--json`: machine-readable summary on stdout instead of text lines.
+
+Exit codes: `0` success, `1` hard error, `2` apply mode was blocked somewhere:
+a candidate hit a safety check, a fetch failed, or a `--repo` path was
+missing. The systemd unit treats `2` as success because skipped dirty
+candidates are expected on a schedule; persistent fetch failures therefore
+only surface in the journal, not as a failed unit.
+
+## Safety Model
+
+- Candidates are only branches whose configured upstream is `[gone]` after a
+  successful `git fetch --all --prune`. A failed fetch skips the whole
+  repository for that run.
+- `main`, `master`, the repository default branch, and the branch checked out
+  in the primary worktree are never touched.
+- Worktree removal goes through `scripts/git-worktree-remove-safe.sh`, which
+  refuses dirty, untracked, non-disposable-ignored, locked, and
+  dirty-submodule state. The helper is the final arbiter: a worktree the
+  dry-run lists as removable can still be refused at apply time, reported as
+  `reason=helper-refused`.
+- Every deleted branch tip is first preserved as
+  `refs/prune-backup/<branch>/<epoch>`. This repository squash-merges PRs, so
+  `git branch -d` cannot confirm merged-ness; recoverability comes from the
+  backup ref instead, and deletion uses `-D` after the backup exists.
+- `pushed=verified` means the branch tip matched the last-seen upstream SHA
+  captured before the prune fetch. `pushed=unpushed` blocks the candidate
+  without `--force`. `pushed=unverified` means the tracking ref was already
+  pruned earlier, so the tip cannot be compared; the candidate is still
+  cleaned in apply mode because the backup ref keeps it recoverable.
+- `--force` stashes dirty worktree state
+  (`git stash push --include-untracked`) before removal, so even forced
+  cleanup keeps the work recoverable via `git stash list`.
+- Orphan directories under the roots (not a worktree, or a broken `gitdir`
+  link such as a worktree whose owning repository moved) are reported and
+  never deleted.
+- Empty container directories left behind under a root are removed with
+  `rmdir`, which cannot delete content.
+
+## flake.lock Exception
+
+A stale worktree whose only dirty path is `flake.lock` counts as disposable
+lockfile drift: the drift is discarded with
+`git restore --source=HEAD --staged --worktree -- flake.lock` and cleanup
+continues on the safe path, reported as `flake-lock-drift=discarded`. If any
+other path is dirty, including an untracked `flake.lock`, the candidate is
+skipped without `--force`.
+
+## Scheduled Cleanup
+
+`programs.worktreePrune` (Home Manager) provisions a user service and timer:
+
+- `OnCalendar=*-*-01,15 05:00:00` by default. systemd has no `biweekly`
+  shorthand; the 1st and 15th give an approximately two-week cadence.
+- `Persistent=true`, so a missed run fires after the next login or boot.
+- The service runs `prune-stale-worktrees --apply` with the configured roots
+  and repos, never `--force`, with `GIT_TERMINAL_PROMPT=0` and a 30 minute
+  timeout.
+- Shared hosts enable it for the primary user with the `~/nixos` checkout as
+  an explicit `--repo`. Disable per host or per user by setting
+  `programs.worktreePrune.enable = false;` at a higher priority, or adjust
+  `roots`, `repos`, `schedule`, and `backupRetentionDays`.
+
+Inspect scheduled runs:
+
+```sh
+systemctl --user list-timers worktree-prune.timer
+journalctl --user -u worktree-prune.service
+```
+
+## Recovery
+
+- Deleted branch: `git branch <name> "$(git rev-parse 'refs/prune-backup/<name>/<epoch>')"`.
+  List backups with `git for-each-ref refs/prune-backup`.
+- Force-stashed worktree state: `git stash list` shows
+  `prune-stale-worktrees: <branch> <timestamp>` entries; restore with
+  `git stash apply`.
+- Backup refs expire after `--backup-retention-days` (default 90) on later
+  apply runs. Discarded `flake.lock` drift is not preserved.
+
+## Tests
+
+```sh
+tests/prune-stale-worktrees/run.sh
+```
+
+The suite covers dry-run reporting, safe apply, protected refs, the unpushed
+guard, dirty and `flake.lock`-only handling, `--force` stash behavior,
+branch-only deletion, multi-root scans, orphan reporting, backup expiry,
+fetch failure, filters, and JSON output validity.

--- a/modules/hm-apps/worktree-prune.nix
+++ b/modules/hm-apps/worktree-prune.nix
@@ -83,9 +83,13 @@
         };
 
         backupRetentionDays = lib.mkOption {
-          type = lib.types.ints.positive;
+          type = lib.types.ints.unsigned;
           default = 90;
-          description = "Days to keep refs/prune-backup/* refs of deleted branches.";
+          description = ''
+            Days to keep refs/prune-backup/* refs of deleted branches. 0
+            disables expiry (keep backups indefinitely), matching the CLI's
+            --backup-retention-days 0.
+          '';
         };
       };
 

--- a/modules/hm-apps/worktree-prune.nix
+++ b/modules/hm-apps/worktree-prune.nix
@@ -1,0 +1,130 @@
+/*
+  Scheduled cleanup of local branches whose upstream is gone on the remote,
+  together with the worktrees backing them under the configured roots.
+  Wraps scripts/prune-stale-worktrees.sh; the timer only ever runs the safe
+  --apply mode, never --force. Deleted tips stay recoverable under
+  refs/prune-backup/ for backupRetentionDays.
+*/
+{
+  flake.homeManagerModules.apps."worktree-prune" =
+    {
+      lib,
+      pkgs,
+      config,
+      ...
+    }:
+    let
+      cfg = config.programs.worktreePrune;
+
+      worktreeRemoveSafe = pkgs.writeShellApplication {
+        name = "git-worktree-remove-safe";
+        runtimeInputs = with pkgs; [
+          git
+          coreutils
+          gnused
+        ];
+        text = builtins.readFile ../../scripts/git-worktree-remove-safe.sh;
+      };
+
+      pruneScript = pkgs.writeShellApplication {
+        name = "prune-stale-worktrees";
+        runtimeInputs = with pkgs; [
+          git
+          coreutils
+          util-linux
+          jq
+          worktreeRemoveSafe
+        ];
+        text = builtins.readFile ../../scripts/prune-stale-worktrees.sh;
+      };
+
+      applyArgs = [
+        "--apply"
+        "--backup-retention-days"
+        (toString cfg.backupRetentionDays)
+      ]
+      ++ lib.concatMap (root: [
+        "--root"
+        root
+      ]) cfg.roots
+      ++ lib.concatMap (repo: [
+        "--repo"
+        repo
+      ]) cfg.repos;
+    in
+    {
+      options.programs.worktreePrune = {
+        enable = lib.mkEnableOption "scheduled pruning of stale local branches and worktrees";
+
+        roots = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ "${config.home.homeDirectory}/trees" ];
+          description = "Worktree roots scanned for stale worktrees.";
+        };
+
+        repos = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          example = [ "/home/user/nixos" ];
+          description = ''
+            Repositories scanned for gone branches even when they have no
+            worktree under the roots. Missing paths are reported and skipped.
+          '';
+        };
+
+        schedule = lib.mkOption {
+          type = lib.types.str;
+          default = "*-*-01,15 05:00:00";
+          description = ''
+            Systemd calendar expression for the cleanup timer. systemd has no
+            "biweekly" shorthand; the default runs on the 1st and 15th of each
+            month for an approximately two-week cadence.
+          '';
+        };
+
+        backupRetentionDays = lib.mkOption {
+          type = lib.types.ints.positive;
+          default = 90;
+          description = "Days to keep refs/prune-backup/* refs of deleted branches.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = cfg.roots != [ ] || cfg.repos != [ ];
+            message = "programs.worktreePrune needs at least one root or repo to scan.";
+          }
+        ];
+
+        home.packages = [ pruneScript ];
+
+        systemd.user = {
+          services.worktree-prune = {
+            Unit = {
+              Description = "Prune stale local branches and worktrees";
+              X-SwitchMethod = "keep-old";
+            };
+            Service = {
+              Type = "oneshot";
+              ExecStart = "${pruneScript}/bin/prune-stale-worktrees ${lib.escapeShellArgs applyArgs}";
+              Environment = [ "GIT_TERMINAL_PROMPT=0" ];
+              # Exit 2 means candidates were skipped by a safety check, which
+              # is expected on a schedule (dirty WIP trees stay in place).
+              SuccessExitStatus = "2";
+              TimeoutStartSec = "30m";
+            };
+          };
+
+          timers.worktree-prune = {
+            Unit.Description = "Prune stale local branches and worktrees timer";
+            Timer = {
+              OnCalendar = cfg.schedule;
+              Persistent = true;
+            };
+            Install.WantedBy = [ "timers.target" ];
+          };
+        };
+      };
+    };
+}

--- a/modules/hosts/common/worktree-prune.nix
+++ b/modules/hosts/common/worktree-prune.nix
@@ -1,0 +1,32 @@
+# Biweekly-ish cleanup of stale branches and worktrees for the primary user.
+# The nixos checkout is scanned explicitly so gone branches are pruned even
+# when no worktree for them remains under ~/trees; hosts without that path
+# get a reported, non-fatal skip.
+{
+  config,
+  lib,
+  metaOwner,
+  ...
+}:
+let
+  worktreePruneModule =
+    config.flake.homeManagerModules.apps."worktree-prune"
+      or (throw "Home Manager app module 'worktree-prune' not found in flake.homeManagerModules.apps");
+
+  body = _: {
+    config = {
+      home-manager = {
+        extraAppImports = lib.mkAfter [ "worktree-prune" ];
+        sharedModules = lib.mkAfter [ worktreePruneModule ];
+
+        users.${metaOwner.username}.programs.worktreePrune = {
+          enable = true;
+          repos = [ "/home/${metaOwner.username}/nixos" ];
+        };
+      };
+    };
+  };
+in
+{
+  flake.nixosModules.hosts-common.imports = [ body ];
+}

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -13,6 +13,9 @@ repository-wide workflow, commit, PR, safety, and Nix module rules.
 - `hooks/`: generated-hook installation and sync helpers used by the dev shell.
 - `updater/`: shared Python library for package updater scripts. Reuse these
   helpers instead of duplicating HTTP, hash, Nix, npm, or version parsing logic.
+- `prune-stale-worktrees.sh`: prunes branches with gone upstreams and their
+  worktrees; wrapped by the `worktree-prune` Home Manager timer. Tests live in
+  `tests/prune-stale-worktrees/run.sh`; see `docs/reference/worktree-prune.md`.
 - Top-level scripts are task-specific entrypoints. Keep them runnable from the
   repository root and avoid hidden dependencies on the current shell session.
 

--- a/scripts/prune-stale-worktrees.sh
+++ b/scripts/prune-stale-worktrees.sh
@@ -1,0 +1,681 @@
+#!/usr/bin/env bash
+# Prunes local branches whose upstream is gone on the remote, together with
+# the worktrees backing them. Dry-run by default; --apply performs safe
+# deletions; --force additionally handles unpushed commits and dirty
+# worktrees after preserving their state (backup ref, stash).
+#
+# Deleted branch tips are always preserved under refs/prune-backup/<branch>/<epoch>
+# because this repository squash-merges PRs, so `git branch -d` can never
+# confirm merged-ness and recoverability must come from backups instead.
+set -Eeuo pipefail
+export LC_ALL=C
+
+prog_name="${0##*/}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+  cat >&2 <<EOF
+usage: ${prog_name} [options]
+
+Detects local branches whose upstream tracking branch is gone after
+'git fetch --all --prune', then removes the matching worktree under the
+scanned roots and deletes the local branch. Dry-run unless --apply.
+
+options:
+  --apply                     perform safe deletions (default: dry-run)
+  --force                     also prune candidates with unpushed commits or a
+                              dirty worktree; unpushed tips are kept as backup
+                              refs and dirty state is stashed first (implies
+                              --apply)
+  --root DIR                  worktree root to scan (repeatable,
+                              default: \$HOME/trees)
+  --repo DIR                  repository to scan even when it has no worktree
+                              under the roots (repeatable)
+  --include GLOB              only consider branches matching GLOB (repeatable)
+  --exclude GLOB              skip branches matching GLOB (repeatable)
+  --backup-retention-days N   expire refs/prune-backup/* after N days
+                              (default: 90, 0 disables expiry)
+  --json                      emit a machine-readable summary on stdout
+  -h, --help                  show this help
+
+exit codes:
+  0  success (dry-run always exits 0 unless a hard error occurs)
+  1  hard error (usage, lock contention, missing helper)
+  2  apply mode: a candidate was blocked by a safety check or a repository
+     could not be scanned (failed fetch, missing --repo path)
+EOF
+}
+
+error_msg() {
+  printf '%s: %s\n' "${prog_name}" "$1" >&2
+}
+
+die() {
+  error_msg "$1"
+  exit 1
+}
+
+mode=dry-run
+declare -a roots=()
+declare -a extra_repos=()
+declare -a include_globs=()
+declare -a exclude_globs=()
+backup_retention_days=90
+json_output=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  --apply)
+    if [[ ${mode} == dry-run ]]; then mode=apply; fi
+    shift
+    ;;
+  --force)
+    mode=force
+    shift
+    ;;
+  --root)
+    [[ $# -ge 2 ]] || die "--root requires a directory argument"
+    roots+=("$2")
+    shift 2
+    ;;
+  --repo)
+    [[ $# -ge 2 ]] || die "--repo requires a directory argument"
+    extra_repos+=("$2")
+    shift 2
+    ;;
+  --include)
+    [[ $# -ge 2 ]] || die "--include requires a glob argument"
+    include_globs+=("$2")
+    shift 2
+    ;;
+  --exclude)
+    [[ $# -ge 2 ]] || die "--exclude requires a glob argument"
+    exclude_globs+=("$2")
+    shift 2
+    ;;
+  --backup-retention-days)
+    [[ $# -ge 2 && $2 =~ ^[0-9]+$ ]] || die "--backup-retention-days requires a non-negative integer"
+    backup_retention_days="$2"
+    shift 2
+    ;;
+  --json)
+    json_output=true
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+  esac
+done
+
+if [[ ${#roots[@]} -eq 0 ]]; then
+  roots=("${HOME}/trees")
+fi
+
+if ${json_output} && ! command -v jq >/dev/null 2>&1; then
+  die "--json requires jq on PATH"
+fi
+
+find_remove_helper() {
+  if [[ -n ${PRUNE_WORKTREE_REMOVE_HELPER:-} ]]; then
+    printf '%s\n' "${PRUNE_WORKTREE_REMOVE_HELPER}"
+    return 0
+  fi
+  if [[ -x "${script_dir}/git-worktree-remove-safe.sh" ]]; then
+    printf '%s\n' "${script_dir}/git-worktree-remove-safe.sh"
+    return 0
+  fi
+  if command -v git-worktree-remove-safe >/dev/null 2>&1; then
+    command -v git-worktree-remove-safe
+    return 0
+  fi
+  return 1
+}
+
+remove_helper="$(find_remove_helper)" ||
+  die "git-worktree-remove-safe helper not found (set PRUNE_WORKTREE_REMOVE_HELPER)"
+
+lock_dir="${XDG_RUNTIME_DIR:-${TMPDIR:-/tmp}}"
+lock_file="${lock_dir}/prune-stale-worktrees.$(id -u).lock"
+exec 200>"${lock_file}"
+flock -n 200 || die "another instance is already running (lock: ${lock_file})"
+
+now_epoch="$(date +%s)"
+
+# Global counters and record accumulators.
+count_removed=0
+count_would_remove=0
+count_blocked=0
+count_orphans=0
+count_still_remote=0
+count_no_upstream=0
+count_backups_expired=0
+
+declare -a repo_records=()
+declare -a branch_records=()
+declare -a orphan_records=()
+
+log_line() {
+  if ! ${json_output}; then
+    printf '%s\n' "$1"
+  fi
+}
+
+record_repo() {
+  local path fetch_state
+  path="$1"
+  fetch_state="$2"
+  repo_records+=("${path}"$'\t'"${fetch_state}")
+  log_line "repo=${path} fetch=${fetch_state}"
+}
+
+# record_branch <repo> <branch> <worktree> <state> <reason> <pushed> <drift>
+record_branch() {
+  local repo branch worktree state reason pushed drift line
+  repo="$1"
+  branch="$2"
+  worktree="$3"
+  state="$4"
+  reason="$5"
+  pushed="$6"
+  drift="$7"
+  branch_records+=("${repo}"$'\t'"${branch}"$'\t'"${worktree}"$'\t'"${state}"$'\t'"${reason}"$'\t'"${pushed}"$'\t'"${drift}")
+  line="branch=${branch} repo=${repo} worktree=${worktree} state=${state}"
+  [[ -n ${reason} ]] && line+=" reason=${reason}"
+  [[ -n ${pushed} ]] && line+=" pushed=${pushed}"
+  [[ -n ${drift} ]] && line+=" flake-lock-drift=${drift}"
+  log_line "${line}"
+}
+
+record_orphan() {
+  local path reason
+  path="$1"
+  reason="$2"
+  orphan_records+=("${path}"$'\t'"${reason}")
+  count_orphans=$((count_orphans + 1))
+  log_line "orphan=${path} reason=${reason}"
+}
+
+canonical() {
+  readlink -f -- "$1"
+}
+
+is_under_roots() {
+  local path root canon_root
+  path="$1"
+  for root in "${roots[@]}"; do
+    canon_root="$(canonical "${root}" 2>/dev/null)" || continue
+    if [[ ${path} == "${canon_root}"/* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+branch_matches_filters() {
+  local branch glob matched
+  branch="$1"
+  if [[ ${#include_globs[@]} -gt 0 ]]; then
+    matched=false
+    for glob in "${include_globs[@]}"; do
+      # shellcheck disable=SC2053 # glob matching is intentional
+      if [[ ${branch} == ${glob} ]]; then
+        matched=true
+        break
+      fi
+    done
+    ${matched} || return 1
+  fi
+  for glob in "${exclude_globs[@]}"; do
+    # shellcheck disable=SC2053 # glob matching is intentional
+    if [[ ${branch} == ${glob} ]]; then
+      return 1
+    fi
+  done
+  return 0
+}
+
+# Discovery: map worktree directories under the roots to their owning
+# repositories (the main worktree that holds the shared .git directory).
+declare -A repo_set=()
+
+register_worktree_dir() {
+  local dir common_dir owner
+  dir="$1"
+  if ! common_dir="$(git -C "${dir}" rev-parse --git-common-dir 2>/dev/null)"; then
+    record_orphan "${dir}" broken-gitdir
+    return
+  fi
+  if [[ ${common_dir} != /* ]]; then
+    common_dir="${dir}/${common_dir}"
+  fi
+  common_dir="$(canonical "${common_dir}")"
+  owner="$(dirname "${common_dir}")"
+  if [[ "$(basename "${common_dir}")" != ".git" ]]; then
+    # Bare repository or unusual layout; branch cleanup still works from the
+    # git directory itself, worktree removal is guarded per candidate.
+    owner="${common_dir}"
+  fi
+  repo_set["${owner}"]=1
+}
+
+scan_roots() {
+  local root canon_root level1 level2 found_worktree
+  for root in "${roots[@]}"; do
+    canon_root="$(canonical "${root}" 2>/dev/null)" || {
+      error_msg "root does not exist, skipping: ${root}"
+      continue
+    }
+    for level1 in "${canon_root}"/*/; do
+      [[ -d ${level1} ]] || continue
+      level1="${level1%/}"
+      if [[ -e "${level1}/.git" ]]; then
+        register_worktree_dir "${level1}"
+        continue
+      fi
+      found_worktree=false
+      for level2 in "${level1}"/*/; do
+        [[ -d ${level2} ]] || continue
+        level2="${level2%/}"
+        if [[ -e "${level2}/.git" ]]; then
+          register_worktree_dir "${level2}"
+          found_worktree=true
+        else
+          record_orphan "${level2}" not-a-worktree
+        fi
+      done
+      # Containers without any worktree are left alone; their contents were
+      # already reported as orphans.
+      ${found_worktree} || true
+    done
+  done
+}
+
+scan_roots
+
+for extra in ${extra_repos[@]+"${extra_repos[@]}"}; do
+  if ! canon="$(canonical "${extra}" 2>/dev/null)" || [[ ! -d ${canon} ]]; then
+    record_repo "${extra}" missing
+    count_blocked=$((count_blocked + 1))
+    continue
+  fi
+  if ! git -C "${canon}" rev-parse --git-dir >/dev/null 2>&1; then
+    record_repo "${canon}" not-a-repo
+    count_blocked=$((count_blocked + 1))
+    continue
+  fi
+  repo_set["${canon}"]=1
+done
+
+# Per-repo working state, populated by load_repo_state.
+declare -A pre_fetch_sha=()
+declare -A branch_worktree=()
+declare -A worktree_locked=()
+main_worktree=""
+main_branch=""
+
+snapshot_remote_refs() {
+  local repo line
+  pre_fetch_sha=()
+  while IFS= read -r line; do
+    [[ -n ${line} ]] || continue
+    pre_fetch_sha["${line%% *}"]="${line#* }"
+  done < <(git -C "$1" for-each-ref --format='%(refname:short) %(objectname)' refs/remotes)
+}
+
+load_worktree_map() {
+  local repo entry current_path first
+  repo="$1"
+  branch_worktree=()
+  worktree_locked=()
+  main_worktree=""
+  main_branch=""
+  current_path=""
+  first=true
+  while IFS= read -r -d '' entry; do
+    case "${entry}" in
+    worktree\ *)
+      current_path="$(canonical "${entry#worktree }")"
+      if ${first}; then
+        main_worktree="${current_path}"
+        first=false
+      fi
+      ;;
+    branch\ refs/heads/*)
+      branch_worktree["${entry#branch refs/heads/}"]="${current_path}"
+      if [[ ${current_path} == "${main_worktree}" ]]; then
+        main_branch="${entry#branch refs/heads/}"
+      fi
+      ;;
+    locked*)
+      worktree_locked["${current_path}"]=1
+      ;;
+    esac
+  done < <(git -C "${repo}" worktree list --porcelain -z)
+}
+
+default_branch_of() {
+  local repo head_ref
+  if head_ref="$(git -C "$1" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null)"; then
+    printf '%s\n' "${head_ref#refs/remotes/origin/}"
+  fi
+}
+
+create_backup_ref() {
+  local repo branch tip
+  repo="$1"
+  branch="$2"
+  tip="$3"
+  git -C "${repo}" update-ref "refs/prune-backup/${branch}/${now_epoch}" "${tip}"
+}
+
+expire_backup_refs() {
+  local repo refname epoch cutoff
+  repo="$1"
+  [[ ${backup_retention_days} -gt 0 ]] || return 0
+  cutoff=$((now_epoch - backup_retention_days * 86400))
+  while IFS= read -r refname; do
+    [[ -n ${refname} ]] || continue
+    epoch="${refname##*/}"
+    [[ ${epoch} =~ ^[0-9]+$ ]] || continue
+    if [[ ${epoch} -lt ${cutoff} ]]; then
+      git -C "${repo}" update-ref -d "${refname}" || return 1
+      count_backups_expired=$((count_backups_expired + 1))
+      log_line "backup-expired=${refname} repo=${repo}"
+    fi
+  done < <(git -C "${repo}" for-each-ref --format='%(refname)' refs/prune-backup)
+}
+
+# classify_worktree_status <worktree>
+# Sets status_class to clean | flake-lock-only | dirty.
+classify_worktree_status() {
+  local worktree status line xy path
+  worktree="$1"
+  if ! status="$(git -C "${worktree}" status --porcelain=v1 --untracked-files=normal 2>/dev/null)"; then
+    # A worktree whose state cannot be read is skip-and-report, not a crash.
+    status_class=dirty
+    return
+  fi
+  if [[ -z ${status} ]]; then
+    status_class=clean
+    return
+  fi
+  if [[ "$(wc -l <<<"${status}")" -eq 1 ]]; then
+    line="${status}"
+    xy="${line:0:2}"
+    path="${line:3}"
+    if [[ ${path} == "flake.lock" && ${xy} =~ ^[\ MD][\ MD]$ && ${xy} != "  " ]]; then
+      status_class=flake-lock-only
+      return
+    fi
+  fi
+  status_class=dirty
+}
+
+discard_flake_lock_drift() {
+  # Scoped discard explicitly requested by issue #201: flake.lock as the sole
+  # dirty path in a stale worktree is disposable lockfile drift.
+  git -C "$1" restore --source=HEAD --staged --worktree -- flake.lock
+}
+
+stash_dirty_state() {
+  local worktree branch
+  worktree="$1"
+  branch="$2"
+  git -C "${worktree}" stash push --include-untracked \
+    -m "prune-stale-worktrees: ${branch} $(date -u +%Y%m%dT%H%M%SZ)" >/dev/null
+}
+
+remove_worktree_via_helper() {
+  local repo worktree
+  repo="$1"
+  worktree="$2"
+  helper_output="$(cd "${repo}" && "${remove_helper}" "${worktree}" 2>&1)"
+}
+
+remove_empty_container() {
+  local parent
+  parent="$(dirname "$1")"
+  if is_under_roots "${parent}" && [[ -d ${parent} && -z "$(ls -A "${parent}")" ]]; then
+    rmdir "${parent}"
+    log_line "removed-empty-dir=${parent}"
+  fi
+}
+
+delete_branch() {
+  local repo branch tip
+  repo="$1"
+  branch="$2"
+  tip="$3"
+  # The explicit return keeps the backup mandatory even when this function
+  # runs in an if-condition context where errexit is suspended.
+  create_backup_ref "${repo}" "${branch}" "${tip}" || return 1
+  git -C "${repo}" branch -q -D "${branch}"
+}
+
+process_branch() {
+  local repo branch upstream tip worktree pushed drift reason status_class
+  repo="$1"
+  branch="$2"
+  upstream="$3"
+  tip="$4"
+
+  worktree="${branch_worktree[${branch}]:-none}"
+  drift=""
+
+  if [[ -n ${pre_fetch_sha[${upstream}]:-} ]]; then
+    if [[ ${pre_fetch_sha[${upstream}]} == "${tip}" ]]; then
+      pushed=verified
+    else
+      pushed=unpushed
+    fi
+  else
+    pushed=unverified
+  fi
+
+  if ! branch_matches_filters "${branch}"; then
+    record_branch "${repo}" "${branch}" "${worktree}" skipped excluded "${pushed}" ""
+    return
+  fi
+
+  if [[ ${branch} == main || ${branch} == master || ${branch} == "${repo_default_branch}" ]]; then
+    record_branch "${repo}" "${branch}" "${worktree}" skipped protected "${pushed}" ""
+    return
+  fi
+
+  if [[ ${branch} == "${main_branch}" || ${worktree} == "${main_worktree}" ]]; then
+    record_branch "${repo}" "${branch}" "${worktree}" skipped checked-out "${pushed}" ""
+    return
+  fi
+
+  if [[ ${pushed} == unpushed && ${mode} != force ]]; then
+    record_branch "${repo}" "${branch}" "${worktree}" skipped unpushed "${pushed}" ""
+    count_blocked=$((count_blocked + 1))
+    return
+  fi
+
+  if [[ ${worktree} != none ]]; then
+    if ! is_under_roots "${worktree}"; then
+      record_branch "${repo}" "${branch}" "${worktree}" skipped outside-roots "${pushed}" ""
+      count_blocked=$((count_blocked + 1))
+      return
+    fi
+    if [[ -n ${worktree_locked[${worktree}]:-} ]]; then
+      record_branch "${repo}" "${branch}" "${worktree}" skipped locked "${pushed}" ""
+      count_blocked=$((count_blocked + 1))
+      return
+    fi
+    if [[ ! -d ${worktree} ]]; then
+      # Registration survives but the directory is gone; branch-only cleanup,
+      # 'git worktree prune' clears the stale registration afterwards.
+      worktree=missing
+    fi
+  fi
+
+  if [[ ${worktree} != none && ${worktree} != missing ]]; then
+    classify_worktree_status "${worktree}"
+    case "${status_class}" in
+    flake-lock-only)
+      drift=present
+      ;;
+    dirty)
+      if [[ ${mode} != force ]]; then
+        record_branch "${repo}" "${branch}" "${worktree}" skipped dirty "${pushed}" ""
+        count_blocked=$((count_blocked + 1))
+        return
+      fi
+      ;;
+    esac
+
+    if [[ ${mode} == dry-run ]]; then
+      record_branch "${repo}" "${branch}" "${worktree}" would-remove "" "${pushed}" "${drift}"
+      count_would_remove=$((count_would_remove + 1))
+      return
+    fi
+
+    if [[ ${status_class} == flake-lock-only ]]; then
+      if ! discard_flake_lock_drift "${worktree}"; then
+        record_branch "${repo}" "${branch}" "${worktree}" skipped flake-lock-restore-failed "${pushed}" "${drift}"
+        count_blocked=$((count_blocked + 1))
+        return
+      fi
+      drift=discarded
+    elif [[ ${status_class} == dirty ]]; then
+      if ! stash_dirty_state "${worktree}" "${branch}"; then
+        record_branch "${repo}" "${branch}" "${worktree}" skipped stash-failed "${pushed}" ""
+        count_blocked=$((count_blocked + 1))
+        return
+      fi
+    fi
+
+    if ! remove_worktree_via_helper "${repo}" "${worktree}"; then
+      error_msg "helper refused ${worktree}: ${helper_output}"
+      record_branch "${repo}" "${branch}" "${worktree}" skipped helper-refused "${pushed}" "${drift}"
+      count_blocked=$((count_blocked + 1))
+      return
+    fi
+    remove_empty_container "${worktree}"
+  elif [[ ${mode} == dry-run ]]; then
+    record_branch "${repo}" "${branch}" "${worktree}" would-remove "" "${pushed}" ""
+    count_would_remove=$((count_would_remove + 1))
+    return
+  fi
+
+  if ! delete_branch "${repo}" "${branch}" "${tip}"; then
+    record_branch "${repo}" "${branch}" "${worktree}" skipped branch-delete-failed "${pushed}" "${drift}"
+    count_blocked=$((count_blocked + 1))
+    return
+  fi
+  record_branch "${repo}" "${branch}" "${worktree}" removed "" "${pushed}" "${drift}"
+  count_removed=$((count_removed + 1))
+}
+
+process_repo() {
+  local repo line branch upstream track tip
+  repo="$1"
+
+  snapshot_remote_refs "${repo}"
+
+  local fetch_err
+  if ! fetch_err="$(git -C "${repo}" fetch --all --prune --quiet 2>&1)"; then
+    error_msg "fetch failed for ${repo}: ${fetch_err}"
+    record_repo "${repo}" failed
+    count_blocked=$((count_blocked + 1))
+    return
+  fi
+  record_repo "${repo}" ok
+
+  load_worktree_map "${repo}"
+  repo_default_branch="$(default_branch_of "${repo}")"
+
+  # %1f (unit separator) keeps empty fields intact; tab would collapse as
+  # IFS whitespace and shift fields for branches without an upstream.
+  while IFS=$'\x1f' read -r branch upstream track tip; do
+    [[ -n ${branch} ]] || continue
+    if [[ ${track} != "[gone]" ]]; then
+      if [[ -n ${upstream} ]]; then
+        count_still_remote=$((count_still_remote + 1))
+      else
+        count_no_upstream=$((count_no_upstream + 1))
+      fi
+      continue
+    fi
+    process_branch "${repo}" "${branch}" "${upstream}" "${tip}"
+  done < <(git -C "${repo}" for-each-ref \
+    --format='%(refname:short)%1f%(upstream:short)%1f%(upstream:track)%1f%(objectname)' refs/heads)
+
+  if [[ ${mode} != dry-run ]]; then
+    if ! git -C "${repo}" worktree prune; then
+      error_msg "worktree prune failed for ${repo}"
+      count_blocked=$((count_blocked + 1))
+    fi
+    if ! expire_backup_refs "${repo}"; then
+      error_msg "backup ref expiry failed for ${repo}"
+      count_blocked=$((count_blocked + 1))
+    fi
+  fi
+}
+
+if [[ ${#repo_set[@]} -eq 0 ]]; then
+  error_msg "no repositories found under: ${roots[*]}"
+fi
+
+for repo_path in "${!repo_set[@]}"; do
+  process_repo "${repo_path}"
+done
+
+summary_line="summary mode=${mode} removed=${count_removed} would-remove=${count_would_remove}"
+summary_line+=" blocked=${count_blocked} orphans=${count_orphans}"
+summary_line+=" still-remote=${count_still_remote} no-upstream=${count_no_upstream}"
+summary_line+=" backups-expired=${count_backups_expired}"
+log_line "${summary_line}"
+
+if ${json_output}; then
+  repos_tsv="$(printf '%s\n' ${repo_records[@]+"${repo_records[@]}"})"
+  branches_tsv="$(printf '%s\n' ${branch_records[@]+"${branch_records[@]}"})"
+  orphans_tsv="$(printf '%s\n' ${orphan_records[@]+"${orphan_records[@]}"})"
+  jq -n \
+    --arg mode "${mode}" \
+    --arg repos "${repos_tsv}" \
+    --arg branches "${branches_tsv}" \
+    --arg orphans "${orphans_tsv}" \
+    --argjson summary "{
+      \"removed\": ${count_removed},
+      \"wouldRemove\": ${count_would_remove},
+      \"blocked\": ${count_blocked},
+      \"orphans\": ${count_orphans},
+      \"stillRemote\": ${count_still_remote},
+      \"noUpstream\": ${count_no_upstream},
+      \"backupsExpired\": ${count_backups_expired}
+    }" '
+    def rows($s): $s | split("\n") | map(select(length > 0) | split("\t"));
+    def opt($v): if $v == "" then null else $v end;
+    {
+      version: 1,
+      mode: $mode,
+      repos: (rows($repos) | map(. as $r | {
+        path: $r[0],
+        fetch: $r[1],
+        branches: (rows($branches) | map(select(.[0] == $r[0]) | {
+          branch: .[1],
+          worktree: (if .[2] == "none" then null else .[2] end),
+          state: .[3],
+          reason: opt(.[4]),
+          pushed: opt(.[5]),
+          flakeLockDrift: opt(.[6])
+        }))
+      })),
+      orphans: (rows($orphans) | map({path: .[0], reason: .[1]})),
+      summary: $summary
+    }'
+fi
+
+if [[ ${mode} != dry-run && ${count_blocked} -gt 0 ]]; then
+  exit 2
+fi
+exit 0

--- a/scripts/prune-stale-worktrees.sh
+++ b/scripts/prune-stale-worktrees.sh
@@ -14,7 +14,9 @@ prog_name="${0##*/}"
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 usage() {
-  cat >&2 <<EOF
+  # Help requested explicitly (-h/--help) prints to stdout; callers on the
+  # error path redirect this to stderr with `usage >&2`.
+  cat <<EOF
 usage: ${prog_name} [options]
 
 Detects local branches whose upstream tracking branch is gone after
@@ -107,13 +109,17 @@ while [[ $# -gt 0 ]]; do
     exit 0
     ;;
   *)
-    usage
+    error_msg "unknown option: $1"
+    usage >&2
     exit 1
     ;;
   esac
 done
 
-if [[ ${#roots[@]} -eq 0 ]]; then
+# Only fall back to the default root when the caller named neither a root nor
+# a specific --repo; an explicit --repo alone means "scan just that repo",
+# so pulling in $HOME/trees anyway would be a surprising extra scan.
+if [[ ${#roots[@]} -eq 0 && ${#extra_repos[@]} -eq 0 ]]; then
   roots=("${HOME}/trees")
 fi
 
@@ -255,8 +261,8 @@ register_worktree_dir() {
     common_dir="${dir}/${common_dir}"
   fi
   common_dir="$(canonical "${common_dir}")"
-  owner="$(dirname "${common_dir}")"
-  if [[ "$(basename "${common_dir}")" != ".git" ]]; then
+  owner="${common_dir%/*}"
+  if [[ ${common_dir##*/} != ".git" ]]; then
     # Bare repository or unusual layout; branch cleanup still works from the
     # git directory itself, worktree removal is guarded per candidate.
     owner="${common_dir}"
@@ -265,7 +271,7 @@ register_worktree_dir() {
 }
 
 scan_roots() {
-  local root canon_root level1 level2 found_worktree
+  local root canon_root level1 level2
   for root in "${roots[@]}"; do
     canon_root="$(canonical "${root}" 2>/dev/null)" || {
       error_msg "root does not exist, skipping: ${root}"
@@ -278,20 +284,17 @@ scan_roots() {
         register_worktree_dir "${level1}"
         continue
       fi
-      found_worktree=false
+      # Containers without any worktree are left alone; their nested entries
+      # are each registered or reported as orphans below.
       for level2 in "${level1}"/*/; do
         [[ -d ${level2} ]] || continue
         level2="${level2%/}"
         if [[ -e "${level2}/.git" ]]; then
           register_worktree_dir "${level2}"
-          found_worktree=true
         else
           record_orphan "${level2}" not-a-worktree
         fi
       done
-      # Containers without any worktree are left alone; their contents were
-      # already reported as orphans.
-      ${found_worktree} || true
     done
   done
 }
@@ -405,7 +408,7 @@ classify_worktree_status() {
     status_class=clean
     return
   fi
-  if [[ "$(wc -l <<<"${status}")" -eq 1 ]]; then
+  if [[ ${status} != *$'\n'* ]]; then
     line="${status}"
     xy="${line:0:2}"
     path="${line:3}"
@@ -440,7 +443,7 @@ remove_worktree_via_helper() {
 
 remove_empty_container() {
   local parent
-  parent="$(dirname "$1")"
+  parent="${1%/*}"
   if is_under_roots "${parent}" && [[ -d ${parent} && -z "$(ls -A "${parent}")" ]]; then
     rmdir "${parent}"
     log_line "removed-empty-dir=${parent}"
@@ -468,7 +471,7 @@ process_branch() {
   worktree="${branch_worktree[${branch}]:-none}"
   drift=""
 
-  if [[ -n ${pre_fetch_sha[${upstream}]:-} ]]; then
+  if [[ -n ${upstream} && -n ${pre_fetch_sha[${upstream}]:-} ]]; then
     if [[ ${pre_fetch_sha[${upstream}]} == "${tip}" ]]; then
       pushed=verified
     else

--- a/tests/prune-stale-worktrees/run.sh
+++ b/tests/prune-stale-worktrees/run.sh
@@ -1,0 +1,590 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+set -euo pipefail
+export LC_ALL=C
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="${SCRIPT_DIR}/../../scripts/prune-stale-worktrees.sh"
+
+if [[ ! -x ${SUT} ]]; then
+  printf 'run.sh: SUT not executable at %s\n' "${SUT}" >&2
+  exit 2
+fi
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  if [[ -d ${tmpdir} ]]; then
+    chmod -R u+w "${tmpdir}"
+    rm -r "${tmpdir}"
+  fi
+}
+trap cleanup EXIT
+
+# Isolate from the operator's real environment and git configuration.
+export HOME="${tmpdir}/home"
+mkdir -p "${HOME}"
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+export GIT_TERMINAL_PROMPT=0
+
+tests_passed=0
+
+pass() {
+  tests_passed=$((tests_passed + 1))
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  if [[ -n ${2:-} && -f ${2:-} ]]; then
+    printf '%s\n' '--- SUT output ---' >&2
+    cat "$2" >&2
+    printf '%s\n' '------------------' >&2
+  fi
+  exit 1
+}
+
+init_repo_config() {
+  git -C "$1" config user.email tests@example.invalid
+  git -C "$1" config user.name "prune-stale-worktrees tests"
+}
+
+# make_fixture <name>
+# Creates a bare origin, a clone acting as the primary checkout, and a
+# worktree root. Sets globals: origin, repo, root.
+make_fixture() {
+  local name seed
+  name="$1"
+  seed="${tmpdir}/${name}-seed"
+  origin="${tmpdir}/${name}-origin.git"
+  repo="${tmpdir}/${name}-repo"
+  root="${tmpdir}/${name}-trees"
+
+  git init -q -b main "${seed}"
+  init_repo_config "${seed}"
+  printf '%s\n' readme >"${seed}/README.md"
+  printf '%s\n' '{"nodes":{}}' >"${seed}/flake.lock"
+  git -C "${seed}" add .
+  git -C "${seed}" commit -q -m "initial commit"
+  git clone -q --bare "${seed}" "${origin}"
+  git clone -q "${origin}" "${repo}"
+  init_repo_config "${repo}"
+  mkdir -p "${root}"
+}
+
+# add_worktree_branch <branch> <worktree-path> [push]
+# Creates <branch> in ${repo} checked out at <worktree-path>.
+add_worktree_branch() {
+  local branch worktree push
+  branch="$1"
+  worktree="$2"
+  push="${3:-push}"
+
+  mkdir -p "$(dirname "${worktree}")"
+  git -C "${repo}" worktree add -q -b "${branch}" "${worktree}"
+  if [[ ${push} == push ]]; then
+    git -C "${worktree}" push -q -u origin "${branch}"
+  fi
+}
+
+# delete_on_origin <branch>
+# Deletes the branch on the bare origin without touching the clone's
+# remote-tracking refs, mimicking a remote-side deletion after PR merge.
+delete_on_origin() {
+  git -C "${origin}" update-ref -d "refs/heads/$1"
+}
+
+# run_sut <output-file> <args...>
+run_sut() {
+  local out
+  out="$1"
+  shift
+  if "${SUT}" "$@" >"${out}" 2>&1; then
+    sut_status=0
+  else
+    sut_status=$?
+  fi
+}
+
+assert_contains() {
+  local file pattern label
+  file="$1"
+  pattern="$2"
+  label="$3"
+  if ! grep -Eq "${pattern}" "${file}"; then
+    fail "${label}: output does not match '${pattern}'" "${file}"
+  fi
+}
+
+assert_not_contains() {
+  local file pattern label
+  file="$1"
+  pattern="$2"
+  label="$3"
+  if grep -Eq "${pattern}" "${file}"; then
+    fail "${label}: output unexpectedly matches '${pattern}'" "${file}"
+  fi
+}
+
+assert_branch_exists() {
+  git -C "${repo}" show-ref --verify --quiet "refs/heads/$1" ||
+    fail "$2: branch $1 missing"
+}
+
+assert_branch_absent() {
+  ! git -C "${repo}" show-ref --verify --quiet "refs/heads/$1" ||
+    fail "$2: branch $1 still exists"
+}
+
+assert_dir_exists() {
+  [[ -d $1 ]] || fail "$2: directory $1 missing"
+}
+
+assert_dir_absent() {
+  [[ ! -e $1 ]] || fail "$2: directory $1 still exists"
+}
+
+assert_backup_ref() {
+  local branch expected_sha label refs
+  branch="$1"
+  expected_sha="$2"
+  label="$3"
+  refs="$(git -C "${repo}" for-each-ref --format='%(objectname)' "refs/prune-backup/${branch}/**")"
+  if [[ -z ${refs} ]]; then
+    refs="$(git -C "${repo}" for-each-ref --format='%(objectname)' "refs/prune-backup/${branch}/*")"
+  fi
+  [[ -n ${refs} ]] || fail "${label}: no backup ref for ${branch}"
+  if [[ -n ${expected_sha} ]]; then
+    grep -q "${expected_sha}" <<<"${refs}" ||
+      fail "${label}: backup ref for ${branch} does not point at ${expected_sha}"
+  fi
+}
+
+test_dry_run_reports_and_preserves() {
+  local out wt
+  make_fixture dryrun
+  wt="${root}/proj/feat-alpha"
+  add_worktree_branch feat/alpha "${wt}"
+  delete_on_origin feat/alpha
+
+  out="${tmpdir}/dryrun.out"
+  run_sut "${out}" --root "${root}"
+
+  [[ ${sut_status} -eq 0 ]] || fail "dry-run: expected exit 0, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/alpha .*state=would-remove" "dry-run"
+  assert_dir_exists "${wt}" "dry-run"
+  assert_branch_exists feat/alpha "dry-run"
+  pass
+}
+
+test_apply_removes_branch_worktree_and_backs_up() {
+  local out wt tip
+  make_fixture apply
+  wt="${root}/proj/feat-alpha"
+  add_worktree_branch feat/alpha "${wt}"
+  tip="$(git -C "${repo}" rev-parse refs/heads/feat/alpha)"
+  delete_on_origin feat/alpha
+
+  out="${tmpdir}/apply.out"
+  run_sut "${out}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 0 ]] || fail "apply: expected exit 0, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/alpha .*state=removed" "apply"
+  assert_dir_absent "${wt}" "apply"
+  assert_dir_absent "${root}/proj" "apply: empty container should be removed"
+  assert_branch_absent feat/alpha "apply"
+  assert_backup_ref feat/alpha "${tip}" "apply"
+  pass
+}
+
+test_protects_master_branch() {
+  local out
+  make_fixture protected
+  git -C "${repo}" branch master
+  git -C "${repo}" push -q -u origin master
+  delete_on_origin master
+
+  out="${tmpdir}/protected.out"
+  run_sut "${out}" --repo "${repo}" --root "${root}" --apply
+
+  assert_branch_exists master "protected"
+  assert_contains "${out}" "branch=master .*state=skipped .*reason=protected" "protected"
+  pass
+}
+
+test_protects_branch_checked_out_in_primary_worktree() {
+  local out
+  make_fixture checkedout
+  git -C "${repo}" switch -q -c feat/current
+  git -C "${repo}" push -q -u origin feat/current
+  delete_on_origin feat/current
+
+  out="${tmpdir}/checkedout.out"
+  run_sut "${out}" --repo "${repo}" --root "${root}" --apply
+
+  assert_branch_exists feat/current "checked-out"
+  assert_contains "${out}" "branch=feat/current .*state=skipped .*reason=checked-out" "checked-out"
+  pass
+}
+
+test_skips_unpushed_commits_without_force() {
+  local out wt
+  make_fixture unpushed
+  wt="${root}/proj/feat-gamma"
+  add_worktree_branch feat/gamma "${wt}"
+  printf '%s\n' extra >"${wt}/extra.txt"
+  git -C "${wt}" add extra.txt
+  git -C "${wt}" commit -q -m "unpushed work"
+  delete_on_origin feat/gamma
+
+  out="${tmpdir}/unpushed.out"
+  run_sut "${out}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 2 ]] || fail "unpushed: expected exit 2, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/gamma .*state=skipped .*reason=unpushed" "unpushed"
+  assert_dir_exists "${wt}" "unpushed"
+  assert_branch_exists feat/gamma "unpushed"
+  pass
+}
+
+test_force_removes_unpushed_with_backup() {
+  local out wt tip
+  make_fixture forceunpushed
+  wt="${root}/proj/feat-gamma"
+  add_worktree_branch feat/gamma "${wt}"
+  printf '%s\n' extra >"${wt}/extra.txt"
+  git -C "${wt}" add extra.txt
+  git -C "${wt}" commit -q -m "unpushed work"
+  tip="$(git -C "${repo}" rev-parse refs/heads/feat/gamma)"
+  delete_on_origin feat/gamma
+
+  out="${tmpdir}/forceunpushed.out"
+  run_sut "${out}" --root "${root}" --force
+
+  [[ ${sut_status} -eq 0 ]] || fail "force-unpushed: expected exit 0, got ${sut_status}" "${out}"
+  assert_dir_absent "${wt}" "force-unpushed"
+  assert_branch_absent feat/gamma "force-unpushed"
+  assert_backup_ref feat/gamma "${tip}" "force-unpushed"
+  pass
+}
+
+test_skips_dirty_worktree_without_force() {
+  local out wt
+  make_fixture dirty
+  wt="${root}/proj/feat-delta"
+  add_worktree_branch feat/delta "${wt}"
+  printf '%s\n' modified >"${wt}/README.md"
+  delete_on_origin feat/delta
+
+  out="${tmpdir}/dirty.out"
+  run_sut "${out}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 2 ]] || fail "dirty: expected exit 2, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/delta .*state=skipped .*reason=dirty" "dirty"
+  assert_dir_exists "${wt}" "dirty"
+  assert_branch_exists feat/delta "dirty"
+  pass
+}
+
+test_force_stashes_dirty_and_removes() {
+  local out wt
+  make_fixture forcedirty
+  wt="${root}/proj/feat-delta"
+  add_worktree_branch feat/delta "${wt}"
+  printf '%s\n' modified >"${wt}/README.md"
+  printf '%s\n' untracked >"${wt}/scratch.txt"
+  delete_on_origin feat/delta
+
+  out="${tmpdir}/forcedirty.out"
+  run_sut "${out}" --root "${root}" --force
+
+  [[ ${sut_status} -eq 0 ]] || fail "force-dirty: expected exit 0, got ${sut_status}" "${out}"
+  assert_dir_absent "${wt}" "force-dirty"
+  assert_branch_absent feat/delta "force-dirty"
+  git -C "${repo}" stash list | grep -q "prune-stale-worktrees: feat/delta" ||
+    fail "force-dirty: no stash entry preserving dirty state" "${out}"
+  pass
+}
+
+test_flake_lock_only_drift_is_discarded_in_safe_apply() {
+  local out wt
+  make_fixture flakelock
+  wt="${root}/proj/feat-epsilon"
+  add_worktree_branch feat/epsilon "${wt}"
+  printf '%s\n' '{"nodes":{"drift":true}}' >"${wt}/flake.lock"
+  delete_on_origin feat/epsilon
+
+  out="${tmpdir}/flakelock.out"
+  run_sut "${out}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 0 ]] || fail "flake-lock: expected exit 0, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/epsilon .*state=removed .*flake-lock-drift=discarded" "flake-lock"
+  assert_dir_absent "${wt}" "flake-lock"
+  assert_branch_absent feat/epsilon "flake-lock"
+  pass
+}
+
+test_flake_lock_plus_other_dirt_is_skipped() {
+  local out wt
+  make_fixture flakelockmixed
+  wt="${root}/proj/feat-zeta"
+  add_worktree_branch feat/zeta "${wt}"
+  printf '%s\n' '{"nodes":{"drift":true}}' >"${wt}/flake.lock"
+  printf '%s\n' modified >"${wt}/README.md"
+  delete_on_origin feat/zeta
+
+  out="${tmpdir}/flakelockmixed.out"
+  run_sut "${out}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 2 ]] || fail "flake-lock-mixed: expected exit 2, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/zeta .*state=skipped .*reason=dirty" "flake-lock-mixed"
+  assert_dir_exists "${wt}" "flake-lock-mixed"
+  assert_branch_exists feat/zeta "flake-lock-mixed"
+  pass
+}
+
+test_gone_branch_without_worktree_is_deleted() {
+  local out tip
+  make_fixture branchonly
+  git -C "${repo}" branch feat/eta
+  git -C "${repo}" push -q -u origin feat/eta
+  tip="$(git -C "${repo}" rev-parse refs/heads/feat/eta)"
+  delete_on_origin feat/eta
+
+  out="${tmpdir}/branchonly.out"
+  run_sut "${out}" --repo "${repo}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 0 ]] || fail "branch-only: expected exit 0, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/eta .*worktree=none .*state=removed" "branch-only"
+  assert_branch_absent feat/eta "branch-only"
+  assert_backup_ref feat/eta "${tip}" "branch-only"
+  pass
+}
+
+test_still_remote_and_no_upstream_branches_untouched() {
+  local out
+  make_fixture untouched
+  git -C "${repo}" branch feat/alive
+  git -C "${repo}" push -q -u origin feat/alive
+  git -C "${repo}" branch feat/local-only
+
+  out="${tmpdir}/untouched.out"
+  run_sut "${out}" --repo "${repo}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 0 ]] || fail "untouched: expected exit 0, got ${sut_status}" "${out}"
+  assert_branch_exists feat/alive "untouched"
+  assert_branch_exists feat/local-only "untouched"
+  # main + feat/alive track a live upstream; feat/local-only has none.
+  assert_contains "${out}" "summary .*still-remote=2 no-upstream=1" "untouched"
+  assert_not_contains "${out}" "branch=feat/alive .*state=(removed|would-remove|skipped)" "untouched"
+  assert_not_contains "${out}" "branch=feat/local-only .*state=(removed|would-remove|skipped)" "untouched"
+  pass
+}
+
+test_already_gone_upstream_removed_with_unverified_backup() {
+  local out wt tip
+  make_fixture alreadygone
+  wt="${root}/proj/feat-theta"
+  add_worktree_branch feat/theta "${wt}"
+  tip="$(git -C "${repo}" rev-parse refs/heads/feat/theta)"
+  delete_on_origin feat/theta
+  git -C "${repo}" fetch -q --prune origin
+
+  out="${tmpdir}/alreadygone.out"
+  run_sut "${out}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 0 ]] || fail "already-gone: expected exit 0, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/theta .*state=removed .*pushed=unverified" "already-gone"
+  assert_dir_absent "${wt}" "already-gone"
+  assert_branch_absent feat/theta "already-gone"
+  assert_backup_ref feat/theta "${tip}" "already-gone"
+  pass
+}
+
+test_helper_is_final_arbiter_for_ignored_state() {
+  local out wt
+  make_fixture ignoredstate
+  wt="${root}/proj/feat-iota"
+  printf '%s\n' '*.key' >"${repo}/.gitignore"
+  git -C "${repo}" add .gitignore
+  git -C "${repo}" commit -q -m "ignore key files"
+  git -C "${repo}" push -q origin main
+  add_worktree_branch feat/iota "${wt}"
+  printf '%s\n' secret >"${wt}/local.key"
+  delete_on_origin feat/iota
+
+  out="${tmpdir}/ignoredstate.out"
+  run_sut "${out}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 2 ]] || fail "ignored-state: expected exit 2, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/iota .*state=skipped .*reason=helper-refused" "ignored-state"
+  assert_dir_exists "${wt}" "ignored-state"
+  assert_branch_exists feat/iota "ignored-state"
+  pass
+}
+
+test_multiple_roots_are_scanned() {
+  local out wt1 repo1 root1 wt2
+  make_fixture multiroot1
+  repo1="${repo}"
+  root1="${root}"
+  wt1="${root1}/proj/feat-kappa"
+  add_worktree_branch feat/kappa "${wt1}"
+  delete_on_origin feat/kappa
+
+  make_fixture multiroot2
+  wt2="${root}/proj/feat-lambda"
+  add_worktree_branch feat/lambda "${wt2}"
+  delete_on_origin feat/lambda
+
+  out="${tmpdir}/multiroot.out"
+  run_sut "${out}" --root "${root1}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 0 ]] || fail "multi-root: expected exit 0, got ${sut_status}" "${out}"
+  assert_dir_absent "${wt1}" "multi-root"
+  assert_dir_absent "${wt2}" "multi-root"
+  git -C "${repo1}" show-ref --verify --quiet refs/heads/feat/kappa &&
+    fail "multi-root: feat/kappa still exists" "${out}"
+  assert_branch_absent feat/lambda "multi-root"
+  pass
+}
+
+test_orphan_directories_reported_not_deleted() {
+  local out wt orphan_plain orphan_broken
+  make_fixture orphans
+  wt="${root}/proj/feat-mu"
+  add_worktree_branch feat/mu "${wt}"
+  orphan_plain="${root}/proj/not-a-worktree"
+  mkdir -p "${orphan_plain}"
+  printf '%s\n' data >"${orphan_plain}/file.txt"
+  orphan_broken="${root}/proj/broken-gitdir"
+  mkdir -p "${orphan_broken}"
+  printf 'gitdir: %s\n' "${tmpdir}/nonexistent/.git/worktrees/broken" >"${orphan_broken}/.git"
+
+  out="${tmpdir}/orphans.out"
+  run_sut "${out}" --root "${root}" --apply
+
+  assert_contains "${out}" "orphan=${orphan_plain}" "orphans"
+  assert_contains "${out}" "orphan=${orphan_broken}" "orphans"
+  assert_dir_exists "${orphan_plain}" "orphans"
+  assert_dir_exists "${orphan_broken}" "orphans"
+  pass
+}
+
+test_backup_refs_expire_after_retention() {
+  local out old_epoch head_sha
+  make_fixture expiry
+  head_sha="$(git -C "${repo}" rev-parse HEAD)"
+  old_epoch=$(($(date +%s) - 90 * 24 * 3600))
+  git -C "${repo}" update-ref "refs/prune-backup/feat/old/${old_epoch}" "${head_sha}"
+  git -C "${repo}" update-ref "refs/prune-backup/feat/fresh/$(date +%s)" "${head_sha}"
+
+  out="${tmpdir}/expiry.out"
+  run_sut "${out}" --repo "${repo}" --root "${root}" --apply --backup-retention-days 30
+
+  if git -C "${repo}" show-ref --verify --quiet "refs/prune-backup/feat/old/${old_epoch}"; then
+    fail "expiry: expired backup ref survived" "${out}"
+  fi
+  [[ -n "$(git -C "${repo}" for-each-ref "refs/prune-backup/feat/fresh")" ]] ||
+    fail "expiry: fresh backup ref was expired" "${out}"
+  pass
+}
+
+test_backup_failure_blocks_branch_deletion() {
+  local out head_sha
+  make_fixture backupfail
+  git -C "${repo}" branch feat/rho
+  git -C "${repo}" push -q -u origin feat/rho
+  delete_on_origin feat/rho
+  # A ref at the exact directory prefix makes refs/prune-backup/feat/rho/<epoch>
+  # unwritable, forcing the backup step to fail.
+  head_sha="$(git -C "${repo}" rev-parse HEAD)"
+  git -C "${repo}" update-ref refs/prune-backup/feat/rho "${head_sha}"
+
+  out="${tmpdir}/backupfail.out"
+  run_sut "${out}" --repo "${repo}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 2 ]] || fail "backup-fail: expected exit 2, got ${sut_status}" "${out}"
+  assert_contains "${out}" "branch=feat/rho .*state=skipped .*reason=branch-delete-failed" "backup-fail"
+  assert_branch_exists feat/rho "backup-fail"
+  pass
+}
+
+test_fetch_failure_skips_repo() {
+  local out wt
+  make_fixture fetchfail
+  wt="${root}/proj/feat-nu"
+  add_worktree_branch feat/nu "${wt}"
+  delete_on_origin feat/nu
+  git -C "${repo}" remote set-url origin "${tmpdir}/no-such-origin.git"
+
+  out="${tmpdir}/fetchfail.out"
+  run_sut "${out}" --root "${root}" --apply
+
+  [[ ${sut_status} -eq 2 ]] || fail "fetch-fail: expected exit 2, got ${sut_status}" "${out}"
+  assert_contains "${out}" "repo=${repo} fetch=failed" "fetch-fail"
+  assert_dir_exists "${wt}" "fetch-fail"
+  assert_branch_exists feat/nu "fetch-fail"
+  pass
+}
+
+test_exclude_pattern_limits_candidates() {
+  local out wt1 wt2
+  make_fixture patterns
+  wt1="${root}/proj/feat-xi"
+  wt2="${root}/proj/fix-omicron"
+  add_worktree_branch feat/xi "${wt1}"
+  add_worktree_branch fix/omicron "${wt2}"
+  delete_on_origin feat/xi
+  delete_on_origin fix/omicron
+
+  out="${tmpdir}/patterns.out"
+  run_sut "${out}" --root "${root}" --apply --exclude 'feat/*'
+
+  assert_branch_exists feat/xi "patterns"
+  assert_dir_exists "${wt1}" "patterns"
+  assert_branch_absent fix/omicron "patterns"
+  assert_dir_absent "${wt2}" "patterns"
+  pass
+}
+
+test_json_output_is_valid() {
+  local out wt
+  make_fixture json
+  wt="${root}/proj/feat-pi"
+  add_worktree_branch feat/pi "${wt}"
+  delete_on_origin feat/pi
+
+  out="${tmpdir}/json.out"
+  run_sut "${out}" --root "${root}" --json
+
+  [[ ${sut_status} -eq 0 ]] || fail "json: expected exit 0, got ${sut_status}" "${out}"
+  jq -e '.mode == "dry-run"' <"${out}" >/dev/null || fail "json: missing mode" "${out}"
+  jq -e '[.repos[].branches[] | select(.branch == "feat/pi" and .state == "would-remove")] | length == 1' \
+    <"${out}" >/dev/null || fail "json: candidate entry missing" "${out}"
+  assert_dir_exists "${wt}" "json"
+  pass
+}
+
+test_dry_run_reports_and_preserves
+test_apply_removes_branch_worktree_and_backs_up
+test_protects_master_branch
+test_protects_branch_checked_out_in_primary_worktree
+test_skips_unpushed_commits_without_force
+test_force_removes_unpushed_with_backup
+test_skips_dirty_worktree_without_force
+test_force_stashes_dirty_and_removes
+test_flake_lock_only_drift_is_discarded_in_safe_apply
+test_flake_lock_plus_other_dirt_is_skipped
+test_gone_branch_without_worktree_is_deleted
+test_still_remote_and_no_upstream_branches_untouched
+test_already_gone_upstream_removed_with_unverified_backup
+test_helper_is_final_arbiter_for_ignored_state
+test_multiple_roots_are_scanned
+test_orphan_directories_reported_not_deleted
+test_backup_refs_expire_after_retention
+test_backup_failure_blocks_branch_deletion
+test_fetch_failure_skips_repo
+test_exclude_pattern_limits_candidates
+test_json_output_is_valid
+
+printf '%d passed\n' "${tests_passed}"

--- a/tests/prune-stale-worktrees/run.sh
+++ b/tests/prune-stale-worktrees/run.sh
@@ -547,6 +547,27 @@ test_exclude_pattern_limits_candidates() {
   pass
 }
 
+test_include_pattern_limits_candidates() {
+  local out wt1 wt2
+  make_fixture include
+  wt1="${root}/proj/feat-rho"
+  wt2="${root}/proj/chore-sigma"
+  add_worktree_branch feat/rho "${wt1}"
+  add_worktree_branch chore/sigma "${wt2}"
+  delete_on_origin feat/rho
+  delete_on_origin chore/sigma
+
+  out="${tmpdir}/include.out"
+  run_sut "${out}" --root "${root}" --apply --include 'feat/*'
+
+  # Only the included branch is pruned; the non-matching gone branch stays.
+  assert_branch_absent feat/rho "include"
+  assert_dir_absent "${wt1}" "include"
+  assert_branch_exists chore/sigma "include"
+  assert_dir_exists "${wt2}" "include"
+  pass
+}
+
 test_json_output_is_valid() {
   local out wt
   make_fixture json
@@ -585,6 +606,7 @@ test_backup_refs_expire_after_retention
 test_backup_failure_blocks_branch_deletion
 test_fetch_failure_skips_repo
 test_exclude_pattern_limits_candidates
+test_include_pattern_limits_candidates
 test_json_output_is_valid
 
 printf '%d passed\n' "${tests_passed}"


### PR DESCRIPTION
## Summary

- `scripts/prune-stale-worktrees.sh` detects local branches whose upstream is gone after `git fetch --all --prune`, removes the worktree backing each branch under the scanned roots, and deletes the branch. Dry-run by default; `--apply` performs safe deletions; `--force` additionally handles unpushed or dirty candidates after preserving their state; `--root`, `--repo`, `--include`, `--exclude`, `--backup-retention-days`, and `--json` cover scoping and reporting. Exit codes: 0 clean, 1 hard error, 2 blocked candidates in apply mode.
- `modules/hm-apps/worktree-prune.nix` adds `programs.worktreePrune` with a systemd user service and timer (`OnCalendar=*-*-01,15 05:00:00`, `Persistent=true`, `SuccessExitStatus=2`, safe `--apply` only). `modules/hosts/common/worktree-prune.nix` enables it for the primary user on shared hosts with `~/nixos` as an explicit `--repo`, so gone branches without a remaining worktree are pruned too.
- `tests/prune-stale-worktrees/run.sh` adds a 21-test harness following the existing `tests/git-worktree-remove-safe` pattern. `docs/reference/worktree-prune.md` documents manual use, the schedule, the safety model, and recovery; the branch-workflow sections of `CLAUDE.md`, `AGENTS.md`, and `scripts/AGENTS.md` reference the helper.

Closes #201.

### Deviations from the issue proposal

The issue predates some repo realities; these deviations are deliberate:

1. Backup-then-delete instead of `git branch -d`: the repository squash-merges PRs, so `-d` refuses every merged branch and cannot act as the safety gate (the issue's own test plan, deleting a remote branch and expecting safe removal, cannot pass with `-d` either). Every deletion first writes `refs/prune-backup/<branch>/<epoch>` (self-expiring, default 90 days), then uses `-D`. A regression test proves a failed backup blocks the deletion.
2. `OnCalendar=biweekly` is not valid systemd syntax (`systemd-analyze calendar biweekly` fails to parse). The timer defaults to the 1st and 15th at 05:00 for an approximately two-week cadence with `Persistent=true`.
3. Branches whose tracking ref was already pruned before a run are `pushed=unverified` (nothing left to compare) and are cleaned in safe apply mode because the backup ref keeps them recoverable; refusing everything unverified would leave the existing backlog uncleanable forever. Unpushed commits detected through the pre-fetch snapshot still block without `--force`.
4. `--force` never bypasses `scripts/git-worktree-remove-safe.sh`, which stays the final arbiter of worktree cleanliness; it stashes dirty state first (`git stash push --include-untracked`), so forced cleanup stays recoverable. Dirty submodules and non-disposable ignored files remain refusals.
5. Open questions resolved as: Home Manager owns the service (the target trees live under the user home), enabled by default for the primary user on shared hosts with per-host or per-user override through `programs.worktreePrune`, and orphan directories under the roots (including broken `gitdir` links) are reported but never deleted.

## Test plan

- [x] `tests/prune-stale-worktrees/run.sh`: 21 passed (dry-run reporting, safe apply with backup refs, protected and checked-out refs, unpushed guard plus force path, dirty skip plus force stash, flake.lock-only discard, flake.lock plus other dirt skip, branch-only deletion, still-remote and no-upstream untouched, already-gone unverified cleanup, helper-refusal arbiter, multi-root scan, orphan report-only, backup expiry, backup-failure blocks deletion, fetch failure, exclude filter, JSON validity)
- [x] `shellcheck` and `bash -n` on the script and harness
- [x] `nix flake check --accept-flake-config --no-build --offline`
- [x] `nix eval` of the timer and service on system76 and tpnix: safe `--apply` ExecStart, no `--force`, `Persistent=true`
- [x] `nix build .#nixosConfigurations.tpnix.config.system.build.toplevel --offline`
- [x] Live dry-run over `$HOME/trees` plus `~/nixos`: 11 candidates listed, one broken-gitdir orphan reported, 26 live branches untouched, exit 0, nothing modified
- [x] `nix develop -c pre-commit run --all-files --hook-stage manual`
- [x] Adversarial code review pass over the staged diff; both findings fixed and covered by tests