### PR TITLE
refactor(services): register tor client policy via hosts-common

### DIFF
--- a/modules/hosts/common/tor.nix
+++ b/modules/hosts/common/tor.nix
@@ -97,6 +97,5 @@ let
   };
 in
 {
-  configurations.nixos.system76.module = clientOnlyTorModule;
-  configurations.nixos.tpnix.module = clientOnlyTorModule;
+  flake.nixosModules.hosts-common.imports = [ clientOnlyTorModule ];
 }


### PR DESCRIPTION
## Summary

- Register the client-only Tor policy through `flake.nixosModules.hosts-common.imports` instead of writing `configurations.nixos.system76.module` and `configurations.nixos.tpnix.module` by host name.
- Move the file from `modules/services/tor.nix` to `modules/hosts/common/tor.nix` alongside the other cross-host baselines.
- New hosts registered with `shareCommon = true` now inherit the Tor client policy without a second registration point.

Closes #361

## Test plan

- `nix fmt` (no diffs)
- `nix eval .#nixosConfigurations.<host>.config.services.tor.enable` returns `true` for system76 and tpnix
- `nix eval .#nixosConfigurations.<host>.config.services.tor.client.enable` returns `true` for both hosts
- `nix flake check --accept-flake-config --no-build --offline` passes