### PR TITLE
refactor(hosts): move system.stateVersion back to per-host modules

### DIFF
--- a/modules/hosts/common/state-version.nix
+++ b/modules/hosts/common/state-version.nix
@@ -1,9 +1,0 @@
-_:
-let
-  body = {
-    system.stateVersion = "26.05";
-  };
-in
-{
-  flake.nixosModules.hosts-common.imports = [ body ];
-}

--- a/modules/system76/state-version.nix
+++ b/modules/system76/state-version.nix
@@ -1,0 +1,6 @@
+{
+  configurations.nixos.system76.module = {
+    # Install-time constant for this host. Never bump on upgrades.
+    system.stateVersion = "26.05";
+  };
+}

--- a/modules/tpnix/state-version.nix
+++ b/modules/tpnix/state-version.nix
@@ -1,0 +1,6 @@
+{
+  configurations.nixos.tpnix.module = {
+    # Install-time constant for this host. Never bump on upgrades.
+    system.stateVersion = "26.05";
+  };
+}


### PR DESCRIPTION
## Summary

- Delete `modules/hosts/common/state-version.nix`, which pinned `system.stateVersion = "26.05"` fleet-wide at default priority inside the hosts-common aggregate.
- Restore per-host `modules/system76/state-version.nix` and `modules/tpnix/state-version.nix` (the pre-hoist layout). Both hosts were installed at 26.05, so the evaluated value is unchanged.
- A future host (coldfront) must now state its own install-time value instead of silently adopting 26.05, and can do so plainly without `lib.mkForce`.
- Home Manager continues to inherit through `home.stateVersion = osConfig.system.stateVersion`.

Closes #360

## Test plan

- `nix fmt` (no diffs)
- `nix eval .#nixosConfigurations.<host>.config.system.stateVersion` returns `"26.05"` for system76 and tpnix
- `nix flake check --accept-flake-config --no-build --offline` passes