### PR TITLE
chore(packages): resolve searchfox-cli updater through the current host

### DIFF
--- a/packages/searchfox-cli/update.py
+++ b/packages/searchfox-cli/update.py
@@ -16,11 +16,11 @@ REPO = "padenot/searchfox-cli"
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
-from updater_bootstrap import bootstrap  # noqa: E402
+from updater_bootstrap import bootstrap, host_package_attr  # noqa: E402
 
 FLAKE_ROOT, PACKAGE_DIR = bootstrap(__file__, PACKAGE_NAME)
 HASHES_FILE = PACKAGE_DIR / "hashes.json"
-PACKAGE_ATTR = f"{FLAKE_ROOT}#nixosConfigurations.system76.pkgs.{PACKAGE_NAME}"
+PACKAGE_ATTR = host_package_attr(FLAKE_ROOT, PACKAGE_NAME)
 sys.path.insert(0, str(FLAKE_ROOT / "scripts"))
 
 from updater import (  # noqa: E402


### PR DESCRIPTION
## Summary

- `packages/searchfox-cli/update.py` no longer hardcodes `nixosConfigurations.system76.pkgs.searchfox-cli`.
- It now uses `host_package_attr(FLAKE_ROOT, PACKAGE_NAME)` from `scripts/updater_bootstrap.py`, the same current-hostname resolution the wfuzz, webcrack, wappalyzer-next, and age-plugin-fido2prf updaters already use.
- Renaming or retiring system76 can no longer break package tooling; the package evaluates on every fleet host through the apps-enable baseline.

Closes #359

## Test plan

- Imported `update.py` and confirmed `PACKAGE_ATTR` is derived from `socket.gethostname()` (resolves to the running host's attribute path)
- pre-commit hooks (ruff, typos, treefmt) passed on commit