### PR TITLE
fix(i3wm): default powerProfiles.backend to powerprofilesctl

### DIFF
--- a/modules/apps/i3wm/config.nix
+++ b/modules/apps/i3wm/config.nix
@@ -12,7 +12,7 @@
     }:
     let
       hostI3Cfg = lib.attrByPath [ "gui" "i3" ] { } osConfig;
-      powerProfileBackend = lib.attrByPath [ "powerProfiles" "backend" ] "system76-power" hostI3Cfg;
+      powerProfileBackend = lib.attrByPath [ "powerProfiles" "backend" ] "powerprofilesctl" hostI3Cfg;
       powerProfileSelectionAllowed = lib.attrByPath [ "powerProfiles" "allowSelection" ] true hostI3Cfg;
       sessionMetadata = {
         DESKTOP_SESSION = "none+i3";

--- a/modules/apps/i3wm/nixos.nix
+++ b/modules/apps/i3wm/nixos.nix
@@ -26,7 +26,7 @@ let
             "system76-power"
             "powerprofilesctl"
           ];
-          default = "system76-power";
+          default = "powerprofilesctl";
           description = "Power-profile backend exposed to shared i3 launcher scripts.";
         };
 

--- a/modules/system76/services.nix
+++ b/modules/system76/services.nix
@@ -186,6 +186,11 @@ in
         lact.enable = true;
       };
 
+      # This host manages power profiles through the System76 EC daemon
+      # (power-profiles-daemon is force-disabled above), so the shared i3
+      # launcher must shell out to system76-power instead of powerprofilesctl.
+      gui.i3.powerProfiles.backend = "system76-power";
+
       # Power management configuration
       # - powerManagement: kernel-level CPU governor and suspend/resume hooks
       # - system76-power: System76 daemon for fans, backlight, turbo policies

--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -79,7 +79,6 @@ in
         xfsettingsd.enable = false;
       };
       powerProfiles = {
-        backend = "powerprofilesctl";
         allowSelection = false;
       };
     };


### PR DESCRIPTION
## Summary

- Flip the `gui.i3.powerProfiles.backend` option default from `system76-power` to the hardware-neutral `powerprofilesctl`, and flip the matching `osConfig` fallback literal in `modules/apps/i3wm/config.nix` so both stay in sync.
- Declare `system76-power` explicitly in `modules/system76/services.nix`, next to the `power-profiles-daemon` force-disable it pairs with; system76 is the only host running that EC daemon.
- Drop the now-redundant tpnix `backend = "powerprofilesctl"` override; the tpnix `allowSelection = false` choice stays.
- A future host (coldfront) now inherits a launcher that shells out to a binary it actually has.

Closes #357

## Test plan

- `nix fmt` (no diffs)
- `nix eval .#nixosConfigurations.system76.config.gui.i3.powerProfiles.backend` returns `"system76-power"`
- `nix eval .#nixosConfigurations.tpnix.config.gui.i3.powerProfiles.backend` returns `"powerprofilesctl"`
- `nix eval .#nixosConfigurations.tpnix.config.gui.i3.powerProfiles.allowSelection` returns `false`
- `nix flake check --accept-flake-config --no-build --offline` passes