### PR TITLE
refactor(networking): derive ssh aliases and tailscale target from host registry

### DIFF
--- a/docs/architecture/05-host-composition.md
+++ b/docs/architecture/05-host-composition.md
@@ -51,22 +51,23 @@ Every host follows the same shape: each `modules/<host>/*.nix` file extends `con
 
 ### system76 (Oryx Pro laptop)
 
-| File                                          | Purpose                                                               |
-| --------------------------------------------- | --------------------------------------------------------------------- |
-| `modules/system76/imports.nix`                | Baseline module imports and hardware profile wiring                   |
-| `modules/system76/home-manager-apps.nix`      | system76-only HM extras (awscli2, pentesting-devshell)                |
-| `modules/system76/nix-settings.nix`           | Hardware-tuned `max-jobs` and `min-free` overrides                    |
-| `modules/system76/ssh.nix`                    | system76 host public key + `services.openssh.enable` override         |
-| `modules/system76/packages.nix`               | system76-hardware packages (system76-power, firmware, etc.)           |
-| `modules/system76/system76-power-overlay.nix` | `system76-power` patch overlay (host-specific)                        |
-| `modules/system76/r2-runtime.nix`             | Host runtime bindings for external `r2-flake` modules                 |
-| `modules/system76/hardware-config.nix`        | Filesystems, firmware, low-level hardware settings                    |
-| `modules/system76/host-id.nix`                | `networking.hostId`                                                   |
-| `modules/system76/support.nix`                | system76 hardware-support enable (kernel modules, firmware-daemon)    |
-| `modules/system76/nvidia-gpu.nix`             | NVIDIA PRIME (system76-only)                                          |
-| `modules/system76/mpv.nix`                    | mpv `gpu-api = "opengl"` override (NVIDIA Vulkan deadlock workaround) |
-| `modules/system76/pass-secret-service.nix`    | DBus secret-service for `pass` (system76-only)                        |
-| `modules/system76/services.nix`               | Service-level host behavior                                           |
+| File                                          | Purpose                                                                       |
+| --------------------------------------------- | ----------------------------------------------------------------------------- |
+| `modules/system76/imports.nix`                | Baseline module imports and hardware profile wiring                           |
+| `modules/system76/home-manager-apps.nix`      | system76-only HM extras (awscli2, pentesting-devshell)                        |
+| `modules/system76/nix-settings.nix`           | Hardware-tuned `max-jobs` and `min-free` overrides                            |
+| `modules/system76/ssh.nix`                    | system76 host public key + `services.openssh.enable` override                 |
+| `modules/system76/packages.nix`               | system76-hardware packages (system76-power, firmware, etc.)                   |
+| `modules/system76/system76-power-overlay.nix` | `system76-power` patch overlay (host-specific)                                |
+| `modules/system76/r2-runtime.nix`             | Host runtime bindings for external `r2-flake` modules                         |
+| `modules/system76/hardware-config.nix`        | Filesystems, firmware, low-level hardware settings                            |
+| `modules/system76/host-id.nix`                | `networking.hostId`                                                           |
+| `modules/system76/support.nix`                | system76 hardware-support enable (kernel modules, firmware-daemon)            |
+| `modules/system76/nvidia-gpu.nix`             | NVIDIA PRIME (system76-only)                                                  |
+| `modules/system76/mpv.nix`                    | mpv `gpu-api = "opengl"` override (NVIDIA Vulkan deadlock workaround)         |
+| `modules/system76/pass-secret-service.nix`    | DBus secret-service for `pass` (system76-only)                                |
+| `modules/system76/policy.nix`                 | Registry data under `flake.lib.nixos.hosts.system76` (`primary`, `tailnetIp`) |
+| `modules/system76/services.nix`               | Service-level host behavior                                                   |
 
 ### tpnix (ThinkPad)
 
@@ -109,6 +110,8 @@ duplicatiModuleExists = sopsRuntimeReady && lib.hasAttrByPath [ "flake" "nixosMo
 ```
 
 Add new host-conditional flags by declaring them under `flake.lib.nixos.hosts.<hostname>` in a host-owned module; consumers read the path with `lib.hasAttrByPath` to stay safe across hosts.
+
+Registry entries also carry fleet endpoint data. `modules/system76/policy.nix` marks the host `primary = true` and records its `tailnetIp`; `modules/networking/ssh-hosts.nix` derives one `<host>.local` SSH alias per registered host (excluding self), and `modules/apps/tailscale.nix` defaults `sshHostName` to the primary host's `tailnetIp`. Promoting another host to primary is a policy.nix data change, not a module edit.
 
 ## App and Home Manager Wiring
 

--- a/modules/apps/tailscale.nix
+++ b/modules/apps/tailscale.nix
@@ -19,9 +19,17 @@
     interfaceName: Override the network interface name used by tailscaled (default `tailscale0`).
     sshHostAlias: Host alias written to `~/.ssh/hosts/<alias>` when tailscale is enabled.
     sshHostName: HostName used in the generated SSH match block (IP or MagicDNS name).
+      Defaults to the `tailnetIp` of the registry host marked `primary` in
+      `flake.lib.nixos.hosts`, so a primary-host handoff is a registry data change.
 */
-_:
+{ config, lib, ... }:
 let
+  fleetHosts = config.flake.lib.nixos.hosts or { };
+  primaryTailnetIp = lib.findFirst (ip: ip != null) null (
+    lib.mapAttrsToList (_: host: host.tailnetIp or null) (
+      lib.filterAttrs (_: host: host.primary or false) fleetHosts
+    )
+  );
   TailscaleModule =
     {
       config,
@@ -67,9 +75,13 @@ let
         };
 
         sshHostName = lib.mkOption {
-          type = lib.types.str;
-          default = "100.64.1.5";
-          description = "SSH HostName for the tailscale host entry (IP or MagicDNS name).";
+          type = lib.types.nullOr lib.types.str;
+          default = primaryTailnetIp;
+          description = ''
+            SSH HostName for the tailscale host entry (IP or MagicDNS name).
+            Defaults to the tailnetIp of the flake.lib.nixos.hosts entry marked
+            primary; null skips the generated ~/.ssh/hosts alias.
+          '';
         };
       };
 

--- a/modules/networking/ssh-hosts.nix
+++ b/modules/networking/ssh-hosts.nix
@@ -1,4 +1,8 @@
-_: {
+{ config, ... }:
+let
+  fleetHostNames = builtins.attrNames (config.flake.lib.nixos.hosts or { });
+in
+{
   # Provide per-host SSH config via include files under ~/.ssh/hosts/*
   flake.homeManagerModules.base =
     {
@@ -20,11 +24,22 @@ _: {
         "tailscale"
         "extended"
         "sshHostName"
-      ] "100.64.1.5" osConfig;
+      ] null osConfig;
+      selfHostName = lib.attrByPath [ "networking" "hostName" ] "" osConfig;
+      # One LAN alias per registered fleet host, excluding the host itself.
+      lanAliasFiles = lib.listToAttrs (
+        map (name: {
+          name = ".ssh/hosts/${name}.local";
+          value.text = ''
+            Host ${name}.local
+              IdentityFile ~/.ssh/id_ed25519
+          '';
+        }) (lib.filter (name: name != selfHostName) fleetHostNames)
+      );
     in
     {
       home.file = lib.mkMerge [
-        (lib.mkIf tailscaleEnabled {
+        (lib.mkIf (tailscaleEnabled && tailscaleHostName != null) {
           ".ssh/hosts/${tailscaleHostAlias}".text = ''
             Host ${tailscaleHostAlias}
               Port 22
@@ -46,12 +61,8 @@ _: {
               ControlPersist 15m
               ControlPath ~/.ssh/ctl-%C
           '';
-
-          ".ssh/hosts/system76.local".text = ''
-            Host system76.local
-              IdentityFile ~/.ssh/id_ed25519
-          '';
         }
+        lanAliasFiles
       ];
     };
 }

--- a/modules/system76/policy.nix
+++ b/modules/system76/policy.nix
@@ -1,0 +1,9 @@
+_: {
+  flake.lib.nixos.hosts.system76 = {
+    # Primary fleet endpoint: registry consumers (ssh-hosts, tailscale)
+    # point their default aliases at this machine. Hand off by moving
+    # these two keys to the successor host's policy.nix.
+    primary = true;
+    tailnetIp = "100.64.1.5";
+  };
+}


### PR DESCRIPTION
## Summary

- New `modules/system76/policy.nix` exports `primary = true` and `tailnetIp = "100.64.1.5"` under `flake.lib.nixos.hosts.system76`, mirroring the `modules/tpnix/policy.nix` idiom.
- `modules/networking/ssh-hosts.nix` derives one `<host>.local` SSH alias per registered registry host, excluding the evaluating host itself, instead of shipping a hardcoded `system76.local` file to every host.
- `programs.tailscale.extended.sshHostName` is now nullable and defaults to the primary host's `tailnetIp` from the registry; `null` suppresses the generated `~/.ssh/hosts` alias file. The duplicated `100.64.1.5` fallback literal in ssh-hosts.nix is gone.
- Promoting coldfront to primary becomes a policy.nix data change instead of edits to shared modules.
- Documented the registry endpoint keys in `docs/architecture/05-host-composition.md`.

Closes #358

## Test plan

- `nix fmt` (table realignment only)
- `nix eval .#nixosConfigurations.system76.config.home-manager.users.vx.home.file` filtered to `.ssh/hosts/*`: `github.com`, `tailscale`, `tpnix.local` (self alias gone)
- Same eval on tpnix: `github.com`, `system76.local`, `tailscale` (alias text byte-identical to the previous hardcoded block)
- `nix eval .#nixosConfigurations.<host>.config.programs.tailscale.extended.sshHostName` returns `"100.64.1.5"` on both hosts
- `nix flake check --accept-flake-config --no-build --offline` passes