### PR TITLE
feat(hardware): add parameterized nvidia-gpu module shared by all hosts

### DIFF
--- a/docs/architecture/05-host-composition.md
+++ b/docs/architecture/05-host-composition.md
@@ -51,43 +51,43 @@ Every host follows the same shape: each `modules/<host>/*.nix` file extends `con
 
 ### system76 (Oryx Pro laptop)
 
-| File                                          | Purpose                                                                       |
-| --------------------------------------------- | ----------------------------------------------------------------------------- |
-| `modules/system76/imports.nix`                | Baseline module imports and hardware profile wiring                           |
-| `modules/system76/home-manager-apps.nix`      | system76-only HM extras (awscli2, pentesting-devshell)                        |
-| `modules/system76/nix-settings.nix`           | Hardware-tuned `max-jobs` and `min-free` overrides                            |
-| `modules/system76/ssh.nix`                    | system76 host public key + `services.openssh.enable` override                 |
-| `modules/system76/packages.nix`               | system76-hardware packages (system76-power, firmware, etc.)                   |
-| `modules/system76/system76-power-overlay.nix` | `system76-power` patch overlay (host-specific)                                |
-| `modules/system76/r2-runtime.nix`             | Host runtime bindings for external `r2-flake` modules                         |
-| `modules/system76/hardware-config.nix`        | Filesystems, firmware, low-level hardware settings                            |
-| `modules/system76/host-id.nix`                | `networking.hostId`                                                           |
-| `modules/system76/support.nix`                | system76 hardware-support enable (kernel modules, firmware-daemon)            |
-| `modules/system76/nvidia-gpu.nix`             | NVIDIA PRIME (system76-only)                                                  |
-| `modules/system76/mpv.nix`                    | mpv `gpu-api = "opengl"` override (NVIDIA Vulkan deadlock workaround)         |
-| `modules/system76/pass-secret-service.nix`    | DBus secret-service for `pass` (system76-only)                                |
-| `modules/system76/policy.nix`                 | Registry data under `flake.lib.nixos.hosts.system76` (`primary`, `tailnetIp`) |
-| `modules/system76/services.nix`               | Service-level host behavior                                                   |
+| File                                          | Purpose                                                                                    |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| `modules/system76/imports.nix`                | Baseline module imports and hardware profile wiring                                        |
+| `modules/system76/home-manager-apps.nix`      | system76-only HM extras (awscli2, pentesting-devshell)                                     |
+| `modules/system76/nix-settings.nix`           | Hardware-tuned `max-jobs` and `min-free` overrides                                         |
+| `modules/system76/ssh.nix`                    | system76 host public key + `services.openssh.enable` override                              |
+| `modules/system76/packages.nix`               | system76-hardware packages (system76-power, firmware, etc.)                                |
+| `modules/system76/system76-power-overlay.nix` | `system76-power` patch overlay (host-specific)                                             |
+| `modules/system76/r2-runtime.nix`             | Host runtime bindings for external `r2-flake` modules                                      |
+| `modules/system76/hardware-config.nix`        | Filesystems, firmware, low-level hardware settings                                         |
+| `modules/system76/host-id.nix`                | `networking.hostId`                                                                        |
+| `modules/system76/support.nix`                | system76 hardware-support enable (kernel modules, firmware-daemon)                         |
+| `modules/system76/nvidia-gpu.nix`             | GPU profile over `flake.nixosModules.nvidia-gpu` (`system76.gpu.mode` enum, libva routing) |
+| `modules/system76/mpv.nix`                    | mpv `gpu-api = "opengl"` override (NVIDIA Vulkan deadlock workaround)                      |
+| `modules/system76/pass-secret-service.nix`    | DBus secret-service for `pass` (system76-only)                                             |
+| `modules/system76/policy.nix`                 | Registry data under `flake.lib.nixos.hosts.system76` (`primary`, `tailnetIp`)              |
+| `modules/system76/services.nix`               | Service-level host behavior                                                                |
 
 ### tpnix (ThinkPad)
 
-| File                                     | Purpose                                                                                            |
-| ---------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| `modules/tpnix/imports.nix`              | Baseline module imports, gated on `flake.lib.nixos.hosts.tpnix.*` flags                            |
-| `modules/tpnix/apps-enable.nix`          | Per-host overrides over the common app baseline                                                    |
-| `modules/tpnix/home-manager-apps.nix`    | tpnix-only HM extras (libreoffice)                                                                 |
-| `modules/tpnix/default-apps.nix`         | Per-host overrides for `host.defaults` (audioPlayer, videoPlayer = null)                           |
-| `modules/tpnix/nix-settings.nix`         | Hardware-tuned `max-jobs` and `min-free` overrides                                                 |
-| `modules/tpnix/firmware-manager-fix.nix` | tpnix-only `services.fwupd.enable = true;` override                                                |
-| `modules/tpnix/fingerprint.nix`          | Fingerprint auth (`services.fprintd`) and PAM service wiring (tpnix-only)                          |
-| `modules/tpnix/printing.nix`             | Printer provisioning with a SOPS-managed device URI (tpnix-only)                                   |
-| `modules/tpnix/r2-runtime.nix`           | Host runtime bindings for external `r2-flake` modules                                              |
-| `modules/tpnix/hardware-config.nix`      | Filesystems, firmware, low-level hardware settings                                                 |
-| `modules/tpnix/host-id.nix`              | `networking.hostId`                                                                                |
-| `modules/tpnix/support.nix`              | Stub for future tpnix hardware-support hooks                                                       |
-| `modules/tpnix/policy.nix`               | Host-level policy flags exposed under `flake.lib.nixos.hosts.tpnix`                                |
-| `modules/tpnix/power.nix`                | GPU, display, and power services (NVIDIA PRIME sync, `power-profiles-daemon`, logind lid handling) |
-| `modules/tpnix/services.nix`             | Service-level host behavior                                                                        |
+| File                                     | Purpose                                                                                                                         |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `modules/tpnix/imports.nix`              | Baseline module imports, gated on `flake.lib.nixos.hosts.tpnix.*` flags                                                         |
+| `modules/tpnix/apps-enable.nix`          | Per-host overrides over the common app baseline                                                                                 |
+| `modules/tpnix/home-manager-apps.nix`    | tpnix-only HM extras (libreoffice)                                                                                              |
+| `modules/tpnix/default-apps.nix`         | Per-host overrides for `host.defaults` (audioPlayer, videoPlayer = null)                                                        |
+| `modules/tpnix/nix-settings.nix`         | Hardware-tuned `max-jobs` and `min-free` overrides                                                                              |
+| `modules/tpnix/firmware-manager-fix.nix` | tpnix-only `services.fwupd.enable = true;` override                                                                             |
+| `modules/tpnix/fingerprint.nix`          | Fingerprint auth (`services.fprintd`) and PAM service wiring (tpnix-only)                                                       |
+| `modules/tpnix/printing.nix`             | Printer provisioning with a SOPS-managed device URI (tpnix-only)                                                                |
+| `modules/tpnix/r2-runtime.nix`           | Host runtime bindings for external `r2-flake` modules                                                                           |
+| `modules/tpnix/hardware-config.nix`      | Filesystems, firmware, low-level hardware settings                                                                              |
+| `modules/tpnix/host-id.nix`              | `networking.hostId`                                                                                                             |
+| `modules/tpnix/support.nix`              | Stub for future tpnix hardware-support hooks                                                                                    |
+| `modules/tpnix/policy.nix`               | Host-level policy flags exposed under `flake.lib.nixos.hosts.tpnix`                                                             |
+| `modules/tpnix/power.nix`                | GPU profile over `flake.nixosModules.nvidia-gpu` plus display and power services (`power-profiles-daemon`, logind lid handling) |
+| `modules/tpnix/services.nix`             | Service-level host behavior                                                                                                     |
 
 Cross-host baselines (default-apps, mirrors, nix-ld, sudo, zsh, ssh,
 nix-substituters, packages, home-manager-apps, virtualization, ...) live in

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -122,8 +122,8 @@ gpu.nvidia = {
   open = false;                  # Pascal predates the open kernel modules
   vaapi.backend = "intel-media"; # VA-API routes to Intel iHD, not NVDEC (Xid 31)
   prime = {
-    enable = cfg.mode == "hybrid-sync";
-    inherit (cfg) intelBusId nvidiaBusId;
+    enable = config.system76.gpu.mode == "hybrid-sync";
+    inherit (config.system76.gpu) intelBusId nvidiaBusId;
   };
 };
 

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -98,6 +98,12 @@ sudo system76-power charge-thresholds --profile full_charge   # 96-100%
 
 ## NVIDIA GPU
 
+Shared NVIDIA wiring (driver selection, open-module toggle, container
+toolkit, VA-API routing, PRIME) lives in the parameterized
+`flake.nixosModules.nvidia-gpu` module (`modules/hardware/nvidia-gpu.nix`).
+The host file maps the `system76.gpu.mode` enum onto it and keeps the
+chassis-specific libva routing.
+
 ```nix
 # modules/system76/nvidia-gpu.nix
 options.system76.gpu = {
@@ -109,17 +115,17 @@ options.system76.gpu = {
   nvidiaBusId = lib.mkOption { type = lib.types.str; default = "PCI:1:0:0"; };
 };
 
-hardware.nvidia = {
+gpu.nvidia = {
+  enable = true;
   # GTX 1070 Max-Q is supported by the 580.xx legacy branch only.
   package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
-  modesetting.enable = true;
-  videoAcceleration = false;  # No nvidia-vaapi-driver; VA-API routes to Intel iHD
-  powerManagement.enable = true;
-  powerManagement.finegrained = false;  # Incompatible with PRIME sync
-  open = false;          # Proprietary driver
-  nvidiaSettings = true;
+  open = false;                  # Pascal predates the open kernel modules
+  vaapi.backend = "intel-media"; # VA-API routes to Intel iHD, not NVDEC (Xid 31)
+  prime = {
+    enable = cfg.mode == "hybrid-sync";
+    inherit (cfg) intelBusId nvidiaBusId;
+  };
 };
-hardware.nvidia-container-toolkit.enable = true;  # GPU passthrough for containers
 
 # nvidia-only branch: libva uses Intel Quick Sync through the stable iGPU render node.
 environment.sessionVariables.LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
@@ -129,13 +135,6 @@ environment.sessionVariables.LIBVA_DRM_DEVICE = lib.mkDefault "/dev/dri/by-path/
 ```nix
 # Active host mode is set in hardware-config.nix (overrides the hybrid-sync default):
 system76.gpu.mode = "nvidia-only";
-
-# hybrid-sync branch enables PRIME sync (NOT active on this host):
-hardware.nvidia.prime = {
-  sync.enable = true;
-  intelBusId = "PCI:0:2:0";
-  nvidiaBusId = "PCI:1:0:0";
-};
 ```
 
 | Mode          | Description                                                | Active                       |

--- a/modules/hardware/nvidia-gpu.nix
+++ b/modules/hardware/nvidia-gpu.nix
@@ -1,0 +1,162 @@
+/*
+  Module: nvidia-gpu
+  Description: Parameterized NVIDIA GPU wiring shared by all hosts with an
+  NVIDIA card. Hosts pick the driver branch, kernel-module flavor, VA-API
+  routing, and display topology instead of restating the full stack.
+
+  Profiles:
+    * Desktop (single GPU, e.g. Blackwell): set `package` to a current branch,
+      `open = true`, leave `prime.enable = false`.
+    * Laptop (hybrid graphics): set `prime.enable = true` with the chassis bus
+      IDs so the iGPU drives the panel through PRIME sync.
+*/
+_:
+let
+  NvidiaGpuModule =
+    {
+      config,
+      pkgs,
+      lib,
+      ...
+    }:
+    let
+      cfg = config.gpu.nvidia;
+    in
+    {
+      options.gpu.nvidia = {
+        enable = lib.mkEnableOption "shared NVIDIA GPU wiring";
+
+        package = lib.mkOption {
+          type = lib.types.package;
+          default = config.boot.kernelPackages.nvidiaPackages.production;
+          defaultText = lib.literalExpression "config.boot.kernelPackages.nvidiaPackages.production";
+          description = ''
+            NVIDIA driver package. Pick the branch matching the GPU generation
+            (legacy_* for cards dropped from production, production/latest for
+            current silicon; Blackwell requires 570+).
+          '';
+        };
+
+        open = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Use the open NVIDIA kernel modules. Required on Blackwell and newer
+            (the proprietary modules do not support them); keep false on
+            pre-Turing cards, which the open modules do not support.
+          '';
+        };
+
+        containerToolkit.enable = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Enable nvidia-container-toolkit for GPU passthrough into containers.";
+        };
+
+        vaapi.backend = lib.mkOption {
+          type = lib.types.enum [
+            "nvidia"
+            "intel-media"
+          ];
+          default = "nvidia";
+          description = ''
+            VA-API decode path. "nvidia" installs nvidia-vaapi-driver (VA-API
+            handed to NVDEC). "intel-media" routes decode to the Intel iGPU via
+            intel-media-driver and suppresses nvidia-vaapi-driver; use it when
+            the NVDEC handoff is unstable (Xid 31 MMU faults under decode-context
+            churn) or when the iGPU should own decode.
+          '';
+        };
+
+        prime = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Enable PRIME sync so the iGPU drives the panel while NVIDIA renders (dual-GPU laptops).";
+          };
+
+          intelBusId = lib.mkOption {
+            type = lib.types.str;
+            default = "PCI:0:2:0";
+            example = "PCI:0:2:0";
+            description = ''
+              PCI address for the Intel iGPU when PRIME sync is enabled. Determine via
+              `lspci -nn | grep VGA` if the default does not match this chassis.
+            '';
+          };
+
+          nvidiaBusId = lib.mkOption {
+            type = lib.types.str;
+            default = "PCI:1:0:0";
+            example = "PCI:1:0:0";
+            description = ''
+              PCI address for the NVIDIA dGPU when PRIME sync is enabled. Override if
+              `lspci -nn | grep NVIDIA` reports a different slot.
+            '';
+          };
+        };
+      };
+
+      config = lib.mkIf cfg.enable (
+        lib.mkMerge [
+          {
+            services.xserver = {
+              videoDrivers = lib.mkDefault [ "nvidia" ];
+              # Tear-free: Force full composition pipeline for NVIDIA
+              screenSection = lib.mkDefault ''
+                Option "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"
+              '';
+            };
+
+            hardware = {
+              graphics.extraPackages = [ pkgs.vulkan-validation-layers ];
+
+              nvidia = {
+                inherit (cfg) package open;
+                modesetting.enable = lib.mkDefault true;
+                powerManagement.enable = lib.mkDefault true;
+                # Fine-grained power management (D3 power gating) is incompatible
+                # with PRIME sync and only useful on offload setups.
+                powerManagement.finegrained = lib.mkDefault false;
+                nvidiaSettings = lib.mkDefault true;
+              };
+
+              # Containers: NVIDIA container toolkit for GPU passthrough
+              nvidia-container-toolkit.enable = cfg.containerToolkit.enable;
+            };
+
+            # Diagnostics: vulkaninfo and glxinfo
+            environment.systemPackages = with pkgs; [
+              vulkan-tools
+              mesa-demos
+            ];
+          }
+
+          (lib.mkIf (cfg.vaapi.backend == "nvidia") {
+            hardware.graphics.extraPackages = [ pkgs.nvidia-vaapi-driver ];
+          })
+
+          (lib.mkIf (cfg.vaapi.backend == "intel-media") {
+            # VA-API decode routes through Intel Quick Sync (iHD), not NVDEC.
+            # Suppress nixpkgs' default nvidia-vaapi-driver install
+            # (videoAcceleration defaults to true and is its only consumer).
+            hardware.graphics.extraPackages = [ pkgs.intel-media-driver ];
+            hardware.nvidia.videoAcceleration = false;
+          })
+
+          (lib.mkIf cfg.prime.enable {
+            services.xserver.videoDrivers = lib.mkForce [ "nvidia" ];
+
+            hardware.nvidia.prime = {
+              offload.enable = lib.mkForce false;
+              sync.enable = true;
+              inherit (cfg.prime) intelBusId nvidiaBusId;
+            };
+          })
+        ]
+      );
+    };
+in
+{
+  flake.nixosModules.nvidia-gpu = NvidiaGpuModule;
+}

--- a/modules/hardware/nvidia-gpu.nix
+++ b/modules/hardware/nvidia-gpu.nix
@@ -133,7 +133,11 @@ let
           }
 
           (lib.mkIf (cfg.vaapi.backend == "nvidia") {
-            hardware.graphics.extraPackages = [ pkgs.nvidia-vaapi-driver ];
+            # VA-API handed to NVDEC: videoAcceleration is nixpkgs' knob that
+            # installs nvidia-vaapi-driver into hardware.graphics.extraPackages.
+            # Setting it here (rather than adding the package directly) avoids a
+            # double-install, since it already defaults to true.
+            hardware.nvidia.videoAcceleration = true;
           })
 
           (lib.mkIf (cfg.vaapi.backend == "intel-media") {

--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -47,6 +47,7 @@ in
       config.flake.nixosModules.lang
       config.flake.nixosModules.ssh
       config.flake.nixosModules.bluetooth
+      config.flake.nixosModules.nvidia-gpu
       config.flake.nixosModules.zshKeybindings
 
       # External hardware modules

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -1,11 +1,6 @@
 _: {
   configurations.nixos.system76.module =
-    {
-      config,
-      pkgs,
-      lib,
-      ...
-    }:
+    { config, lib, ... }:
     let
       cfg = config.system76.gpu;
     in
@@ -43,71 +38,36 @@ _: {
 
       config = lib.mkMerge [
         {
-          services.xserver = {
-            videoDrivers = lib.mkDefault [ "nvidia" ];
-            # Tear-free: Force full composition pipeline for NVIDIA
-            screenSection = lib.mkDefault ''
-              Option "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"
-            '';
-          };
-
-          hardware = {
-            # VA-API decode routes through Intel Quick Sync (iHD), not NVDEC.
+          gpu.nvidia = {
+            enable = true;
+            # GTX 1070 Max-Q is supported by the 580.xx legacy branch; newer production drivers ignore it.
+            package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
+            # Pascal predates the open kernel modules.
+            open = false;
             # nvidia-vaapi-driver's VA-API -> NVDEC handoff faults under decode-context
-            # churn: switching videos quickly or reloading stalled SMB/SFTP streams
-            # produces an Xid 31 MMU page fault on ENGINE NVDEC, hanging the dGPU and
-            # freezing the session (the dGPU drives the display in nvidia-only mode).
-            # Intel UHD 630 (i915 stays loaded here, see the nvidia-only branch) decodes
-            # H.264/HEVC/VP9 in hardware; AV1 falls back to software. mpv is unaffected
-            # because hwdec=auto uses FFmpeg NVCUVID (nvdec), never libva.
-            # (generic graphics enablement lives in modules/hosts/common/graphics-support.nix)
-            graphics.extraPackages = with pkgs; [
-              intel-media-driver
-              vulkan-validation-layers
-            ];
-
-            nvidia = {
-              # GTX 1070 Max-Q is supported by the 580.xx legacy branch; newer production drivers ignore it.
-              package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
-              modesetting.enable = true;
-              # Suppress nixpkgs' default nvidia-vaapi-driver install (this option
-              # defaults to true and is its only consumer). VA-API decode is handled by
-              # Intel iHD instead; see the graphics.extraPackages note for the Xid 31
-              # NVDEC fault rationale.
-              videoAcceleration = false;
-              powerManagement.enable = true;
-              # Fine-grained power management (D3 power gating) is incompatible with PRIME sync.
-              # Sync mode keeps the dGPU always on to drive display output through the iGPU.
-              # To enable finegrained, switch system76.gpu.mode to use offload instead.
-              powerManagement.finegrained = false;
-              open = false;
-              nvidiaSettings = true;
+            # churn on this chassis: switching videos quickly or reloading stalled
+            # SMB/SFTP streams produces an Xid 31 MMU page fault on ENGINE NVDEC,
+            # hanging the dGPU and freezing the session (the dGPU drives the display
+            # in nvidia-only mode). Intel UHD 630 decodes H.264/HEVC/VP9 in hardware;
+            # AV1 falls back to software. mpv is unaffected because hwdec=auto uses
+            # FFmpeg NVCUVID (nvdec), never libva.
+            vaapi.backend = "intel-media";
+            prime = {
+              # PRIME sync keeps the internal panel on the iGPU while NVIDIA renders.
+              enable = cfg.mode == "hybrid-sync";
+              inherit (cfg) intelBusId nvidiaBusId;
             };
-
-            # Containers: NVIDIA container toolkit for GPU passthrough
-            nvidia-container-toolkit.enable = true;
           };
-
-          # Diagnostics: vulkaninfo and glxinfo
-          environment.systemPackages = with pkgs; [
-            vulkan-tools
-            mesa-demos
-          ];
         }
 
         (lib.mkIf (cfg.mode == "nvidia-only") {
-          # Keep the Intel iGPU disabled so only the dGPU drives displays.
-          hardware.nvidia.prime = {
-            offload.enable = lib.mkForce false;
-            sync.enable = lib.mkForce false;
-          };
+          # Only the dGPU drives displays; PRIME stays disabled via gpu.nvidia.prime.
 
           # Do not blacklist i915: internal HDA/SOF audio on this chassis can
           # depend on Intel graphics-side plumbing even when NVIDIA renders X11.
 
-          # Route VA-API to Intel Quick Sync (iHD), not NVDEC, to avoid the Xid 31
-          # decode fault (see graphics.extraPackages above). i915 stays loaded here,
-          # and the by-path render node keeps libva off the NVIDIA DRM device.
+          # Route libva to the Intel render node by stable path so it never opens
+          # the NVIDIA DRM device (see the vaapi.backend note above).
           # VDPAU_DRIVER is intentionally unset: VDPAU is legacy, and pointing it at
           # nvidia would route back into NVDEC.
           # sessionVariables (PAM-initialised) so GUI apps launched outside a
@@ -115,19 +75,6 @@ _: {
           environment.sessionVariables = {
             LIBVA_DRM_DEVICE = lib.mkDefault "/dev/dri/by-path/pci-0000:00:02.0-render";
             LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
-          };
-        })
-
-        (lib.mkIf (cfg.mode == "hybrid-sync") {
-          services.xserver.videoDrivers = lib.mkForce [
-            "nvidia"
-          ];
-
-          # Enable PRIME sync so the internal panel stays driven by the iGPU but surfaces are rendered on NVIDIA.
-          hardware.nvidia.prime = {
-            offload.enable = lib.mkForce false;
-            sync.enable = true;
-            inherit (cfg) intelBusId nvidiaBusId;
           };
         })
       ];

--- a/modules/tpnix/imports.nix
+++ b/modules/tpnix/imports.nix
@@ -42,6 +42,7 @@ in
       config.flake.nixosModules.lang
       config.flake.nixosModules.ssh
       config.flake.nixosModules.bluetooth
+      config.flake.nixosModules.nvidia-gpu
       config.flake.nixosModules.zshKeybindings
 
       # External hardware modules

--- a/modules/tpnix/power.nix
+++ b/modules/tpnix/power.nix
@@ -9,43 +9,25 @@
     {
       boot.blacklistedKernelModules = [ "nouveau" ];
 
+      gpu.nvidia = {
+        enable = true;
+        package = config.boot.kernelPackages.nvidiaPackages.production;
+        open = false;
+        vaapi.backend = "nvidia";
+        # PRIME sync with the chassis default bus IDs (PCI:0:2:0 / PCI:1:0:0).
+        prime.enable = true;
+      };
+
       hardware = {
         bluetooth = {
           enable = true;
           powerOnBoot = true;
         };
 
-        graphics.extraPackages = [
-          pkgs.nvidia-vaapi-driver
-          pkgs.vulkan-validation-layers
-        ];
-
-        nvidia = {
-          package = config.boot.kernelPackages.nvidiaPackages.production;
-          modesetting.enable = true;
-          open = false;
-          gsp.enable = true;
-          powerManagement.enable = true;
-          powerManagement.finegrained = false;
-          nvidiaSettings = true;
-
-          prime = {
-            offload.enable = lib.mkForce false;
-            sync.enable = true;
-            intelBusId = "PCI:0:2:0";
-            nvidiaBusId = "PCI:1:0:0";
-          };
-        };
-
-        nvidia-container-toolkit.enable = true;
+        nvidia.gsp.enable = true;
       };
 
       security.rtkit.enable = true;
-
-      environment.systemPackages = with pkgs; [
-        mesa-demos
-        vulkan-tools
-      ];
 
       services = {
         dbus = {
@@ -64,10 +46,6 @@
 
         xserver = {
           enable = true;
-          videoDrivers = lib.mkForce [ "nvidia" ];
-          screenSection = lib.mkDefault ''
-            Option "metamodes" "nvidia-auto-select +0+0 {ForceFullCompositionPipeline=On}"
-          '';
           xkb = {
             layout = "us";
             variant = "";


### PR DESCRIPTION
## Summary

- New `flake.nixosModules.nvidia-gpu` (`modules/hardware/nvidia-gpu.nix`) with options `gpu.nvidia.{enable, package, open, containerToolkit.enable, vaapi.backend, prime.{enable, intelBusId, nvidiaBusId}}`.
  - Desktop profile (coldfront, RTX 5080 Blackwell): current driver branch via `package`, `open = true`, `prime.enable = false`, single-GPU `videoDrivers = [ "nvidia" ]` with modesetting.
  - Laptop profile: `prime.enable = true` + chassis bus IDs (PRIME sync, offload forced off).
- `vaapi.backend` hoists the previously buried `intel-media-driver` wiring: `"intel-media"` routes VA-API to Intel Quick Sync and suppresses nvidia-vaapi-driver (Xid 31 NVDEC fault avoidance); `"nvidia"` installs nvidia-vaapi-driver. Container toolkit enablement is likewise shared.
- system76 migrates onto it, keeping its `system76.gpu.mode` enum (`hybrid-sync`/`nvidia-only`) and the chassis-specific libva `sessionVariables`; tpnix's `power.nix` keeps only `gsp.enable` and the nouveau blacklist as host extras.
- Docs updated: `docs/architecture/05-host-composition.md` table rows and the `docs/system76/system76-configuration.md` NVIDIA section.

Closes #362

## Test plan

- Before/after JSON diff of the GPU-relevant option subset (`videoDrivers`, `screenSection`, `hardware.nvidia.*` incl. prime and gsp, `nvidia-container-toolkit.enable`, `hardware.graphics.extraPackages` names, `LIBVA_*` session variables) for both hosts: identical except entry order inside `graphics.extraPackages` (same package set)
- `nix flake check --accept-flake-config --no-build --offline` passes (fully evaluates both host toplevels, covering the nixpkgs NVIDIA/PRIME assertions)
- `nix fmt` (table realignment only)