### PR TITLE
feat(r2): re-enable R2 runtime on system76 and tpnix

### DIFF
--- a/modules/system76/imports.nix
+++ b/modules/system76/imports.nix
@@ -97,13 +97,13 @@ in
       # Do not grant broad systemd unit management without explicit elevation.
       polkit.wheelSystemdManagement.enable = false;
       repoSecrets.enable = lib.mkDefault true;
-      r2CloudSecrets.enable = lib.mkForce false;
+      r2CloudSecrets.enable = lib.mkDefault true;
     };
     home-manager.users.${metaOwner.username}.home = {
       context7Secrets.enable = lib.mkDefault true;
       geckoSecrets.enable = lib.mkDefault true;
       greptileSecrets.enable = lib.mkForce false;
-      r2Secrets.enable = lib.mkForce false;
+      r2Secrets.enable = lib.mkDefault true;
       virustotalSecrets.enable = lib.mkDefault true;
     }
     // lib.optionalAttrs repoGpgModuleExists {

--- a/modules/system76/r2-runtime.nix
+++ b/modules/system76/r2-runtime.nix
@@ -13,9 +13,9 @@
       secretsRoot
       ;
     policy = {
-      enableExternalFlake = false;
-      sopsRuntimeReady = false;
-      disabledReason = "system76 R2 integration is disabled until the upstream r2-flake stops referencing removed pkgs.nodePackages.";
+      enableExternalFlake = true;
+      sopsRuntimeReady = true;
+      disabledReason = "system76 R2 runtime is disabled; requires policy.enableExternalFlake, policy.sopsRuntimeReady, and secrets/r2.yaml.";
     };
   };
 }

--- a/modules/tpnix/policy.nix
+++ b/modules/tpnix/policy.nix
@@ -1,6 +1,6 @@
 _: {
   flake.lib.nixos.hosts.tpnix = {
     sopsRuntimeReady = true;
-    r2RuntimeReady = false;
+    r2RuntimeReady = true;
   };
 }

--- a/modules/tpnix/r2-runtime.nix
+++ b/modules/tpnix/r2-runtime.nix
@@ -18,7 +18,7 @@ in
     policy = {
       enableExternalFlake = ready;
       sopsRuntimeReady = ready;
-      disabledReason = "tpnix R2 runtime services are disabled until the upstream r2-flake stops referencing removed pkgs.nodePackages.";
+      disabledReason = "tpnix R2 runtime is disabled; set flake.lib.nixos.hosts.tpnix.r2RuntimeReady = true and provide secrets/r2.yaml.";
     };
   };
 }


### PR DESCRIPTION
## Summary

Re-enables the Cloudflare R2 runtime on **system76** and **tpnix**, reverting the local workaround that disabled it. The workaround existed only because the upstream flake input `Bad3r/nix-R2-CloudFlare-Flake` referenced the removed `pkgs.nodePackages.wrangler`; its PR #103 removes that coupling (the `r2` CLI now resolves wrangler from top-level `pkgs.wrangler`).

## Changes

- `modules/tpnix/policy.nix`: `r2RuntimeReady` `false -> true` (drives `enableExternalFlake` and `sopsRuntimeReady` through `modules/tpnix/r2-runtime.nix`).
- `modules/system76/r2-runtime.nix`: `enableExternalFlake` and `sopsRuntimeReady` `false -> true`.
- `modules/system76/imports.nix`: `security.r2CloudSecrets.enable` and Home Manager `r2Secrets.enable` `mkForce false -> mkDefault true`, matching tpnix so `/run/secrets/r2/*` renders on system76.
- Refreshed both `disabledReason` strings that still cited the removed `nodePackages` coupling.

## Blocked on upstream (do not merge yet)

This branch still pins `r2-flake` to the pre-PR `main` (`28676205`). It must not be merged or switched until:

1. `Bad3r/nix-R2-CloudFlare-Flake` PR #103 merges to `main`, then
2. `nix flake update r2-flake` re-locks the consumer to that commit.

Building against the current lock would re-hit the `nodePackages` blocker. Kept as a draft with `status(blocked-upstream)` for that reason.

## Validation

`nix eval` with `--override-input r2-flake` pointed at the PR branch (`modernize/r2-stack-recreation @ 306b9b7`), simulating the post-merge state:

- `nixosConfigurations.{system76,tpnix}`: **zero failed assertions**.
- All seven `r2-mount-*` / `r2-bisync-*` / `r2-restic-backup` units present with `User=vx`.
- Home Manager `programs.r2-cloud.package` resolves (`r2-0.1.0+src...`), confirming `pkgs.wrangler` resolves with no `nodePackages` access.
- `services.r2-sync.enable` and `services.r2-restic.enable` `= true` on both hosts.
- `nixfmt --check` clean on all four files.

## Operational note

On the first switch after unblocking, both hosts will start the R2 mounts, bisync timers, and restic backups for the first time.
