### PR TITLE
feat(apps): add Tinfoil Wiper

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1415,6 +1415,7 @@
         "sops-nix": "sops-nix",
         "stylix": "stylix",
         "systems": "systems_7",
+        "tinfoil-wiper": "tinfoil-wiper",
         "tinted-schemes": "tinted-schemes",
         "treefmt-nix": "treefmt-nix_2",
         "vim-autoread": "vim-autoread",
@@ -1633,6 +1634,26 @@
       "original": {
         "owner": "nix-systems",
         "repo": "default",
+        "type": "github"
+      }
+    },
+    "tinfoil-wiper": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1783716011,
+        "narHash": "sha256-Bw5UBjkKP4dfx6vt4Fu50JaFxrfOy6JeDwn++Q/OoS0=",
+        "owner": "Bad3r",
+        "repo": "Tinfoil-Wiper",
+        "rev": "d6c9071a88c8076ef59cefe49534d7fb692bbf32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Bad3r",
+        "repo": "Tinfoil-Wiper",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -491,6 +491,22 @@
         "type": "github"
       }
     },
+    "flake-compat_5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-file": {
       "locked": {
         "lastModified": 1777679829,
@@ -591,11 +607,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1772408722,
-        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -613,11 +629,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1769996383,
-        "narHash": "sha256-AnYjnFWgS49RlqX7LrC4uA+sCCDBj0Ry/WOJ5XWAsa0=",
+        "lastModified": 1782949081,
+        "narHash": "sha256-vp6Y/Grm98ESt6ceOkWiHWyZRDV3J1RID4w+6NWK9yA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "57928607ea566b5db3ad13af0e57e921e6b12381",
+        "rev": "17c9d6cdfc60c64f4ee8d306f9bc0b4ccb51481e",
         "type": "github"
       },
       "original": {
@@ -765,11 +781,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772845525,
-        "narHash": "sha256-Dp5Ir2u4jJDGCgeMRviHvEQDe+U37hMxp6RSNOoMMPc=",
+        "lastModified": 1783525612,
+        "narHash": "sha256-OEFYdbtG6Qy04KGteknnrx15Uo2XXkYVuUvBvFNEn+Q=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "27b93804fbef1544cb07718d3f0a451f4c4cd6c0",
+        "rev": "1aac8895fea6fcabc6a0184c63a80fb2f99fd208",
         "type": "github"
       },
       "original": {
@@ -1078,11 +1094,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1772328832,
-        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "lastModified": 1782614948,
+        "narHash": "sha256-ePjCwr1sNm9NYUqywL7QfK3JnlS015msC+eBu2zKlp8=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "rev": "db3f255737b94216eb71cce308e2912cf6bc2d7c",
         "type": "github"
       },
       "original": {
@@ -1186,11 +1202,11 @@
     },
     "nixpkgs_4": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {
@@ -1202,11 +1218,11 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1771423170,
-        "narHash": "sha256-K7Dg9TQ0mOcAtWTO/FX/FaprtWQ8BmEXTpLIaNRhEwU=",
+        "lastModified": 1783279667,
+        "narHash": "sha256-/NAkDSsve+GNM0Bt6tleJdCGfsTlK89nPjkVOzZMo0s=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "bcc4a9d9533c033d806a46b37dc444f9b0da49dd",
+        "rev": "f205b5574fd0cb7da5b702a2da51507b7f4fdd1b",
         "type": "github"
       },
       "original": {
@@ -1346,17 +1362,18 @@
     },
     "r2-flake": {
       "inputs": {
+        "flake-compat": "flake-compat_5",
         "flake-parts": "flake-parts_5",
         "home-manager": "home-manager_2",
         "nixpkgs": "nixpkgs_4",
         "wrangler": "wrangler"
       },
       "locked": {
-        "lastModified": 1783703071,
-        "narHash": "sha256-a3p1GEdAuCoAlohJ4OG0/dXCjojEbGw39ydBvI2AEZk=",
+        "lastModified": 1783711947,
+        "narHash": "sha256-GKT2iNYIXa+MWNjUgLr8CjRPsk/x1HEkUEPYfyMsJFI=",
         "owner": "Bad3r",
         "repo": "nix-R2-CloudFlare-Flake",
-        "rev": "586874e11a1b600a91afab2cd0217256843b0ba3",
+        "rev": "328129ed757325c687b703ee8088ea30737101f8",
         "type": "github"
       },
       "original": {
@@ -1796,11 +1813,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1772759894,
-        "narHash": "sha256-iWk0RuXWwcWuguKepkzT1WndkM4i4GAVud05UzDyjK0=",
+        "lastModified": 1783460135,
+        "narHash": "sha256-dTY4WKjGG0VliGQa1n/SOuY1f85xRUc4Bcf1WSr6Kbk=",
         "owner": "emrldnix",
         "repo": "wrangler",
-        "rev": "054321adb5f68c6dbb1d3c10792f4f21ef0521c3",
+        "rev": "78ed9e7728a34932e416e62c85c16444a1b54c94",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    tinfoil-wiper = {
+      url = "github:Bad3r/Tinfoil-Wiper";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     # R2 integration module flake (portable source; no machine-local paths)
     r2-flake.url = "github:Bad3r/nix-R2-CloudFlare-Flake?ref=main";
 

--- a/modules/apps/tinfoil-wiper.nix
+++ b/modules/apps/tinfoil-wiper.nix
@@ -1,0 +1,49 @@
+/*
+  Package: tinfoil-wiper
+  Description: Securely erase NVMe SSDs with controller-native or software methods
+  Homepage: https://github.com/Bad3r/Tinfoil-Wiper
+  Repository: https://github.com/Bad3r/Tinfoil-Wiper
+
+  Usage:
+    * `tinfoil_wiper --dry-run /dev/nvme0n1` -- Preview an erase plan.
+    * `sudo tinfoil_wiper /dev/nvme0n1` -- Run the selected erase method.
+
+  The package grants no privileges. Real wipes still require an explicit root
+  invocation.
+*/
+{ inputs, ... }:
+let
+  TinfoilWiperModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs."tinfoil-wiper".extended;
+    in
+    {
+      options.programs."tinfoil-wiper".extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable Tinfoil Wiper.";
+        };
+
+        package = lib.mkOption {
+          type = lib.types.package;
+          default = inputs.tinfoil-wiper.packages.${pkgs.stdenv.hostPlatform.system}.tinfoil-wiper;
+          defaultText = lib.literalExpression "inputs.tinfoil-wiper.packages.\${pkgs.stdenv.hostPlatform.system}.tinfoil-wiper";
+          description = "The Tinfoil Wiper package to use.";
+        };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps."tinfoil-wiper" = TinfoilWiperModule;
+}

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -427,6 +427,7 @@ let
       tesseract.extended.enable = lib.mkOverride 1100 true;
       testdisk.extended.enable = lib.mkOverride 1100 true;
       thunderbird.extended.enable = lib.mkOverride 1100 true;
+      "tinfoil-wiper".extended.enable = lib.mkOverride 1100 true;
       tokei.extended.enable = lib.mkOverride 1100 true;
       tor.extended.enable = lib.mkOverride 1100 true;
       "tor-browser".extended.enable = lib.mkOverride 1100 true;


### PR DESCRIPTION
## Summary

- add the published `Bad3r/Tinfoil-Wiper` flake input with its nixpkgs input following the system pin
- register an overridable `programs."tinfoil-wiper".extended` app module and enable it for both common hosts
- install the package through `environment.systemPackages` so explicit `sudo tinfoil_wiper` invocations retain the wrapped runtime
- refresh `r2-flake` from `586874e` to `328129e`, where the producer no longer forces the removed `pkgs.nodePackages` alias during host evaluation

## Test plan

- [x] `nix fmt -- flake.nix flake.lock modules/apps/tinfoil-wiper.nix modules/hosts/common/apps-enable.nix`
- [x] evaluate Tinfoil enablement and `meta.mainProgram` for `system76` and `tpnix` with `--override-input tinfoil-wiper path:/data/Projects/igit/Tinfoil-Wiper`
- [x] build the configured Tinfoil package and verify `tinfoil_wiper 2.0.0`
- [x] `nix flake check --accept-flake-config --offline --no-build` with the local Tinfoil override
- [x] build `system76.config.system.build.toplevel` with the local Tinfoil override
- [x] repeat the flake check and host closure build from the committed GitHub lock
- [x] verify the final closure contains `tinfoil-wiper-2.0.0`
