### PR TITLE
fix(hosts): close the host onboarding traps before coldfront lands

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -44,14 +44,26 @@ jobs:
       # make a git-based self fetch pull the private secrets submodule
       # that CI cannot read; the per-file pathExists guards then evaluate
       # the secretless configuration. --no-build: the flake checks include
-      # both host toplevels, and building them exceeds runner disk.
+      # every host toplevel, and building them exceeds runner disk.
       - name: Check flake
         run: nix flake check --accept-flake-config --no-build "path:."
+      # Dry-run every host closure. The host list comes from the flake, so
+      # a new host is covered without editing this workflow; an empty list
+      # fails instead of passing vacuously.
       - name: Build configurations
         run: |
-          HOST="path:.#nixosConfigurations.system76"
-          nix build "$HOST.config.system.build.toplevel" \
-            --dry-run --accept-flake-config
+          hosts=$(nix eval --accept-flake-config --json \
+            "path:.#nixosConfigurations" --apply builtins.attrNames \
+            | jq -r '.[]')
+          if [ -z "$hosts" ]; then
+            echo "no nixosConfigurations found" >&2
+            exit 1
+          fi
+          for host in $hosts; do
+            echo "Dry-run building $host..."
+            nix build --dry-run --accept-flake-config \
+              "path:.#nixosConfigurations.$host.config.system.build.toplevel"
+          done
 
   format-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -98,26 +98,45 @@ jobs:
       # pull the private secrets submodule that CI cannot read. Secret
       # files are then absent, so the per-file pathExists guards evaluate
       # the secretless configuration and warn about disabled services.
-      # --no-build: the flake checks include both host toplevels, and
-      # building two desktop closures exceeds runner disk.
+      # --no-build: the flake checks include every host toplevel, and
+      # building desktop closures exceeds runner disk.
       - name: Run flake check
         if: steps.update.outputs.changed == 'true'
         run: nix flake check --accept-flake-config --no-build "path:."
 
       - name: Free disk space
         if: steps.update.outputs.changed == 'true'
-        # Reclaim ~15 GB of preinstalled toolchains so one host closure fits.
+        # Reclaim ~15 GB of preinstalled toolchains so a host closure fits.
         run: sudo rm -rf /usr/local/lib/android /usr/share/dotnet /opt/ghc
 
-      # Realise one host closure (both exceed runner disk, hence --no-build on
-      # the flake check). Gates the auto-merged PR on an actual build: a lock
-      # bump that evaluates but fails to build (broken patch, a package that no
-      # longer compiles) fails the run before the PR is created and merged.
-      - name: Build host closure
+      # Realise every host closure, one at a time (a single closure fits the
+      # runner disk, several at once do not, hence --no-build on the flake
+      # check and the garbage collection between hosts). Gates the
+      # auto-merged PR on actual builds: a lock bump that evaluates but fails
+      # to build (broken patch, a package that no longer compiles) fails the
+      # run before the PR is created and merged. The host list comes from the
+      # flake, so a new host is covered without editing this workflow.
+      - name: Build host closures
         if: steps.update.outputs.changed == 'true'
         run: |
-          nix build --accept-flake-config --no-link -L \
-            "path:.#nixosConfigurations.system76.config.system.build.toplevel"
+          hosts=$(nix eval --accept-flake-config --json \
+            "path:.#nixosConfigurations" --apply builtins.attrNames \
+            | jq -r '.[]')
+          if [ -z "$hosts" ]; then
+            echo "no nixosConfigurations found" >&2
+            exit 1
+          fi
+          first=1
+          for host in $hosts; do
+            if [ "$first" -eq 1 ]; then
+              first=0
+            else
+              nix store gc
+            fi
+            echo "Building $host closure..."
+            nix build --accept-flake-config --no-link -L \
+              "path:.#nixosConfigurations.$host.config.system.build.toplevel"
+          done
 
       - name: Show updated inputs
         if: steps.update.outputs.changed == 'true'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,10 @@ The registry is `flake.lib.nixos.hosts.<name>.shareCommon`, declared in
 Common modules contribute to the aggregate `flake.nixosModules.hosts-common`
 module. `modules/configurations/nixos.nix` imports that aggregate for each host
 whose registry entry has `shareCommon = true`, before importing the
-host-specific module so per-host overrides still win.
+host-specific module so per-host overrides still win. Every host under
+`configurations.nixos` must set `shareCommon` explicitly; the host constructor
+aborts evaluation for hosts without a registry entry, so a host cannot skip
+the common baseline silently.
 
 ```nix
 { ... }:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,8 +289,10 @@ sops.secrets."context7/api-key" = {
 ## Troubleshooting
 
 - Unfree package blocked:
-  Add the package to `config.nixpkgs.allowedUnfreePackages` in
-  `modules/meta/nixpkgs-allowed-unfree.nix`.
+  Add the package to the flake-parts `nixpkgs.allowedUnfreePackages` option
+  from the module that needs it (option declared in
+  `modules/meta/nixpkgs-allowed-unfree.nix`). There is no NixOS-scope
+  allowlist option; host-level `nixpkgs.allowedUnfreePackages` fails eval.
 - Missing reference:
   Ensure the file is tracked by git.
 - Need to explore config:

--- a/docs/architecture/05-host-composition.md
+++ b/docs/architecture/05-host-composition.md
@@ -55,9 +55,12 @@ Every host follows the same shape: NixOS fragments under `modules/<host>/` exten
 
 The planned `coldfront` managed-workstation footprint is `hardware-config.nix`,
 `host-id.nix`, `state-version.nix`, a GPU module, `support.nix`, and a
-`policy.nix` carrying the registry values the common layer consumes. The NixOS
-evaluator itself only requires a `configurations.nixos.<name>.module`
-contribution; common-baseline participation is a separate registry choice.
+`policy.nix` carrying the registry values the common layer consumes. Every
+host additionally needs an explicit `shareCommon` entry in
+`modules/hosts/common/registry.nix`: the host constructor aborts evaluation
+for hosts without one, so common-baseline participation is always a recorded
+choice (`true` to opt in, `false` to deliberately opt out). The full
+procedure lives in the [host onboarding runbook](../guides/host-onboarding.md).
 
 ### system76 (Oryx Pro laptop)
 

--- a/docs/architecture/06-reference.md
+++ b/docs/architecture/06-reference.md
@@ -37,15 +37,15 @@ nix flake check --accept-flake-config --no-build --offline
 
 ## Troubleshooting
 
-| Scenario                                                | Resolution                                                                                                                   |
-| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
-| Git hooks fail in a new worktree                        | Run `nix develop` (auto-sync runs in shellHook) or run `nix develop -c bash scripts/hooks/sync-pre-commit-hooks.sh` manually |
-| Commit fails with `hooks were refreshed; retry commit.` | The `pre-commit-config-sync` hook resynced generated hook state after a hook source change; rerun the same `git commit`      |
-| Missing app reference                                   | Use `config.flake.lib.nixos.hasApp "name"` or `nix eval --json .#nixosModules.apps --apply builtins.attrNames`               |
-| Helper assertion failures                               | Run `nix flake check --accept-flake-config` and inspect `checks.<system>.helpers-exist`                                      |
-| Managed file drift                                      | Run `nix develop -c write-files` then `git diff`                                                                             |
-| Unfree package blocked                                  | Add to `config.nixpkgs.allowedUnfreePackages` in `modules/meta/nixpkgs-allowed-unfree.nix`                                   |
-| "Cannot coerce null to string"                          | See [Two-Context Problem](02-module-authoring.md#the-two-context-problem)                                                    |
+| Scenario                                                | Resolution                                                                                                                                                             |
+| ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Git hooks fail in a new worktree                        | Run `nix develop` (auto-sync runs in shellHook) or run `nix develop -c bash scripts/hooks/sync-pre-commit-hooks.sh` manually                                           |
+| Commit fails with `hooks were refreshed; retry commit.` | The `pre-commit-config-sync` hook resynced generated hook state after a hook source change; rerun the same `git commit`                                                |
+| Missing app reference                                   | Use `config.flake.lib.nixos.hasApp "name"` or `nix eval --json .#nixosModules.apps --apply builtins.attrNames`                                                         |
+| Helper assertion failures                               | Run `nix flake check --accept-flake-config` and inspect `checks.<system>.helpers-exist`                                                                                |
+| Managed file drift                                      | Run `nix develop -c write-files` then `git diff`                                                                                                                       |
+| Unfree package blocked                                  | Add to the flake-parts `nixpkgs.allowedUnfreePackages` option from any module (declared in `modules/meta/nixpkgs-allowed-unfree.nix`); no NixOS-scope allowlist exists |
+| "Cannot coerce null to string"                          | See [Two-Context Problem](02-module-authoring.md#the-two-context-problem)                                                                                              |
 
 ## Introspection
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -7,6 +7,7 @@ Style guides, coding standards, and how-to documentation.
 | [Apps Module Style Guide](apps-module-style-guide.md)         | Header format and conventions for `modules/apps/`   |
 | [Custom Packages Style Guide](custom-packages-style-guide.md) | Templates and conventions for `packages/`           |
 | [GitHub Deployments](github-deployments.md)                   | Deployment tracking via GitHub API                  |
+| [Host Onboarding Runbook](host-onboarding.md)                 | Checklist for adding a NixOS host                   |
 | [Nix Debugging Manual](nix-debugging-manual.md)               | General Nix/NixOS/Home Manager debugging techniques |
 | [Stylix Integration](stylix-integration.md)                   | Theming constraints for module authors              |
 | [Tray Icon Theming (i3/i3bar)](tray-icon-theming.md)          | Runtime tray ownership and icon theming remediation |

--- a/docs/guides/host-onboarding.md
+++ b/docs/guides/host-onboarding.md
@@ -1,0 +1,169 @@
+# Host Onboarding Runbook
+
+Procedural checklist for adding a NixOS host to this repository. The
+composition model behind these steps is documented in
+[Host Composition](../architecture/05-host-composition.md); hardware planning
+for the next host lives in
+[project-coldfront](../coldfront/project-coldfront.md). Follow the steps in
+order: the validation ladder at the end assumes everything before it is in
+place.
+
+## 1. Register the host
+
+Add an explicit entry to `modules/hosts/common/registry.nix`:
+
+```nix
+flake.lib.nixos.hosts.<host>.shareCommon = true;
+```
+
+`shareCommon = true` imports the entire `flake.nixosModules.hosts-common`
+aggregate (hostname, boot defaults, networking base, firewall, sops runtime,
+app baseline, state defaults) before the host module, so per-host overrides
+still win. `shareCommon = false` is a deliberate opt-out.
+
+This step cannot be forgotten: `modules/configurations/nixos.nix` aborts
+evaluation for any host under `configurations.nixos` without an explicit
+`shareCommon` entry, so `nix flake check` and every closure build fail until
+the registry line exists.
+
+## 2. Create the host module directory
+
+Create `modules/<host>/` with the per-host file set. Every file contributes
+to `configurations.nixos.<host>.module`; import-tree discovers the files
+automatically, so no imports need registering. The minimal managed-workstation
+footprint:
+
+| File                  | Purpose                                                                                                                                                                     |
+| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `hardware-config.nix` | Hardware truth from `nixos-generate-config`: filesystems, initrd modules, firmware, loader entry limit                                                                      |
+| `host-id.nix`         | Unique `networking.hostId` (8 hex chars; derive with `head -c 8 /etc/machine-id` on the target)                                                                             |
+| `state-version.nix`   | Install-time `system.stateVersion` constant; never bump on upgrades                                                                                                         |
+| `policy.nix`          | Registry flags under `flake.lib.nixos.hosts.<host>` consumed by `modules/hosts/common/*` (see step 3)                                                                       |
+| `ssh.nix`             | `services.openssh.publicKey` (the host ed25519 public key, consumed by `flake.nixosModules.ssh` for fleet known_hosts) and the enable choice                                |
+| `imports.nix`         | Chassis-specific modules only (nixos-hardware profile, vendor support module); the fleet baseline comes from hosts-common                                                   |
+| GPU module            | GPU wiring over `flake.nixosModules.nvidia-gpu` when the hardware has an NVIDIA GPU (`modules/system76/nvidia-gpu.nix`, `modules/tpnix/power.nix` are the current examples) |
+
+Baseline behavior that does NOT need per-host files:
+
+- `networking.hostName` is derived from the host directory name by
+  `modules/hosts/common/hostname.nix`.
+- The kernel defaults to `linuxPackages_zen` (`modules/hosts/common/boot.nix`,
+  `lib.mkDefault`); add a per-host `boot.nix` only to override it.
+- Firewall, networking base, duplicati wiring, tor client, and the app
+  baseline are hosts-common modules parameterized by policy flags.
+
+Common per-host divergence files, all optional:
+
+| File               | Purpose                                                                                                                                                                                   |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `apps-enable.nix`  | App overrides at `lib.mkOverride 1000` over the common baseline; publish the override set under `flake.lib.nixos._hostAppsOverrides.<host>` so the FR-5 flake check rejects no-op entries |
+| `default-apps.nix` | Per-host `host.defaults` overrides (audio player, video player)                                                                                                                           |
+| `networking.nix`   | DNS or routing layered on the common NetworkManager base                                                                                                                                  |
+| `nix-settings.nix` | Hardware-tuned `max-jobs` and `min-free` only                                                                                                                                             |
+| `services.nix`     | Host-divergent services; on non-System76 hardware keep the default `powerprofilesctl` i3 power backend, System76 chassis override `gui.i3.powerProfiles.backend = "system76-power"`       |
+| `support.nix`      | Vendor hardware-support enables (firmware daemon, kernel modules)                                                                                                                         |
+
+Unfree packages are declared at the flake-parts level only (the
+`nixpkgs.allowedUnfreePackages` option declared in
+`modules/meta/nixpkgs-allowed-unfree.nix`, contributed from any module).
+There is no NixOS-scope allowlist: setting `nixpkgs.allowedUnfreePackages`
+inside the host module fails evaluation.
+
+## 3. Fill in policy.nix
+
+`policy.nix` publishes per-host registry data read by `modules/hosts/common/*`
+and fleet consumers. Start conservative and flip gates as the host becomes
+ready:
+
+```nix
+_: {
+  flake.lib.nixos.hosts.<host> = {
+    # Gate for sops-consuming common modules. Keep false until the age
+    # identity is installed on the machine (step 4), then flip to true.
+    sopsRuntimeReady = false;
+
+    # Gate read by modules/<host>/r2-runtime.nix, if the host binds the
+    # external R2 module chain.
+    r2RuntimeReady = false;
+
+    # Values consumed by modules/hosts/common/*.
+    extraHomeApps = [ ];
+    firewallDnsInterfaces = [ "<real-interface-name>" ];
+    # firewallExtraTcpPortRanges = [ { from = 8000; to = 8999; } ];
+    # duplicatiStateDirReadable = true;
+  };
+}
+```
+
+Use the host's real interface names (`ip link` on the target) for
+`firewallDnsInterfaces`. If the new host becomes the primary fleet endpoint,
+move `primary = true` and `tailnetIp` from the current primary host's
+`policy.nix`: `modules/networking/ssh-hosts.nix` aliases and the tailscale
+SSH default follow that registry data automatically.
+
+## 4. Provision secrets (sops)
+
+`modules/hosts/common/imports.nix` already imports
+`flake.nixosModules.sopsRuntime` and `flake.nixosModules.repoSecrets` for
+every `shareCommon` host; no per-host sops wiring is needed.
+
+1. Install the single canonical age identity on the machine, following
+   Host Preparation in [SOPS usage](../sops/README.md): the private key goes
+   to `/var/lib/sops-nix/key.txt` (system) and `~/.config/sops/age/keys.txt`
+   (Home Manager). Single-recipient design: no `.sops.yaml` change and no
+   `sops updatekeys`.
+2. Flip `sopsRuntimeReady = true` in `policy.nix` once the identity is in
+   place.
+3. Add `secrets/<host>.yaml` in the secrets submodule only if the host needs
+   host-specific secrets (the catch-all creation rule in `.sops.yaml` already
+   matches). Guard every new `sops.secrets` declaration with the
+   `builtins.pathExists` pattern so secretless CI evaluation keeps working.
+4. Push the secrets submodule before evaluating or opening a PR:
+   `self.submodules = true` pins `secrets/` by revision, so an unpushed
+   submodule commit fails `nix flake check` and CI with
+   `Cannot find Git revision`.
+
+## 5. Backups (duplicati)
+
+`modules/hosts/common/duplicati.nix` enables `services.duplicati-r2`
+automatically once the duplicati module and secrets exist and
+`sopsRuntimeReady` is true; `duplicatiStateDirReadable = true` additionally
+grants the owner read access to the state directory. Confirm the source
+paths in the shared `secrets/duplicati-config.json` manifest exist on the new
+host; a manifest that references only absent paths yields a silently idle
+backup timer.
+
+## 6. Documentation and labels
+
+- Update the host-enumerating docs: `docs/index.md`, `docs/ONBOARDING.md`,
+  `docs/architecture/01-pattern-overview.md`,
+  `docs/architecture/03-nixos-modules.md`,
+  `docs/architecture/04-home-manager.md`,
+  `docs/architecture/05-host-composition.md`, and
+  `docs/reference/github-labels.md`.
+- Create the GitHub label manually (no label-sync config exists):
+  `gh label create "host(<host>)" --color <hex> --description "<host> host"`.
+
+## 7. CI
+
+No workflow edits are needed: `.github/workflows/check.yml` and
+`.github/workflows/update-flake.yml` derive the host list from
+`nix eval .#nixosConfigurations --apply builtins.attrNames`, so the new host
+is dry-run built on every compliance run and fully built in the nightly
+update gate. Budget for the added nightly build time: update-flake builds
+each host closure sequentially with garbage collection in between to respect
+runner disk.
+
+## 8. Validation ladder
+
+```bash
+nix fmt
+nix flake check --accept-flake-config --no-build --offline
+nix build ".#nixosConfigurations.<host>.config.system.build.toplevel"
+./build.sh --host <host> --boot   # on the target machine
+nix run .#generation-manager -- score   # target: 20/20
+```
+
+Run the first two before every push; the closure build proves the host
+evaluates and compiles; `--boot` activates it on next reboot without
+switching the running system.

--- a/docs/index.md
+++ b/docs/index.md
@@ -92,6 +92,8 @@
   - Conventions for packages/ directory including templates for Rust, Go, Python, and binary downloads.
 - [guides/github-deployments.md](guides/github-deployments.md)
   - Using GitHub's Deployments API via gh CLI for tracking deployments (metadata only, not actual deployment).
+- [guides/host-onboarding.md](guides/host-onboarding.md)
+  - Procedural checklist for adding a NixOS host: registry entry, per-host module set, policy flags, sops provisioning, backups, docs, and validation.
 - [guides/nix-debugging-manual.md](guides/nix-debugging-manual.md)
   - Debugging techniques for Nix expressions, NixOS modules, and Home Manager including REPL, tracing, and common errors.
 - [guides/stylix-integration.md](guides/stylix-integration.md)

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -233,10 +233,10 @@ nixpkgs.allowedUnfreePackages = [
 ```
 
 NVIDIA unfree entries (`nvidia-kernel-modules`, `nvidia-x11`,
-`nvidia-settings`) are allowed in the shared
-`modules/hosts/common/packages.nix` allowlist, not in the System76 module.
-`modules/hosts/common/imports.nix` additionally allows `p7zip-rar`, `rar`, and
-`unrar`.
+`nvidia-settings`) and the archive utilities (`p7zip-rar`, `rar`, `unrar`)
+are allowed in the shared `modules/hosts/common/packages.nix` allowlist, not
+in the System76 module. All entries contribute to the single flake-parts
+`nixpkgs.allowedUnfreePackages` option; there is no NixOS-scope allowlist.
 
 > **Note:** All firmware packages are redistributable, not unfree.
 

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -40,6 +40,8 @@ let
   };
 in
 {
+  nixpkgs.allowedUnfreePackages = [ "claude-code" ];
+
   flake.nixosModules.apps.claude-code =
     {
       config,
@@ -179,7 +181,6 @@ in
           [
             {
               environment.systemPackages = lib.optional cfg.installMethods.nix.enable cfg.package;
-              nixpkgs.allowedUnfreePackages = lib.optionals cfg.installMethods.nix.enable [ "claude-code" ];
               # Import by Home Manager app key so import-tree resolves the module location.
               # The bun HM module owns BUN_INSTALL/PATH setup and the createBunDir DAG node.
               home-manager.extraAppImports = lib.mkAfter (lib.optional cfg.installMethods.bun.enable "bun");

--- a/modules/configurations/nixos.nix
+++ b/modules/configurations/nixos.nix
@@ -12,7 +12,20 @@ let
     { module }:
     let
       hostName = name;
-      shareCommon = lib.attrByPath [ hostName "shareCommon" ] false (config.flake.lib.nixos.hosts or { });
+      # shareCommon must be declared explicitly per host: a silent `false`
+      # default let an unregistered host build green without the entire
+      # hosts-common baseline (hostname, stateVersion, sops pin, ...) and
+      # surface only at runtime. The throw is lazy, so enumerating host
+      # names (nix eval .#nixosConfigurations --apply builtins.attrNames)
+      # still works while any deeper eval of the host aborts.
+      hostsRegistry = config.flake.lib.nixos.hosts or { };
+      registryHint = "add `${hostName}.shareCommon = true;` (opt in to the hosts-common baseline) or `= false;` (deliberate opt-out) to modules/hosts/common/registry.nix";
+      hostEntry =
+        hostsRegistry.${hostName}
+          or (throw "Host ${hostName} has no entry in flake.lib.nixos.hosts; ${registryHint}");
+      shareCommon =
+        hostEntry.shareCommon
+          or (throw "flake.lib.nixos.hosts.${hostName} does not set shareCommon; ${registryHint}");
       commonModule =
         config.flake.nixosModules.hosts-common
           or (throw "Host ${hostName} has shareCommon enabled but flake.nixosModules.hosts-common is missing");

--- a/modules/hosts/common/imports.nix
+++ b/modules/hosts/common/imports.nix
@@ -30,12 +30,6 @@ let
   ] inputs;
 
   body = _: {
-    nixpkgs.allowedUnfreePackages = lib.mkAfter [
-      "p7zip-rar"
-      "rar"
-      "unrar"
-    ];
-
     # Cybersecurity wordlist symlinks under /usr/share/wordlists/
     csec.wordlists.enable = true;
 

--- a/modules/hosts/common/registry.nix
+++ b/modules/hosts/common/registry.nix
@@ -1,3 +1,7 @@
+# Every host under configurations.nixos needs an explicit shareCommon entry
+# here; modules/configurations/nixos.nix aborts evaluation for hosts without
+# one, so a new host cannot silently skip the hosts-common baseline.
+# shareCommon = false is a deliberate opt-out, not the default.
 _: {
   flake.lib.nixos.hosts = {
     system76.shareCommon = true;

--- a/modules/meta/nixpkgs-allowed-unfree.nix
+++ b/modules/meta/nixpkgs-allowed-unfree.nix
@@ -7,16 +7,11 @@
 let
   cfg = config;
   predicate = pkg: builtins.elem (lib.getName pkg) cfg.nixpkgs.allowedUnfreePackages;
-  optionModule =
-    { lib, ... }:
-    {
-      options.nixpkgs.allowedUnfreePackages = lib.mkOption {
-        type = lib.types.listOf lib.types.str;
-        default = [ ];
-      };
-    };
 in
 {
+  # Unfree entries are declared at the flake-parts level only (any module can
+  # contribute to this option); there is deliberately no NixOS-scope or
+  # Home Manager-scope allowlist option, the predicate below is shared.
   options.nixpkgs.allowedUnfreePackages = lib.mkOption {
     type = lib.types.listOf lib.types.str;
     default = [ ];
@@ -36,7 +31,6 @@ in
       };
 
     flake = {
-      nixosModules.base.imports = [ optionModule ];
       nixosModules.base.nixpkgs.config.allowUnfreePredicate = predicate;
 
       homeManagerModules.base = args: {

--- a/modules/tpnix/power.nix
+++ b/modules/tpnix/power.nix
@@ -9,11 +9,6 @@
     {
       boot.blacklistedKernelModules = [ "nouveau" ];
 
-      nixpkgs.allowedUnfreePackages = lib.mkAfter [
-        "nvidia-settings"
-        "nvidia-x11"
-      ];
-
       gpu.nvidia = {
         enable = true;
         package = config.boot.kernelPackages.nvidiaPackages.production;


### PR DESCRIPTION
## Summary

Coldfront prep: four issues in one PR, each as its own commit.

- **#354, registry guard**: `modules/configurations/nixos.nix` resolved the hosts-common opt-in with a silent `false` default, so a host missing from `modules/hosts/common/registry.nix` built green without the entire baseline (hostname, stateVersion, sops pin, substituters, app baseline). The constructor now throws at eval time with a registry hint, distinguishing a missing entry from an entry without `shareCommon`. The throw is deliberate instead of a `runCommandLocal` check derivation: fail-drvs do not gate CI's `nix flake check --no-build` run, an eval throw does. Host-name enumeration (`--apply builtins.attrNames`) stays lazy, which the CI host-list derivation below relies on.
- **#346, dead unfree option**: the `allowUnfree` predicate reads only the flake-parts `nixpkgs.allowedUnfreePackages` list; the NixOS-scope option and its three writers were inert. Of the two directions the issue offered, this PR deletes rather than wires: the repo has 60+ working flake-parts-level writers, the two host lists (`modules/hosts/common/imports.nix`, `modules/tpnix/power.nix`) duplicated entries already live in `modules/hosts/common/packages.nix`, and wiring would create a second live scope with a different predicate per context (perSystem pkgs, HM, NixOS). The claude-code entry moves to flake-parts scope like every other app module. A host-scope declaration now fails eval as an undeclared option instead of silently doing nothing. CLAUDE.md, `docs/architecture/06-reference.md`, and `docs/system76/system76-configuration.md` updated to match.
- **#355, per-host CI build coverage**: `check.yml` and `update-flake.yml` pinned `nixosConfigurations.system76`, leaving every other host without build coverage and auto-merging nightly input bumps on one host's build. Both workflows now derive the host list from `nix eval .#nixosConfigurations --apply builtins.attrNames`; check.yml dry-runs every host, update-flake.yml realises every closure sequentially with `nix store gc` between hosts (the runner disk fits one desktop closure at a time, which is why a matrix was not used: it would need artifact plumbing for `flake.lock` and the firefoxpwa pin across jobs). An empty host list fails instead of passing vacuously; hardcoded host-count comments are gone. Nightly runtime grows with each host added.
- **#353, onboarding runbook**: `docs/guides/host-onboarding.md` carries the ordered checklist (registry entry, per-host file set, policy.nix flags, sops identity, backups, docs/labels, CI, validation ladder), written against the current post-#370 layout: the issue's references to per-host duplicati files and per-host tor enumeration are obsolete, both are hosts-common now. Indexed from `docs/guides/README.md` and `docs/index.md`, linked from `docs/architecture/05-host-composition.md`.

Closes #346
Closes #353
Closes #354
Closes #355

## Test plan

- `nix eval --accept-flake-config .#nixosConfigurations.<host>.config.networking.hostName` for each host (guard positive path).
- Negative tests: removing the tpnix registry line fails eval with the `does not set shareCommon` message; also removing the `policy.nix` entry fails with the `has no entry` message; `builtins.attrNames` enumeration keeps working in both broken states.
- `nix flake check --accept-flake-config --no-build --offline` passes (evaluates every host toplevel, so a lost unfree allowance, a remaining NixOS-scope writer, or a guard regression would fail).
- `nix run nixpkgs#actionlint` on both workflows passes; `nix eval --accept-flake-config --json .#nixosConfigurations --apply builtins.attrNames` (the exact command both workflows run) returns the host list.
- `nix fmt` and `nix develop -c pre-commit run --all-files --hook-stage manual` pass (actionlint, deadnix, statix, treefmt, typos, yamllint, shellcheck).