### PR TITLE
perf(build): remove rebuild cascade and build-queue bottlenecks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -252,8 +252,9 @@ BOOTSTRAP_TRUSTED_KEYS=(
 )
 
 configure_build_flags() {
-  local build_cores="0"    # "$(($(nproc --all) - 1))" # Nix default = 0 (all cores per build job)
-  local build_max_jobs="2" # Nix default = 1
+  local build_cores="0"       # 0 = all cores per build job
+  local build_max_jobs="auto" # one slot per core; a low fixed cap serializes the
+  # many small derivations in a system closure behind long compiles
 
   BUILD_FLAGS=(
     "--cores" "${build_cores}"

--- a/build.sh
+++ b/build.sh
@@ -252,9 +252,12 @@ BOOTSTRAP_TRUSTED_KEYS=(
 )
 
 configure_build_flags() {
-  local build_cores="0"       # 0 = all cores per build job
-  local build_max_jobs="auto" # one slot per core; a low fixed cap serializes the
-  # many small derivations in a system closure behind long compiles
+  local build_cores="0" # 0 = all cores per build job
+  # Half the cores: a low fixed cap serializes the many small derivations in a
+  # system closure behind long compiles, while cores=0 with one job per core
+  # lets peak RAM stack with every concurrent source build.
+  local build_max_jobs
+  build_max_jobs="$((($(nproc) + 1) / 2))"
 
   BUILD_FLAGS=(
     "--cores" "${build_cores}"

--- a/modules/apps/inkscape.nix
+++ b/modules/apps/inkscape.nix
@@ -40,11 +40,6 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        # Stylix patches gtksourceview (inkscape dependency) with a custom color
-        # scheme, changing its derivation hash and causing a binary cache miss.
-        # Disable to avoid rebuilding inkscape and all gtksourceview consumers.
-        stylix.targets.gtksourceview.enable = false;
-
         environment.systemPackages = [ cfg.package ];
       };
     };

--- a/modules/base/nix-settings.nix
+++ b/modules/base/nix-settings.nix
@@ -12,7 +12,10 @@ let
     # Update both this comment and flake.nix when adding or removing IFD
     # consumers.
     allow-import-from-derivation = true;
-    auto-optimise-store = lib.mkDefault true;
+    # Hard-linking on every store write taxes builds and large substitution
+    # runs and serializes on the store lock; the scheduled
+    # nix.optimise.automatic run below deduplicates instead.
+    auto-optimise-store = lib.mkDefault false;
     cores = lib.mkDefault 0;
     keep-outputs = false;
     experimental-features = [
@@ -36,7 +39,12 @@ in
   };
   config = {
     nix.settings = settings;
-    flake.nixosModules.base.nix.settings = settings;
+    flake.nixosModules.base.nix = {
+      inherit settings;
+      # Store deduplication off the critical path; replaces
+      # auto-optimise-store (defaults to 03:45 daily).
+      optimise.automatic = true;
+    };
 
     flake.homeManagerModules.base = _: {
       nix.settings = settings;

--- a/modules/hosts/common/nix-substituters.nix
+++ b/modules/hosts/common/nix-substituters.nix
@@ -2,8 +2,12 @@
 let
   body = {
     nix.settings = {
+      # The NixOS module default already contributes https://cache.nixos.org/
+      # (trailing slash) and its trusted key. Re-adding the unslashed
+      # spelling is not deduplicated (Lix getDefaultSubstituters compares
+      # exact URI strings), so it opens a second store against the same host
+      # and doubles narinfo misses.
       substituters = lib.mkAfter [
-        "https://cache.nixos.org" # fallback
         "https://cache.garnix.io"
         "https://cache.numtide.com"
         "https://nixpkgs-unfree.cachix.org" # unfree packages (unrar, etc.)
@@ -11,7 +15,6 @@ let
         # appended by modules/apps/doom-emacs.nix when the module is enabled.
       ];
       trusted-public-keys = lib.mkAfter [
-        "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
         "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
         "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
         "nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs="

--- a/modules/stylix/stylix.nix
+++ b/modules/stylix/stylix.nix
@@ -48,6 +48,13 @@ in
             regreet.enable = false;
             # Enable Chromium theming (applies to Google Chrome via browser policies)
             chromium.enable = true;
+            # The NixOS-scope target only enables a nixpkgs overlay that
+            # patches gtksourceview 2/3/4/5 with the generated color scheme.
+            # The hash change forces gtksourceview and every consumer
+            # (planify, inkscape, ...) to rebuild from source on each nixpkgs
+            # bump. The Home Manager target ships the same scheme as
+            # user-scope data files, keeping the theming without rebuilds.
+            gtksourceview.enable = false;
           };
         };
       };


### PR DESCRIPTION
## Summary
- Disable the stylix NixOS-scope gtksourceview target globally. The target only enables an overlay that patches gtksourceview 2/3/4/5, so the hash change forced gtksourceview and every consumer to rebuild from source on each nixpkgs bump: the 2026-07-17 build logs show planify 4.19.4 compiling for about 19 minutes. With the overlay off, pkgs.planify resolves to the stock nixpkgs path, which cache.nixos.org serves. The Home Manager gtksourceview target still ships the generated scheme as user-scope data files, so theming is unchanged. The inkscape-scoped disable moves into modules/stylix/stylix.nix.
- Raise the fixed `--max-jobs 2` cap in build.sh to `auto`. The 2026-07-17 morning log shows queued derivations waiting 2h8m with zero build time on a 12-core host while two slots worked through source rebuilds.
- Drop the re-added cache.nixos.org substituter and trusted key. The NixOS module default already contributes the trailing-slash form, and Lix `getDefaultSubstituters` deduplicates exact URI strings only, so both stores were opened and every narinfo miss queried the same host twice.
- Replace `auto-optimise-store` with scheduled `nix.optimise.automatic`. Per-registration hard-linking taxes builds and large substitution runs; the daily 03:45 run keeps the disk savings off the build path.

Known cosmetic leftover: `nix-logseq-git-flake.cachix.org` appears twice in `extra-substituters` when both logseq modules are enabled. Lix deduplicates exact duplicates at store open, so there is no runtime cost.

## Test plan
- `nix eval "path:.#nixosConfigurations.<host>.config.stylix.targets.gtksourceview.enable"` returns `false` for system76 and tpnix
- `nix eval ...nix.settings.substituters` shows a single cache.nixos.org entry with the module default intact
- `nix eval ...nix.settings.auto-optimise-store` returns `false` and `...nix.optimise.automatic` returns `true` on both validated hosts
- `pkgs.planify.outPath` narinfo on cache.nixos.org: overlaid path returns 404, stock path after this change returns 200
- `bash -n build.sh` plus shellcheck via pre-commit
- `nix flake check path:. --accept-flake-config --no-build --offline` exits 0