### PR TITLE
feat(nix): publish free custom derivations to a cachix cache

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -1,0 +1,68 @@
+---
+name: Cache Push
+"on":
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - flake.lock
+      - modules/meta/cache-roots.nix
+      - modules/custom-overlays/**
+      - packages/**
+concurrency:
+  group: cache-push
+  cancel-in-progress: true
+permissions:
+  contents: read
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
+      # Preinstalled toolchains the build never uses; the cache-roots
+      # closure plus its build inputs exceeds the runner's default free
+      # space.
+      - name: Free runner disk
+        run: |
+          sudo rm -rf /usr/local/lib/android /usr/share/dotnet \
+            /opt/ghc /usr/local/.ghcup
+          df -h /
+      - name: Install Lix
+        uses: ./.github/actions/install-lix
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      # path:. bypasses the git fetcher: self.submodules = true would make
+      # a git-based self fetch pull the private secrets submodule that CI
+      # cannot read. cache-roots only references package sets, so the
+      # secretless evaluation yields the same derivations hosts build.
+      - name: Build cache roots
+        run: |
+          nix build --accept-flake-config --print-build-logs \
+            "path:.#cache-roots"
+      # actionlint: the secrets context is not available in step `if`
+      # expressions, so a gate step exports token presence as an output.
+      - name: Detect Cachix token
+        id: cachix-token
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          if [ -n "$CACHIX_AUTH_TOKEN" ]; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Push closure to Cachix
+        if: ${{ steps.cachix-token.outputs.present == 'true' }}
+        env:
+          CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN }}
+        run: |
+          nix run --accept-flake-config --inputs-from "path:." \
+            nixpkgs#cachix -- push bad3r-nixos "$(readlink -f result)"
+      - name: Report unpushed build
+        if: ${{ steps.cachix-token.outputs.present == 'false' }}
+        run: |
+          echo "::warning::CACHIX_AUTH_TOKEN is not set;" \
+            "cache-roots was built but not pushed."

--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -6,9 +6,12 @@ name: Cache Push
     branches:
       - main
     paths:
+      # modules/** is deliberately broad: overlay packages inherit
+      # indirect inputs from sibling modules (browser policy data, icon
+      # assets), so narrower filters would skip pushes for derivation
+      # changes hosts still evaluate.
       - flake.lock
-      - modules/meta/cache-roots.nix
-      - modules/custom-overlays/**
+      - modules/**
       - packages/**
 concurrency:
   group: cache-push

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -1,0 +1,169 @@
+# Binary Cache Coverage
+
+Operator surface for serving custom derivations from a binary cache instead
+of rebuilding them on every host switch (issue
+https://github.com/Bad3r/nixos/issues/382). Cache topology and substituter
+wiring live in `modules/hosts/common/nix-substituters.nix`; the build surface
+lives in `modules/meta/cache-roots.nix`; the CI publisher is
+`.github/workflows/cache-push.yml`.
+
+## Audit findings (2026-07-17)
+
+Build-log profiling under `~/.local/state/nixos-build/` after PR
+https://github.com/Bad3r/nixos/pull/380 still showed on the order of 170
+derivations built locally per full system build. Three groups remain:
+
+- custom flake packages and overlay-modified packages (pnpm and npm
+  dependency trees, patched browser runtimes, pentest tooling)
+- unfree binary repacks (vscode, webex, kiro, veracrypt, ventoy, and
+  others)
+- host-specific config and text derivations (cheap, acceptable)
+
+The garnix question from the issue resolves as follows:
+
+- The garnix GitHub app is not installed for this repository. Recent
+  commits carry no garnix check suites, and the garnix badge API returns
+  an empty badge. The few `cache.garnix.io` hits observed during builds
+  come from garnix's shared public cache, populated by other projects'
+  builds, not from CI coverage of this repository.
+- garnix cannot build this flake in its current shape even if installed:
+  `flake.nix` sets `self.submodules = true`, so any git-based fetch of the
+  flake pulls the private `secrets/` submodule, which external CI cannot
+  read. The repository's own GitHub Actions work around this with `path:.`
+  checkouts and secretless evaluation (see `.github/workflows/check.yml`),
+  a mechanism garnix does not document an equivalent for. Revisit garnix
+  only if it documents submodule-free fetching or the submodule leaves the
+  fetch path.
+
+Coverage therefore comes from this repository's own CI pushing to Cachix,
+the mechanism already proven by the `nix-logseq-git-flake` input, whose CI
+builds logseq and pushes to its own Cachix cache trusted in
+`modules/hosts/common/nix-substituters.nix`.
+
+## Build surface
+
+`packages.<system>.cache-roots` is a `linkFarm` over an explicit allowlist
+of free, redistribution-safe packages:
+
+- Host-sourced entries come from the primary host's package set so custom
+  overlays (firefoxpwa policy injection, wfuzz patches, john patches) and
+  nixpkgs config produce exactly the derivations a host switch evaluates.
+  `nix build --dry-run "path:.#cache-roots"` on a host that has switched
+  recently should report no unexpected package rebuilds; that is the
+  derivation-parity check.
+- perSystem-sourced entries (codeburn, restringer) are consumed through
+  the devshell surface and build from the perSystem nixpkgs instance.
+
+The allowlist is explicit because `cachix push` publishes the full runtime
+closure to a public cache. Every entry's closure must be redistributable.
+
+## Classification (2026-07-17 build logs)
+
+License fields read from each package's `meta.license` on the primary
+host's package set.
+
+Cached via cache-roots (free, redistributable):
+
+| Package              | License            |
+| -------------------- | ------------------ |
+| codeburn             | MIT                |
+| context7-mcp         | MIT                |
+| electron-mail        | GPL-3.0            |
+| firefoxpwa           | MPL-2.0            |
+| john                 | GPL-2.0-or-later   |
+| mullvad-browser      | MPL-2.0 + LGPL     |
+| nemo-with-extensions | GPL-2.0 + LGPL-2.0 |
+| planify              | GPL-3.0-or-later   |
+| proton-vpn           | GPL-3.0-only       |
+| restringer           | MIT                |
+| tor-browser          | MPL-2.0 + LGPL     |
+| tweakcc              | MIT                |
+| upscayl              | AGPL-3.0-or-later  |
+| wappalyzer-next      | GPL-3.0-only       |
+| wfuzz                | GPL-2.0-only       |
+
+Intentionally local, unfree with redistribution not permitted or unclear
+(publishing these to a public cache would violate their licenses):
+
+| Package       | License note                       |
+| ------------- | ---------------------------------- |
+| charles       | unfree                             |
+| discord       | unfree                             |
+| dropbox       | unfree                             |
+| google-chrome | unfree                             |
+| kiro          | Amazon Software License            |
+| veracrypt     | TrueCrypt-derived, unfree          |
+| ventoy        | unfree (vendored blobs)            |
+| vscode        | unfree (Microsoft product license) |
+| webex         | unfree                             |
+
+Unfree but marked redistributable in nixpkgs; candidates for a later
+operator decision, kept local until then:
+
+| Package     | License note                               |
+| ----------- | ------------------------------------------ |
+| firefox-bin | Firefox trademark license, redistributable |
+| nvidia-x11  | unfreeRedistributable                      |
+| steam       | unfreeRedistributable                      |
+
+Residual local builds accepted with reasons:
+
+- logseq family: served by `nix-logseq-git-flake.cachix.org`. Local builds
+  happen when that input repository's CI has not yet built the pinned
+  nightly; the fix belongs in that repository's build schedule, not in a
+  backfill here.
+- pentest wrappers (`pentest-*`): the wrapper derivations embed the flake
+  self path and change on every commit; their heavy runtime payloads are
+  either Hydra-built (metasploit, nmap, sqlmap, ...), covered by
+  cache-roots entries (john, wfuzz, wappalyzer-next), or unfree (burpsuite,
+  charles) and excluded by license.
+- nix-index-with-full-db: fetch-dominated assembly of a prebuilt database,
+  negligible build cost.
+- host config and systemd unit text derivations: cheap by design.
+- nixpkgs packages missing from `cache.nixos.org` right after a fresh
+  nixpkgs pin (Hydra lag): transient; the heaviest recurring cases (nemo,
+  planify) are pinned into cache-roots.
+
+## Operator runbook
+
+One-time setup, in order:
+
+1. Create a public Cachix cache named `bad3r-nixos` under the account that
+   owns `nix-logseq-git-flake`.
+2. Create a Cachix auth token with write access to that cache and store it
+   as the `CACHIX_AUTH_TOKEN` repository secret:
+   `gh secret set CACHIX_AUTH_TOKEN --repo Bad3r/nixos`.
+   Until the secret exists, the workflow builds cache-roots and emits a
+   warning instead of pushing.
+3. Run the `Cache Push` workflow once via `workflow_dispatch` and confirm
+   the push step succeeds.
+4. Wire the substituter into `modules/hosts/common/nix-substituters.nix`:
+   add `https://bad3r-nixos.cachix.org` to `extra-substituters` and the
+   cache's public key (shown on the Cachix cache page after creation) to
+   `extra-trusted-public-keys`. The key exists only after step 1, so this
+   lands as a follow-up change.
+5. After the next nixpkgs bump and merge, compare a host switch build log
+   against a pre-cache log: the cache-roots packages should appear as
+   downloads, not builds.
+
+The workflow also runs automatically on pushes to `main` that change
+`flake.lock`, the cache-roots module, custom overlays, or `packages/`, so
+the cache tracks the input revisions hosts evaluate against.
+
+## Extending the allowlist
+
+Add a package to `modules/meta/cache-roots.nix` when it shows up in build
+logs and its full runtime closure is redistributable:
+
+- Source it from the host package set when a custom overlay or host
+  nixpkgs config shapes it; source it from `self'.packages` when only the
+  devshell surface consumes it.
+- Verify the license before adding:
+  `nix eval "path:.#nixosConfigurations.<host>.pkgs.<name>.meta.license"`.
+- Confirm derivation parity with
+  `nix build --dry-run "path:.#cache-roots"` on a recently switched host:
+  the new entry must not introduce rebuilds of paths the host already has.
+
+Unfree packages must never enter the allowlist while the cache is public.
+Serving them requires the issue's phase 2: a private or authenticated
+cache with the token provisioned to hosts via sops.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -71,16 +71,22 @@ Cached via cache-roots (free, redistributable):
 | electron-mail        | GPL-3.0            |
 | firefoxpwa           | MPL-2.0            |
 | john                 | GPL-2.0-or-later   |
-| mullvad-browser      | MPL-2.0 + LGPL     |
 | nemo-with-extensions | GPL-2.0 + LGPL-2.0 |
 | planify              | GPL-3.0-or-later   |
 | proton-vpn           | GPL-3.0-only       |
 | restringer           | MIT                |
-| tor-browser          | MPL-2.0 + LGPL     |
 | tweakcc              | MIT                |
 | upscayl              | AGPL-3.0-or-later  |
 | wappalyzer-next      | GPL-3.0-only       |
 | wfuzz                | GPL-2.0-only       |
+
+context7-mcp is sourced from the `mcp-servers-nix` input, matching the
+consumer in `modules/agents/mcp.nix`; the host package set carries a
+same-named but different derivation no consumer runs. For entries built
+through `buildFHSEnv` or wrapper derivations (electron-mail, upscayl,
+nemo-with-extensions), the outer wrapper sets `allowSubstitutes = false`
+and always rebuilds locally; that is trivial assembly work, and the heavy
+dependency closure underneath substitutes normally.
 
 Intentionally local, unfree with redistribution not permitted or unclear
 (publishing these to a public cache would violate their licenses):
@@ -108,6 +114,10 @@ operator decision, kept local until then:
 
 Residual local builds accepted with reasons:
 
+- tor-browser and mullvad-browser: free and redistributable, but nixpkgs
+  sets `allowSubstitutes = false` on the main derivation, so hosts build
+  them locally regardless of cache contents; caching them would only
+  spend CI time.
 - logseq family: served by `nix-logseq-git-flake.cachix.org`. Local builds
   happen when that input repository's CI has not yet built the pinned
   nightly; the fix belongs in that repository's build schedule, not in a
@@ -155,9 +165,13 @@ logs and its full runtime closure is redistributable:
 
 - Source it from the host package set when a custom overlay or host
   nixpkgs config shapes it; source it from `self'.packages` when only the
-  devshell surface consumes it.
+  devshell surface consumes it; source it from the owning flake input
+  when a module consumes the input's package directly (context7-mcp).
 - Verify the license before adding:
   `nix eval "path:.#nixosConfigurations.<host>.pkgs.<name>.meta.license"`.
+- Verify the heavy derivation substitutes: entries whose main derivation
+  sets `allowSubstitutes = false` (check `drvAttrs.allowSubstitutes`)
+  never hit the cache and do not belong in the list.
 - Confirm derivation parity with
   `nix build --dry-run "path:.#cache-roots"` on a recently switched host:
   the new entry must not introduce rebuilds of paths the host already has.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -124,31 +124,29 @@ Residual local builds accepted with reasons:
   nixpkgs pin (Hydra lag): transient; the heaviest recurring cases (nemo,
   planify) are pinned into cache-roots.
 
-## Operator runbook
+## Operator setup
 
-One-time setup, in order:
+Completed 2026-07-17:
 
-1. Create a public Cachix cache named `bad3r-nixos` under the account that
+1. The public Cachix cache `bad3r-nixos` exists under the account that
    owns `nix-logseq-git-flake`.
-2. Create a Cachix auth token with write access to that cache and store it
-   as the `CACHIX_AUTH_TOKEN` repository secret:
-   `gh secret set CACHIX_AUTH_TOKEN --repo Bad3r/nixos`.
-   Until the secret exists, the workflow builds cache-roots and emits a
-   warning instead of pushing.
-3. Run the `Cache Push` workflow once via `workflow_dispatch` and confirm
-   the push step succeeds.
-4. Wire the substituter into `modules/hosts/common/nix-substituters.nix`:
-   add `https://bad3r-nixos.cachix.org` to `extra-substituters` and the
-   cache's public key (shown on the Cachix cache page after creation) to
-   `extra-trusted-public-keys`. The key exists only after step 1, so this
-   lands as a follow-up change.
-5. After the next nixpkgs bump and merge, compare a host switch build log
+2. A Cachix auth token with write access to the cache is stored as the
+   `CACHIX_AUTH_TOKEN` repository secret
+   (`gh secret set CACHIX_AUTH_TOKEN --repo Bad3r/nixos`; rotate the same
+   way). Whenever the secret is absent, the workflow builds cache-roots
+   and emits a warning instead of pushing.
+3. Common hosts trust the cache: `modules/hosts/common/nix-substituters.nix`
+   carries `https://bad3r-nixos.cachix.org` and its public key.
+
+Remaining:
+
+1. First populated run: the workflow triggers on pushes to `main` that
+   change `flake.lock`, the cache-roots module, custom overlays, or
+   `packages/` (the merge introducing the module qualifies), or run it via
+   `workflow_dispatch`; confirm the push step succeeds.
+2. After the next nixpkgs bump and merge, compare a host switch build log
    against a pre-cache log: the cache-roots packages should appear as
    downloads, not builds.
-
-The workflow also runs automatically on pushes to `main` that change
-`flake.lock`, the cache-roots module, custom overlays, or `packages/`, so
-the cache tracks the input revisions hosts evaluate against.
 
 ## Extending the allowlist
 

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -46,8 +46,12 @@ builds logseq and pushes to its own Cachix cache trusted in
 of free, redistribution-safe packages:
 
 - Host-sourced entries come from the primary host's package set so custom
-  overlays (firefoxpwa policy injection, wfuzz patches, john patches) and
-  nixpkgs config produce exactly the derivations a host switch evaluates.
+  overlays (firefoxpwa policy injection, john patches) and nixpkgs config
+  produce exactly the derivations a host switch evaluates. Every entry's
+  app must be enabled on that host: overlays are gated on
+  `programs.<name>.extended.enable`, and a disabled app resolves to the
+  stock nixpkgs attr that no host consumes (which is why wfuzz is not
+  listed).
   `nix build --dry-run "path:.#cache-roots"` on a host that has switched
   recently should report no unexpected package rebuilds; that is the
   derivation-parity check.
@@ -78,7 +82,6 @@ Cached via cache-roots (free, redistributable):
 | tweakcc              | MIT                |
 | upscayl              | AGPL-3.0-or-later  |
 | wappalyzer-next      | GPL-3.0-only       |
-| wfuzz                | GPL-2.0-only       |
 
 context7-mcp is sourced from the `mcp-servers-nix` input, matching the
 consumer in `modules/agents/mcp.nix`; the host package set carries a
@@ -125,7 +128,7 @@ Residual local builds accepted with reasons:
 - pentest wrappers (`pentest-*`): the wrapper derivations embed the flake
   self path and change on every commit; their heavy runtime payloads are
   either Hydra-built (metasploit, nmap, sqlmap, ...), covered by
-  cache-roots entries (john, wfuzz, wappalyzer-next), or unfree (burpsuite,
+  cache-roots entries (john, wappalyzer-next), or unfree (burpsuite,
   charles) and excluded by license.
 - nix-index-with-full-db: fetch-dominated assembly of a prebuilt database,
   negligible build cost.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -59,7 +59,12 @@ of free, redistribution-safe packages:
   the devshell surface and build from the perSystem nixpkgs instance.
 
 The allowlist is explicit because `cachix push` publishes the full runtime
-closure to a public cache. Every entry's closure must be redistributable.
+closure to a public cache. Every entry's closure must be redistributable, and
+`cache-roots` enforces it: an `assertFree` guard aborts evaluation for any entry
+whose `meta.license` is missing or is neither free nor redistributable, so a
+license-violating addition fails `nix flake check` (the check
+`modules/package-checks.nix` mirrors from this output) instead of reaching the
+cache.
 
 ## Classification (2026-07-17 build logs)
 
@@ -181,4 +186,8 @@ logs and its full runtime closure is redistributable:
 
 Unfree packages must never enter the allowlist while the cache is public.
 Serving them requires the issue's phase 2: a private or authenticated
-cache with the token provisioned to hosts via sops.
+cache with the token provisioned to hosts via sops. The `assertFree` guard
+in `cache-roots.nix` backstops this: a package whose license is missing or
+non-redistributable aborts evaluation. Unfree-but-redistributable packages
+(firefox-bin, nvidia-x11, steam) pass the guard's legal check but stay out of
+the allowlist until that phase-2 operator decision.

--- a/modules/hosts/common/nix-substituters.nix
+++ b/modules/hosts/common/nix-substituters.nix
@@ -11,6 +11,9 @@ let
         "https://cache.garnix.io"
         "https://cache.numtide.com"
         "https://nixpkgs-unfree.cachix.org" # unfree packages (unrar, etc.)
+        # CI-built custom derivations (cache-roots); see
+        # docs/reference/binary-cache-coverage.md
+        "https://bad3r-nixos.cachix.org"
         # nix-community.cachix.org / doom-emacs-unstraightened.cachix.org are
         # appended by modules/apps/doom-emacs.nix when the module is enabled.
       ];
@@ -18,6 +21,7 @@ let
         "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
         "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
         "nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs="
+        "bad3r-nixos.cachix.org-1:CWwJIEV6kogZP/xZPRXdT6hkKvs84haLxYgK9oF59JE="
       ];
 
       download-attempts = lib.mkDefault 3;

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -25,17 +25,17 @@ let
 
   # Free-license, redistribution-safe packages observed building locally
   # in ~/.local/state/nixos-build profiling (issue #382). Extend only
-  # with packages whose full runtime closure is redistributable.
+  # with packages whose full runtime closure is redistributable and whose
+  # heavy derivations substitute: tor-browser and mullvad-browser are
+  # excluded because nixpkgs sets allowSubstitutes = false on the main
+  # derivation, so hosts rebuild them no matter what the cache holds.
   hostPackageNames = [
-    "context7-mcp"
     "electron-mail"
     "firefoxpwa"
     "john"
-    "mullvad-browser"
     "nemo-with-extensions"
     "planify"
     "proton-vpn"
-    "tor-browser"
     "tweakcc"
     "upscayl"
     "wappalyzer-next"
@@ -55,6 +55,7 @@ in
       pkgs,
       system,
       self',
+      inputs',
       ...
     }:
     let
@@ -71,6 +72,15 @@ in
             inherit name;
             path = self'.packages.${name};
           }) perSystemPackageNames
+          ++ [
+            # modules/agents/mcp.nix resolves MCP server packages from the
+            # mcp-servers-nix input; hostPkgs carries a same-named but
+            # different context7-mcp derivation no consumer runs.
+            {
+              name = "context7-mcp";
+              path = inputs'.mcp-servers-nix.packages.context7-mcp;
+            }
+          ]
         );
       };
     };

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -10,7 +10,7 @@
 
   A cache hit requires the exact derivation a consumer evaluates, so
   each entry is sourced from the package set that owns it: host-enabled
-  overlay packages (firefoxpwa policy injection, wfuzz patches, ...)
+  overlay packages (firefoxpwa policy injection, john patches, ...)
   come from the primary host's pkgs, and devshell-consumed packages
   come from the perSystem instance that `nix develop` uses. The lists
   are explicit allowlists because the pushed closure lands on a public
@@ -39,7 +39,6 @@ let
     "tweakcc"
     "upscayl"
     "wappalyzer-next"
-    "wfuzz"
   ];
 
   # Built through the perSystem nixpkgs instance (devshell surface),

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -1,0 +1,77 @@
+/*
+  Cache Roots (issue #382)
+
+  Aggregates the heavy custom derivations that every host switch would
+  otherwise build locally into one buildable flake output,
+  `packages.<system>.cache-roots`. The cache-push workflow builds this
+  output on CI and pushes its closure to the binary cache, so hosts
+  substitute these packages instead of rebuilding them after each
+  nixpkgs bump.
+
+  A cache hit requires the exact derivation a consumer evaluates, so
+  each entry is sourced from the package set that owns it: host-enabled
+  overlay packages (firefoxpwa policy injection, wfuzz patches, ...)
+  come from the primary host's pkgs, and devshell-consumed packages
+  come from the perSystem instance that `nix develop` uses. The lists
+  are explicit allowlists because the pushed closure lands on a public
+  cache: every entry must be free software whose redistribution is
+  permitted. Unfree repacks (vscode, webex, kiro, ...) stay out; see
+  docs/reference/binary-cache-coverage.md for the per-package
+  classification and the operator runbook.
+*/
+{ config, lib, ... }:
+let
+  primaryHost = "system76";
+
+  # Free-license, redistribution-safe packages observed building locally
+  # in ~/.local/state/nixos-build profiling (issue #382). Extend only
+  # with packages whose full runtime closure is redistributable.
+  hostPackageNames = [
+    "context7-mcp"
+    "electron-mail"
+    "firefoxpwa"
+    "john"
+    "mullvad-browser"
+    "nemo-with-extensions"
+    "planify"
+    "proton-vpn"
+    "tor-browser"
+    "tweakcc"
+    "upscayl"
+    "wappalyzer-next"
+    "wfuzz"
+  ];
+
+  # Built through the perSystem nixpkgs instance (devshell surface),
+  # not enabled as host apps; same redistribution constraint applies.
+  perSystemPackageNames = [
+    "codeburn"
+    "restringer"
+  ];
+in
+{
+  perSystem =
+    {
+      pkgs,
+      system,
+      self',
+      ...
+    }:
+    let
+      hostPkgs = config.flake.nixosConfigurations.${primaryHost}.pkgs;
+    in
+    {
+      packages = lib.mkIf (hostPkgs.stdenv.hostPlatform.system == system) {
+        cache-roots = pkgs.linkFarm "cache-roots" (
+          map (name: {
+            inherit name;
+            path = hostPkgs.${name};
+          }) hostPackageNames
+          ++ map (name: {
+            inherit name;
+            path = self'.packages.${name};
+          }) perSystemPackageNames
+        );
+      };
+    };
+}

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -59,17 +59,36 @@ in
     }:
     let
       hostPkgs = config.flake.nixosConfigurations.${primaryHost}.pkgs;
+
+      # The pushed closure lands on a public cache, so the allowlist above is
+      # only safe while every entry stays redistributable. This aborts
+      # evaluation (and therefore the nix flake check that
+      # modules/package-checks.nix mirrors from this output) when an entry has
+      # no meta.license or carries a license that is neither free nor
+      # redistributable, instead of silently publishing a license violation.
+      assertFree =
+        name: pkg:
+        let
+          licenses = lib.toList (pkg.meta.license or [ ]);
+          redistributable =
+            licenses != [ ]
+            && lib.all (license: (license.free or false) || (license.redistributable or false)) licenses;
+        in
+        if redistributable then
+          pkg
+        else
+          throw "cache-roots: ${name} is not free or redistributable; refusing to publish it to the public cache";
     in
     {
       packages = lib.mkIf (hostPkgs.stdenv.hostPlatform.system == system) {
         cache-roots = pkgs.linkFarm "cache-roots" (
           map (name: {
             inherit name;
-            path = hostPkgs.${name};
+            path = assertFree name hostPkgs.${name};
           }) hostPackageNames
           ++ map (name: {
             inherit name;
-            path = self'.packages.${name};
+            path = assertFree name self'.packages.${name};
           }) perSystemPackageNames
           ++ [
             # modules/agents/mcp.nix resolves MCP server packages from the
@@ -77,7 +96,7 @@ in
             # different context7-mcp derivation no consumer runs.
             {
               name = "context7-mcp";
-              path = inputs'.mcp-servers-nix.packages.context7-mcp;
+              path = assertFree "context7-mcp" inputs'.mcp-servers-nix.packages.context7-mcp;
             }
           ]
         );


### PR DESCRIPTION
## Summary

Phase 1 of https://github.com/Bad3r/nixos/issues/382.

Audit outcome that reshapes the issue's garnix plan:

- The garnix GitHub app is not installed for this repository (no garnix check suites on recent commits, empty badge API response). The few `cache.garnix.io` hits during builds come from garnix's shared public cache populated by other projects.
- garnix cannot build this flake even if installed: `self.submodules = true` makes any git-based self fetch pull the private `secrets/` submodule, which external CI cannot read. This repo's own workflows avoid that with `path:.` checkouts and secretless evaluation, a mechanism garnix does not document.

The issue's fallback for anything garnix does not cover is a CI-built Cachix cache (the mechanism already proven by `nix-logseq-git-flake`), so coverage moves there:

- `modules/meta/cache-roots.nix`: `packages.<system>.cache-roots`, a linkFarm over an explicit free-license allowlist. Host-overlay packages are sourced from the primary host's pkgs, devshell packages from `self'.packages`, and context7-mcp from the `mcp-servers-nix` input its consumer resolves, so the cached derivations are exactly what consumers evaluate. tor-browser and mullvad-browser are excluded: nixpkgs sets `allowSubstitutes = false` on their main derivations, so hosts rebuild them regardless of cache contents. `modules/package-checks.nix` automatically mirrors the output into `checks`, so existing CI evaluates it.
- `.github/workflows/cache-push.yml`: builds `cache-roots` on pushes to `main` touching `flake.lock`, `modules/**`, or `packages/**` (plus `workflow_dispatch`), and pushes the closure to `bad3r-nixos.cachix.org` when the `CACHIX_AUTH_TOKEN` secret exists; until then it builds and emits a warning. `modules/**` is deliberately broad because overlay packages inherit indirect inputs from sibling modules (browser policy data, icon assets).
- `modules/hosts/common/nix-substituters.nix`: common hosts trust `https://bad3r-nixos.cachix.org` and its public key. The cache and the `CACHIX_AUTH_TOKEN` secret were created during review, so the wiring originally planned as a follow-up lands here.
- `docs/reference/binary-cache-coverage.md`: audit findings, per-package license classification (cached, unfree-local, unfree-redistributable pending decision, residual-with-reasons), and the operator setup record (completed steps plus the remaining first-run and measurement steps).

No unfree binary is published: the allowlist carries only `meta.license`-verified free, redistributable closures (vscode, webex, kiro, veracrypt, ventoy, google-chrome, discord, dropbox, charles stay local). An `assertFree` guard in `cache-roots.nix` machine-enforces the invariant: an entry whose `meta.license` is missing or is neither free nor redistributable aborts evaluation, failing the mirrored `nix flake check` before the closure can reach the public cache.

## Test plan

- `nix eval path:.#packages.x86_64-linux.cache-roots.drvPath` succeeds (forces every `assertFree` over all 12 entries).
- The `assertFree` predicate rejects `lib.licenses.unfree` and a missing license, and accepts mit / gpl / unfreeRedistributable.
- Derivation parity: `nix build --dry-run path:.#cache-roots` on the freshly switched primary host reports no unexpected rebuilds; only the devshell-sourced npm trees (codeburn, restringer) and the nemo-with-extensions build the host itself still has pending appear. The input-sourced context7-mcp 3.2.4 is already in the host store, confirming it is the derivation the MCP config runs.
- `nix eval path:.#nixosConfigurations.system76.config.nix.settings.substituters` (and `.trusted-public-keys`) contain the new cache entries.
- `nix flake check path:. --accept-flake-config --no-build --offline` exits 0.
- `nix develop path:. -c pre-commit run --files <changed files> --hook-stage manual` exits 0 (actionlint, yamllint, formatting).
- First populated run: merging this PR triggers `Cache Push` (the merge touches `modules/**`, a filtered path); the push step must succeed against `bad3r-nixos.cachix.org`.
- Download-vs-build measurement: after the next `flake.lock` bump lands, compare a host switch build log against the 2026-07-17 baseline profile; cache-roots packages must appear as downloads. Coordinate the report format with issue #381.