### PR TITLE
feat(apps): add and enable PowerShell

### DIFF
--- a/modules/apps/powershell.nix
+++ b/modules/apps/powershell.nix
@@ -1,0 +1,48 @@
+/*
+  Package: powershell
+  Description: Powerful cross-platform (Windows, Linux, and macOS) shell and scripting language based on .NET.
+  Homepage: https://microsoft.com/PowerShell
+  Documentation: https://learn.microsoft.com/en-us/powershell/
+  Repository: https://github.com/PowerShell/PowerShell
+
+  Summary:
+    * Provides a cross-platform shell and scripting language for automation and configuration.
+    * Works with structured data, REST APIs, object models, and existing command-line tools.
+
+  Options:
+    -Command: Execute a command, script block, or command string.
+    -File: Run a PowerShell script file.
+    -NoProfile: Start without loading PowerShell profiles.
+    -NonInteractive: Disable prompts that require user input.
+*/
+_:
+let
+  PowershellModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.powershell.extended;
+    in
+    {
+      options.programs.powershell.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable powershell.";
+        };
+
+        package = lib.mkPackageOption pkgs "powershell" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.powershell = PowershellModule;
+}

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -343,6 +343,7 @@ let
       pnpm.extended.enable = lib.mkOverride 1100 true;
       "poppler-utils".extended.enable = lib.mkOverride 1100 true;
       potrace.extended.enable = lib.mkOverride 1100 true;
+      powershell.extended.enable = lib.mkOverride 1100 true;
       "pre-commit".extended.enable = lib.mkOverride 1100 true;
       "prefetch-yarn-deps".extended.enable = lib.mkOverride 1100 true;
       procps.extended.enable = lib.mkOverride 1100 true;


### PR DESCRIPTION
## Summary

- Add a package-only `modules/apps/powershell.nix` module following the app-module style guide.
- Expose `programs.powershell.extended` and install the pinned nixpkgs `powershell` package, whose executable is `pwsh`.
- Enable PowerShell in the shared common app baseline for `system76` and `tpnix`.

## Test plan

- `nix fmt -- modules/apps/powershell.nix modules/hosts/common/apps-enable.nix`
- `nix flake check --accept-flake-config --no-build --offline`
- `nix develop --accept-flake-config --offline -c pre-commit run --all-files --hook-stage manual`
- Targeted `nix eval` checks confirmed the option is enabled on both hosts and the system package set contains `pname = "powershell"`, version `7.6.3`.
