### PR TITLE
fix(scripts): commit only the manual pathspec in update-nixos-manual.sh

### DIFF
--- a/scripts/update-nixos-manual.sh
+++ b/scripts/update-nixos-manual.sh
@@ -117,14 +117,16 @@ else
   echo "Non-interactive shell; skipped commit prompt."
 fi
 if [[ $response =~ ^[Yy]$ ]]; then
-  git add "$MANUAL_DIR"
+  git add -A -- "$MANUAL_DIR"
+  # Pathspec-limited commit: pre-staged content outside MANUAL_DIR stays in
+  # the index instead of riding into the manual-refresh commit.
   git commit -m "$(
     cat <<EOF
 docs(nixos-manual): update from nixpkgs@${NIXPKGS_REV_SHORT}
 
 Source: https://github.com/NixOS/nixpkgs/tree/${NIXPKGS_REV}/nixos/doc/manual
 EOF
-  )"
+  )" -- "$MANUAL_DIR"
   echo "✅ Committed"
 else
   echo "⏭️  Skipped commit"

--- a/scripts/update-nixos-manual.sh
+++ b/scripts/update-nixos-manual.sh
@@ -20,6 +20,7 @@ case "$REPO_ROOT" in
 esac
 
 MANUAL_DIR="$REPO_ROOT/docs/nixos-manual"
+MANUAL_PATHSPEC=':(literal,top)docs/nixos-manual'
 # TMP_PARENT is owned jointly by the success path (which clears it inline and
 # resets it to "") and the EXIT trap (which cleans up early exits). The empty
 # reset is what keeps the trap from double-acting after a successful run.
@@ -117,17 +118,21 @@ else
   echo "Non-interactive shell; skipped commit prompt."
 fi
 if [[ $response =~ ^[Yy]$ ]]; then
-  git add -A -- "$MANUAL_DIR"
-  # Pathspec-limited commit: pre-staged content outside MANUAL_DIR stays in
-  # the index instead of riding into the manual-refresh commit.
-  git commit -m "$(
-    cat <<EOF
+  git add -A -- "$MANUAL_PATHSPEC"
+  if git diff --cached --quiet -- "$MANUAL_PATHSPEC"; then
+    echo "⏭️  No manual changes to commit"
+  else
+    # Pathspec-limited commit: pre-staged content outside MANUAL_DIR stays in
+    # the index instead of riding into the manual-refresh commit.
+    git commit -m "$(
+      cat <<EOF
 docs(nixos-manual): update from nixpkgs@${NIXPKGS_REV_SHORT}
 
 Source: https://github.com/NixOS/nixpkgs/tree/${NIXPKGS_REV}/nixos/doc/manual
 EOF
-  )" -- "$MANUAL_DIR"
-  echo "✅ Committed"
+    )" -- "$MANUAL_PATHSPEC"
+    echo "✅ Committed"
+  fi
 else
   echo "⏭️  Skipped commit"
 fi

--- a/scripts/update-nixos-manual.sh
+++ b/scripts/update-nixos-manual.sh
@@ -113,7 +113,8 @@ echo ""
 
 # Ask for commit approval
 if [[ -t 0 ]]; then
-  read -rp "📝 Commit changes? [y/N] " response || response=""
+  response=""
+  read -rp "📝 Commit changes? [y/N] " response || true
 else
   response=""
   echo "Non-interactive shell; skipped commit prompt."

--- a/scripts/update-nixos-manual.sh
+++ b/scripts/update-nixos-manual.sh
@@ -19,8 +19,9 @@ case "$REPO_ROOT" in
   ;;
 esac
 
-MANUAL_DIR="$REPO_ROOT/docs/nixos-manual"
-MANUAL_PATHSPEC=':(literal,top)docs/nixos-manual'
+MANUAL_RELPATH='docs/nixos-manual'
+MANUAL_DIR="$REPO_ROOT/$MANUAL_RELPATH"
+MANUAL_PATHSPEC=":(literal,top)$MANUAL_RELPATH"
 # TMP_PARENT is owned jointly by the success path (which clears it inline and
 # resets it to "") and the EXIT trap (which cleans up early exits). The empty
 # reset is what keeps the trap from double-acting after a successful run.
@@ -112,7 +113,7 @@ echo ""
 
 # Ask for commit approval
 if [[ -t 0 ]]; then
-  read -rp "📝 Commit changes? [y/N] " response
+  read -rp "📝 Commit changes? [y/N] " response || response=""
 else
   response=""
   echo "Non-interactive shell; skipped commit prompt."


### PR DESCRIPTION
## Summary

`scripts/update-nixos-manual.sh` ran `git add "$MANUAL_DIR"` followed by a bare `git commit`, so any index entries staged before invocation were swept into the manual-refresh commit under the `docs(nixos-manual): ...` message.

The commit-approval branch now derives the absolute manual directory and literal repository-root pathspec from one relative path. It uses that pathspec for staging, change detection, and commit. An unchanged manual refresh prints `No manual changes to commit` and exits successfully. Empty EOF follows the existing decline path, while partial input such as `y` followed by Ctrl-D remains affirmative. Pre-staged unrelated work stays in the index.

Fixes #351

## Test plan

- `bash -n scripts/update-nixos-manual.sh`
- `shellcheck scripts/update-nixos-manual.sh`
- `nix run path:.#formatter.x86_64-linux -- scripts/update-nixos-manual.sh` (0 files changed)
- Temporary Git behavior check: an unchanged manual path skips the commit and preserves an unrelated staged file; a changed manual path commits only the derived literal pathspec and preserves that unrelated staged file.
- Direct pseudo-terminal checks: empty EOF selects the decline path; `y` followed by Ctrl-D remains affirmative and exits successfully.
- Commit hooks: ShellCheck, treefmt, typos, and repository pre-commit checks passed.