### PR TITLE
chore(nomachine-client): drop 9.5.7 src override now that nixpkgs ships 9.7.3

### DIFF
--- a/modules/apps/nomachine-client.nix
+++ b/modules/apps/nomachine-client.nix
@@ -27,14 +27,6 @@ let
     }:
     let
       cfg = config.programs."nomachine-client".extended;
-
-      nomachine-client = pkgs.nomachine-client.overrideAttrs (_: {
-        version = "9.5.7";
-        src = pkgs.fetchurl {
-          url = "https://download.nomachine.com/download/9.5/Linux/nomachine_9.5.7_2_x86_64.tar.gz";
-          sha256 = "sha256-8f4ZL3Ko5VunojXLvTS9P3oB+ZVCSYIA0GIjM8VpUO4=";
-        };
-      });
     in
     {
       options.programs."nomachine-client".extended = {
@@ -46,7 +38,7 @@ let
 
         package = lib.mkOption {
           type = lib.types.package;
-          default = nomachine-client;
+          default = pkgs.nomachine-client;
           defaultText = lib.literalExpression "pkgs.nomachine-client";
           description = "The nomachine-client package to use.";
         };


### PR DESCRIPTION
## Summary

`modules/apps/nomachine-client.nix` carried a temporary `overrideAttrs` pinning nomachine-client to 9.5.7 because nixpkgs shipped 9.4.14 whose vendor tarball had been pulled (tracked by NixOS/nixpkgs#518152). The flake's current nixpkgs pin (`572d619e`) ships nomachine-client **9.7.3**, so the override now holds the client back on an older release through a hardcoded download URL the vendor can pull the same way it pulled 9.4.14.

The override is removed; `programs.nomachine-client.extended.package` defaults to `pkgs.nomachine-client`.

Fixes #197

## Test plan

- `nix eval 'path:.#nixosConfigurations.system76.config.programs."nomachine-client".extended.package.version'` returns `"9.7.3"` (full host module eval, unfree allowance intact)
- `nix run path:.#formatter.x86_64-linux -- modules/apps/nomachine-client.nix` (0 files changed)