### PR TITLE
feat(browsers): switch default search engine to Kagi

### DIFF
--- a/modules/browsers/_chromium-policies.nix
+++ b/modules/browsers/_chromium-policies.nix
@@ -21,11 +21,11 @@
 
   managedDefaultSearchProvider = {
     DefaultSearchProviderEnabled = true;
-    DefaultSearchProviderName = "Google";
-    DefaultSearchProviderKeyword = "google.com";
-    DefaultSearchProviderSearchURL = "https://www.google.com/search?q={searchTerms}&hl=en&gl=US&pws=0&safe=off";
-    DefaultSearchProviderSuggestURL = "https://www.google.com/complete/search?hl=en&gl=US&client=chrome&q={searchTerms}";
-    DefaultSearchProviderIconURL = "https://www.google.com/favicon.ico";
+    DefaultSearchProviderName = "Kagi";
+    DefaultSearchProviderKeyword = "kagi.com";
+    DefaultSearchProviderSearchURL = "https://kagi.com/search?q={searchTerms}";
+    DefaultSearchProviderSuggestURL = "https://kagi.com/api/autosuggest?q={searchTerms}";
+    DefaultSearchProviderIconURL = "https://kagi.com/favicon-32x32.png";
     DefaultSearchProviderEncodings = [ "UTF-8" ];
   };
 }

--- a/modules/browsers/_gecko-search.nix
+++ b/modules/browsers/_gecko-search.nix
@@ -7,7 +7,7 @@
 _: {
   policies = {
     SearchEngines = {
-      Default = "Google US";
+      Default = "Kagi";
       PreventInstalls = false;
       Remove = [
         "Google"
@@ -29,15 +29,15 @@ _: {
           URLTemplate = "https://www.google.com/search?q={searchTerms}&hl=en&persist_hl=1&gl=US&persist_gl=1&pws=0&safe=off";
           IconURL = "https://www.google.com/favicon.ico";
         }
-        # {
-        #   Name = "Kagi";
-        #   Description = "Premium private search engine.";
-        #   Alias = "@k";
-        #   Method = "GET";
-        #   URLTemplate = "https://kagi.com/search?q={searchTerms}";
-        #   SuggestURLTemplate = "https://kagi.com/api/autosuggest?q={searchTerms}";
-        #   IconURL = "https://kagi.com/favicon-32x32.png";
-        # }
+        {
+          Name = "Kagi";
+          Description = "Premium private search engine.";
+          Alias = "@k";
+          Method = "GET";
+          URLTemplate = "https://kagi.com/search?q={searchTerms}";
+          SuggestURLTemplate = "https://kagi.com/api/autosuggest?q={searchTerms}";
+          IconURL = "https://kagi.com/favicon-32x32.png";
+        }
         {
           Name = "YouTube US";
           Description = "YouTube search with English, US region, and no separate suggest endpoint.";

--- a/modules/browsers/brave/apps.nix
+++ b/modules/browsers/brave/apps.nix
@@ -32,6 +32,10 @@ let
     let
       cfg = config.programs.brave.extended;
 
+      # Kagi default search provider, shared verbatim with google-chrome and
+      # ungoogled-chromium so every Chromium-family browser stays symmetric.
+      inherit (import ../_chromium-policies.nix) managedDefaultSearchProvider;
+
       defaultManagedPolicies = {
         # Brave product features and promotions.
         BraveAIChatEnabled = false;
@@ -155,7 +159,8 @@ let
         # Disable online spellcheck/translate services.
         SpellCheckServiceEnabled = false;
         TranslateEnabled = false;
-      };
+      }
+      // managedDefaultSearchProvider;
     in
     {
       options.programs.brave.extended = {


### PR DESCRIPTION
## Summary

Switch the managed default search engine to Kagi across every browser that pins
one, replacing Google.

- Firefox + LibreWolf: set `policies.SearchEngines.Default` to `Kagi` in the
  shared `_gecko-search.nix` and enable the Kagi engine entry that was carried
  commented-out (keeps the `@k` alias, `kagi.com/search` URLTemplate, and
  `kagi.com/api/autosuggest` SuggestURLTemplate). Google US stays selectable
  under `@g` as a non-default engine.
- Google Chrome + ungoogled-chromium: switch `managedDefaultSearchProvider` in
  the shared `_chromium-policies.nix` from Google to Kagi; both browsers inherit
  the attrset verbatim and emit it to their managed
  `default-search-provider.json`.
- Brave: merge the shared `managedDefaultSearchProvider` into Brave's
  `defaultManagedPolicies` so the Chromium family has one source of truth for
  the default search provider instead of duplicated URL templates.

Out of scope: Tor Browser and Mullvad Browser keep their built-in defaults
(Kagi requires a logged-in session, which undermines their anonymity model), and
brave-origin ships without managed policies.

## Test plan

- `nix-instantiate --parse` on all three edited files: OK.
- Targeted eval: `_gecko-search.nix` `SearchEngines.Default` = `"Kagi"` and the
  Add list contains `Kagi`.
- Targeted eval: `_chromium-policies.nix` `managedDefaultSearchProvider`
  resolves to the Kagi provider keys.
- Targeted eval: Brave `managedPolicies` default merges the Kagi
  `DefaultSearchProvider*` keys and preserves the existing Brave keys.
- `nix flake check --accept-flake-config --no-build --offline`: pass.
- `nix run .#formatter` on each file: no changes.
- pre-commit and pre-push hooks: pass.
