### PR TITLE
fix(tpnix): declare the sshd host key and pin fleet host keys cross-host

### DIFF
--- a/modules/configurations/nixos.nix
+++ b/modules/configurations/nixos.nix
@@ -63,15 +63,7 @@ let
         fleetKeys = config.flake.lib.nixos.fleetHostKeys or { };
         pinnedKey = fleetKeys.${name} or null;
         hostKey = nixos.config.services.openssh.publicKey;
-        stripComment =
-          key:
-          let
-            parts = builtins.filter (s: s != "") (lib.splitString " " key);
-          in
-          if (builtins.length parts) >= 2 then
-            "${builtins.elemAt parts 0} ${builtins.elemAt parts 1}"
-          else
-            key;
+        stripComment = config.flake.lib.nixos.sshStripKeyComment;
         keyValid = pinnedKey == null || hostKey == null || stripComment pinnedKey == stripComment hostKey;
       in
       if !keyValid then

--- a/modules/configurations/nixos.nix
+++ b/modules/configurations/nixos.nix
@@ -64,7 +64,7 @@ let
         pinnedKey = fleetKeys.${name} or null;
         hostKey = nixos.config.services.openssh.publicKey;
         stripComment = config.flake.lib.nixos.sshStripKeyComment;
-        keyValid = pinnedKey == null || hostKey == null || stripComment pinnedKey == stripComment hostKey;
+        keyValid = pinnedKey == null || (hostKey != null && stripComment pinnedKey == stripComment hostKey);
       in
       if !keyValid then
         throw "Host ${name}: fleetHostKeys pinned key does not match config.services.openssh.publicKey"

--- a/modules/configurations/nixos.nix
+++ b/modules/configurations/nixos.nix
@@ -57,11 +57,32 @@ let
     }
   );
   checksMap = lib.attrValues (
-    lib.mapAttrs (name: nixos: {
-      ${nixos.config.nixpkgs.hostPlatform.system} = {
-        "configurations/nixos/${name}" = nixos.config.system.build.toplevel;
-      };
-    }) nixosConfigs
+    lib.mapAttrs (
+      name: nixos:
+      let
+        fleetKeys = config.flake.lib.nixos.fleetHostKeys or { };
+        pinnedKey = fleetKeys.${name} or null;
+        hostKey = nixos.config.services.openssh.publicKey;
+        stripComment =
+          key:
+          let
+            parts = builtins.filter (s: s != "") (lib.splitString " " key);
+          in
+          if (builtins.length parts) >= 2 then
+            "${builtins.elemAt parts 0} ${builtins.elemAt parts 1}"
+          else
+            key;
+        keyValid = pinnedKey == null || hostKey == null || stripComment pinnedKey == stripComment hostKey;
+      in
+      if !keyValid then
+        throw "Host ${name}: fleetHostKeys pinned key does not match config.services.openssh.publicKey"
+      else
+        {
+          ${nixos.config.nixpkgs.hostPlatform.system} = {
+            "configurations/nixos/${name}" = nixos.config.system.build.toplevel;
+          };
+        }
+    ) nixosConfigs
   );
 in
 {

--- a/modules/configurations/nixos.nix
+++ b/modules/configurations/nixos.nix
@@ -64,10 +64,14 @@ let
         pinnedKey = fleetKeys.${name} or null;
         hostKey = nixos.config.services.openssh.publicKey;
         stripComment = config.flake.lib.nixos.sshStripKeyComment;
-        keyValid = pinnedKey == null || (hostKey != null && stripComment pinnedKey == stripComment hostKey);
+        keyValid =
+          if hostKey == null then
+            pinnedKey == null
+          else
+            pinnedKey != null && stripComment pinnedKey == stripComment hostKey;
       in
       if !keyValid then
-        throw "Host ${name}: fleetHostKeys pinned key does not match config.services.openssh.publicKey"
+        throw "Host ${name}: services.openssh.publicKey has no matching fleetHostKeys pin (missing pin or key mismatch)"
       else
         {
           ${nixos.config.nixpkgs.hostPlatform.system} = {

--- a/modules/hosts/common/ssh-known-hosts.nix
+++ b/modules/hosts/common/ssh-known-hosts.nix
@@ -28,4 +28,5 @@ let
 in
 {
   flake.nixosModules.hosts-common.imports = [ body ];
+  flake.lib.nixos.fleetHostKeys = fleetHostKeys;
 }

--- a/modules/hosts/common/ssh-known-hosts.nix
+++ b/modules/hosts/common/ssh-known-hosts.nix
@@ -1,0 +1,31 @@
+# Cross-host SSH host-key pinning: every shared host carries the other
+# fleet members' host keys in /etc/ssh/ssh_known_hosts, so the first
+# connection between fleet hosts is never trust-on-first-use (issue #349).
+# Each host's own key is pinned separately by nixosModules.ssh from
+# services.openssh.publicKey. The tailnet FQDN is intentionally not listed:
+# this repository is public and the MagicDNS name is not disclosed here.
+{ lib, ... }:
+let
+  fleetHostKeys = {
+    system76 = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKzgpGcpEJ7oOxjcKyr6/2/joFKN+yDP0G3YyTbp/ilb";
+    tpnix = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBhF9ZGsiViA4iOeGgNSjlzIcSdHZV0m3kTXU6fHusJ0";
+  };
+
+  body =
+    { config, ... }:
+    {
+      programs.ssh.knownHosts = lib.mapAttrs' (
+        name: publicKey:
+        lib.nameValuePair "fleet-${name}" {
+          hostNames = [
+            name
+            "${name}.local"
+          ];
+          inherit publicKey;
+        }
+      ) (lib.filterAttrs (name: _: name != config.networking.hostName) fleetHostKeys);
+    };
+in
+{
+  flake.nixosModules.hosts-common.imports = [ body ];
+}

--- a/modules/networking/ssh.nix
+++ b/modules/networking/ssh.nix
@@ -1,5 +1,19 @@
-_: {
+{ lib, ... }:
+let
+  sshStripKeyComment =
+    key:
+    let
+      parts = builtins.filter (s: s != "") (lib.splitString " " key);
+    in
+    if (builtins.length parts) >= 2 then
+      "${builtins.elemAt parts 0} ${builtins.elemAt parts 1}"
+    else
+      key;
+in
+{
   flake = {
+    lib.nixos.sshStripKeyComment = sshStripKeyComment;
+
     nixosModules.ssh =
       {
         lib,
@@ -41,20 +55,11 @@ _: {
               domain = config.networking.domain or "";
               fqdn = lib.optional (domain != "") "${host}.${domain}";
               hostNames = lib.unique ([ host ] ++ fqdn);
-              stripComment =
-                key:
-                let
-                  parts = builtins.filter (s: s != "") (lib.splitString " " key);
-                in
-                if (builtins.length parts) >= 2 then
-                  "${builtins.elemAt parts 0} ${builtins.elemAt parts 1}"
-                else
-                  key;
             in
             lib.optionalAttrs (host != "") {
               "${host}" = {
                 inherit hostNames;
-                publicKey = stripComment config.services.openssh.publicKey;
+                publicKey = sshStripKeyComment config.services.openssh.publicKey;
               };
             }
           );

--- a/modules/tpnix/ssh.nix
+++ b/modules/tpnix/ssh.nix
@@ -1,0 +1,10 @@
+{ lib, ... }:
+{
+  configurations.nixos.tpnix.module = {
+    services.openssh = {
+      enable = lib.mkDefault false;
+      # Host SSH public key for known_hosts population (consumed by nixosModules.ssh)
+      publicKey = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBhF9ZGsiViA4iOeGgNSjlzIcSdHZV0m3kTXU6fHusJ0";
+    };
+  };
+}


### PR DESCRIPTION
## Summary

`modules/networking/ssh.nix` gates known_hosts pinning on `services.openssh.publicKey`, which only system76 set. tpnix runs LAN- and tailscale-reachable sshd with no pinned key anywhere, so every first connection to it was trust-on-first-use.

- `modules/tpnix/ssh.nix` (new, mirrors `modules/system76/ssh.nix`): declares tpnix's ed25519 host key, activating the existing self-pin mechanism for tpnix.
- `modules/hosts/common/ssh-known-hosts.nix` (new): the issue's cross-host variant. Self-pinning alone never protects the first cross-host connection, so each shared host now pins every *other* fleet member's key under hostNames `<name>` and `<name>.local` (`networking.domain` is `local` fleet-wide). Entry keys are `fleet-<name>` to avoid merging with the self-pin entry.
- The tailnet FQDN is deliberately not listed: this repository is public and the MagicDNS name is not disclosed anywhere in it. If pinning under the tailnet name is wanted, say so and it can be added (or kept in a private overlay).

**Key provenance:** the tpnix key comes from the operator's `known_hosts` entry learned over the authenticated tailscale path. Before merging, ideally confirm it against `cat /etc/ssh/ssh_host_ed25519_key.pub` on tpnix itself.

Fixes #349

## Test plan

- `nix eval path:.#nixosConfigurations.tpnix.config.programs.ssh.knownHosts`: now contains the `tpnix` self entry (gate fires) plus `fleet-system76`
- `nix eval path:.#nixosConfigurations.system76.config.programs.ssh.knownHosts`: `system76` self entry plus `fleet-tpnix`
- `nix flake check --accept-flake-config --no-build --offline path:.` rc=0
- `nix run path:.#formatter.x86_64-linux -- <new files>` (0 files changed)
- Post-deploy: first `ssh tpnix` from system76 verifies against the pinned key instead of prompting