### PR TITLE
chore(agents): deny claude.ai Indeed connector by default

### DIFF
--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -183,6 +183,7 @@ in
             "claude.ai Gmail"
             "claude.ai Google Calendar"
             "claude.ai Google Drive"
+            "claude.ai Indeed"
             "claude.ai JobDataLake"
             "claude.ai Jobs and Careers"
             "claude.ai Todoist"


### PR DESCRIPTION
## Summary

Follow-up to #388. Adds `claude.ai Indeed` to `programs.claude-code.extended.deniedMcpServers`, so the job-search connector is off by default and stays out of Claude Code session context, consistent with the JobDataLake and Jobs and Careers connectors.

Re-enabling note: `deniedMcpServers` is a hard block (the denylist always wins and a denied connector cannot be toggled back on mid-session via `/mcp`; the per-project soft toggle is unenforced upstream, anthropics/claude-code#13311). To use Indeed, remove it from the list and rebuild. The claude.ai account stays the source of truth for the connector.

## Test plan

- `nix eval path:.#nixosConfigurations.tpnix.config.programs.claude-code.extended.deniedMcpServers` lists all 8 connectors including `claude.ai Indeed`.
- `treefmt` and pre-commit hooks pass.
- Applies on the next `home-manager switch` via the activation jq-merge into `~/.claude/settings.json`.
