### PR TITLE
feat(fonts): add Microsoft corefonts to the shared font stack

### DIFF
--- a/modules/hosts/common/fonts.nix
+++ b/modules/hosts/common/fonts.nix
@@ -45,6 +45,9 @@ let
               noto-fonts-cjk-sans
               noto-fonts-color-emoji
               liberation_ttf
+              # Genuine Microsoft fonts (Arial, Times New Roman, Webdings, ...) so
+              # Office documents render their embedded faces instead of substitutes.
+              corefonts
               font-awesome_6
               material-icons
               nerd-fonts.symbols-only
@@ -158,5 +161,8 @@ let
     };
 in
 {
+  # corefonts ships under an unfree-redistributable EULA; gate it through the
+  # shared allowlist so allowUnfreePredicate lets the font derivation build.
+  nixpkgs.allowedUnfreePackages = [ "corefonts" ];
   flake.nixosModules.hosts-common.imports = [ body ];
 }


### PR DESCRIPTION
## Summary

- Add `corefonts` (Microsoft Core Fonts for the Web) to the shared
  `fonts.packages` in `modules/hosts/common/fonts.nix`, so every `shareCommon`
  host (system76, tpnix) gets the genuine Arial, Times New Roman, Courier New,
  Verdana, and Webdings faces instead of the `liberation_ttf` metric
  substitutes.
- Gate the unfree-redistributable package through
  `nixpkgs.allowedUnfreePackages` (the shared `allowUnfreePredicate` in
  `modules/meta/nixpkgs-allowed-unfree.nix`), next to the existing `symbola`
  entry.

This clears the LibreOffice missing-font warning for **Webdings** and improves
fidelity of Office documents that embed the core text faces.

The other symbol fonts from the same warning (Wingdings, Wingdings 2,
Wingdings 3, MT Extra) are proprietary and absent from nixpkgs; tracked
separately in #405.

## Test plan

- `nix fmt modules/hosts/common/fonts.nix` reports 0 files changed.
- `nix eval --offline path:.#nixosConfigurations.system76.config.fonts.packages
  --apply 'ps: map (p: p.name) ps'` resolves `corefonts-1` through the unfree
  predicate with no error (exercises the allowlist gate end to end).
