### PR TITLE
chore(python): adopt Python 3.14 as the repo standard

### DIFF
--- a/docs/cloudflare/containers/lifecycle.md
+++ b/docs/cloudflare/containers/lifecycle.md
@@ -269,10 +269,12 @@ process.on("SIGTERM", async () => {
 import signal
 import sys
 
+
 def handle_sigterm(signum, frame):
     print("SIGTERM received, shutting down gracefully")
     # Cleanup code here
     sys.exit(0)
+
 
 signal.signal(signal.SIGTERM, handle_sigterm)
 ```

--- a/docs/cloudflare/containers/use-cases.md
+++ b/docs/cloudflare/containers/use-cases.md
@@ -69,13 +69,16 @@ from pydantic import BaseModel
 
 app = FastAPI()
 
+
 class Item(BaseModel):
     name: str
     value: float
 
+
 @app.get("/api/health")
 async def health():
     return {"status": "healthy"}
+
 
 @app.post("/api/process")
 async def process(item: Item):
@@ -159,24 +162,23 @@ import json
 import requests
 from datetime import datetime
 
+
 def run_job():
     print(f"Job started at {datetime.now()}")
 
     # Fetch data from external API
-    response = requests.get(os.environ['DATA_SOURCE_URL'])
+    response = requests.get(os.environ["DATA_SOURCE_URL"])
     data = response.json()
 
     # Process data
-    processed = [
-        {"id": item["id"], "value": item["value"] * 2}
-        for item in data
-    ]
+    processed = [{"id": item["id"], "value": item["value"] * 2} for item in data]
 
     # Store results (would use R2 or external storage)
     print(f"Processed {len(processed)} items")
 
     # Signal completion
     print("Job completed successfully")
+
 
 if __name__ == "__main__":
     run_job()
@@ -530,29 +532,28 @@ import torch
 app = FastAPI()
 
 # Load model once at startup
-classifier = pipeline(
-    "sentiment-analysis",
-    device=0 if torch.cuda.is_available() else -1
-)
+classifier = pipeline("sentiment-analysis", device=0 if torch.cuda.is_available() else -1)
+
 
 class TextInput(BaseModel):
     text: str
 
+
 class BatchInput(BaseModel):
     texts: list[str]
+
 
 @app.post("/predict")
 async def predict(input: TextInput):
     result = classifier(input.text)[0]
-    return {
-        "label": result["label"],
-        "score": result["score"]
-    }
+    return {"label": result["label"], "score": result["score"]}
+
 
 @app.post("/batch")
 async def batch_predict(input: BatchInput):
     results = classifier(input.texts)
     return {"results": results}
+
 
 @app.get("/health")
 async def health():

--- a/docs/csec/additional-tools-reference.md
+++ b/docs/csec/additional-tools-reference.md
@@ -40,7 +40,7 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Maintained (v3.2.2.0, 2026-01-26).
 - evil-winrm
   - run..: `nix run nixpkgs#evil-winrm -- -i $ip -u $user -p $pass`
-    - ⚠️ Failed to run: Ruby 3.4 LoadError. The `csv` gem is missing and `winrm-fs` fails to load. Upstream nixpkgs build is currently broken.
+    - ⚠️ Failed to run: the derivation builds, but startup aborts with `cannot load such file -- csv (LoadError)`, cascading to `winrm-fs`. Ruby 3.4 removed `csv` from the default gems and the nixpkgs `Gemfile` does not add it back.
   - Repo.: <https://github.com/Hackplayers/evil-winrm>
   - Docs.: <https://github.com/Hackplayers/evil-winrm#readme>
   - Desc.: Interactive WinRM shell with built-in upload/download, AMSI bypass scaffolding, and PowerShell pass-through.
@@ -434,7 +434,7 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Deprecated (no formal releases; last commit 2018-03-14; Python 2 vintage, abandoned 7+ years).
 - patator
   - run..: `uvx patator $module host=$target ...`
-    - ⚠️ Failed to run: build of the transitive `cx-oracle 8.3.0` dependency fails. The build backend depends on `pkg_resources` without declaring it.
+    - ⚠️ Failed to run: build of the transitive `mysqlclient 2.2.8` dependency fails. Its setup script aborts with `Can not find valid pkg-config name` because no MySQL client library is on the `uvx` build path.
   - Repo.: <https://github.com/lanjelot/patator>
   - Docs.: <https://github.com/lanjelot/patator/wiki>
   - Desc.: Multi-purpose modular brute-forcer covering services hydra/medusa miss (Telnet, finger, MySQL, custom). Not in nixpkgs.
@@ -519,7 +519,7 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Maintained (2026.02.18, 2026-02-18).
 - angr
   - run..: `nix shell nixpkgs#python3Packages.angr -c python3`
-    - ⚠️ Failed to run: nixpkgs build fails. `setuptools-rust` is missing from `nativeBuildInputs` during wheel preparation.
+    - ⚠️ Failed to run: nixpkgs build fails. `setuptools-rust` is missing from `nativeBuildInputs` during wheel preparation. Tracked upstream as <https://github.com/NixOS/nixpkgs/issues/501379>.
   - Repo.: <https://github.com/angr/angr>
   - Docs.: <https://docs.angr.io/>
   - Desc.: Symbolic-execution and binary-analysis framework for CFG recovery, taint tracking, and concolic exploration.
@@ -578,7 +578,6 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Deprecated (no formal releases; last commit 2021-03-26; maintainers state effort abandoned).
 - dc3dd
   - run..: `nix run nixpkgs#dc3dd -- if=$src hof=$dst hash=sha256`
-    - ⚠️ Failed to run: nixpkgs compile failure with modern gcc. `argmatch.c:63: too many arguments to function 'usage'` (legacy macro mismatch).
   - Repo.: <https://sourceforge.net/projects/dc3dd/>
   - Docs.: <https://sourceforge.net/projects/dc3dd/files/>
   - Desc.: Forensic-focused dd patch with hashing-on-the-fly, progress reporting, and split output.

--- a/docs/csec/additional-tools-reference.md
+++ b/docs/csec/additional-tools-reference.md
@@ -59,7 +59,6 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Maintained (5.0.4, 2025-11-22).
 - mitm6
   - run..: `nix run nixpkgs#mitm6 -- -d $domain`
-    - ⚠️ Failed to run: Python 3.14 evaluation error. `future-1.0.0` is not supported on the active interpreter.
   - Repo.: <https://github.com/dirkjanm/mitm6>
   - Docs.: <https://blog.fox-it.com/2018/01/11/mitm6-compromising-ipv4-networks-via-ipv6/>
   - Desc.: DHCPv6 spoofer for IPv6-based DNS takeover and NTLM relay setup.
@@ -215,7 +214,6 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Maintained (v2.2.19, 2025-12-11).
 - maigret
   - run..: `nix run nixpkgs#maigret -- $username`
-    - ⚠️ Failed to run: blocked by the `python3.14-pypdf2-3.0.1` insecure marker. Requires a `permittedInsecurePackages` override.
   - Repo.: <https://github.com/soxoj/maigret>
   - Docs.: <https://maigret.readthedocs.io/>
   - Desc.: Username enumerator across 3000+ sites with profile-data extraction; extended fork of sherlock.

--- a/docs/csec/additional-tools-reference.md
+++ b/docs/csec/additional-tools-reference.md
@@ -40,7 +40,7 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Maintained (v3.2.2.0, 2026-01-26).
 - evil-winrm
   - run..: `nix run nixpkgs#evil-winrm -- -i $ip -u $user -p $pass`
-    - ⚠️ Failed to run: the derivation builds, but startup aborts with `cannot load such file -- csv (LoadError)`, cascading to `winrm-fs`. Ruby 3.4 removed `csv` from the default gems and the nixpkgs `Gemfile` does not add it back.
+    - ℹ️ `-h` writes its usage banner only to a TTY; piped or redirected it exits 0 with no output.
   - Repo.: <https://github.com/Hackplayers/evil-winrm>
   - Docs.: <https://github.com/Hackplayers/evil-winrm#readme>
   - Desc.: Interactive WinRM shell with built-in upload/download, AMSI bypass scaffolding, and PowerShell pass-through.

--- a/docs/csec/additional-tools-reference.md
+++ b/docs/csec/additional-tools-reference.md
@@ -232,7 +232,7 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Maintenance mode (last release v5.1.2, 2021-08-25; active upstream commits through 2024-11-01).
 - maltego
   - run..: `nix run nixpkgs#maltego`
-    - ⚠️ Failed to run: unfree license. Requires `allowUnfree = true` and an entry in `modules/meta/nixpkgs-allowed-unfree.nix`.
+    - ⚠️ Failed to run: unfree license. Needs `NIXPKGS_ALLOW_UNFREE=1 --impure`, or `nixpkgs.allowedUnfreePackages` set from the module that wants it (the option is declared in `modules/meta/nixpkgs-allowed-unfree.nix`, which holds no entries itself).
   - Repo.: <https://www.maltego.com/>
   - Docs.: <https://docs.maltego.com/>
   - Desc.: Graph-based OSINT and link-analysis platform with transforms across public and commercial data sources (community edition usable from nixpkgs).
@@ -548,7 +548,7 @@ Each entry lists a representative run command, upstream repository, official doc
   - run..: `NIXPKGS_ALLOW_UNFREE=1 nix shell --impure nixpkgs#volatility3 -c vol -- -f $memdump windows.info`
   - Repo.: <https://github.com/volatilityfoundation/volatility3>
   - Docs.: <https://volatility3.readthedocs.io/>
-  - Desc.: Memory forensics framework for Windows/Linux/macOS captures. Binaries are `vol` and `volshell`; the derivation is marked unfree, so the invocation needs `NIXPKGS_ALLOW_UNFREE=1 --impure` (or an entry in `modules/meta/nixpkgs-allowed-unfree.nix`).
+  - Desc.: Memory forensics framework for Windows/Linux/macOS captures. Binaries are `vol` and `volshell`; the derivation is marked unfree, so the invocation needs `NIXPKGS_ALLOW_UNFREE=1 --impure` (or `nixpkgs.allowedUnfreePackages` set from the module that wants it).
   - Stat.: Maintained (v2.28.0, 2026-04-30).
 - sleuthkit
   - run..: `nix shell nixpkgs#sleuthkit -c fls -- -r $image`

--- a/docs/csec/additional-tools-reference.md
+++ b/docs/csec/additional-tools-reference.md
@@ -302,7 +302,6 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Maintenance mode (last release 2.2.7, 2024-11-03; active upstream commits through 2025-02-20).
 - waybackurls
   - run..: `nix run nixpkgs#waybackurls -- $domain`
-    - ⚠️ Failed to run: marked unfree in nixpkgs. Refuses to evaluate without `NIXPKGS_ALLOW_UNFREE=1 --impure` (or an entry in `modules/meta/nixpkgs-allowed-unfree.nix`).
   - Repo.: <https://github.com/tomnomnom/waybackurls>
   - Docs.: <https://github.com/tomnomnom/waybackurls#readme>
   - Desc.: Stream all URLs the Wayback Machine knows for a domain.

--- a/docs/csec/additional-tools-reference.md
+++ b/docs/csec/additional-tools-reference.md
@@ -59,7 +59,7 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Maintained (5.0.4, 2025-11-22).
 - mitm6
   - run..: `nix run nixpkgs#mitm6 -- -d $domain`
-    - ⚠️ Failed to run: Python 3.13 evaluation error. `future-1.0.0` is not supported on the active interpreter.
+    - ⚠️ Failed to run: Python 3.14 evaluation error. `future-1.0.0` is not supported on the active interpreter.
   - Repo.: <https://github.com/dirkjanm/mitm6>
   - Docs.: <https://blog.fox-it.com/2018/01/11/mitm6-compromising-ipv4-networks-via-ipv6/>
   - Desc.: DHCPv6 spoofer for IPv6-based DNS takeover and NTLM relay setup.
@@ -215,7 +215,7 @@ Each entry lists a representative run command, upstream repository, official doc
   - Stat.: Maintained (v2.2.19, 2025-12-11).
 - maigret
   - run..: `nix run nixpkgs#maigret -- $username`
-    - ⚠️ Failed to run: blocked by the `python3.13-pypdf2-3.0.1` insecure marker. Requires a `permittedInsecurePackages` override.
+    - ⚠️ Failed to run: blocked by the `python3.14-pypdf2-3.0.1` insecure marker. Requires a `permittedInsecurePackages` override.
   - Repo.: <https://github.com/soxoj/maigret>
   - Docs.: <https://maigret.readthedocs.io/>
   - Desc.: Username enumerator across 3000+ sites with profile-data extraction; extended fork of sherlock.

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -7,9 +7,13 @@ confirm the package could launch on the `flake.lock` state used for the smoke
 test.
 
 The runtime smoke test was run on 2026-05-04 against the active flake pin at
-that time. The inventory and summary below were reconciled on 2026-08-01
-against the companion reference; no run commands were re-executed on the
-current `flake.lock`. The `mitm6` and `maigret` entries were re-verified on
+that time, and the inventory and summary below were reconciled on 2026-08-01
+against the companion reference without re-executing anything. Nine entries
+have since been re-run on the current `flake.lock`: `mitm6` and `maigret` on
+2026-07-23, and the seven former build-error entries on 2026-08-04. Every other
+entry still carries its 2026-05-04 result.
+
+The `mitm6` and `maigret` entries were re-verified on
 2026-07-23 under Python 3.14.6 and now run as documented: upstream `mitm6`
 dropped its `future` dependency (closure is netifaces / scapy / twisted only)
 and `maigret` migrated the insecure `pypdf2-3.0.1` to `pypdf-6.14.2`, clearing

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -16,21 +16,28 @@ and `maigret` migrated the insecure `pypdf2-3.0.1` to `pypdf-6.14.2`, clearing
 the two evaluation blocks recorded earlier.
 
 Every entry that the 2026-05-04 snapshot recorded under "build or evaluation
-error" was re-run on 2026-08-04 against the current pin (python3 3.14.6). Two
-outcomes changed: `dc3dd` now builds and runs, and `patator` still fails but on
-a different dependency than the one recorded. `waybackurls` was blocked only by
-an incorrect `unfree` placeholder license, corrected upstream in
-`Bad3r/nixpkgs@a71f346e` (waybackurls is MIT), so it now runs with no override
-and is counted as documented. `maltego` was never a build defect either; it is
-genuinely unfree and gets its own category.
+error" was re-run on 2026-08-04 against the current pin (python3 3.14.6), and
+four of the seven cleared:
+
+- `dc3dd` now builds and runs; the recorded gcc failure is gone.
+- `evil-winrm` was fixed by `Bad3r/nixpkgs@807b1085` (3.7 -> 3.9), whose
+  regenerated Bundler environment adds the `csv`, `benchmark` and `syslog` gems
+  that Ruby unbundled.
+- `waybackurls` was blocked only by an incorrect `unfree` placeholder license,
+  corrected in `Bad3r/nixpkgs@a71f346e` (waybackurls is MIT), so it now runs
+  with no override.
+- `patator` still fails, but on a different dependency than the one recorded.
+
+`maltego` was never a build defect either; it is genuinely unfree and gets its
+own category.
 
 ## Summary
 
 | Result                                                           | Count   |
 | ---------------------------------------------------------------- | ------- |
-| ✅ Run as documented                                             | 99      |
+| ✅ Run as documented                                             | 100     |
 | ⚠️ Documented as unavailable in the reference                    | 10      |
-| ⚠️ Build or evaluation error                                     | 4       |
+| ⚠️ Build or evaluation error                                     | 3       |
 | ⚠️ Blocked by the unfree license gate                            | 1       |
 | ⚠️ Binary path mismatch in the documented attribute              | 5       |
 | ⚠️ Documented attribute resolves to a different upstream project | 2       |
@@ -63,6 +70,7 @@ no longer entries in the companion reference.
 - ✅ adidnsdump
 - ✅ ldapdomaindump
 - ✅ donpapi
+- ✅ evil-winrm (`-h` writes usage only to a TTY; piped or redirected it exits 0 silently)
 
 ### Network Reconnaissance and Enumeration
 
@@ -206,12 +214,6 @@ The reference itself flags these. Listed for completeness.
 
 Re-verified 2026-08-04 under python3 3.14.6.
 
-- ⚠️ evil-winrm: the derivation builds, but the binary aborts at startup with
-  `cannot load such file -- csv (LoadError)`, cascading to
-  `cannot load such file -- winrm-fs`. Ruby 3.4 removed `csv` from the default
-  gems, and the package's `Gemfile` adds `stringio`, `logger` and `fileutils`
-  for that same reason but not `csv`. Reproduces identically on
-  `nixpkgs-unstable`; no upstream issue is open for it.
 - ⚠️ droopescan (uvx): runtime crash, `cement 2.6.2` imports the `imp` module
   that Python 3.12 removed. Unchanged under 3.14.
 - ⚠️ patator (uvx): the recorded `cx-oracle` cause no longer applies. The

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -18,18 +18,20 @@ the two evaluation blocks recorded earlier.
 Every entry that the 2026-05-04 snapshot recorded under "build or evaluation
 error" was re-run on 2026-08-04 against the current pin (python3 3.14.6). Two
 outcomes changed: `dc3dd` now builds and runs, and `patator` still fails but on
-a different dependency than the one recorded. The `maltego` and `waybackurls`
-entries were never build defects and now have their own category, because both
-build and run once the unfree gate is opened.
+a different dependency than the one recorded. `waybackurls` was blocked only by
+an incorrect `unfree` placeholder license, corrected upstream in
+`Bad3r/nixpkgs@a71f346e` (waybackurls is MIT), so it now runs with no override
+and is counted as documented. `maltego` was never a build defect either; it is
+genuinely unfree and gets its own category.
 
 ## Summary
 
 | Result                                                           | Count   |
 | ---------------------------------------------------------------- | ------- |
-| ✅ Run as documented                                             | 98      |
+| ✅ Run as documented                                             | 99      |
 | ⚠️ Documented as unavailable in the reference                    | 10      |
 | ⚠️ Build or evaluation error                                     | 4       |
-| ⚠️ Blocked by the unfree license gate                            | 2       |
+| ⚠️ Blocked by the unfree license gate                            | 1       |
 | ⚠️ Binary path mismatch in the documented attribute              | 5       |
 | ⚠️ Documented attribute resolves to a different upstream project | 2       |
 | ⚠️ Documented smoke flag incompatible with the binary            | 2       |
@@ -106,6 +108,7 @@ no longer entries in the companion reference.
 - ✅ gospider
 - ✅ hakrawler
 - ✅ photon
+- ✅ waybackurls
 
 ### Credential Attacks and Wordlists
 
@@ -223,17 +226,12 @@ Re-verified 2026-08-04 under python3 3.14.6.
 
 ### Blocked by the unfree license gate
 
-Both packages build and run; the only blocker is policy. Add them to
+The package builds and runs; the only blocker is policy. Add it to
 `modules/meta/nixpkgs-allowed-unfree.nix` for repo configs, or pass
 `NIXPKGS_ALLOW_UNFREE=1` with `--impure` for a one-off. Re-verified
 2026-08-04.
 
 - ⚠️ maltego: unfree license. `NIXPKGS_ALLOW_UNFREE=1 nix build --impure nixpkgs#maltego` completes.
-- ⚠️ waybackurls: marked unfree in nixpkgs.
-  `NIXPKGS_ALLOW_UNFREE=1 nix run --impure nixpkgs#waybackurls -- -h` prints
-  full help. The license attribute is the bare `unfree` placeholder
-  (`fullName: "Unfree"`) rather than a named license, which is likely a
-  mislabel for an MIT-licensed Go tool.
 
 ### Binary path mismatch in the documented attribute
 

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -188,9 +188,9 @@ The reference itself flags these. Listed for completeness.
 
 - ⚠️ evil-winrm: Ruby 3.4 LoadError, `csv` gem missing then `winrm-fs` cannot
   load. Upstream nixpkgs build is currently broken.
-- ⚠️ mitm6: Python 3.13 evaluation error, `future-1.0.0` is not supported on
+- ⚠️ mitm6: Python 3.14 evaluation error, `future-1.0.0` is not supported on
   the active interpreter.
-- ⚠️ maigret: blocked by `python3.13-pypdf2-3.0.1` insecure marker. Requires
+- ⚠️ maigret: blocked by `python3.14-pypdf2-3.0.1` insecure marker. Requires
   `permittedInsecurePackages` override.
 - ⚠️ maltego: unfree license. Requires `allowUnfree = true` and inclusion in
   `modules/meta/nixpkgs-allowed-unfree.nix`.

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -234,10 +234,11 @@ Re-verified 2026-08-04 under python3 3.14.6.
 
 ### Blocked by the unfree license gate
 
-The package builds and runs; the only blocker is policy. Add it to
-`modules/meta/nixpkgs-allowed-unfree.nix` for repo configs, or pass
-`NIXPKGS_ALLOW_UNFREE=1` with `--impure` for a one-off. Re-verified
-2026-08-04.
+The package builds and runs; the only blocker is policy. For repo configs, set
+`nixpkgs.allowedUnfreePackages` from the module that wants the package; the
+flake-parts option is declared in `modules/meta/nixpkgs-allowed-unfree.nix`,
+which holds no entries of its own. For a one-off, pass `NIXPKGS_ALLOW_UNFREE=1`
+with `--impure`. Re-verified 2026-08-04.
 
 - ⚠️ maltego: unfree license. `NIXPKGS_ALLOW_UNFREE=1 nix build --impure nixpkgs#maltego` completes.
 

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -9,15 +9,19 @@ test.
 The runtime smoke test was run on 2026-05-04 against the active flake pin at
 that time. The inventory and summary below were reconciled on 2026-08-01
 against the companion reference; no run commands were re-executed on the
-current `flake.lock`.
+current `flake.lock`. The `mitm6` and `maigret` entries were re-verified on
+2026-07-23 under Python 3.14.6 and now run as documented: upstream `mitm6`
+dropped its `future` dependency (closure is netifaces / scapy / twisted only)
+and `maigret` migrated the insecure `pypdf2-3.0.1` to `pypdf-6.14.2`, clearing
+the two evaluation blocks recorded earlier.
 
 ## Summary
 
 | Result                                                           | Count   |
 | ---------------------------------------------------------------- | ------- |
-| ✅ Run as documented                                             | 95      |
+| ✅ Run as documented                                             | 97      |
 | ⚠️ Documented as unavailable in the reference                    | 10      |
-| ⚠️ Build or evaluation error                                     | 9       |
+| ⚠️ Build or evaluation error                                     | 7       |
 | ⚠️ Binary path mismatch in the documented attribute              | 5       |
 | ⚠️ Documented attribute resolves to a different upstream project | 2       |
 | ⚠️ Documented smoke flag incompatible with the binary            | 2       |
@@ -43,6 +47,7 @@ no longer entries in the companion reference.
 - ✅ bloodhound-py
 - ✅ responder
 - ✅ certipy
+- ✅ mitm6
 - ✅ enum4linux-ng
 - ✅ smbmap
 - ✅ adidnsdump
@@ -54,6 +59,7 @@ no longer entries in the companion reference.
 - ✅ rustscan
 - ✅ theharvester
 - ✅ sherlock
+- ✅ maigret
 - ✅ bettercap
 - ✅ ettercap
 - ✅ hping (binary `hping3`)
@@ -188,10 +194,6 @@ The reference itself flags these. Listed for completeness.
 
 - ⚠️ evil-winrm: Ruby 3.4 LoadError, `csv` gem missing then `winrm-fs` cannot
   load. Upstream nixpkgs build is currently broken.
-- ⚠️ mitm6: Python 3.14 evaluation error, `future-1.0.0` is not supported on
-  the active interpreter.
-- ⚠️ maigret: blocked by `python3.14-pypdf2-3.0.1` insecure marker. Requires
-  `permittedInsecurePackages` override.
 - ⚠️ maltego: unfree license. Requires `allowUnfree = true` and inclusion in
   `modules/meta/nixpkgs-allowed-unfree.nix`.
 - ⚠️ waybackurls: marked unfree in nixpkgs. Refuses to evaluate without

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -16,8 +16,8 @@ and `maigret` migrated the insecure `pypdf2-3.0.1` to `pypdf-6.14.2`, clearing
 the two evaluation blocks recorded earlier.
 
 Every entry that the 2026-05-04 snapshot recorded under "build or evaluation
-error" was re-run on 2026-08-04 against the current pin (python3 3.14.6), and
-four of the seven cleared:
+error" was re-run on 2026-08-04 against the current pin (python3 3.14.6). Three
+cleared, one was reclassified, and the group went from seven entries to three:
 
 - `dc3dd` now builds and runs; the recorded gcc failure is gone.
 - `evil-winrm` was fixed by `Bad3r/nixpkgs@807b1085` (3.7 -> 3.9), whose

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -8,20 +8,22 @@ test.
 
 The runtime smoke test was run on 2026-05-04 against the active flake pin at
 that time, and the inventory and summary below were reconciled on 2026-08-01
-against the companion reference without re-executing anything. Nine entries
-have since been re-run on the current `flake.lock`: `mitm6` and `maigret` on
-2026-07-23, and the seven former build-error entries on 2026-08-04. Every other
-entry still carries its 2026-05-04 result.
+against the companion reference without re-executing anything.
 
-The `mitm6` and `maigret` entries were re-verified on
-2026-07-23 under Python 3.14.6 and now run as documented: upstream `mitm6`
-dropped its `future` dependency (closure is netifaces / scapy / twisted only)
-and `maigret` migrated the insecure `pypdf2-3.0.1` to `pypdf-6.14.2`, clearing
-the two evaluation blocks recorded earlier.
+The only entries re-run since are the nine the 2026-05-04 snapshot recorded
+under "build or evaluation error"; all 118 others still carry their 2026-05-04
+result. Those nine were re-run in two batches. Five cleared and one was
+reclassified, taking the group from nine entries to three and "run as
+documented" from 95 to 100.
 
-Every entry that the 2026-05-04 snapshot recorded under "build or evaluation
-error" was re-run on 2026-08-04 against the current pin (python3 3.14.6). Three
-cleared, one was reclassified, and the group went from seven entries to three:
+`mitm6` and `maigret` were re-verified on 2026-07-23 under Python 3.14.6 and
+now run as documented: upstream `mitm6` dropped its `future` dependency
+(closure is netifaces / scapy / twisted only) and `maigret` migrated the
+insecure `pypdf2-3.0.1` to `pypdf-6.14.2`, clearing the two evaluation blocks
+recorded earlier.
+
+The remaining seven were re-run on 2026-08-04 against the current pin
+(python3 3.14.6). Three cleared and one was reclassified:
 
 - `dc3dd` now builds and runs; the recorded gcc failure is gone.
 - `evil-winrm` was fixed by `Bad3r/nixpkgs@807b1085` (3.7 -> 3.9), whose

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -15,13 +15,21 @@ dropped its `future` dependency (closure is netifaces / scapy / twisted only)
 and `maigret` migrated the insecure `pypdf2-3.0.1` to `pypdf-6.14.2`, clearing
 the two evaluation blocks recorded earlier.
 
+Every entry that the 2026-05-04 snapshot recorded under "build or evaluation
+error" was re-run on 2026-08-04 against the current pin (python3 3.14.6). Two
+outcomes changed: `dc3dd` now builds and runs, and `patator` still fails but on
+a different dependency than the one recorded. The `maltego` and `waybackurls`
+entries were never build defects and now have their own category, because both
+build and run once the unfree gate is opened.
+
 ## Summary
 
 | Result                                                           | Count   |
 | ---------------------------------------------------------------- | ------- |
-| ✅ Run as documented                                             | 97      |
+| ✅ Run as documented                                             | 98      |
 | ⚠️ Documented as unavailable in the reference                    | 10      |
-| ⚠️ Build or evaluation error                                     | 7       |
+| ⚠️ Build or evaluation error                                     | 4       |
+| ⚠️ Blocked by the unfree license gate                            | 2       |
 | ⚠️ Binary path mismatch in the documented attribute              | 5       |
 | ⚠️ Documented attribute resolves to a different upstream project | 2       |
 | ⚠️ Documented smoke flag incompatible with the binary            | 2       |
@@ -129,6 +137,7 @@ no longer entries in the companion reference.
 - ✅ dcfldd
 - ✅ safecopy
 - ✅ chainsaw
+- ✅ dc3dd
 
 ### Cryptography, Stego and CTF
 
@@ -192,22 +201,39 @@ The reference itself flags these. Listed for completeness.
 
 ### Build or evaluation error
 
-- ⚠️ evil-winrm: Ruby 3.4 LoadError, `csv` gem missing then `winrm-fs` cannot
-  load. Upstream nixpkgs build is currently broken.
-- ⚠️ maltego: unfree license. Requires `allowUnfree = true` and inclusion in
-  `modules/meta/nixpkgs-allowed-unfree.nix`.
-- ⚠️ waybackurls: marked unfree in nixpkgs. Refuses to evaluate without
-  `NIXPKGS_ALLOW_UNFREE=1` and `--impure` (or an entry in
-  `modules/meta/nixpkgs-allowed-unfree.nix`).
-- ⚠️ droopescan (uvx): runtime crash, `cement 2.6.2` imports the removed
-  `imp` module on Python 3.12+.
-- ⚠️ patator (uvx): build of transitive `cx-oracle 8.3.0` fails, its build
-  backend depends on `pkg_resources` without declaring it.
-- ⚠️ python3Packages.angr: nixpkgs build fails, `setuptools-rust` missing
-  from `nativeBuildInputs` during wheel preparation.
-- ⚠️ dc3dd: nixpkgs compile failure with modern gcc,
-  `argmatch.c:63: too many arguments to function 'usage'` (legacy macro
-  mismatch).
+Re-verified 2026-08-04 under python3 3.14.6.
+
+- ⚠️ evil-winrm: the derivation builds, but the binary aborts at startup with
+  `cannot load such file -- csv (LoadError)`, cascading to
+  `cannot load such file -- winrm-fs`. Ruby 3.4 removed `csv` from the default
+  gems, and the package's `Gemfile` adds `stringio`, `logger` and `fileutils`
+  for that same reason but not `csv`. Reproduces identically on
+  `nixpkgs-unstable`; no upstream issue is open for it.
+- ⚠️ droopescan (uvx): runtime crash, `cement 2.6.2` imports the `imp` module
+  that Python 3.12 removed. Unchanged under 3.14.
+- ⚠️ patator (uvx): the recorded `cx-oracle` cause no longer applies. The
+  install now fails building transitive `mysqlclient 2.2.8`, whose setup
+  script aborts with `Can not find valid pkg-config name` because no MySQL
+  client library is on the `uvx` build path.
+- ⚠️ python3Packages.angr: wheel preparation aborts with
+  `angr requires setuptools-rust to build`, which is missing from
+  `nativeBuildInputs`. Tracked upstream as
+  [NixOS/nixpkgs#501379](https://github.com/NixOS/nixpkgs/issues/501379),
+  which covers the `python314Packages.angr` job.
+
+### Blocked by the unfree license gate
+
+Both packages build and run; the only blocker is policy. Add them to
+`modules/meta/nixpkgs-allowed-unfree.nix` for repo configs, or pass
+`NIXPKGS_ALLOW_UNFREE=1` with `--impure` for a one-off. Re-verified
+2026-08-04.
+
+- ⚠️ maltego: unfree license. `NIXPKGS_ALLOW_UNFREE=1 nix build --impure nixpkgs#maltego` completes.
+- ⚠️ waybackurls: marked unfree in nixpkgs.
+  `NIXPKGS_ALLOW_UNFREE=1 nix run --impure nixpkgs#waybackurls -- -h` prints
+  full help. The license attribute is the bare `unfree` placeholder
+  (`fullName: "Unfree"`) rather than a named license, which is likely a
+  mislabel for an MIT-licensed Go tool.
 
 ### Binary path mismatch in the documented attribute
 

--- a/flake.lock
+++ b/flake.lock
@@ -1066,11 +1066,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785760262,
-        "narHash": "sha256-lII3f3Mk4WlJWh2YPyjc0BMzOhvb//1BYVHwlVMJOE8=",
+        "lastModified": 1785803884,
+        "narHash": "sha256-tPoZGrqIORHDiOlg8gcRNZ5f8etXvFT1D0Qwz/gsJOI=",
         "owner": "Bad3r",
         "repo": "nixpkgs",
-        "rev": "7a47fa3020c3b0fbaaf8908c651b097a71b12b33",
+        "rev": "a71f346e586010602ba6981d3a7a7193420a172f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1066,11 +1066,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785803884,
-        "narHash": "sha256-tPoZGrqIORHDiOlg8gcRNZ5f8etXvFT1D0Qwz/gsJOI=",
+        "lastModified": 1785805292,
+        "narHash": "sha256-ItPrQWEjSwPq9xjOATEKxq7igN0ZeekH6bgo0ZJKKFQ=",
         "owner": "Bad3r",
         "repo": "nixpkgs",
-        "rev": "a71f346e586010602ba6981d3a7a7193420a172f",
+        "rev": "807b1085982876124b512ab2cd1962cdd117911e",
         "type": "github"
       },
       "original": {

--- a/modules/apps/direnv.nix
+++ b/modules/apps/direnv.nix
@@ -15,7 +15,7 @@
     direnv exec <dir> <command>: Execute a command within another directory’s environment.
 
   Example Usage:
-    * `echo 'use flake' > .envrc {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} direnv allow` -- Activate the current flake automatically when entering the directory.
+    * `echo 'use flake' > .envrc && direnv allow` -- Activate the current flake automatically when entering the directory.
     * `direnv exec .. nix shell nixpkgs#hello` -- Run a command using another directory’s environment.
     * `direnv reload` -- Re-evaluate the environment after editing `.envrc`.
 */

--- a/modules/apps/dunst.nix
+++ b/modules/apps/dunst.nix
@@ -17,7 +17,7 @@
     dunstctl history-pop: Re-display the most recent notification from history.
 
   Example Usage:
-    * `dunst -config ~/.config/dunst/dunstrc {PRESERVED_DOCUMENTATION}` -- Start dunst with a custom configuration file.
+    * `dunst -config ~/.config/dunst/dunstrc &` -- Start dunst with a custom configuration file.
     * `dunstctl set-paused true` -- Temporarily pause displaying notifications.
     * `dunstctl history-pop` -- Quickly restore the last dismissed notification.
 */

--- a/modules/apps/gnome-disk-utility.nix
+++ b/modules/apps/gnome-disk-utility.nix
@@ -17,7 +17,7 @@
   Example Usage:
     * `gnome-disks` -- Open the GNOME Disks application to inspect devices, run benchmarks, or configure mounts.
     * Use the “Create Disk Image...” menu to back up a removable drive to an image file.
-    * Use “SMART Data {PRESERVED_DOCUMENTATION} Self-Tests” to review drive health and initiate a self-test.
+    * Use “SMART Data & Self-Tests” to review drive health and initiate a self-test.
 */
 _:
 let

--- a/modules/apps/hydra.nix
+++ b/modules/apps/hydra.nix
@@ -11,13 +11,13 @@
 
   Options:
     hydra -L users.txt -P passwords.txt ssh://host: Attack SSH with username and password lists.
-    hydra -C creds.txt http-get-form "/login:username=^USER^{PRESERVED_DOCUMENTATION}password=^PASS^:F=failed": Test web form authentication.
+    hydra -C creds.txt http-get-form "/login:username=^USER^&password=^PASS^:F=failed": Test web form authentication.
     hydra -R: Resume a previous session from the `hydra.restore` file.
 
   Example Usage:
     * `hydra -L users.txt -P rockyou.txt ftp://192.0.2.5` -- Audit FTP credentials using a wordlist.
     * `hydra -V -t 4 -l admin -P passwords.txt rdp://target` -- Try RDP logins with tuned thread count.
-    * `hydra -L api_keys.txt -p secret http-post-form "/api/login:key=^USER^{PRESERVED_DOCUMENTATION}secret=^PASS^:S=200"` -- Test custom HTTP POST flow.
+    * `hydra -L api_keys.txt -p secret http-post-form "/api/login:key=^USER^&secret=^PASS^:S=200"` -- Test custom HTTP POST flow.
 */
 _:
 let

--- a/modules/apps/hyperfine.nix
+++ b/modules/apps/hyperfine.nix
@@ -18,7 +18,7 @@
 
   Example Usage:
     * `hyperfine 'rg foo' 'ack foo'` -- Compare ripgrep and ack for a search task.
-    * `hyperfine -w 3 -r 10 'make clean {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} make'` -- Benchmark a build pipeline with warmup and specific run counts.
+    * `hyperfine -w 3 -r 10 'make clean && make'` -- Benchmark a build pipeline with warmup and specific run counts.
     * `hyperfine --export-json results.json 'python script.py'` -- Save benchmark metrics for further analysis.
 */
 _:

--- a/modules/apps/i3lock-color.nix
+++ b/modules/apps/i3lock-color.nix
@@ -19,7 +19,7 @@
   Example Usage:
     * `i3lock-color -c 1d2021 --indicator` -- Lock the screen with a solid color and indicator.
     * `i3lock-color -i ~/Pictures/wallpaper.jpg -B 5 --time-color ffffffff` -- Use a background image with blur and white time display.
-    * `i3lock-color --nofork {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} systemctl suspend` -- Lock the screen synchronously before suspending.
+    * `i3lock-color --nofork && systemctl suspend` -- Lock the screen synchronously before suspending.
 */
 _:
 let

--- a/modules/apps/networkmanagerapplet.nix
+++ b/modules/apps/networkmanagerapplet.nix
@@ -15,7 +15,7 @@
     nm-connection-editor: Launch the advanced connection configuration dialog.
 
   Example Usage:
-    * `nm-applet --indicator {PRESERVED_DOCUMENTATION}` -- Run the applet in the background on minimal desktops.
+    * `nm-applet --indicator &` -- Run the applet in the background on minimal desktops.
     * Click the tray icon to connect/disconnect Wi-Fi and VPN connections.
     * `nm-connection-editor` -- Edit advanced connection settings such as IPv6, DNS, and security settings.
 */

--- a/modules/apps/nodejs_22.nix
+++ b/modules/apps/nodejs_22.nix
@@ -17,7 +17,7 @@
 
   Example Usage:
     * `node app.js` -- Run a Node.js server or script entrypoint.
-    * `npm init -y {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} npm install express` -- Initialize a project and add dependencies.
+    * `npm init -y && npm install express` -- Initialize a project and add dependencies.
     * `npx tsc` -- Execute TypeScript compiler via npx using the Node 22 toolchain.
 */
 _:

--- a/modules/apps/nodejs_24.nix
+++ b/modules/apps/nodejs_24.nix
@@ -18,7 +18,7 @@
   Example Usage:
     * `node --test` -- Run tests using the built-in test runner infrastructure.
     * `npm create vite@latest my-app` -- Scaffold a web project using the latest npm toolchains.
-    * `corepack enable pnpm {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} pnpm install` -- Switch to pnpm package management for the project.
+    * `corepack enable pnpm && pnpm install` -- Switch to pnpm package management for the project.
 */
 _:
 let

--- a/modules/apps/picom.nix
+++ b/modules/apps/picom.nix
@@ -19,7 +19,7 @@
   Example Usage:
     * `picom --config ~/.config/picom/picom.conf --daemon` -- Start compositing with a custom config.
     * `picom --experimental-backends --backend glx` -- Use GLX backend with blur effects.
-    * `pkill picom {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} picom --vsync` -- Restart picom with VSYNC enabled to mitigate tearing.
+    * `pkill picom && picom --vsync` -- Restart picom with VSYNC enabled to mitigate tearing.
 */
 _:
 let

--- a/modules/apps/pkg-config.nix
+++ b/modules/apps/pkg-config.nix
@@ -19,7 +19,7 @@
   Example Usage:
     * `pkg-config --cflags --libs gtk+-3.0` -- Obtain compiler and linker flags for GTK 3.
     * `PKG_CONFIG_PATH=$PWD/build/lib/pkgconfig pkg-config --modversion mylib` -- Query a locally built library.
-    * `pkg-config --exists openssl {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} echo "OpenSSL available"` -- Check for dependency presence in build scripts.
+    * `pkg-config --exists openssl && echo "OpenSSL available"` -- Check for dependency presence in build scripts.
 */
 _:
 let

--- a/modules/apps/python.nix
+++ b/modules/apps/python.nix
@@ -1,28 +1,28 @@
 /*
-  Package: python313
-  Description: CPython 3.13 interpreter and standard library.
+  Package: python3
+  Description: Default CPython 3 interpreter and standard library.
   Homepage: https://www.python.org/
-  Documentation: https://docs.python.org/3.13/
+  Documentation: https://docs.python.org/3/
   Repository: https://github.com/python/cpython
 
   Summary:
     * Provides the default Python interpreter with `pip`, `venv`, and a batteries-included standard library for scripting, web services, and data science.
-    * Supports zero-cost exceptions, improved f-string diagnostics, and other enhancements introduced in Python 3.13.
+    * Tracks the default `python3` from the pinned nixpkgs, so the interpreter version follows nixpkgs instead of a hardcoded release.
 
   Options:
-    python3.13 <script.py>: Execute Python scripts.
-    python3.13 -m <module>: Run library modules as scripts (e.g. `python -m http.server`).
-    python3.13 -m venv <envdir>: Create virtual environments for dependency isolation.
+    python3 <script.py>: Execute Python scripts.
+    python3 -m <module>: Run library modules as scripts (e.g. `python -m http.server`).
+    python3 -m venv <envdir>: Create virtual environments for dependency isolation.
     pip install <pkg>: Install packages into the active environment.
 
   Example Usage:
-    * `python3.13` -- Launch the interactive REPL.
-    * `python3.13 -m venv .venv {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} source .venv/bin/activate` -- Create and activate a virtual environment.
-    * `python3.13 -m pip install requests` -- Install packages using pip within the environment.
+    * `python3` -- Launch the interactive REPL.
+    * `python3 -m venv .venv && source .venv/bin/activate` -- Create and activate a virtual environment.
+    * `python3 -m pip install requests` -- Install packages using pip within the environment.
 */
 _:
 let
-  Python313Module =
+  PythonModule =
     {
       config,
       lib,
@@ -37,10 +37,10 @@ let
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Whether to enable Python 3.13.";
+          description = "Whether to enable the default CPython 3 interpreter.";
         };
 
-        package = lib.mkPackageOption pkgs "python313" { };
+        package = lib.mkPackageOption pkgs "python3" { };
       };
 
       config = lib.mkIf cfg.enable {
@@ -51,5 +51,5 @@ let
     };
 in
 {
-  flake.nixosModules.apps.python = Python313Module;
+  flake.nixosModules.apps.python = PythonModule;
 }

--- a/modules/apps/temurin-bin-25.nix
+++ b/modules/apps/temurin-bin-25.nix
@@ -16,7 +16,7 @@
     jlink --module-path <path> --add-modules <modules> --output <dir>: Create custom runtime images.
 
   Example Usage:
-    * `javac Main.java {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} java Main` -- Compile and run a Java application.
+    * `javac Main.java && java Main` -- Compile and run a Java application.
     * `jshell` -- Start the interactive Java REPL for prototyping.
     * `JAVA_HOME=$(dirname $(dirname $(readlink -f $(which java))))` -- Export the JDK root for build tools.
 */

--- a/modules/apps/udiskie.nix
+++ b/modules/apps/udiskie.nix
@@ -17,7 +17,7 @@
     --notify: Enable desktop notifications (default).
 
   Example Usage:
-    * `udiskie --tray {PRESERVED_DOCUMENTATION}` -- Run udiskie in the background to automount USB drives with a tray icon.
+    * `udiskie --tray &` -- Run udiskie in the background to automount USB drives with a tray icon.
     * `udiskie-mount -a` -- Mount all currently available devices.
     * Customize `~/.config/udiskie/config.yml` to specify mount options or blacklist devices.
 */

--- a/modules/apps/uv.nix
+++ b/modules/apps/uv.nix
@@ -18,7 +18,7 @@
 
   Example Usage:
     * `uv pip install requests` -- Install a Python package using uv instead of pip.
-    * `uv lock {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} uv sync` -- Produce a lockfile and sync dependencies into `.venv`.
+    * `uv lock && uv sync` -- Produce a lockfile and sync dependencies into `.venv`.
     * `uv run pytest` -- Execute a command using the synced environment without manually activating it.
 */
 _:

--- a/modules/apps/valgrind.nix
+++ b/modules/apps/valgrind.nix
@@ -18,7 +18,7 @@
 
   Example Usage:
     * `valgrind ./app` -- Run a binary under Memcheck to catch memory issues.
-    * `valgrind --tool=callgrind ./app {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} kcachegrind callgrind.out.*` -- Profile CPU hotspots and inspect results.
+    * `valgrind --tool=callgrind ./app && kcachegrind callgrind.out.*` -- Profile CPU hotspots and inspect results.
     * `valgrind --tool=massif --massif-out-file=massif.out ./server` -- Monitor heap growth for long-running services.
 */
 _:

--- a/modules/apps/yarn.nix
+++ b/modules/apps/yarn.nix
@@ -17,7 +17,7 @@
     yarn workspaces run <script>: Run commands across all workspaces.
 
   Example Usage:
-    * `yarn init -y {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} yarn add react` -- Bootstrap a project and add React dependency.
+    * `yarn init -y && yarn add react` -- Bootstrap a project and add React dependency.
     * `yarn install --frozen-lockfile` -- Install dependencies exactly as specified in the lockfile.
     * `yarn workspaces run test` -- Run the `test` script across all monorepo workspaces.
 */

--- a/packages/age-plugin-fido2prf/update.py
+++ b/packages/age-plugin-fido2prf/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for age-plugin-fido2prf."""
 
 from __future__ import annotations

--- a/packages/azd/update.py
+++ b/packages/azd/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for azd."""
 
 from __future__ import annotations

--- a/packages/brave-origin/update.py
+++ b/packages/brave-origin/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for brave-origin."""
 
 from __future__ import annotations

--- a/packages/charles/update.py
+++ b/packages/charles/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for Charles."""
 
 from __future__ import annotations

--- a/packages/codeburn/update.py
+++ b/packages/codeburn/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for codeburn."""
 
 from __future__ import annotations

--- a/packages/duplicati-r2-tools/duplicati_r2_extract.py
+++ b/packages/duplicati-r2-tools/duplicati_r2_extract.py
@@ -803,7 +803,7 @@ class OpenedVolume:
         if expected_blocksize is not None:
             try:
                 actual_blocksize = int(self.manifest.get("Blocksize"))
-            except (TypeError, ValueError):
+            except TypeError, ValueError:
                 fail(
                     f"{self.name}: manifest Blocksize {self.manifest.get('Blocksize')!r} is invalid",
                     EXIT_DATA_ERR,
@@ -840,7 +840,7 @@ class OpenedVolume:
         # downstream cares once we are tearing down.
         try:
             self._zip.close()
-        except (zipfile.BadZipFile, OSError):
+        except zipfile.BadZipFile, OSError:
             pass
 
 

--- a/packages/electron-mail/update.py
+++ b/packages/electron-mail/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for electron-mail."""
 
 from __future__ import annotations

--- a/packages/gitlawb/update.py
+++ b/packages/gitlawb/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for gitlawb."""
 
 from __future__ import annotations

--- a/packages/malimite/update.py
+++ b/packages/malimite/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for malimite."""
 
 from __future__ import annotations

--- a/packages/opendirectorydownloader/update.py
+++ b/packages/opendirectorydownloader/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for opendirectorydownloader."""
 
 from __future__ import annotations

--- a/packages/restringer/update.py
+++ b/packages/restringer/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for restringer."""
 
 from __future__ import annotations

--- a/packages/searchfox-cli/update.py
+++ b/packages/searchfox-cli/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for searchfox-cli."""
 
 from __future__ import annotations

--- a/packages/source-map-explorer/update.py
+++ b/packages/source-map-explorer/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for source-map-explorer."""
 
 from __future__ import annotations

--- a/packages/tweakcc/update.py
+++ b/packages/tweakcc/update.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
 
 """Update script for tweakcc.
 

--- a/packages/wakaru/update.py
+++ b/packages/wakaru/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for wakaru.
 
 Upstream migrated the project from a pnpm JavaScript monorepo (``cli-v*`` tags,

--- a/packages/wappalyzer-next/update.py
+++ b/packages/wappalyzer-next/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for wappalyzer-next."""
 
 from __future__ import annotations

--- a/packages/webcrack/update.py
+++ b/packages/webcrack/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3 yq-go
+# Copyright (c) 2026 Bad3r
+
 """Update script for webcrack."""
 
 from __future__ import annotations

--- a/packages/wfuzz/update.py
+++ b/packages/wfuzz/update.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env nix-shell
 #! nix-shell -i python3 --packages python3
+# Copyright (c) 2026 Bad3r
+
 """Update script for wfuzz."""
 
 from __future__ import annotations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.ruff]
 line-length = 100
 indent-width = 4
-target-version = "py313"
+target-version = "py314"
 
 [tool.ruff.lint]
 select = ["ALL"]
@@ -49,7 +49,7 @@ indent-style = "space"
 
 [tool.pyright]
 typeCheckingMode = "strict"
-pythonVersion = "3.13"
+pythonVersion = "3.14"
 pythonPlatform = "Linux"
 include = ["packages", "scripts"]
 exclude = ["packages/duplicati-r2-tools", "scripts/url-catalog-add.py", "scripts/usbguard-ensure-allow.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,18 @@ line-length = 100
 indent-width = 4
 target-version = "py314"
 
+# update-flake.yml and update-firefoxpwa-extension.yml run
+# scripts/update-firefoxpwa-extension.py on ubuntu-latest through its
+# `#!/usr/bin/env python3` shebang, and scripts/updater/__init__.py eagerly
+# imports every submodule, so those files are parsed by the runner's
+# interpreter and never by the pinned 3.14. Without this floor the formatter
+# is free to emit 3.14-only syntax into them, which surfaces as a SyntaxError
+# in a scheduled workflow. py312 is the floor because updater/http.py uses
+# PEP 695 `type` statements.
+[tool.ruff.per-file-target-version]
+"scripts/update-firefoxpwa-extension.py" = "py312"
+"scripts/updater/*.py" = "py312"
+
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,13 @@ target-version = "py314"
 # so the whole package is parsed alongside the scripts that import it. py312 is
 # the floor because updater/http.py uses PEP 695 `type` statements.
 #
+# updater_bootstrap.py is reached only through packages/*/update.py, which run
+# on the pinned interpreter, so it is here to keep the two gates agreeing: the
+# pyright environment below floors everything under scripts/ at 3.12, and
+# without a matching ruff floor the formatter emits `except A, B:` that pyright
+# then rejects as "Multiple exception types must be parenthesized prior to
+# Python 3.14", leaving both gates unsatisfiable at once.
+#
 # Scripts that provision their own interpreter do not belong here:
 # url-catalog-add.py declares requires-python >=3.14 in its PEP 723 block and
 # runs under `uv run --script`, and packages/*/update.py run under
@@ -28,6 +35,7 @@ target-version = "py314"
 "scripts/update-firefoxpwa-extension.py" = "py312"
 "scripts/update-gecko-userscripts.py" = "py312"
 "scripts/updater/*.py" = "py312"
+"scripts/updater_bootstrap.py" = "py312"
 "scripts/usbguard-ensure-allow.py" = "py312"
 
 [tool.ruff.lint]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,16 +3,18 @@ line-length = 100
 indent-width = 4
 target-version = "py314"
 
-# update-flake.yml and update-firefoxpwa-extension.yml run
-# scripts/update-firefoxpwa-extension.py on ubuntu-latest through its
-# `#!/usr/bin/env python3` shebang, and scripts/updater/__init__.py eagerly
-# imports every submodule, so those files are parsed by the runner's
-# interpreter and never by the pinned 3.14. Without this floor the formatter
-# is free to emit 3.14-only syntax into them, which surfaces as a SyntaxError
-# in a scheduled workflow. py312 is the floor because updater/http.py uses
-# PEP 695 `type` statements.
+# Files whose interpreter is chosen by the invoker rather than by the flake.
+# Without a floor the formatter may emit 3.14-only syntax into them, which
+# surfaces as a SyntaxError only when they actually run.
+#
+# The two `#!/usr/bin/env python3` entry scripts run under whatever python3 is
+# on PATH, and scripts/updater/__init__.py eagerly imports every submodule, so
+# the whole package is parsed alongside them; update-flake.yml and
+# update-firefoxpwa-extension.yml take that path on ubuntu-latest. py312 is the
+# floor there because updater/http.py uses PEP 695 `type` statements.
 [tool.ruff.per-file-target-version]
 "scripts/update-firefoxpwa-extension.py" = "py312"
+"scripts/update-gecko-userscripts.py" = "py312"
 "scripts/updater/*.py" = "py312"
 
 [tool.ruff.lint]
@@ -65,4 +67,19 @@ pythonVersion = "3.14"
 pythonPlatform = "Linux"
 include = ["packages", "scripts"]
 exclude = ["packages/duplicati-r2-tools", "scripts/url-catalog-add.py", "scripts/usbguard-ensure-allow.py"]
+extraPaths = ["scripts"]
+
+# The ruff floor above only constrains syntax the formatter emits. Type-checking
+# scripts/ at 3.14 would accept a 3.14-only stdlib API (Path.copy, annotationlib,
+# the new typing members) in files that run on the invoker's interpreter, failing
+# at runtime instead of at check time. Array-of-tables must stay last in this
+# table.
+[[tool.pyright.executionEnvironments]]
+root = "scripts"
+pythonVersion = "3.12"
+extraPaths = ["scripts"]
+
+[[tool.pyright.executionEnvironments]]
+root = "."
+pythonVersion = "3.14"
 extraPaths = ["scripts"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,17 @@ target-version = "py314"
 # surfaces as a SyntaxError only when they actually run.
 #
 # Every `#!/usr/bin/env python3` entry script here runs under whatever python3
-# is on PATH: the two update scripts via workflows on ubuntu-latest, and
-# usbguard-ensure-allow.py via `EDITOR=... sops`, which execs it from the dev
-# shell where modules/devshell.nix provides no python. scripts/updater is listed
-# because __init__.py eagerly imports every submodule, so the whole package is
-# parsed alongside the update scripts that import it. py312 is the floor because
-# updater/http.py uses PEP 695 `type` statements.
+# is on PATH, which is the criterion for this list; how each one is reached
+# only changes who hits the SyntaxError first.
+#   update-firefoxpwa-extension.py  run by the update-flake and
+#                                   update-firefoxpwa-extension workflows on
+#                                   ubuntu-latest
+#   update-gecko-userscripts.py     no workflow; operator-run only
+#   usbguard-ensure-allow.py        exec'd by `EDITOR=... sops` from a dev shell
+#                                   that modules/devshell.nix gives no python
+# scripts/updater is listed because __init__.py eagerly imports every submodule,
+# so the whole package is parsed alongside the scripts that import it. py312 is
+# the floor because updater/http.py uses PEP 695 `type` statements.
 #
 # Scripts that provision their own interpreter do not belong here:
 # url-catalog-add.py declares requires-python >=3.14 in its PEP 723 block and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,15 +7,23 @@ target-version = "py314"
 # Without a floor the formatter may emit 3.14-only syntax into them, which
 # surfaces as a SyntaxError only when they actually run.
 #
-# The two `#!/usr/bin/env python3` entry scripts run under whatever python3 is
-# on PATH, and scripts/updater/__init__.py eagerly imports every submodule, so
-# the whole package is parsed alongside them; update-flake.yml and
-# update-firefoxpwa-extension.yml take that path on ubuntu-latest. py312 is the
-# floor there because updater/http.py uses PEP 695 `type` statements.
+# Every `#!/usr/bin/env python3` entry script here runs under whatever python3
+# is on PATH: the two update scripts via workflows on ubuntu-latest, and
+# usbguard-ensure-allow.py via `EDITOR=... sops`, which execs it from the dev
+# shell where modules/devshell.nix provides no python. scripts/updater is listed
+# because __init__.py eagerly imports every submodule, so the whole package is
+# parsed alongside the update scripts that import it. py312 is the floor because
+# updater/http.py uses PEP 695 `type` statements.
+#
+# Scripts that provision their own interpreter do not belong here:
+# url-catalog-add.py declares requires-python >=3.14 in its PEP 723 block and
+# runs under `uv run --script`, and packages/*/update.py run under
+# `nix-shell -i python3` off the pinned nixpkgs.
 [tool.ruff.per-file-target-version]
 "scripts/update-firefoxpwa-extension.py" = "py312"
 "scripts/update-gecko-userscripts.py" = "py312"
 "scripts/updater/*.py" = "py312"
+"scripts/usbguard-ensure-allow.py" = "py312"
 
 [tool.ruff.lint]
 select = ["ALL"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,11 @@ target-version = "py314"
 # then rejects as "Multiple exception types must be parenthesized prior to
 # Python 3.14", leaving both gates unsatisfiable at once.
 #
-# Scripts that provision their own interpreter do not belong here:
-# url-catalog-add.py declares requires-python >=3.14 in its PEP 723 block and
-# runs under `uv run --script`, and packages/*/update.py run under
-# `nix-shell -i python3` off the pinned nixpkgs.
+# Not listed here: url-catalog-add.py, which declares requires-python >=3.14 in
+# its PEP 723 block so uv selects the interpreter, and packages/*/update.py,
+# whose `nix-shell -i python3 --packages python3` resolves <nixpkgs> from
+# NIX_PATH, which modules/base/nixpkgs.nix points at the flake's nixpkgs on repo
+# hosts.
 [tool.ruff.per-file-target-version]
 "scripts/update-firefoxpwa-extension.py" = "py312"
 "scripts/update-gecko-userscripts.py" = "py312"

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -43,9 +43,12 @@ A new `#!/usr/bin/env python3` script here also needs an entry in
 from the invoker's `PATH` rather than the flake, and `ubuntu-latest` still ships
 3.12, so at the repo-wide `py314` target `ruff format` will rewrite portable
 code such as `except (KeyError, ValueError):` into the PEP 758 unbracketed form
-and break the script where it actually runs. The floor does not apply to the
-`uv run --script` and `nix-shell` shebangs above, which pin their own
-interpreter.
+and break the script where it actually runs. The `uv run --script` shebang above
+needs no floor, because uv selects the interpreter from the script's own PEP 723
+`requires-python`. The `nix-shell -i python3` shebang does not pin one either:
+`--packages` resolves against `<nixpkgs>` from the ambient `NIX_PATH`, which is
+3.14 only because `modules/base/nixpkgs.nix` points `nix.nixPath` at the flake's
+nixpkgs on repo hosts.
 
 ## Validation Commands
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -38,6 +38,15 @@ pattern already used by `url-catalog-add.py`. Package updaters under
 `#!/usr/bin/env nix` shebang. Add packages for commands invoked directly,
 such as `yq-go` in `packages/webcrack/update.py`.
 
+A new `#!/usr/bin/env python3` script here also needs an entry in
+`[tool.ruff.per-file-target-version]` in `pyproject.toml`. Its interpreter comes
+from the invoker's `PATH` rather than the flake, and `ubuntu-latest` still ships
+3.12, so at the repo-wide `py314` target `ruff format` will rewrite portable
+code such as `except (KeyError, ValueError):` into the PEP 758 unbracketed form
+and break the script where it actually runs. The floor does not apply to the
+`uv run --script` and `nix-shell` shebangs above, which pin their own
+interpreter.
+
 ## Validation Commands
 
 Validate the exact entrypoint changed before broader hooks:

--- a/scripts/update-firefoxpwa-extension.py
+++ b/scripts/update-firefoxpwa-extension.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Bad3r
 
 """Sync the firefoxpwa management-extension pin with the nixpkgs connector.
 

--- a/scripts/update-gecko-userscripts.py
+++ b/scripts/update-gecko-userscripts.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# Copyright (c) 2026 Bad3r
 
 """Update Gecko Violentmonkey userscript pins."""
 

--- a/scripts/updater/__init__.py
+++ b/scripts/updater/__init__.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """Nix package updater library.
 
 This library provides utilities for updating Nix packages in flakes,

--- a/scripts/updater/bun.py
+++ b/scripts/updater/bun.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """Bun package utilities for Nix package updates.
 
 Provides helpers for regenerating bun.nix lockfiles using bun2nix,

--- a/scripts/updater/deps.py
+++ b/scripts/updater/deps.py
@@ -5,12 +5,14 @@ This module provides utilities for calculating dependency hashes
 dummy-hash-and-build pattern.
 """
 
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from .hash import DUMMY_SHA256_HASH, extract_hash_from_build_error
 from .hashes_file import save_hashes
 from .nix import NixCommandError, nix_build
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def calculate_dependency_hash(

--- a/scripts/updater/deps.py
+++ b/scripts/updater/deps.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """Dependency hash calculation utilities for Nix package updaters.
 
 This module provides utilities for calculating dependency hashes

--- a/scripts/updater/deps.py
+++ b/scripts/updater/deps.py
@@ -7,6 +7,8 @@ This module provides utilities for calculating dependency hashes
 dummy-hash-and-build pattern.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from .hash import DUMMY_SHA256_HASH, extract_hash_from_build_error

--- a/scripts/updater/hash.py
+++ b/scripts/updater/hash.py
@@ -6,10 +6,13 @@ import shutil
 import tempfile
 import urllib.parse
 import urllib.request
-from collections.abc import Mapping
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from .nix import nix_hash_file, nix_prefetch_url, nix_store_prefetch_file
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
 
 # Dummy hash used to trigger Nix build errors to extract correct hash
 DUMMY_SHA256_HASH = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA="

--- a/scripts/updater/hash.py
+++ b/scripts/updater/hash.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """Hash calculation utilities for Nix packages."""
 
 import base64

--- a/scripts/updater/hash.py
+++ b/scripts/updater/hash.py
@@ -2,6 +2,8 @@
 
 """Hash calculation utilities for Nix packages."""
 
+from __future__ import annotations
+
 import base64
 import re
 import shutil

--- a/scripts/updater/hashes_file.py
+++ b/scripts/updater/hashes_file.py
@@ -1,8 +1,10 @@
 """Hashes file I/O utilities for Nix package updaters."""
 
 import json
-from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def load_hashes(path: Path) -> dict[str, Any]:

--- a/scripts/updater/hashes_file.py
+++ b/scripts/updater/hashes_file.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """Hashes file I/O utilities for Nix package updaters."""
 
 import json

--- a/scripts/updater/hashes_file.py
+++ b/scripts/updater/hashes_file.py
@@ -2,6 +2,8 @@
 
 """Hashes file I/O utilities for Nix package updaters."""
 
+from __future__ import annotations
+
 import json
 from typing import TYPE_CHECKING, Any, cast
 

--- a/scripts/updater/http.py
+++ b/scripts/updater/http.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """HTTP utilities for fetching data from URLs."""
 
 import json
@@ -6,7 +8,7 @@ import urllib.parse
 import urllib.request
 from typing import cast
 
-type JsonValue = None | bool | int | float | str | list[JsonValue] | dict[str, JsonValue]
+type JsonValue = bool | int | float | str | list[JsonValue] | dict[str, JsonValue] | None
 type JsonObject = dict[str, JsonValue]
 type JsonArray = list[JsonValue]
 

--- a/scripts/updater/nix.py
+++ b/scripts/updater/nix.py
@@ -2,8 +2,10 @@
 
 import json
 import subprocess
-from pathlib import Path
-from typing import cast
+from typing import TYPE_CHECKING, cast
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 class NixCommandError(Exception):

--- a/scripts/updater/nix.py
+++ b/scripts/updater/nix.py
@@ -2,6 +2,8 @@
 
 """Nix command wrappers for package updates."""
 
+from __future__ import annotations
+
 import json
 import subprocess
 from typing import TYPE_CHECKING, cast

--- a/scripts/updater/nix.py
+++ b/scripts/updater/nix.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """Nix command wrappers for package updates."""
 
 import json

--- a/scripts/updater/npm.py
+++ b/scripts/updater/npm.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """NPM package utilities for Nix package updates."""
 
 import os

--- a/scripts/updater/platforms.py
+++ b/scripts/updater/platforms.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """Multi-platform hash calculation utilities for Nix package updaters."""
 
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/scripts/updater/version.py
+++ b/scripts/updater/version.py
@@ -277,7 +277,7 @@ def fetch_npm_version(package: str) -> str:
         cmd = ["npm", "view", package, "version"]
         result = run_command(cmd)
         return result.stdout.strip()
-    except (FileNotFoundError, OSError):
+    except FileNotFoundError, OSError:
         # npm command not available, fallback to registry API
         url = f"https://registry.npmjs.org/{package}/latest"
         data = fetch_json(url)

--- a/scripts/updater/version.py
+++ b/scripts/updater/version.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """Version fetching from various sources (GitHub, npm, custom APIs)."""
 
 import re

--- a/scripts/updater/version.py
+++ b/scripts/updater/version.py
@@ -279,7 +279,7 @@ def fetch_npm_version(package: str) -> str:
         cmd = ["npm", "view", package, "version"]
         result = run_command(cmd)
         return result.stdout.strip()
-    except FileNotFoundError, OSError:
+    except OSError:
         # npm command not available, fallback to registry API
         url = f"https://registry.npmjs.org/{package}/latest"
         data = fetch_json(url)

--- a/scripts/updater_bootstrap.py
+++ b/scripts/updater_bootstrap.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2026 Bad3r
+
 """Bootstrap helpers for package update scripts."""
 
 from __future__ import annotations

--- a/scripts/url-catalog-add.py
+++ b/scripts/url-catalog-add.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S uv run --script
 # /// script
-# requires-python = ">=3.11"
+# requires-python = ">=3.14"
 # dependencies = [
 #   "ruamel.yaml>=0.18.10",
 # ]


### PR DESCRIPTION
## Summary

Python 3.14 is the default `python3` in the pinned nixpkgs (3.14.6). This moves the repo's Python standard to 3.14: tooling targets, the system interpreter, docs, and the small code changes the bump requires.

- **`pyproject.toml`**: ruff `target-version` `py313` -> `py314`; pyright `pythonVersion` `3.13` -> `3.14`. Plus a `per-file-target-version` floor of `py312` for the three `#!/usr/bin/env python3` entry scripts and `scripts/updater/*.py`, and a matching `[[tool.pyright.executionEnvironments]]` root, because those are parsed by the invoker's interpreter rather than the pinned one (see below).
- **`scripts/updater/{deps,hash,hashes_file,nix}.py`**: PEP 649 deferred annotations make annotation-only stdlib imports non-runtime under 3.14, so ruff `TC003` moves `pathlib.Path` / `collections.abc.Mapping` into `TYPE_CHECKING` blocks. `hash.py` keeps `Path` (used at runtime).
- **`modules/apps/python.nix`**: drop the `python313` pin and use the default `pkgs.python3`, so the system interpreter tracks nixpkgs (currently 3.14.6) with no hardcoded release. Header docs made version-agnostic.
- **PEP 758 bracket removal** in `packages/duplicati-r2-tools/duplicati_r2_extract.py`: raising `target-version` to `py314` turns on ruff's PEP 758 formatting, which drops the now-redundant brackets from multi-exception `except` clauses that have no `as` binding:

  ```diff
  - except (zipfile.BadZipFile, OSError):
  + except zipfile.BadZipFile, OSError:
  ```

  This is emitted by `ruff format`, not hand-written, and reverting it makes `ruff format --check .` fail. PEP 758 landed in 3.14 (`Doc/whatsnew/3.14.rst`, "Allow `except` and `except*` expressions without brackets", gh-131831), so the file parses only on 3.14+. That is safe here and only here: `extract.nix` rewrites the shebang to `${pythonEnv}/bin/python3` off the flake's `python3`, no workflow reaches the file, and its two exception pairs are unrelated types that cannot collapse to a single name.
- **Interpreter portability for `scripts/updater/`**: that package is *not* only consumed under the pinned interpreter. `update-flake.yml` and `update-firefoxpwa-extension.yml` both run `scripts/update-firefoxpwa-extension.py` directly on `ubuntu-latest` via its `#!/usr/bin/env python3` shebang, with no `setup-python` and no `nix develop`, and `updater/__init__.py` eagerly re-exports from `.deps`, `.hash`, `.hashes_file`, `.nix` and `.version`. Two things in this branch broke that path and are fixed:
  - The `TC003` moves need `from __future__ import annotations` in `deps.py`, `hash.py`, `hashes_file.py` and `nix.py`. Ruff makes the move because `py314` implies PEP 649 lazy annotations, but below 3.14 the annotations evaluate at `def` time: `import updater` under 3.13.14 raised `NameError: name 'Path' is not defined`. The future import matches what `bun.py`, `updater_bootstrap.py` and every `packages/*/update.py` already do.
  - `version.py` had `except FileNotFoundError, OSError:`. Since `FileNotFoundError` is a subclass of `OSError` the tuple was redundant, so it collapses to `except OSError:`, which is equivalent, parses on every 3.x, and has no brackets for the py314 formatter to strip.

  Both of those are per-occurrence fixes, so the root cause is pinned too: a repo-wide `py314` target lets the formatter emit 3.14-only syntax into files CI parses with an older interpreter, and the next `except (A, B):` written there would be unbracketed again, surfacing only as a `SyntaxError` in a scheduled run. `per-file-target-version` now floors those paths at `py312`. Verified by construction: inserting `except (KeyError, ValueError):` into the guarded `scripts/updater/version.py` leaves the brackets intact, while the same construct in the unguarded `duplicati_r2_extract.py` is still unbracketed. The guarded set was enumerated by importing the entry script under 3.13 and listing what loads (`updater` plus `updater.{bun,deps,hash,hashes_file,http,nix,npm,platforms,version}`). `scripts/update-gecko-userscripts.py` is floored too: it has the same `#!/usr/bin/env python3` + `from updater import ...` shape, so the invoker picks its interpreter regardless of whether a workflow calls it. No workflow runs any `packages/*/update.py`, which stay at py314 under `nix-shell -i python3`.

  `scripts/usbguard-ensure-allow.py` is floored for the same reason: `#!/usr/bin/env python3`, no PEP 723 block, and its documented `EDITOR=... nix develop -c sops ...` invocation execs it from PATH inside a dev shell that `modules/devshell.nix` gives no python. Verified live, not hypothetical: before the floor ruff rewrote an inserted `except (KeyError, ValueError):` into the unbracketed form.

  The list is complete rather than incrementally longer. Every tracked `#!/usr/bin/env python3` script was swept against it; the only unfloored ones are the four under `packages/duplicati-r2-tools`, and none reach that shebang (`extract.nix` and `list.nix` `--replace-fail` it to the pinned interpreter, and `make_fixture.py` / `check_extract_regressions.py` are build-time only, invoked as `${pythonEnv}/bin/python3 $src/scripts/...` and never installed).

  The ruff floor only constrains syntax the *formatter* emits, so pyright gets the matching floor: a `[[tool.pyright.executionEnvironments]]` entry roots `scripts` at 3.12 and keeps the repo root at 3.14. Otherwise a 3.14-only stdlib API (`Path.copy`, `annotationlib`) in those files would type-check clean and fail at runtime. Confirmed the override is live rather than silently ignored: temporarily rooting `scripts` at 3.8 makes pyright emit `Type alias statement requires Python 3.12 or newer` on `updater/http.py`, which it does not emit at 3.12.
- **`scripts/url-catalog-add.py`**: PEP 723 `requires-python` `>=3.11` -> `>=3.14`. It declared a 3.11 floor while `ruff format` targeted it at py314, and that gap reproduced: an inserted `except (KeyError, ValueError):` was rewritten to the unbracketed PEP 758 form, a `SyntaxError` on every interpreter the declaration allowed. It is invoked only through `uv run --script`, so uv provisions the interpreter; `uv python find '>=3.14'` resolves and `--help` exits 0.
- **`modules/apps/*.nix` headers (16 files)**: restore the literal `&` that the `5a0867fc` app-module standardization pass replaced with the string `{PRESERVED_DOCUMENTATION}` and never restored. 17 example commands were mangled (`uv lock {PRESERVED_DOCUMENTATION}{PRESERVED_DOCUMENTATION} uv sync`, `udiskie --tray {PRESERVED_DOCUMENTATION}`, the hydra query strings, ...); a doubled placeholder is `&&`, a lone one is a background `&` / URL separator / menu label. Comment-only, confirmed against the pre-standardization text at `5a0867fc^`.
- **Ruff validation cleanup**: add the repository copyright notice required by `CPY001` to 30 tracked Python files, fix the Python 3.14 `RUF036` union-ordering diagnostic in `scripts/updater/http.py`, and format the two Cloudflare container Python examples.
- **`docs/csec/*`**: re-ran every entry in the runtime report's "build or evaluation error" group under the 3.14.6 pin, since those were 2026-05-04 snapshots taken before the bump. Details below.

Deliberately kept: `wfuzz` references to Python 3.13 are historical facts (`pipes` was removed *in* 3.13) and are left unchanged.

### csec runtime-status re-verification (2026-08-04)

`mitm6` and `maigret` were re-verified first: upstream `mitm6` dropped its `future` dependency (closure is netifaces / scapy / twisted) and `maigret` migrated the insecure `pypdf2-3.0.1` to `pypdf-6.14.2`, so both moved to "run as documented". Re-running the rest of the group against `Bad3r/nixpkgs@7a47fa30` changed two more outcomes and corrected one recorded cause:

| Tool | Recorded (2026-05-04) | Verified (2026-08-04) |
| --- | --- | --- |
| `dc3dd` | gcc failure, `argmatch.c:63: too many arguments to function 'usage'` | Builds and runs; promoted to "run as documented" |
| `patator` (uvx) | `cx-oracle 8.3.0` build, undeclared `pkg_resources` | Still fails, different cause: `mysqlclient 2.2.8` aborts with `Can not find valid pkg-config name` |
| `evil-winrm` | "upstream nixpkgs build is currently broken" | Was a runtime break, now fixed. 3.7 built but died on `cannot load such file -- csv (LoadError)` cascading to `winrm-fs`, because Ruby 3.4 unbundled `csv` and the Gemfile listed `stringio`/`logger`/`fileutils` but not `csv`. `Bad3r/nixpkgs@807b1085` (3.7 -> 3.9) regenerates the Bundler env with `csv`, `benchmark`, `syslog`. Promoted to "run as documented" |
| `python3Packages.angr` | `setuptools-rust` missing from `nativeBuildInputs` | Unchanged; already tracked upstream by NixOS/nixpkgs#501379, which covers the `python314Packages.angr` job |
| `droopescan` (uvx) | `cement 2.6.2` imports the removed `imp` module | Unchanged under 3.14 |
| `maltego` | unfree license | Not a build defect. `nix build --impure` completes with `NIXPKGS_ALLOW_UNFREE=1` |
| `waybackurls` | marked unfree | Was a mislabel, now fixed. The bare `unfree` placeholder (`fullName: "Unfree"`) gated an MIT Go tool; `Bad3r/nixpkgs@a71f346e` sets `meta.license` to `lib.licenses.mit`. Runs with no override; promoted to "run as documented" |

This PR advances the `nixpkgs` input `7a47fa30` -> `807b1085` to pick up those two fixes. The bump spans exactly two commits, touching only `pkgs/by-name/wa/waybackurls/package.nix` and the four `pkgs/by-name/ev/evil-winrm/` files; python3 (3.14.6), ruff (0.16.1) and the `system76` interpreter resolution are unchanged across it.

`maltego` stays gated but is not a build defect, so it moves to a new "blocked by the unfree license gate" category.

Counts against `origin/main`, whose 2026-05-04 snapshot recorded **nine** entries in this group (`evil-winrm`, `mitm6`, `maigret`, `maltego`, `waybackurls`, `droopescan`, `patator`, `angr`, `dc3dd`): five cleared into "run as documented" (`mitm6`, `maigret`, `dc3dd`, `evil-winrm`, `waybackurls`) and `maltego` was reclassified, so run-as-documented goes 95 -> 100 and build-or-evaluation-error goes 9 -> 3, with the new unfree-gate category at 1. Total stays 127 and still reconciles against the companion reference. Those nine are also the only entries re-run on the current pin; the other 118 still carry their 2026-05-04 result, which the report now says explicitly.

One follow-on worth flagging: `evil-winrm -h` writes its usage banner only to a TTY, so a piped smoke test sees exit 0 and no output. Both docs now record that, so it does not later read as a silent failure.

## Test plan

Run against the merged tree at the current pin (`Bad3r/nixpkgs@807b1085`, python3 3.14.6, ruff 0.16.1):

- [x] `py_compile -W error` under python3 3.14.6 over all 37 tracked `.py` files: 0 failures (no `SyntaxError` / `SyntaxWarning`, incl. PEP 765)
- [x] `pyright`: 0 errors, 0 warnings, 0 informations
- [x] `ruff check .`: All checks passed
- [x] `ruff format --check .`: 306 files already formatted
- [x] `nix build .#duplicati-r2-extract`: succeeds, including the `installCheckPhase` that runs the binary end-to-end over the tiny / medium / single-blocklist / multi-blocklist fixtures plus the HMAC-corruption, missing-path and wrong-passphrase exit-code cases. This exercises both PEP 758 `except` clauses in that file at runtime
- [x] `nix flake check --accept-flake-config --no-build --offline`: exit 0
- [x] `system76` host eval: `programs.python.extended.package = python3-3.14.6`
- [x] csec re-verification: all 7 entries re-run; per-section entry counts recomputed against the summary table (100 + 10 + 3 + 1 + 5 + 2 + 2 + 1 + 1 + 2 = 127)
- [x] `waybackurls` after the lock bump: `meta.license` evaluates to `{"free": true, "spdxId": "MIT"}`, and `nix run nixpkgs#waybackurls -- -h` exits 0 with no `NIXPKGS_ALLOW_UNFREE` and no `--impure`
- [x] `evil-winrm -h` after the lock bump: under a pty it prints the full `Evil-WinRM shell v3.9` usage, exit 0; the `csv` / `winrm-fs` LoadError is gone
- [x] pyright `executionEnvironments` proven live: rooting `scripts` at 3.8 makes pyright reject `updater/http.py`'s PEP 695 type aliases, which it accepts at 3.12
- [x] `uv run --script scripts/url-catalog-add.py --help`: exits 0 with full usage under the raised `>=3.14` floor
- [x] `per-file-target-version` guard proven by construction: `except (KeyError, ValueError):` inserted into the guarded `scripts/updater/version.py` stays bracketed ("1 file already formatted"); re-bracketing the same construct in the unguarded `duplicati_r2_extract.py` is still unbracketed to the PEP 758 form
- [x] `import updater` plus the exact symbol set the workflow script imports (`fetch_json`, `load_hashes`, `save_hashes`, `nix_command`, `compare_versions`, `parse_version`): succeeds under python3 3.12.13 and 3.13.14, the plausible `ubuntu-latest` interpreters. It raised `NameError: name 'Path' is not defined` before this fix
- [x] `py_compile` over the 13 CI-reachable files (`scripts/update-*.py`, `scripts/updater_bootstrap.py`, `scripts/updater/*.py`): 0 failures under both 3.12.13 and 3.13.14
- [x] `nix-instantiate --parse` over all 17 touched `modules/apps/*.nix` files (16 header restorations plus `python.nix`): all parse; `nix fmt` reports 0 reflow