### PR TITLE
feat(csec): add katana, gau, nikto, wafw00f, and gowitness recon tools

### DIFF
--- a/docs/csec/additional-tools-reference.md
+++ b/docs/csec/additional-tools-reference.md
@@ -103,18 +103,6 @@ Each entry lists a representative run command, upstream repository, official doc
 
 ## Network Reconnaissance & Enumeration
 
-- nikto
-  - run..: `nix run nixpkgs#nikto -- -h $url`
-  - Repo.: <https://github.com/sullo/nikto>
-  - Docs.: <https://github.com/sullo/nikto/wiki>
-  - Desc.: Long-running web server scanner with thousands of misconfiguration and dangerous-file checks.
-  - Stat.: Maintained (2.6.0, 2026-02-11).
-- wafw00f
-  - run..: `nix run nixpkgs#wafw00f -- $url`
-  - Repo.: <https://github.com/EnableSecurity/wafw00f>
-  - Docs.: <https://github.com/EnableSecurity/wafw00f#readme>
-  - Desc.: Fingerprints which Web Application Firewall (if any) sits in front of a target.
-  - Stat.: Maintained (v2.4.2, 2026-01-26).
 - rustscan
   - run..: `nix run nixpkgs#rustscan -- -a $ip -- -A`
   - Repo.: <https://github.com/RustScan/RustScan>
@@ -314,18 +302,6 @@ Each entry lists a representative run command, upstream repository, official doc
   - Docs.: <https://github.com/s0md3v/Arjun/wiki>
   - Desc.: HTTP parameter discovery suite using GET/POST/JSON/XML probing.
   - Stat.: Maintenance mode (last release 2.2.7, 2024-11-03; active upstream commits through 2025-02-20).
-- katana
-  - run..: `nix run nixpkgs#katana -- -u $url`
-  - Repo.: <https://github.com/projectdiscovery/katana>
-  - Docs.: <https://docs.projectdiscovery.io/tools/katana>
-  - Desc.: JS-aware crawler with headless and standard modes for endpoint discovery.
-  - Stat.: Maintained (v1.6.1, 2026-05-05).
-- gau
-  - run..: `nix run nixpkgs#gau -- $domain`
-  - Repo.: <https://github.com/lc/gau>
-  - Docs.: <https://github.com/lc/gau#readme>
-  - Desc.: Pull known URLs from Wayback Machine, Common Crawl, OTX, and URLScan.
-  - Stat.: Maintenance mode (last release v2.2.4, 2024-10-28; active upstream commits through 2026-03-20).
 - waybackurls
   - run..: `nix run nixpkgs#waybackurls -- $domain`
     - ⚠️ Failed to run: marked unfree in nixpkgs. Refuses to evaluate without `NIXPKGS_ALLOW_UNFREE=1 --impure` (or an entry in `modules/meta/nixpkgs-allowed-unfree.nix`).
@@ -333,12 +309,6 @@ Each entry lists a representative run command, upstream repository, official doc
   - Docs.: <https://github.com/tomnomnom/waybackurls#readme>
   - Desc.: Stream all URLs the Wayback Machine knows for a domain.
   - Stat.: Deprecated (v0.1.0, 2022-04-05; no commits in 3+ years; superseded by gau).
-- gowitness
-  - run..: `nix run nixpkgs#gowitness -- scan -u $url`
-  - Repo.: <https://github.com/sensepost/gowitness>
-  - Docs.: <https://github.com/sensepost/gowitness/wiki>
-  - Desc.: Headless-Chrome web screenshot utility with reporting UI. The legacy `single` subcommand was renamed to `scan` in v3.
-  - Stat.: Maintained (3.1.1, 2025-11-24).
 - eyewitness
   - run..: `nix run nixpkgs#eyewitness -- --web -f urls.txt`
     - ⚠️ Failed to run: the derivation builds but `bin/eye-witness` is missing inside the store path. `nix run` fails with `No such file or directory`.

--- a/docs/csec/additional-tools-reference.md
+++ b/docs/csec/additional-tools-reference.md
@@ -308,7 +308,7 @@ Each entry lists a representative run command, upstream repository, official doc
   - Repo.: <https://github.com/tomnomnom/waybackurls>
   - Docs.: <https://github.com/tomnomnom/waybackurls#readme>
   - Desc.: Stream all URLs the Wayback Machine knows for a domain.
-  - Stat.: Deprecated (v0.1.0, 2022-04-05; no commits in 3+ years; superseded by gau).
+  - Stat.: Deprecated (v0.1.0, 2022-04-05; no commits in 3+ years; superseded by [`gau` in the active toolkit](toolkit.md#web-application-testing--proxies)).
 - eyewitness
   - run..: `nix run nixpkgs#eyewitness -- --web -f urls.txt`
     - ⚠️ Failed to run: the derivation builds but `bin/eye-witness` is missing inside the store path. `nix run` fails with `No such file or directory`.

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -3,15 +3,18 @@
 Companion report for `docs/csec/additional-tools-reference.md`. Each tool's
 documented `run` command was invoked with a help or version flag (placeholders
 such as `$target`, `$url`, `$domain` substituted) under a 60-second timeout to
-confirm the package can launch on the current `flake.lock` state.
+confirm the package could launch on the `flake.lock` state used for the smoke
+test.
 
-Verified on 2026-05-04 against the active flake pin.
+The runtime smoke test was run on 2026-05-04 against the active flake pin at
+that time. The inventory and summary below were reconciled on 2026-08-01
+against the current `flake.lock` state and companion reference.
 
 ## Summary
 
 | Result                                                           | Count   |
 | ---------------------------------------------------------------- | ------- |
-| ✅ Run as documented                                             | 100     |
+| ✅ Run as documented                                             | 95      |
 | ⚠️ Documented as unavailable in the reference                    | 10      |
 | ⚠️ Build or evaluation error                                     | 9       |
 | ⚠️ Binary path mismatch in the documented attribute              | 5       |
@@ -20,11 +23,14 @@ Verified on 2026-05-04 against the active flake pin.
 | ⚠️ External (non-nixpkgs) toolchain blocked                      | 1       |
 | ⚠️ Closure too large for smoke budget                            | 1       |
 | ⚠️ Documented uvx / PyPI invocation broken                       | 2       |
-| **Total entries in the reference**                               | **132** |
+| **Total entries in the reference**                               | **127** |
 
 The reference doc flags each unavailable tool inline (the entry's `run..:`
 field carries text such as `Not in nixpkgs ...` or `Must create a custom nixpkg`); there is no dedicated section for them. The groupings below are
 this report's, collected by the underlying reason for the failure.
+
+The five tools promoted into `docs/csec/toolkit.md` are intentionally absent
+from this report because they are no longer entries in the companion reference.
 
 ## ✅ Tools that run as documented
 
@@ -43,8 +49,6 @@ this report's, collected by the underlying reason for the failure.
 
 ### Network Reconnaissance and Enumeration
 
-- ✅ nikto
-- ✅ wafw00f
 - ✅ rustscan
 - ✅ theharvester
 - ✅ sherlock
@@ -76,9 +80,6 @@ this report's, collected by the underlying reason for the failure.
 
 - ✅ dalfox
 - ✅ arjun
-- ✅ katana
-- ✅ gau
-- ✅ gowitness (CLI subcommand `single` was renamed to `scan` in v3)
 - ✅ unfurl
 - ✅ qsreplace
 - ✅ meg
@@ -268,8 +269,6 @@ exist (or `meta.mainProgram` is wrong).
 Run-command corrections that would prevent a future smoke run from
 regressing on these entries:
 
-- `gowitness`: replace `single -u $url` with `scan -u $url` (CLI changed in
-  v3).
 - `impacket`: invoke the canonical `secretsdump.py` script names rather
   than `impacket-secretsdump`.
 - `volatility3`: invoke `vol` (or `volshell`) and prefix with

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -8,7 +8,8 @@ test.
 
 The runtime smoke test was run on 2026-05-04 against the active flake pin at
 that time. The inventory and summary below were reconciled on 2026-08-01
-against the current `flake.lock` state and companion reference.
+against the companion reference; no run commands were re-executed on the
+current `flake.lock`.
 
 ## Summary
 

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -30,8 +30,9 @@ The reference doc flags each unavailable tool inline (the entry's `run..:`
 field carries text such as `Not in nixpkgs ...` or `Must create a custom nixpkg`); there is no dedicated section for them. The groupings below are
 this report's, collected by the underlying reason for the failure.
 
-The five tools promoted into `docs/csec/toolkit.md` are intentionally absent
-from this report because they are no longer entries in the companion reference.
+The five tools promoted into `docs/csec/toolkit.md` (katana, gau, gowitness,
+nikto, and wafw00f) are intentionally absent from this report because they are
+no longer entries in the companion reference.
 
 ## ✅ Tools that run as documented
 

--- a/docs/csec/toolkit.md
+++ b/docs/csec/toolkit.md
@@ -105,6 +105,12 @@ Each entry below lists a representative invocation, upstream repository, officia
   - Docs.: <https://docs.projectdiscovery.io/tools/tlsx>
   - Desc.: TLS certificate, handshake, cipher, and fingerprint data collector for host triage.
   - Stat.: Maintained (latest release v1.2.2, 2025-11-17).
+- wafw00f
+  - run..: `wafw00f $url`
+  - Repo.: <https://github.com/EnableSecurity/wafw00f>
+  - Docs.: <https://github.com/EnableSecurity/wafw00f#readme>
+  - Desc.: Fingerprints the Web Application Firewall (if any) fronting a target; complements cdncheck's passive detection with active probing.
+  - Stat.: Maintained (v2.4.2, 2026-01-26).
 - wappalyzer-next
   - run..: `wappalyzer -i $url`
   - Repo.: <https://github.com/s0md3v/wappalyzer-next>
@@ -168,18 +174,42 @@ Each entry below lists a representative invocation, upstream repository, officia
   - Docs.: <https://github.com/ffuf/ffuf/wiki>
   - Desc.: Fast Go-based web fuzzer for content discovery, vhost, and parameter brute forcing.
   - Stat.: Maintenance mode (last release v2.1.0, 2023-09-16; active upstream commits, no recent tag).
+- gau
+  - run..: `gau $domain`
+  - Repo.: <https://github.com/lc/gau>
+  - Docs.: <https://github.com/lc/gau#readme>
+  - Desc.: Fetches known URLs for a domain from the Wayback Machine, Common Crawl, OTX, and URLScan for passive endpoint discovery.
+  - Stat.: Maintenance mode (last release v2.2.4, 2024-10-28; active upstream commits through 2026-03-20).
 - gobuster
   - run..: `gobuster dir -u $url -w $wordlist`
   - Repo.: <https://github.com/OJ/gobuster>
   - Docs.: <https://github.com/OJ/gobuster#readme>
   - Desc.: Go-based directory, DNS, and vhost brute forcer.
   - Stat.: Maintained (latest release 2025-09-04).
+- gowitness
+  - run..: `gowitness scan -u $url`
+  - Repo.: <https://github.com/sensepost/gowitness>
+  - Docs.: <https://github.com/sensepost/gowitness/wiki>
+  - Desc.: Headless-Chrome web screenshotter with a reporting UI for triaging large host lists.
+  - Stat.: Maintained (3.1.1, 2025-11-24).
+- katana
+  - run..: `katana -u $url`
+  - Repo.: <https://github.com/projectdiscovery/katana>
+  - Docs.: <https://docs.projectdiscovery.io/tools/katana>
+  - Desc.: JavaScript-aware crawler with headless and standard modes for endpoint discovery; slots into the ProjectDiscovery recon pipeline.
+  - Stat.: Maintained (v1.6.1, 2026-05-05).
 - mitmproxy
   - run..: `mitmproxy`
   - Repo.: <https://github.com/mitmproxy/mitmproxy>
   - Docs.: <https://docs.mitmproxy.org/>
   - Desc.: Interactive HTTPS interception proxy with Python scripting.
   - Stat.: Maintained (latest release 2026-04-12).
+- nikto
+  - run..: `nikto -h $url`
+  - Repo.: <https://github.com/sullo/nikto>
+  - Docs.: <https://github.com/sullo/nikto/wiki>
+  - Desc.: Long-running web server scanner with thousands of misconfiguration and dangerous-file checks; prefer nuclei for template-based coverage and reach for nikto's classic default-file and outdated-server signature checks.
+  - Stat.: Maintained (2.6.0, 2026-02-11).
 - sqlmap
   - run..: `sqlmap -u $url`
   - Repo.: <https://github.com/sqlmapproject/sqlmap>

--- a/docs/csec/toolkit.md
+++ b/docs/csec/toolkit.md
@@ -187,7 +187,7 @@ Each entry below lists a representative invocation, upstream repository, officia
   - Desc.: Go-based directory, DNS, and vhost brute forcer.
   - Stat.: Maintained (latest release 2025-09-04).
 - gowitness
-  - run..: `gowitness scan -u $url`
+  - run..: `gowitness scan single --url $url`
   - Repo.: <https://github.com/sensepost/gowitness>
   - Docs.: <https://github.com/sensepost/gowitness/wiki>
   - Desc.: Headless-Chrome web screenshotter with a reporting UI for triaging large host lists.

--- a/modules/apps/gau.nix
+++ b/modules/apps/gau.nix
@@ -10,13 +10,13 @@
     * Emits pipeline-friendly URL lists for passive endpoint discovery and fuzzing input; pairs with the active katana crawler.
 
   Options:
-    -providers <list>: Sources to query (wayback, commoncrawl, otx, urlscan).
-    -subs: Include subdomains of the target domain.
-    -blacklist <exts>: Skip URLs with the listed extensions.
-    -fp: Collapse URLs that differ only in query-parameter values.
-    -threads <n>: Number of worker threads.
-    -json: Emit JSON output.
-    -o <file>: Write results to the given file.
+    --providers <list>: Sources to query (wayback, commoncrawl, otx, urlscan).
+    --subs: Include subdomains of the target domain.
+    --blacklist <exts>: Skip URLs with the listed extensions.
+    --fp: Collapse URLs that differ only in query-parameter values.
+    --threads <n>: Number of worker threads.
+    --json: Emit JSON output.
+    --o <file>: Write results to the given file.
 */
 _:
 let

--- a/modules/apps/gau.nix
+++ b/modules/apps/gau.nix
@@ -1,0 +1,51 @@
+/*
+  Package: gau
+  Description: Fetch known URLs for a domain from third-party archive sources.
+  Homepage: nil
+  Documentation: nil
+  Repository: https://github.com/lc/gau
+
+  Summary:
+    * Pulls historical and known URLs for a domain from the Wayback Machine, Common Crawl, Open Threat Exchange, and URLScan.
+    * Emits pipeline-friendly URL lists for passive endpoint discovery and fuzzing input; pairs with the active katana crawler.
+
+  Options:
+    -providers <list>: Sources to query (wayback, commoncrawl, otx, urlscan).
+    -subs: Include subdomains of the target domain.
+    -blacklist <exts>: Skip URLs with the listed extensions.
+    -fp: Collapse URLs that differ only in query-parameter values.
+    -threads <n>: Number of worker threads.
+    -json: Emit JSON output.
+    -o <file>: Write results to the given file.
+*/
+_:
+let
+  GauModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.gau.extended;
+    in
+    {
+      options.programs.gau.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable gau.";
+        };
+
+        package = lib.mkPackageOption pkgs "gau" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.gau = GauModule;
+}

--- a/modules/apps/gowitness.nix
+++ b/modules/apps/gowitness.nix
@@ -15,9 +15,10 @@
       -u, --url <target>: Single URL to screenshot.
     scan file:
       -f, --file <file>: File of URLs to screenshot.
+    scan (persistent across scan subcommands):
+      --screenshot-path <dir>: Directory to write screenshots to.
+      --write-db: Persist results to the SQLite database.
     report: Serve or export the web report UI over captured results.
-    --screenshot-path <dir>: Directory to write screenshots to.
-    --write-db: Persist results to the SQLite database.
 */
 _:
 let

--- a/modules/apps/gowitness.nix
+++ b/modules/apps/gowitness.nix
@@ -10,10 +10,12 @@
     * Stores captures in a database and serves a report UI for browsing screenshots, headers, and technologies.
 
   Options:
-    scan: Screenshot targets from flags, files, CIDR ranges, or Nmap input.
+    scan: Screenshot targets using the subcommands below.
+    scan single:
+      -u, --url <target>: Single URL to screenshot.
+    scan file:
+      -f, --file <file>: File of URLs to screenshot.
     report: Serve or export the web report UI over captured results.
-    -u, --url <target>: Single URL to screenshot (under `scan`).
-    -f, --file <file>: File of URLs to screenshot (under `scan`).
     --screenshot-path <dir>: Directory to write screenshots to.
     --write-db: Persist results to the SQLite database.
 */

--- a/modules/apps/gowitness.nix
+++ b/modules/apps/gowitness.nix
@@ -1,0 +1,50 @@
+/*
+  Package: gowitness
+  Description: Headless-Chrome web screenshot utility with a reporting interface.
+  Homepage: nil
+  Documentation: https://github.com/sensepost/gowitness/wiki
+  Repository: https://github.com/sensepost/gowitness
+
+  Summary:
+    * Drives headless Chrome to capture screenshots of URLs and host lists for visual recon triage.
+    * Stores captures in a database and serves a report UI for browsing screenshots, headers, and technologies.
+
+  Options:
+    scan: Screenshot targets from flags, files, CIDR ranges, or Nmap input.
+    report: Serve or export the web report UI over captured results.
+    -u, --url <target>: Single URL to screenshot (under `scan`).
+    -f, --file <file>: File of URLs to screenshot (under `scan`).
+    --screenshot-path <dir>: Directory to write screenshots to.
+    --write-db: Persist results to the SQLite database.
+*/
+_:
+let
+  GowitnessModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.gowitness.extended;
+    in
+    {
+      options.programs.gowitness.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable gowitness.";
+        };
+
+        package = lib.mkPackageOption pkgs "gowitness" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.gowitness = GowitnessModule;
+}

--- a/modules/apps/katana.nix
+++ b/modules/apps/katana.nix
@@ -1,0 +1,52 @@
+/*
+  Package: katana
+  Description: Next-generation crawling and spidering framework for endpoint discovery.
+  Homepage: https://github.com/projectdiscovery/katana
+  Documentation: https://docs.projectdiscovery.io/tools/katana
+  Repository: https://github.com/projectdiscovery/katana
+
+  Summary:
+    * Crawls web applications in standard and headless (JavaScript-aware) modes to enumerate endpoints, parameters, and assets.
+    * Slots into the ProjectDiscovery pipeline downstream of subfinder, dnsx, and httpx for end-to-end recon.
+
+  Options:
+    -u, -list <target>: Target URL or host to crawl (repeatable or file input).
+    -headless: Enable headless-browser crawling for JavaScript-rendered content.
+    -jc, -js-crawl: Parse and crawl endpoints discovered inside JavaScript files.
+    -d, -depth <n>: Maximum crawl depth.
+    -kf, -known-files <value>: Crawl well-known files such as robots.txt and sitemap.xml.
+    -fs, -field-scope <value>: Restrict crawl scope by field (rdn, fqdn, dn).
+    -o, -output <file>: Write output to the specified file.
+    -jsonl: Emit JSON-line output for downstream tooling.
+*/
+_:
+let
+  KatanaModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.katana.extended;
+    in
+    {
+      options.programs.katana.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable katana.";
+        };
+
+        package = lib.mkPackageOption pkgs "katana" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.katana = KatanaModule;
+}

--- a/modules/apps/nikto.nix
+++ b/modules/apps/nikto.nix
@@ -1,0 +1,57 @@
+/*
+  Package: nikto
+  Description: Web server scanner for dangerous files, outdated components, and misconfigurations.
+  Homepage: https://cirt.net/Nikto2
+  Documentation: https://github.com/sullo/nikto/wiki
+  Repository: https://github.com/sullo/nikto
+
+  Summary:
+    * Scans web servers for thousands of potentially dangerous files/CGIs, outdated server versions, and version-specific problems.
+    * Checks server configuration items such as index files, permitted HTTP methods, and TLS/certificate issues.
+
+  Options:
+    -h, -host <target>: Target host, IP, URL, or file of hosts to scan.
+    -p, -port <ports>: Port(s) to scan (default 80).
+    -ssl: Force a TLS/SSL connection.
+    -Tuning <value>: Restrict tests to the selected scan-category classes.
+    -Format <value>: Report output format (csv, htm, json, txt, xml).
+    -output <file>: Write the report to the specified file.
+    -Plugins <value>: Select which plugins to run.
+
+  Notes:
+    * Prefer nuclei for template-based vulnerability coverage: its actively updated
+      corpus (nuclei-templates) supersedes most of nikto's checks. Keep nikto for
+      its built-in default-file and outdated-server signature scans and quick,
+      zero-config server triage.
+*/
+_:
+let
+  NiktoModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.nikto.extended;
+    in
+    {
+      options.programs.nikto.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable nikto.";
+        };
+
+        package = lib.mkPackageOption pkgs "nikto" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.nikto = NiktoModule;
+}

--- a/modules/apps/wafw00f.nix
+++ b/modules/apps/wafw00f.nix
@@ -1,0 +1,50 @@
+/*
+  Package: wafw00f
+  Description: Identify and fingerprint the Web Application Firewall protecting a site.
+  Homepage: nil
+  Documentation: nil
+  Repository: https://github.com/EnableSecurity/wafw00f
+
+  Summary:
+    * Sends crafted requests and analyzes the responses to detect and name the WAF (if any) fronting a target.
+    * Recognizes a large set of WAF products; complements cdncheck's passive WAF detection with active probing.
+
+  Options:
+    -a, --findall: Report every matching WAF instead of stopping at the first.
+    -l, --list: List all WAFs that wafw00f can detect.
+    -i, --input <file>: Read targets from a file (text, JSON, or CSV).
+    -o, --output <file>: Write results to the specified file.
+    -f, --format <fmt>: Output format (json, csv, text) when writing to a file.
+    -p, --proxy <url>: Route requests through the given proxy.
+*/
+_:
+let
+  Wafw00fModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.wafw00f.extended;
+    in
+    {
+      options.programs.wafw00f.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable wafw00f.";
+        };
+
+        package = lib.mkPackageOption pkgs "wafw00f" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.wafw00f = Wafw00fModule;
+}

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -161,6 +161,7 @@ let
       "fuse-overlayfs".extended.enable = lib.mkOverride 1100 true;
       fzf.extended.enable = lib.mkOverride 1100 true;
       gamescope.extended.enable = lib.mkOverride 1100 false;
+      gau.extended.enable = lib.mkOverride 1100 true;
       gawk.extended.enable = lib.mkOverride 1100 true;
       gcc.extended.enable = lib.mkOverride 1100 true;
       gdb.extended.enable = lib.mkOverride 1100 true;
@@ -185,6 +186,7 @@ let
       "google-chrome".extended.enable = lib.mkOverride 1100 true;
       gopass.extended.enable = lib.mkOverride 1100 true;
       gopls.extended.enable = lib.mkOverride 1100 false;
+      gowitness.extended.enable = lib.mkOverride 1100 true;
       gparted.extended.enable = lib.mkOverride 1100 true;
       "gpg-tui".extended.enable = lib.mkOverride 1100 true;
       greenclip.extended.enable = lib.mkOverride 1100 true;
@@ -219,6 +221,7 @@ let
       "jupyter-all".extended.enable = lib.mkOverride 1100 true;
       just.extended.enable = lib.mkOverride 1100 true;
       karere.extended.enable = lib.mkOverride 1100 true;
+      katana.extended.enable = lib.mkOverride 1100 true;
       kcolorchooser.extended.enable = lib.mkOverride 1100 true;
       kdiskmark.extended.enable = lib.mkOverride 1100 true;
       keepassxc.extended.enable = lib.mkOverride 1100 true;
@@ -285,6 +288,7 @@ let
       networkmanagerapplet.extended.enable = lib.mkOverride 1100 true;
       nftables.extended.enable = lib.mkOverride 1100 true;
       nicotine.extended.enable = lib.mkOverride 1100 true;
+      nikto.extended.enable = lib.mkOverride 1100 true;
       nixd.extended.enable = lib.mkOverride 1100 true;
       nixfmt.extended.enable = lib.mkOverride 1100 true;
       niv.extended.enable = lib.mkOverride 1100 true;
@@ -460,6 +464,7 @@ let
       "vscode-fhs".extended.enable = lib.mkOverride 1100 true;
       "vt-cli".extended.enable = lib.mkOverride 1100 true;
       vulnix.extended.enable = lib.mkOverride 1100 true;
+      wafw00f.extended.enable = lib.mkOverride 1100 true;
       wakaru.extended.enable = lib.mkOverride 1100 false;
       "wappalyzer-next".extended.enable = lib.mkOverride 1100 true;
       webcrack.extended.enable = lib.mkOverride 1100 false;


### PR DESCRIPTION
## Summary

Promote five web-recon tools from the additional-tools reference catalog into the active toolkit, wired as standard `modules/apps/<name>.nix` modules and enabled in the common baseline:

- **katana** (v1.6.1): active JS-aware crawler for endpoint discovery; fills the missing active-crawler slot in the ProjectDiscovery stack (httpx, dnsx, naabu, subfinder, nuclei).
- **gau** (v2.2.4): passive URL source (Wayback, Common Crawl, OTX, URLScan); pairs with katana.
- **gowitness** (3.1.1): bulk headless-Chrome screenshotter; the only maintained option that builds in nixpkgs (eyewitness is broken there).
- **wafw00f** (v2.4.2): active WAF fingerprinting, complementing cdncheck's passive detection.
- **nikto** (2.6.0): classic web-server signature scanner. The module and toolkit entry note that nuclei is preferred for template-based coverage; nikto is kept for default-file and outdated-server checks.

Each module exports `flake.nixosModules.apps.<name>` with `programs.<name>.extended`, enabled at `lib.mkOverride 1100` so every `shareCommon` host installs them. Entries move from `docs/csec/additional-tools-reference.md` into `docs/csec/toolkit.md`.

The companion `docs/csec/additional-tools-runtime-status.md` now excludes the five promoted entries, records 95 successful entries across the 127-entry reference, and removes its stale gowitness v3 command note. Follow-up documentation fixes align gau's module-header long-option spelling with pinned gau 2.2.4 help and link the waybackurls supersession note to the active toolkit entry.

### nixpkgs staleness note

The pinned `nixpkgs` (tracks `nixpkgs-unstable`) currently packages older katana (1.5.0 vs 1.6.1) and nikto (2.5.0 vs 2.6.0). `nixpkgs-unstable` HEAD already carries both newer versions, so `nix flake update nixpkgs` picks them up. gau, wafw00f, and gowitness are current.

## Test plan

- `nix fmt`: 0 files changed (idempotent).
- `nix flake check --accept-flake-config --no-build --offline`: exit 0.
- `nix eval` on system76: `programs.<name>.extended.enable` is true for all five.
- `nix eval` on system76: all five packages present in `environment.systemPackages`.
- Pinned gowitness 3.1.1: `scan --help`, `scan single --help`, and `scan file --help` expose the documented subcommands and flags; `scan -u https://example.com` exits with `unknown shorthand flag: 'u'`.
- Pinned gau 2.2.4: `gau --help` confirms the documented `--providers`, `--subs`, `--blacklist`, `--fp`, `--threads`, `--json`, and `--o` options.
- Static inventory reconciliation: 127 reference entries equals 95 successful entries plus 32 classified failures, and the five promoted tools are absent from the companion reference and report.
- Commit hooks: `nix-parse`, `statix`, `treefmt`, and `typos` passed.