### PR TITLE
fix(flake): pin nixpkgs rev carrying the lact libdisplay-info_0_3 backport

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1066,11 +1066,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785123526,
-        "narHash": "sha256-oHLVgihk44fbtBZcKDap17xgvU1WPr9hMHlG5y8ojWs=",
+        "lastModified": 1785126695,
+        "narHash": "sha256-YBvkTEJuy8uHRbG8DXj6TmJ3aBjQi61JA4zK55WvhcQ=",
         "owner": "Bad3r",
         "repo": "nixpkgs",
-        "rev": "5ed6d0e7bc40515278d03ca9d5e1f116518266bd",
+        "rev": "a51f96385937bb1a8078a73d72740b02ff40dece",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

`lact` 0.9.1 vendors `libdisplay-info-sys` 0.3.0, whose `build.rs` asks pkg-config for
`libdisplay-info >= 0.1.0, < 0.4.0`. The previous pin `5ed6d0e` ships libdisplay-info 0.4.0, so the build panicked and
took the system76 closure with it:

```
Requested 'libdisplay-info < 0.4.0' but version of libdisplay-info is 0.4.0
```

Upstream pinned lact to the versioned `libdisplay-info_0_3` attribute in NixOS/nixpkgs#546155 (`bcca8dd3bba0`), merged
2026-07-27T03:39:49Z, one minute after `5ed6d0e` was cut. The fix is carried on the maintained fork branch as a single
commit, [Bad3r/nixpkgs@a51f9638](https://github.com/Bad3r/nixpkgs/commit/a51f96385937bb1a8078a73d72740b02ff40dece):

- `libdisplay-info_0_3` added in the `overrideAttrs` style that branch already uses for `libdisplay-info_0_2`
- upstream's verbatim `lact` hunk (`libdisplay-info` -> `libdisplay-info_0_3`)

Upstream's own `libdisplay-info_0_3` (`938d5365ad2f`) sits on top of the generic-package refactor `f73b403747d3`, which
also adds `strictDeps` and `__structuredAttrs` to libdisplay-info 0.4.0 and would rebuild every 0.4.0 consumer (mutter,
mpv-unwrapped, gamescope, weston, ...). Backporting it was therefore avoided: this pin rebuilds only lact plus the new
libdisplay-info 0.3.0.

Removal condition: revert both fork hunks once `nixpkgs-unstable` merges an upstream state containing `bcca8dd3bba0`.

## Test plan

- `nix flake update nixpkgs --flake path:.` touches the `nixpkgs` node only (3 lines: `lastModified`, `narHash`, `rev`)
- `nix flake check --accept-flake-config --no-build --offline` (rc=0)
- `nix eval .#nixosConfigurations.system76.pkgs.lact.drvPath` resolves to
  `/nix/store/0gyzpavmkrxzpfswp46pk0mk81bxjs6w-lact-0.9.1.drv`, replacing the failing
  `/nix/store/s8lmrsx4xhxjw93gh6mdq8786dypxmwz-lact-0.9.1.drv`, and it builds:
  `/nix/store/m6wfq6h1r2pac2bnbxarmy1z6ifj3l4l-lact-0.9.1`
- `nix build .#nixosConfigurations.system76.config.system.build.toplevel` completes:
  `/nix/store/q94vknpfrlgm271rriri8nc521fh7kzy-nixos-system-system76-26.11.20260727.a51f963`
- `nixfmt --check` clean on both fork files