### PR TITLE
fix(cache-roots): push the configured nemo package and stop cancelling cache pushes

### DIFF
--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -25,6 +25,11 @@ permissions:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
+    # cancel-in-progress: false removes the eviction a later push used to
+    # perform, so a stalled build (substituter hang, runner disk exhaustion)
+    # would otherwise hold the concurrency group for the GitHub default of 6
+    # hours. Bounded above the observed 60-90 minute worst case.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@v5.0.0
         with:

--- a/.github/workflows/cache-push.yml
+++ b/.github/workflows/cache-push.yml
@@ -15,7 +15,11 @@ name: Cache Push
       - packages/**
 concurrency:
   group: cache-push
-  cancel-in-progress: true
+  # A push after a nixpkgs bump rebuilds the whole closure and runs 60-90
+  # minutes, so cancelling in progress discarded finished builds and left
+  # hosts rebuilding cache-roots packages locally until a later run caught
+  # up. Queued runs re-push only paths the cache still lacks.
+  cancel-in-progress: false
 permissions:
   contents: read
 jobs:

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -218,9 +218,14 @@ logs and its full runtime closure is redistributable:
   `nemo-with-extensions` reports GPL-2.0 and LGPL-2.0 while carrying
   nemo-preview, nemo-seahorse, nemo-python, nemo-fileroller (GPL-2.0-or-later),
   nemo-emblems, and folder-color-switcher (GPL-3.0-only).
-- Verify the heavy derivation substitutes: entries whose main derivation
-  sets `allowSubstitutes = false` (check `drvAttrs.allowSubstitutes`)
-  never hit the cache and do not belong in the list.
+- Verify the heavy derivation substitutes: a derivation that sets
+  `allowSubstitutes = false` (check `drvAttrs.allowSubstitutes`) never hits
+  the cache itself, so what matters is whether that derivation is the
+  expensive one. An entry belongs in the list when the non-substitutable
+  derivation is thin assembly over a substitutable dependency closure
+  (electron-mail, upscayl, nemo-with-extensions all set it on the outer
+  wrapper). It does not belong when the non-substitutable derivation is
+  itself the expensive build (tor-browser, mullvad-browser).
 - Confirm derivation parity with
   `nix build --dry-run "path:.#cache-roots"` on a recently switched host:
   the new entry must not introduce rebuilds of paths the host already has.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -59,10 +59,12 @@ of free, redistribution-safe packages:
   read-only resolved-package option on the primary host, for modules that
   install a configured variant the bare package-set attribute never produces
   (nemo-with-extensions, via `programs.nemo.extended.finalPackage`). The
-  enable invariant is not self-enforcing here: an option default evaluates
-  even when the module is disabled, so `cache-roots.nix` reads the sibling
-  `enable` explicitly and throws when it is off instead of publishing a
-  closure no host requests.
+  enable invariant holds here through the option's shape: `finalPackage` is
+  declared with no default and assigned inside `config = lib.mkIf cfg.enable`,
+  so a disabled module leaves it undefined rather than resolving to a closure
+  no host installs. `cache-roots.nix` reads the sibling `enable` as well, so
+  the failure names the entry, the option path, and the host instead of
+  surfacing a bare "option used but not defined".
 - perSystem-sourced entries (codeburn, restringer) are consumed through
   the devshell surface and build from the perSystem nixpkgs instance.
 - Input-sourced entries (context7-mcp, codex) come from the flake input the
@@ -194,9 +196,11 @@ logs and its full runtime closure is redistributable:
     directly (context7-mcp);
   - the owning module's read-only resolved-package option, listed in
     `hostFinalPackagePaths`, when the module installs a configured variant
-    rather than the bare package-set attribute (nemo-with-extensions). That
-    option needs a sibling `enable`, which `cache-roots.nix` reads to keep
-    the entry tied to a host that actually requests it.
+    rather than the bare package-set attribute (nemo-with-extensions).
+    Declare that option with no default and assign it inside
+    `config = lib.mkIf cfg.enable`, next to a sibling `enable` that
+    `cache-roots.nix` reads; `modules/browsers/ungoogled-chromium/apps.nix`
+    and `modules/apps/nemo.nix` are the reference shape.
 - Verify the license before adding:
   `nix eval "path:.#nixosConfigurations.<host>.pkgs.<name>.meta.license"`.
 - Verify the heavy derivation substitutes: entries whose main derivation

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -72,12 +72,14 @@ of free, redistribution-safe packages:
   carry a same-named but different derivation.
 
 The allowlist is explicit because `cachix push` publishes the full runtime
-closure to a public cache. Every entry's closure must be redistributable, and
-`cache-roots` enforces it: an `assertFree` guard aborts evaluation for any entry
-whose `meta.license` is missing or is neither free nor redistributable, so a
-license-violating addition fails `nix flake check` (the check
-`modules/package-checks.nix` mirrors from this output) instead of reaching the
-cache.
+closure to a public cache. Every entry's closure must be redistributable. An
+`assertFree` guard aborts evaluation for any entry whose `meta.license` is
+missing or is neither free nor redistributable, so a license-violating addition
+fails `nix flake check` (the check `modules/package-checks.nix` mirrors from
+this output) instead of reaching the cache. The guard reads the entry's own
+`meta.license` only; it does not walk the closure, so a wrapper that pulls in
+separately licensed packages still needs the manual check under
+"Extending the allowlist".
 
 ## Classification (2026-07-17 build logs)
 
@@ -201,8 +203,21 @@ logs and its full runtime closure is redistributable:
     `config = lib.mkIf cfg.enable`, next to a sibling `enable` that
     `cache-roots.nix` reads; `modules/browsers/ungoogled-chromium/apps.nix`
     and `modules/apps/nemo.nix` are the reference shape.
-- Verify the license before adding:
-  `nix eval "path:.#nixosConfigurations.<host>.pkgs.<name>.meta.license"`.
+- Verify the license on the surface the entry is sourced from, not on the
+  host package set by default, because the bare `pkgs.<name>` attribute can
+  be a different derivation than the one that gets published:
+  - host-sourced:
+    `nix eval "path:.#nixosConfigurations.<host>.pkgs.<name>.meta.license"`
+  - option-sourced:
+    `nix eval "path:.#nixosConfigurations.<host>.config.<option-path>.meta.license"`
+  - perSystem- and input-sourced: the matching `self'.packages.<name>` or
+    flake-input attribute.
+- For a wrapper-style entry, check the packages it wraps as well. `meta.license`
+  on the wrapper describes the wrapper alone, and `assertFree` reads that same
+  field, so neither covers what the wrapper pulls into the published closure:
+  `nemo-with-extensions` reports GPL-2.0 and LGPL-2.0 while carrying
+  nemo-preview, nemo-seahorse, nemo-python, nemo-fileroller (GPL-2.0-or-later),
+  nemo-emblems, and folder-color-switcher (GPL-3.0-only).
 - Verify the heavy derivation substitutes: entries whose main derivation
   sets `allowSubstitutes = false` (check `drvAttrs.allowSubstitutes`)
   never hit the cache and do not belong in the list.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -90,7 +90,11 @@ Cached via cache-roots (free, redistributable):
 
 context7-mcp is sourced from the `mcp-servers-nix` input, matching the
 consumer in `modules/agents/mcp.nix`; the host package set carries a
-same-named but different derivation no consumer runs. For entries built
+same-named but different derivation no consumer runs. nemo-with-extensions
+is sourced from `programs.nemo.extended.finalPackage` for the same reason:
+`modules/apps/nemo.nix` re-wraps nemo with an explicit extension list, so
+the bare `pkgs.nemo-with-extensions` attribute is a derivation no host
+installs, and its closure omits nemo-preview and nemo-seahorse. For entries built
 through `buildFHSEnv` or wrapper derivations (electron-mail, upscayl,
 nemo-with-extensions), the outer wrapper sets `allowSubstitutes = false`
 and always rebuilds locally; that is trivial assembly work, and the heavy

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -64,7 +64,7 @@ of free, redistribution-safe packages:
   so a disabled module leaves it undefined rather than resolving to a closure
   no host installs. `cache-roots.nix` reads the sibling `enable` as well, so
   the failure names the entry, the option path, and the host instead of
-  surfacing a bare "option used but not defined".
+  surfacing a bare "was accessed but has no value defined".
 - perSystem-sourced entries (codeburn, restringer) are consumed through
   the devshell surface and build from the perSystem nixpkgs instance.
 - Input-sourced entries (context7-mcp, codex) come from the flake input the

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -55,8 +55,19 @@ of free, redistribution-safe packages:
   `nix build --dry-run "path:.#cache-roots"` on a host that has switched
   recently should report no unexpected package rebuilds; that is the
   derivation-parity check.
+- Option-sourced entries (`hostFinalPackagePaths`) read the owning module's
+  read-only resolved-package option on the primary host, for modules that
+  install a configured variant the bare package-set attribute never produces
+  (nemo-with-extensions, via `programs.nemo.extended.finalPackage`). The
+  enable invariant is not self-enforcing here: an option default evaluates
+  even when the module is disabled, so `cache-roots.nix` reads the sibling
+  `enable` explicitly and throws when it is off instead of publishing a
+  closure no host requests.
 - perSystem-sourced entries (codeburn, restringer) are consumed through
   the devshell surface and build from the perSystem nixpkgs instance.
+- Input-sourced entries (context7-mcp, codex) come from the flake input the
+  consuming module resolves them from, because the host package set can
+  carry a same-named but different derivation.
 
 The allowlist is explicit because `cachix push` publishes the full runtime
 closure to a public cache. Every entry's closure must be redistributable, and
@@ -175,10 +186,17 @@ Remaining:
 Add a package to `modules/meta/cache-roots.nix` when it shows up in build
 logs and its full runtime closure is redistributable:
 
-- Source it from the host package set when a custom overlay or host
-  nixpkgs config shapes it; source it from `self'.packages` when only the
-  devshell surface consumes it; source it from the owning flake input
-  when a module consumes the input's package directly (context7-mcp).
+- Source it from the surface that owns the derivation:
+  - the host package set, when a custom overlay or host nixpkgs config
+    shapes it;
+  - `self'.packages`, when only the devshell surface consumes it;
+  - the owning flake input, when a module consumes the input's package
+    directly (context7-mcp);
+  - the owning module's read-only resolved-package option, listed in
+    `hostFinalPackagePaths`, when the module installs a configured variant
+    rather than the bare package-set attribute (nemo-with-extensions). That
+    option needs a sibling `enable`, which `cache-roots.nix` reads to keep
+    the entry tied to a host that actually requests it.
 - Verify the license before adding:
   `nix eval "path:.#nixosConfigurations.<host>.pkgs.<name>.meta.license"`.
 - Verify the heavy derivation substitutes: entries whose main derivation

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -83,14 +83,19 @@ separately licensed packages still needs the manual check under
 
 ## Classification (2026-07-17 build logs)
 
-License fields read from each package's `meta.license` on the primary
-host's package set.
+License fields read from each package's `meta.license` on the surface that
+entry is sourced from, per the rule under "Extending the allowlist": the
+primary host's package set for host-sourced entries,
+`programs.nemo.extended.finalPackage` for nemo-with-extensions, the owning
+flake input for context7-mcp and codex, and `self'.packages` for codeburn
+and restringer.
 
 Cached via cache-roots (free, redistributable):
 
 | Package              | License            |
 | -------------------- | ------------------ |
 | codeburn             | MIT                |
+| codex                | Apache-2.0         |
 | context7-mcp         | MIT                |
 | electron-mail        | GPL-3.0            |
 | firefoxpwa           | MPL-2.0            |

--- a/modules/apps/nemo.nix
+++ b/modules/apps/nemo.nix
@@ -112,6 +112,17 @@ let
           default = true;
           description = "Whether to install video and XApp thumbnail generators for media previews.";
         };
+
+        # modules/meta/cache-roots.nix pushes this instead of the bare
+        # pkgs.nemo-with-extensions attribute: the extension override produces a
+        # different derivation, so the bare attribute's closure never matches.
+        finalPackage = lib.mkOption {
+          type = lib.types.package;
+          readOnly = true;
+          default = configuredPackage;
+          defaultText = lib.literalExpression "config.programs.nemo.extended.package with the enabled extensions wrapped in";
+          description = "Resolved Nemo package installed by this module, including enabled extensions.";
+        };
       };
 
       config = lib.mkIf cfg.enable {
@@ -123,7 +134,7 @@ let
         ];
 
         environment.systemPackages = [
-          configuredPackage
+          cfg.finalPackage
         ]
         ++ lib.optionals cfg.thumbnailers.enable [
           pkgs.ffmpegthumbnailer
@@ -133,7 +144,7 @@ let
 
         services = {
           dbus.packages = [
-            configuredPackage
+            cfg.finalPackage
           ]
           ++ lib.optionals cfg.seahorse.enable [
             pkgs.libcryptui

--- a/modules/apps/nemo.nix
+++ b/modules/apps/nemo.nix
@@ -116,16 +116,18 @@ let
         # modules/meta/cache-roots.nix pushes this instead of the bare
         # pkgs.nemo-with-extensions attribute: the extension override produces a
         # different derivation, so the bare attribute's closure never matches.
+        # Defined only under config, never as a default, so reading it while the
+        # module is off fails instead of resolving to a package no host installs.
         finalPackage = lib.mkOption {
           type = lib.types.package;
           readOnly = true;
-          default = configuredPackage;
-          defaultText = lib.literalMD "`programs.nemo.extended.package`, wrapped by `nemo-with-extensions` with the enabled extensions (`useDefaultExtensions = false`) when any extension is enabled";
           description = "Resolved Nemo package installed by this module, including enabled extensions.";
         };
       };
 
       config = lib.mkIf cfg.enable {
+        programs.nemo.extended.finalPackage = configuredPackage;
+
         assertions = [
           {
             assertion = nemoExtensionPackages == [ ] || canWrapPackage || canExtendWrappedPackage;

--- a/modules/apps/nemo.nix
+++ b/modules/apps/nemo.nix
@@ -120,7 +120,7 @@ let
           type = lib.types.package;
           readOnly = true;
           default = configuredPackage;
-          defaultText = lib.literalExpression "config.programs.nemo.extended.package with the enabled extensions wrapped in";
+          defaultText = lib.literalMD "`programs.nemo.extended.package`, wrapped by `nemo-with-extensions` with the enabled extensions (`useDefaultExtensions = false`) when any extension is enabled";
           description = "Resolved Nemo package installed by this module, including enabled extensions.";
         };
       };

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -29,13 +29,26 @@ let
     "electron-mail"
     "firefoxpwa"
     "john"
-    "nemo-with-extensions"
     "planify"
     "proton-vpn"
     "tweakcc"
     "upscayl"
     "wappalyzer-next"
   ];
+
+  # Modules that install a configured variant evaluate a derivation the bare
+  # package-set attribute never produces, so pushing the attribute caches a
+  # closure no host requests. nemo.extended wraps nemo with an explicit
+  # extension list (useDefaultExtensions = false), which is what pulls
+  # nemo-preview and nemo-seahorse in; neither is published by Hydra.
+  hostFinalPackagePaths = {
+    nemo-with-extensions = [
+      "programs"
+      "nemo"
+      "extended"
+      "finalPackage"
+    ];
+  };
 
   # Built through the perSystem nixpkgs instance (devshell surface),
   # not enabled as host apps; same redistribution constraint applies.
@@ -55,6 +68,7 @@ in
     }:
     let
       hostPkgs = config.flake.nixosConfigurations.${primaryHost}.pkgs;
+      hostConfig = config.flake.nixosConfigurations.${primaryHost}.config;
 
       # The pushed closure lands on a public cache, so the allowlist above is
       # only safe while every entry stays redistributable. This aborts
@@ -82,6 +96,10 @@ in
             inherit name;
             path = assertFree name hostPkgs.${name};
           }) hostPackageNames
+          ++ lib.mapAttrsToList (name: optionPath: {
+            inherit name;
+            path = assertFree name (lib.getAttrFromPath optionPath hostConfig);
+          }) hostFinalPackagePaths
           ++ map (name: {
             inherit name;
             path = assertFree name self'.packages.${name};

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -41,6 +41,9 @@ let
   # closure no host requests. nemo.extended wraps nemo with an explicit
   # extension list (useDefaultExtensions = false), which is what pulls
   # nemo-preview and nemo-seahorse in; neither is published by Hydra.
+  # Each path must address a read-only resolved-package option with a sibling
+  # `enable`: an option default evaluates even for a disabled module, so the
+  # enable flag is the only thing tying the entry to a host that requests it.
   hostFinalPackagePaths = {
     nemo-with-extensions = [
       "programs"
@@ -96,10 +99,20 @@ in
             inherit name;
             path = assertFree name hostPkgs.${name};
           }) hostPackageNames
-          ++ lib.mapAttrsToList (name: optionPath: {
-            inherit name;
-            path = assertFree name (lib.getAttrFromPath optionPath hostConfig);
-          }) hostFinalPackagePaths
+          ++ lib.mapAttrsToList (
+            name: optionPath:
+            let
+              enablePath = lib.init optionPath ++ [ "enable" ];
+            in
+            {
+              inherit name;
+              path =
+                if lib.getAttrFromPath enablePath hostConfig then
+                  assertFree name (lib.getAttrFromPath optionPath hostConfig)
+                else
+                  throw "cache-roots: ${name} is sourced from ${lib.concatStringsSep "." optionPath}, but that module is disabled on ${primaryHost}";
+            }
+          ) hostFinalPackagePaths
           ++ map (name: {
             inherit name;
             path = assertFree name self'.packages.${name};

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -42,8 +42,10 @@ let
   # extension list (useDefaultExtensions = false), which is what pulls
   # nemo-preview and nemo-seahorse in; neither is published by Hydra.
   # Each path must address a read-only resolved-package option with a sibling
-  # `enable`: an option default evaluates even for a disabled module, so the
-  # enable flag is the only thing tying the entry to a host that requests it.
+  # `enable`. Owning modules define these options under `config` rather than as
+  # an option default, so a disabled module leaves the option undefined; the
+  # sibling `enable` is read here anyway, both to name the entry and host in the
+  # error and to catch an owning module that grows a default later.
   hostFinalPackagePaths = {
     nemo-with-extensions = [
       "programs"


### PR DESCRIPTION
## Summary

Investigating why `firefoxpwa` built locally during a `tpnix` switch surfaced two distinct problems.

**firefoxpwa was not misconfigured.** It is already a cache-roots entry, and the derivation the switch built
(`gfl13xvdp2jjpmbs0srrsgy6lapq20fi-firefoxpwa-unwrapped-2.18.4.drv`) is byte-identical to the one CI builds. It
missed the cache on timing alone: the Cache Push run carrying the current nixpkgs rev pushed at 06:43:16Z, and
the local switch started at 06:22:32Z.

That timing gap is not incidental. `cancel-in-progress: true` cancelled 13 of the last 37 Cache Push runs, and
after a nixpkgs bump the job runs 60-90 minutes, so consecutive pushes to `main` repeatedly discarded finished
builds before the cachix step ran. Run 30237927947 was cancelled 34m in by the push that became run
30239415509. Setting `cancel-in-progress: false` lets the queued run finish; it is cheap because cachix skips
paths already present (`Pushing 10 paths (892 are already present)`).

`cancel-in-progress: true` was also the only thing evicting a stuck run, so `build-and-push` now carries an
explicit `timeout-minutes: 150`. Without it the job inherits the GitHub default of 6 hours, and a stalled
`nix build` would hold the `cache-push` concurrency group for that whole window, queueing every later push
behind it.

**`nemo-with-extensions` was a real cache-roots defect.** `modules/apps/nemo.nix` installs
`pkgs.nemo-with-extensions.override { useDefaultExtensions = false; extensions = [...]; }`, which evaluates to a
derivation the bare attribute never produces, while cache-roots pushed the bare attribute. The pushed closure could
never match a host request, and it omitted `nemo-preview` and `nemo-seahorse`, which Hydra does not publish
either, so both rebuilt on every switch. `scripts/cache-coverage.sh --host tpnix` reported them under
`uncached-stock` and flagged three `unexpected-local` nemo entries.

The fix exposes the resolved package as read-only `programs.nemo.extended.finalPackage`, routes
`environment.systemPackages` and `services.dbus.packages` through it so the option cannot drift from what is
installed, and sources the cache-roots entry from that option.

Option-sourced entries need one guard host-sourced entries get for free. `finalPackage` was first declared with
`default = configuredPackage`, which resolves to a full wrapped closure whether or not the module is enabled:
disabling nemo on `system76` would have left CI publishing a closure no host requests, with nothing failing.

That is fixed at the source. `finalPackage` now follows the shape already used by
`modules/browsers/ungoogled-chromium/apps.nix`: declared `readOnly` with no default and assigned inside
`config = lib.mkIf cfg.enable`, so a disabled module leaves the option undefined and any consumer fails loudly.
`cache-roots.nix` additionally reads the sibling `enable` for each `hostFinalPackagePaths` entry, which makes the
failure name the entry, the option path, and the host rather than surfacing a bare "accessed but has no value
defined", and keeps the invariant enforced cache-roots-side if an owning module grows a default later. `linkFarm`
interpolates every entry path into the derivation, so the throw fires at instantiation and gates
`nix flake check --no-build` through the `modules/package-checks.nix` mirror, rather than a fail-drv CI skips.

`planify` and `upscayl` return 404 on bad3r-nixos but are unmodified nixpkgs packages served by
cache.nixos.org, so cachix correctly skips them. No change needed.

Adding a fourth sourcing surface exposed three operator rules in `docs/reference/binary-cache-coverage.md` that no
longer held, all now corrected: the license-verification step showed only the host-package-set eval form (wrong
derivation by construction for option- and input-sourced entries); the `assertFree` description claimed
closure-wide enforcement when the guard reads only the entry's own `meta.license`; and the `allowSubstitutes` rule,
read literally, excluded three entries the allowlist already carries (nemo-with-extensions, electron-mail, upscayl
all set it on a thin outer wrapper, unlike tor-browser where the non-substitutable derivation is the expensive
build).

## Test plan

- `nix flake check path:. --accept-flake-config --no-build --offline` exits 0.
- `nix derivation show -r path:.#nixosConfigurations.tpnix.config.system.build.toplevel` is unchanged across the
  branch: 0 derivations differ, confirming the nemo module refactor is a no-op for hosts.
- `packages.x86_64-linux.cache-roots` links `nemo-with-extensions` to
  `/nix/store/3lmxrns9nh9prslsliydghniq5k5cm9c-nemo-with-extensions-6.7.2`, byte-identical to
  `nixosConfigurations.system76.config.programs.nemo.extended.finalPackage`. The closure carries
  `nemo-preview-6.7.0` and `nemo-seahorse-6.7.0`, which the bare attribute omitted. (The exact path tracks the
  pinned nixpkgs; the invariant under test is equality with `finalPackage`, not the hash.)
- The enable gate is exercised on both branches against synthetic host configs: enabled returns the package
  unchanged, disabled throws
  `cache-roots: nemo-with-extensions is sourced from programs.nemo.extended.finalPackage, but that module is disabled on system76`.
- With nemo disabled via `extendModules { programs.nemo.extended.enable = lib.mkForce false; }`, reading
  `finalPackage` fails with "The option `programs.nemo.extended.finalPackage' was accessed but has no value
  defined", where it previously returned a store path.
- `packages.x86_64-linux.cache-roots.drvPath` is `/nix/store/scjag1mf2jkvjaq2hwi943a7k8297594-cache-roots.drv` both
  before and after the `finalPackage` refactor, so the option reshape is a no-op for the enabled case.
- Every nemo extension entering the published closure checked against the free-or-redistributable predicate
  `assertFree` applies: nemo-preview, nemo-seahorse, nemo-python, nemo-fileroller (GPL-2.0-or-later),
  nemo-emblems, folder-color-switcher (GPL-3.0-only).
- `drvAttrs.allowSubstitutes` evaluated for every entry named in the rewritten rule: nemo-with-extensions,
  electron-mail, upscayl, and tor-browser are all `false`; firefoxpwa and john are unset.
- `actionlint .github/workflows/cache-push.yml` exits 0.
- `pre-commit run --files <changed>` passes every hook.
- Cache-roots coverage is confirmed only after the next Cache Push run publishes the new closure.