### PR TITLE
fix(flake): advance nixpkgs past the duplicate libdisplay-info_0_3 definition

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1066,11 +1066,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1785174863,
-        "narHash": "sha256-ygzycyTCk+sjIfqRDqEiR1dF8dqvC4FNP6dCMX6QBtc=",
+        "lastModified": 1785220787,
+        "narHash": "sha256-4LnwO//y3315JVvC2KhJABj5yprBXGvy0uWj9HYkMaA=",
         "owner": "Bad3r",
         "repo": "nixpkgs",
-        "rev": "e432052f36803c8e638d320901d360d08df99a82",
+        "rev": "bd2eee7f4a2245052d83db004e78dd45b0ba5a04",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Summary

Every evaluation against the pinned `Bad3r/nixpkgs` rev `e432052f3680` aborted before any host closure could be built:

```
error: The following attributes were defined both in `pkgs/top-level/all-packages.nix` and elsewhere,
most likely in `pkgs/by-name/`: libdisplay-info_0_3
```

Cause: two independent definitions of the same attribute collided in one tree.

- Fork-local `Bad3r/nixpkgs@a51f96385937` (pinned here by 8a66471c) backported the lact fix by adding
  `pkgs/by-name/li/libdisplay-info_0_3/package.nix` in the `overrideAttrs` style the branch already used for
  `libdisplay-info_0_2`.
- Upstream landed the same attribute in `938d5365ad2f` ("libdisplay-info_0_3: init at 0.3.0") on top of
  `f73b403747d3` ("libdisplay-info{,_0_2}: make generic"), declaring it in `pkgs/top-level/all-packages.nix` as
  `callPackage ../by-name/li/libdisplay-info/0.3.nix`.
- The daily input update 46a20a3c merged upstream's version alongside the fork-local one, and the by-name overlay
  rejects the duplicate.

Fix applied at the producer: `Bad3r/nixpkgs@bd2eee7f` removes the fork-local `pkgs/by-name/li/libdisplay-info_0_3`
directory and keeps upstream's definition. `pkgs/by-name/la/lact/package.nix` in the fork is already byte-identical to
upstream's, so the backport carries no remaining delta. This PR only advances the lock to that rev.

`libdisplay-info_0_3` stays at 0.3.0 with the same `sha256-nXf2KGovNKvcchlHlzKBkAOeySMJXgxMpbi5z9gLrdc=` source, so
lact 0.9.1 remains inside the `libdisplay-info >= 0.1.0, < 0.4.0` range its vendored `libdisplay-info-sys` 0.3.0
requires, while `libdisplay-info` itself stays at 0.4.0 for mutter, mpv-unwrapped, gamescope, and weston.

## Test plan

- `nix eval path:.#nixosConfigurations.tpnix.config.system.build.toplevel.drvPath`
  -> `nixos-system-tpnix-26.11.20260728.bd2eee7.drv`
- `nix eval path:.#nixosConfigurations.system76.config.system.build.toplevel.drvPath`
  -> `nixos-system-system76-26.11.20260728.bd2eee7.drv`
- `nix build path:.#nixosConfigurations.system76.pkgs.lact`
  -> `lact-0.9.1`, pulling `libdisplay-info-0.3.0` as a dependency
- `nix-instantiate --eval --strict` in the nixpkgs fork:
  `libdisplay-info_0_3` 0.3.0, `libdisplay-info` 0.4.0, lact 0.9.1 with libdisplay-info 0.3.0 in `buildInputs`
- `nix fmt flake.lock` (no diff)
- `pre-commit` full hook run on commit: passed