### PR TITLE
fix(nix): remove Garnix and replan cache coverage

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,6 +2,11 @@
 name: Dendritic Pattern Compliance Check
 "on":
   workflow_dispatch:
+  # The flake checks carry eval-time guards that fail only when something
+  # forces checks.<system>: cache-roots-allowlist-disjoint and
+  # bootstrap-substituter-parity. On dispatch alone they enforce nothing at
+  # review time, which is when the drift they catch is introduced.
+  pull_request:
 jobs:
   flake-lock-health:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ concurrency:
   # Two of these jobs install Lix and run a full flake evaluation, so a
   # superseded run is pure waste. cache-push.yml opts out because its long
   # builds are worth preserving; nothing here builds.
-  group: check-${{ github.event.pull_request.number || github.ref }}
+  group: check-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 permissions:
   # No job here writes. The trigger above mints this token for every pull
@@ -38,6 +38,11 @@ jobs:
 
   check-compliance:
     runs-on: ubuntu-latest
+    # Installs Lix and evaluates the whole flake. Nothing on the runner
+    # sets stalled-download-timeout, so a stuck substituter fetch would
+    # otherwise hold a runner and this concurrency slot for the 6 hour
+    # job default.
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5.0.0
         with:
@@ -92,6 +97,7 @@ jobs:
 
   format-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5.0.0
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,6 +7,17 @@ name: Dendritic Pattern Compliance Check
   # bootstrap-substituter-parity. On dispatch alone they enforce nothing at
   # review time, which is when the drift they catch is introduced.
   pull_request:
+concurrency:
+  # Two of these jobs install Lix and run a full flake evaluation, so a
+  # superseded run is pure waste. cache-push.yml opts out because its long
+  # builds are worth preserving; nothing here builds.
+  group: check-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+permissions:
+  # No job here writes. The trigger above mints this token for every pull
+  # request, and it reaches ./.github/actions/install-lix, which resolves
+  # from the pull request head.
+  contents: read
 jobs:
   flake-lock-health:
     runs-on: ubuntu-latest

--- a/build.sh
+++ b/build.sh
@@ -242,7 +242,6 @@ BOOTSTRAP_SUBSTITUTERS=(
   #"https://mirror.sjtu.edu.cn/nix-channels/store"
   # "https://mirrors.ustc.edu.cn/nix-channels/store"
   "https://cache.nixos.org"
-  "https://cache.garnix.io?priority=38"
   "https://cache.numtide.com"
   "https://nixpkgs-unfree.cachix.org"
   "https://nix-logseq-git-flake.cachix.org"
@@ -251,7 +250,6 @@ BOOTSTRAP_SUBSTITUTERS=(
 )
 BOOTSTRAP_TRUSTED_KEYS=(
   "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
-  "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
   "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
   "nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs="
   "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo="

--- a/build.sh
+++ b/build.sh
@@ -244,6 +244,9 @@ BOOTSTRAP_SUBSTITUTERS=(
   "https://cache.nixos.org"
   "https://cache.numtide.com"
   "https://nixpkgs-unfree.cachix.org"
+  # CI-built custom derivations (cache-roots); this list replaces rather than
+  # extends nix.conf, so omitting it makes a bootstrap build rebuild them.
+  "https://bad3r-nixos.cachix.org"
   "https://nix-logseq-git-flake.cachix.org"
   "https://nix-community.cachix.org"
   "https://doom-emacs-unstraightened.cachix.org"
@@ -252,6 +255,7 @@ BOOTSTRAP_TRUSTED_KEYS=(
   "cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY="
   "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
   "nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs="
+  "bad3r-nixos.cachix.org-1:CWwJIEV6kogZP/xZPRXdT6hkKvs84haLxYgK9oF59JE="
   "nix-logseq-git-flake.cachix.org-1:DSBNW07PSRyCvS926tpIWahb53OIydwwZhsP6LhJNZo="
   "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
   "doom-emacs-unstraightened.cachix.org-1:O5oOlRPnmQEvVaFyuMTmthCEooHbrg54WgSLR07tmg4="

--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,8 @@ Options:
       --keep-going       Continue building despite failures
       --repair           Repair corrupted store paths during build
       --fallback         Build from source if binary substitutes fail
-      --bootstrap        Use extra substituters for first build
+      --bootstrap        Replace the substituter list with the bootstrap
+                         caches for a first build
       --cache-coverage   Fail before deploying when the target host closure
                          has unexpected local source builds
                          (scripts/cache-coverage.sh)

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -205,8 +205,13 @@ Completed 2026-07-17:
    `BOOTSTRAP_TRUSTED_KEYS`. That path writes `substituters =`, replacing the
    list rather than extending it, so a cache missing there is unreachable for
    the bootstrap build that runs before the host module is active: exactly the
-   fresh machine that has nothing in its store. Keep both lists in step with
-   the module.
+   fresh machine that has nothing in its store. The
+   `bootstrap-substituter-parity` check keeps the two in step: it parses both
+   arrays out of `build.sh` and aborts evaluation when a substituter or key the
+   primary host trusts is missing from them. The comparison is directional, so
+   the region mirrors and the caches app modules append through
+   `extra-substituters` do not trip it, and an empty parse fails rather than
+   comparing nothing.
 
 Confirmed operating as of 2026-07-31: `cache-push.yml` reaches the "Push
 closure to Cachix" step with a `success` conclusion on merges to `main`, and

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -208,10 +208,13 @@ Completed 2026-07-17:
    fresh machine that has nothing in its store. The
    `bootstrap-substituter-parity` check keeps the two in step: it parses both
    arrays out of `build.sh` and aborts evaluation when a substituter or key the
-   primary host trusts is missing from them. The comparison is directional, so
-   the region mirrors and the caches app modules append through
-   `extra-substituters` do not trip it, and an empty parse fails rather than
-   comparing nothing.
+   primary host trusts is missing from them. `extra-substituters` counts the
+   same as `substituters`, because the bootstrap write replaces the whole list
+   and a cache wired the way `modules/apps/doom-emacs.nix` and
+   `modules/apps/logseq.nix` wire theirs is just as unreachable. The comparison
+   is directional, so the region mirrors for other networks do not trip it, and
+   an array that is missing, unclosed, or empty fails rather than comparing
+   nothing.
 
 Confirmed operating as of 2026-07-31: `cache-push.yml` reaches the "Push
 closure to Cachix" step with a `success` conclusion on merges to `main`, and

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -208,7 +208,7 @@ closure to Cachix" step with a `success` conclusion on merges to `main`, and
 The publisher works; its input list does not keep itself honest. A CI service
 that enumerates flake outputs on its own needs no such list, so what the
 retired one would have contributed is that enumeration, and reproducing it is
-the remaining work. Three gaps carry it.
+the remaining work. Four gaps carry it.
 
 1. The detector and the publisher do not talk to each other
    (https://github.com/Bad3r/nixos/issues/422). `cache-roots.nix` publishes a
@@ -234,6 +234,16 @@ the remaining work. Three gaps carry it.
    is reachable only through `build.sh --cache-coverage` and `nix run`, and
    `check.yml` never invokes it, so allowlist drift and new divergences
    surface during a host switch rather than during review.
+4. Multi-output entries are published in part
+   (https://github.com/Bad3r/nixos/issues/426). `cachix push` uploads the
+   runtime closure of the `linkFarm`, so only an entry's default output reaches
+   the cache, while the detector counts a derivation as substitutable only when
+   every output is served. proton-vpn (`out`, `dist`) and nemo (`out`, `dev`,
+   `man`) report as local builds on system76 although the output hosts install
+   answers 200 from `bad3r-nixos.cachix.org` and the other answers 404
+   everywhere. Neither name belongs in the allowlist: a glob there would
+   restore coverage on paper and suppress the next real divergence on that
+   package.
 
 The unfree group remains the issue's phase 2 and stays out of scope while the
 cache is public: serving it needs a private or authenticated cache with the

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -198,6 +198,12 @@ Completed 2026-07-17:
    and emits a warning instead of pushing.
 3. Common hosts trust the cache: `modules/hosts/common/nix-substituters.nix`
    carries `https://bad3r-nixos.cachix.org` and its public key.
+4. `build.sh` carries the same URL and key in `BOOTSTRAP_SUBSTITUTERS` and
+   `BOOTSTRAP_TRUSTED_KEYS`. That path writes `substituters =`, replacing the
+   list rather than extending it, so a cache missing there is unreachable for
+   the bootstrap build that runs before the host module is active: exactly the
+   fresh machine that has nothing in its store. Keep both lists in step with
+   the module.
 
 Confirmed operating as of 2026-07-31: `cache-push.yml` reaches the "Push
 closure to Cachix" step with a `success` conclusion on merges to `main`, and

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -19,13 +19,14 @@ derivations built locally per full system build. Three groups remain:
   others)
 - host-specific config and text derivations (cheap, acceptable)
 
-The garnix question from the issue resolves as follows:
+The Garnix question from the issue resolves as follows:
 
-- The garnix GitHub app is not installed for this repository. Recent
-  commits carry no garnix check suites, and the garnix badge API returns
-  an empty badge. The few `cache.garnix.io` hits observed during builds
-  come from garnix's shared public cache, populated by other projects'
-  builds, not from CI coverage of this repository.
+- The Garnix GitHub app is not installed for this repository. Recent commits
+  carry no Garnix check suites, and the Garnix badge API returns an empty
+  badge. Earlier `cache.garnix.io` hits came from Garnix's shared public cache,
+  populated by other projects' builds, not from CI coverage of this repository.
+  Garnix is therefore not part of the default substituter set: an optional
+  shared cache must not be a required dependency for host builds.
 - garnix cannot build this flake in its current shape even if installed:
   `flake.nix` sets `self.submodules = true`, so any git-based fetch of the
   flake pulls the private `secrets/` submodule, which external CI cannot

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -306,7 +306,11 @@ logs and its full runtime closure is redistributable:
 - Drop the matching glob from `scripts/cache-coverage-allowlist.txt` in the
   same change. That file records divergences accepted as permanent local
   builds; a package the cache now serves is no longer one, and leaving the
-  glob behind hides the next regression on that name.
+  glob behind hides the next regression on that name. The
+  `cache-roots-allowlist-disjoint` check enforces this: it matches every
+  published entry name against the file's globs and aborts evaluation naming
+  the offender, so forgetting the deletion fails `nix flake check` rather than
+  surfacing as a silently dead glob later.
 - Confirm derivation parity with
   `nix build --dry-run "path:.#cache-roots"` on a recently switched host:
   the new entry must not introduce rebuilds of paths the host already has.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -213,12 +213,17 @@ the remaining work. Three gaps carry it.
 1. The detector and the publisher do not talk to each other
    (https://github.com/Bad3r/nixos/issues/422). `cache-roots.nix` publishes a
    hand-maintained name list, while `scripts/cache-coverage-allowlist.txt`
-   suppresses a larger set of diverged local builds
+   suppresses diverged local builds that list never publishes
    (age-plugin-fido2prf, librepods, snixembed, subjack, cewl, normcap, zap,
-   nixos-icons, nixos-option, and the configuration wrappers). One file
-   accepts rebuilding a package forever and the other decides what to
-   publish, with nothing reconciling them, so a new custom package stays
-   uncached until somebody reads a build log.
+   system76-power, nixos-icons, nixos-option). The two sets are disjoint by
+   hand, not by construction: one file accepts rebuilding a package forever
+   and the other decides what to publish, with nothing reconciling them. So a
+   new custom package stays uncached until somebody reads a build log, and a
+   name added to the publisher leaves behind a dead glob that absorbs the next
+   regression on it. The allowlist's other entries are permanent dispositions
+   `docs/reference/cache-coverage.md` accepts rather than reconciliation debt:
+   the RAR-enabled p7zip is unfree while the cache is public, and the
+   configuration wrappers are too cheap to be worth the CI time.
 2. Only the primary host sources entries
    (https://github.com/Bad3r/nixos/issues/423). `cache-roots.nix` hardcodes
    `primaryHost`, so apps a sibling host enables and the primary does not

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -7,6 +7,46 @@ wiring live in `modules/hosts/common/nix-substituters.nix`; the build surface
 lives in `modules/meta/cache-roots.nix`; the CI publisher is
 `.github/workflows/cache-push.yml`.
 
+This file documents the publisher. The detector that reports which closure
+paths still build locally is `scripts/cache-coverage.sh`, documented in
+`docs/reference/cache-coverage.md`. The two are halves of one mechanism:
+the detector names what is uncovered, the publisher covers it.
+
+## Garnix (retired)
+
+Garnix shut down on 2026-07-15, deleted every stored build artifact, and open
+sourced its CI with no public successor instance, leaving `cache.garnix.io` to
+answer HTTP 502. It never covered this repository in any case: the GitHub app
+was never installed, and `self.submodules = true` in `flake.nix` makes any
+git-based fetch of the flake pull the private `secrets/` submodule that
+external CI cannot read. The substituter and its trusted key are gone from
+`modules/hosts/common/nix-substituters.nix` and the `build.sh` bootstrap
+lists. Do not re-add them, and do not stand up a self-hosted instance: what it
+would have contributed here is output enumeration, not hosting, and the
+"Coverage gaps" section below tracks that.
+
+## Mechanism
+
+CI in this repository builds `packages.<system>.cache-roots` and pushes the
+closure to the public Cachix cache `bad3r-nixos`, which hosts trust as a
+substituter. The `nix-logseq-git-flake` input already used this shape, so the
+trust and wiring pattern was proven in this configuration before being
+generalized.
+
+`cache-push.yml` triggers on `workflow_dispatch` and on pushes to `main`
+touching `flake.lock`, `modules/**`, or `packages/**`. Lock freshness rides on
+`update-flake.yml`, which opens a daily `automated/flake-update` pull request;
+merging it touches `flake.lock` and fires a push. A cache hit requires the
+exact derivation a consumer evaluates, so tracking the merged lock is what
+makes the cache usable: it holds derivations for the revision hosts evaluate
+against.
+
+Alternatives were considered and rejected. Attic and Harmonia reintroduce a
+server to operate, which is the dependency this design removed. FlakeHub Cache
+is paid and pairs with Determinate Nix while hosts here run Lix. Cachix is
+already trusted, already wired, and already publishing, so the remaining work
+is coverage, not a change of service.
+
 ## Audit findings (2026-07-17)
 
 Build-log profiling under `~/.local/state/nixos-build/` after PR
@@ -18,28 +58,6 @@ derivations built locally per full system build. Three groups remain:
 - unfree binary repacks (vscode, webex, kiro, veracrypt, ventoy, and
   others)
 - host-specific config and text derivations (cheap, acceptable)
-
-The Garnix question from the issue resolves as follows:
-
-- The Garnix GitHub app is not installed for this repository. Recent commits
-  carry no Garnix check suites, and the Garnix badge API returns an empty
-  badge. Earlier `cache.garnix.io` hits came from Garnix's shared public cache,
-  populated by other projects' builds, not from CI coverage of this repository.
-  Garnix is therefore not part of the default substituter set: an optional
-  shared cache must not be a required dependency for host builds.
-- garnix cannot build this flake in its current shape even if installed:
-  `flake.nix` sets `self.submodules = true`, so any git-based fetch of the
-  flake pulls the private `secrets/` submodule, which external CI cannot
-  read. The repository's own GitHub Actions work around this with `path:.`
-  checkouts and secretless evaluation (see `.github/workflows/check.yml`),
-  a mechanism garnix does not document an equivalent for. Revisit garnix
-  only if it documents submodule-free fetching or the submodule leaves the
-  fetch path.
-
-Coverage therefore comes from this repository's own CI pushing to Cachix,
-the mechanism already proven by the `nix-logseq-git-flake` input, whose CI
-builds logseq and pushes to its own Cachix cache trusted in
-`modules/hosts/common/nix-substituters.nix`.
 
 ## Build surface
 
@@ -181,15 +199,44 @@ Completed 2026-07-17:
 3. Common hosts trust the cache: `modules/hosts/common/nix-substituters.nix`
    carries `https://bad3r-nixos.cachix.org` and its public key.
 
-Remaining:
+Confirmed operating as of 2026-07-31: `cache-push.yml` reaches the "Push
+closure to Cachix" step with a `success` conclusion on merges to `main`, and
+`https://bad3r-nixos.cachix.org/nix-cache-info` serves `Priority: 41`.
 
-1. First populated run: the workflow triggers on pushes to `main` that
-   change `flake.lock`, the cache-roots module, custom overlays, or
-   `packages/` (the merge introducing the module qualifies), or run it via
-   `workflow_dispatch`; confirm the push step succeeds.
-2. After the next nixpkgs bump and merge, compare a host switch build log
-   against a pre-cache log: the cache-roots packages should appear as
-   downloads, not builds.
+## Coverage gaps
+
+The publisher works; its input list does not keep itself honest. A CI service
+that enumerates flake outputs on its own needs no such list, so what the
+retired one would have contributed is that enumeration, and reproducing it is
+the remaining work. Three gaps carry it.
+
+1. The detector and the publisher do not talk to each other
+   (https://github.com/Bad3r/nixos/issues/422). `cache-roots.nix` publishes a
+   hand-maintained name list, while `scripts/cache-coverage-allowlist.txt`
+   suppresses a larger set of diverged local builds
+   (age-plugin-fido2prf, librepods, snixembed, subjack, cewl, normcap, zap,
+   nixos-icons, nixos-option, and the configuration wrappers). One file
+   accepts rebuilding a package forever and the other decides what to
+   publish, with nothing reconciling them, so a new custom package stays
+   uncached until somebody reads a build log.
+2. Only the primary host sources entries
+   (https://github.com/Bad3r/nixos/issues/423). `cache-roots.nix` hardcodes
+   `primaryHost`, so apps a sibling host enables and the primary does not
+   (`modules/tpnix/apps-enable.nix` turns on projectlibre and thinkfan) never
+   reach the cache, and neither do that host's distinct wrapper closures.
+3. Nothing gates coverage in CI
+   (https://github.com/Bad3r/nixos/issues/424). `scripts/cache-coverage.sh`
+   is reachable only through `build.sh --cache-coverage` and `nix run`, and
+   `check.yml` never invokes it, so allowlist drift and new divergences
+   surface during a host switch rather than during review.
+
+The unfree group remains the issue's phase 2 and stays out of scope while the
+cache is public: serving it needs a private or authenticated cache with the
+token provisioned to hosts through sops.
+
+Before-and-after measurement of switch time belongs to the detector, not to a
+manual log diff. Once gap 3 lands, the report's own class counts are the
+metric.
 
 ## Extending the allowlist
 
@@ -232,6 +279,10 @@ logs and its full runtime closure is redistributable:
   (electron-mail, upscayl, nemo-with-extensions all set it on the outer
   wrapper). It does not belong when the non-substitutable derivation is
   itself the expensive build (tor-browser, mullvad-browser).
+- Drop the matching glob from `scripts/cache-coverage-allowlist.txt` in the
+  same change. That file records divergences accepted as permanent local
+  builds; a package the cache now serves is no longer one, and leaving the
+  glob behind hides the next regression on that name.
 - Confirm derivation parity with
   `nix build --dry-run "path:.#cache-roots"` on a recently switched host:
   the new entry must not introduce rebuilds of paths the host already has.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -182,8 +182,11 @@ Residual local builds accepted with reasons:
   negligible build cost.
 - host config and systemd unit text derivations: cheap by design.
 - nixpkgs packages missing from `cache.nixos.org` right after a fresh
-  nixpkgs pin (Hydra lag): transient; the heaviest recurring cases (nemo,
-  planify) are pinned into cache-roots.
+  nixpkgs pin (Hydra lag): transient; planify is pinned into cache-roots for
+  that reason. nemo is not pinned. It reaches the cache only through the
+  nemo-with-extensions closure, which carries its `out` and not its `dev`, so
+  it reports local under coverage gap 4 instead of clearing on the next Hydra
+  run.
 
 ## Operator setup
 

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -207,8 +207,10 @@ Completed 2026-07-17:
    the bootstrap build that runs before the host module is active: exactly the
    fresh machine that has nothing in its store. The
    `bootstrap-substituter-parity` check keeps the two in step: it parses both
-   arrays out of `build.sh` and aborts evaluation when a substituter or key the
-   primary host trusts is missing from them. `extra-substituters` counts the
+   arrays out of `build.sh` and aborts evaluation when a substituter or key any
+   registered host trusts is missing from them. Every host is covered, not just
+   the primary, because `build.sh` bootstraps whichever host it runs on.
+   `extra-substituters` counts the
    same as `substituters`, because the bootstrap write replaces the whole list
    and a cache wired the way `modules/apps/doom-emacs.nix` and
    `modules/apps/logseq.nix` wire theirs is just as unreachable. The comparison

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -308,9 +308,10 @@ logs and its full runtime closure is redistributable:
   builds; a package the cache now serves is no longer one, and leaving the
   glob behind hides the next regression on that name. The
   `cache-roots-allowlist-disjoint` check enforces this: it matches every
-  published entry name against the file's globs and aborts evaluation naming
-  the offender, so forgetting the deletion fails `nix flake check` rather than
-  surfacing as a silently dead glob later.
+  published entry against the file's globs, on the `linkFarm` key and on the
+  derivation `name` and `pname`, and aborts evaluation naming the offender. So
+  forgetting the deletion fails `nix flake check` rather than surfacing as a
+  silently dead glob later.
 - Confirm derivation parity with
   `nix build --dry-run "path:.#cache-roots"` on a recently switched host:
   the new entry must not introduce rebuilds of paths the host already has.

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -10,6 +10,13 @@ that patches a base package (issue
 the stylix gtksourceview overlay removed in PR 380). Evaluation and HTTP
 narinfo probes only: the script never builds anything.
 
+This file documents the detector. The publisher that puts custom derivations
+on a cache is `modules/meta/cache-roots.nix` plus
+`.github/workflows/cache-push.yml`, documented in
+`docs/reference/binary-cache-coverage.md`. The two are halves of one
+mechanism: what this report classifies as a local build is the candidate set
+the publisher should cover.
+
 ## Manual Use
 
 Report every host, fail on any unexpected divergence:
@@ -86,6 +93,22 @@ The check exits nonzero when unexpected-local entries exceed `--max-count`
 one glob per line, matched against the derivation name and pname, with a
 comment recording the reason. Both files are repo-tracked so changes go
 through review.
+
+Allowlisting and caching are mutually exclusive dispositions, not a
+preference. A glob here declares that the divergence is a permanent local
+build; a name in `cache-roots.nix` declares that CI publishes it. Choose the
+allowlist only when the package cannot be cached: `allowSubstitutes = false`
+on the expensive derivation (tor-browser, mullvad-browser), an unfree or
+non-redistributable license while the cache is public (the RAR-enabled
+p7zip), or a wrapper cheap enough that publishing it costs more CI time than
+it saves. Everything else belongs in `cache-roots.nix`, and adding it there
+means deleting the glob here in the same change. Entries currently
+allowlisted that fail that test are tracked in
+https://github.com/Bad3r/nixos/issues/422.
+
+Nothing runs this script in CI yet, so drift surfaces during a host switch
+rather than during review; `check.yml` coverage is tracked in
+https://github.com/Bad3r/nixos/issues/424.
 
 ## Caveats
 

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -103,7 +103,7 @@ non-redistributable license while the cache is public (the RAR-enabled
 p7zip), or a wrapper cheap enough that publishing it costs more CI time than
 it saves. Everything else belongs in `cache-roots.nix`, and adding it there
 means deleting the glob here in the same change. That is enforced rather than
-asked for: the `cache-roots-allowlist-disjoint` flake check in
+left to memory: the `cache-roots-allowlist-disjoint` flake check in
 `modules/meta/cache-roots.nix` reads this file and aborts evaluation naming the
 offender. It matches each published entry on all three strings a glob could
 have been written against, the `linkFarm` key plus the derivation `name` and
@@ -113,7 +113,10 @@ members the push also serves, because that closure does not exist at evaluation
 time; extending the check to them is
 https://github.com/Bad3r/nixos/issues/428. It throws
 during evaluation, so `nix flake check --no-build` catches it without building
-anything. Entries currently allowlisted that fail the disposition test, rather
+anything. `check.yml` runs on `pull_request` so that this fires at review time:
+the guard is a throw inside `perSystem.checks`, which enforces nothing unless
+something forces `checks.<system>`, and that workflow's "Check flake" step is
+what does. Entries currently allowlisted that fail the disposition test, rather
 than the overlap test, are tracked in
 https://github.com/Bad3r/nixos/issues/422.
 

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -108,7 +108,10 @@ asked for: the `cache-roots-allowlist-disjoint` flake check in
 offender. It matches each published entry on all three strings a glob could
 have been written against, the `linkFarm` key plus the derivation `name` and
 `pname`, so a version-anchored glob such as `proton-vpn-[0-9]*` is caught the
-same as `proton-vpn*`. It throws
+same as `proton-vpn*`. Its domain is the published entries, not the closure
+members the push also serves, because that closure does not exist at evaluation
+time; extending the check to them is
+https://github.com/Bad3r/nixos/issues/428. It throws
 during evaluation, so `nix flake check --no-build` catches it without building
 anything. Entries currently allowlisted that fail the disposition test, rather
 than the overlap test, are tracked in

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -125,7 +125,10 @@ https://github.com/Bad3r/nixos/issues/424.
   only, and those rebuilds are inherent to hydra's thin i686 coverage, not
   divergences. They surface under local-only.
 - All-outputs probing: a derivation counts as substitutable only when
-  every output is served by some probe base.
+  every output is served by some probe base. `cache-roots.nix` publishes only
+  each entry's default output, so a multi-output entry reports as a local build
+  even when the output hosts install is served
+  (https://github.com/Bad3r/nixos/issues/426).
 - Only `200` (served) and `404` (absent) are decisive probe results;
   anything else (`000` from an unreachable cache, or `429`/`403`/`503` from
   a rate-limiting or overloaded cachix/S3 base) is non-definitive and read

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -105,10 +105,12 @@ it saves. Everything else belongs in `cache-roots.nix`, and adding it there
 means deleting the glob here in the same change. That is enforced rather than
 left to memory: the `cache-roots-allowlist-disjoint` flake check in
 `modules/meta/cache-roots.nix` reads this file and aborts evaluation naming the
-offender. It matches each published entry on all three strings a glob could
-have been written against, the `linkFarm` key plus the derivation `name` and
-`pname`, so a version-anchored glob such as `proton-vpn-[0-9]*` is caught the
-same as `proton-vpn*`. Its domain is the published entries, not the closure
+offender. It matches each published entry on the derivation `name` and `pname`,
+which are the strings this report matches globs against, so a version-anchored
+glob such as `proton-vpn-[0-9]*` is caught the same as `proton-vpn*`. The
+`linkFarm` key is checked as well: a glob spelled that way suppresses nothing
+here, since the key never reaches this report, but it declares the same
+disposition the rule forbids. Its domain is the published entries, not the closure
 members the push also serves, because that closure does not exist at evaluation
 time; extending the check to them is
 https://github.com/Bad3r/nixos/issues/428. It throws

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -102,8 +102,13 @@ on the expensive derivation (tor-browser, mullvad-browser), an unfree or
 non-redistributable license while the cache is public (the RAR-enabled
 p7zip), or a wrapper cheap enough that publishing it costs more CI time than
 it saves. Everything else belongs in `cache-roots.nix`, and adding it there
-means deleting the glob here in the same change. Entries currently
-allowlisted that fail that test are tracked in
+means deleting the glob here in the same change. That is enforced rather than
+asked for: the `cache-roots-allowlist-disjoint` flake check in
+`modules/meta/cache-roots.nix` reads this file, matches every published entry
+name against its globs, and aborts evaluation naming the offender. It throws
+during evaluation, so `nix flake check --no-build` catches it without building
+anything. Entries currently allowlisted that fail the disposition test, rather
+than the overlap test, are tracked in
 https://github.com/Bad3r/nixos/issues/422.
 
 Nothing runs this script in CI yet, so drift surfaces during a host switch

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -104,8 +104,11 @@ p7zip), or a wrapper cheap enough that publishing it costs more CI time than
 it saves. Everything else belongs in `cache-roots.nix`, and adding it there
 means deleting the glob here in the same change. That is enforced rather than
 asked for: the `cache-roots-allowlist-disjoint` flake check in
-`modules/meta/cache-roots.nix` reads this file, matches every published entry
-name against its globs, and aborts evaluation naming the offender. It throws
+`modules/meta/cache-roots.nix` reads this file and aborts evaluation naming the
+offender. It matches each published entry on all three strings a glob could
+have been written against, the `linkFarm` key plus the derivation `name` and
+`pname`, so a version-anchored glob such as `proton-vpn-[0-9]*` is caught the
+same as `proton-vpn*`. It throws
 during evaluation, so `nix flake check --no-build` catches it without building
 anything. Entries currently allowlisted that fail the disposition test, rather
 than the overlap test, are tracked in

--- a/modules/browsers/gecko-chrome/userChrome.css
+++ b/modules/browsers/gecko-chrome/userChrome.css
@@ -95,12 +95,12 @@ toolbar#nav-bar::after {
 }
 /* Hide splitter, when using Tree Style Tab. */
 #sidebar-box[sidebarcommand="treestyletab_piro_sakura_ne_jp-sidebar-action"]
-	+ #sidebar-splitter {
++ #sidebar-splitter {
 	display: none !important;
 }
 /* Hide sidebar header, when using Tree Style Tab. */
 #sidebar-box[sidebarcommand="treestyletab_piro_sakura_ne_jp-sidebar-action"]
-	#sidebar-header {
+#sidebar-header {
 	visibility: collapse;
 }
 /* Shrink sidebar until hovered, when using Tree Style Tab. */

--- a/modules/hosts/common/nix-substituters.nix
+++ b/modules/hosts/common/nix-substituters.nix
@@ -8,7 +8,6 @@ let
       # exact URI strings), so it opens a second store against the same host
       # and doubles narinfo misses.
       substituters = lib.mkAfter [
-        "https://cache.garnix.io"
         "https://cache.numtide.com"
         "https://nixpkgs-unfree.cachix.org" # unfree packages (unrar, etc.)
         # CI-built custom derivations (cache-roots); see
@@ -18,7 +17,6 @@ let
         # appended by modules/apps/doom-emacs.nix when the module is enabled.
       ];
       trusted-public-keys = lib.mkAfter [
-        "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
         "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
         "nixpkgs-unfree.cachix.org-1:hqvoInulhbV4nJ9yJOEr+4wxhDV4xq2d1DK7S6Nj6rs="
         "bad3r-nixos.cachix.org-1:CWwJIEV6kogZP/xZPRXdT6hkKvs84haLxYgK9oF59JE="

--- a/modules/meta/bootstrap-substituter-parity.nix
+++ b/modules/meta/bootstrap-substituter-parity.nix
@@ -71,9 +71,12 @@ let
     else
       throw "bootstrap-substituter-parity: build.sh has no closed ${name}=( ... ) array; the comparison would otherwise run against an over-wide list";
 
-  # The NixOS module default contributes cache.nixos.org with a trailing slash
-  # and build.sh spells it without one; they address the same store.
-  normalize = lib.removeSuffix "/";
+  # Spellings that address the same store must compare equal. The NixOS module
+  # default contributes cache.nixos.org with a trailing slash while build.sh
+  # writes it without one, and per-substituter priority is set through a URL
+  # parameter, which is how this array spelled its garnix entry
+  # (`?priority=38`) before it was removed.
+  normalize = url: lib.removeSuffix "/" (lib.head (lib.splitString "?" url));
 
   bootstrapSubstituters = map normalize (arrayEntries "BOOTSTRAP_SUBSTITUTERS");
   bootstrapKeys = arrayEntries "BOOTSTRAP_TRUSTED_KEYS";
@@ -82,7 +85,15 @@ in
   perSystem =
     { pkgs, system, ... }:
     let
-      checkSystem = config.flake.nixosConfigurations.${checkHost}.pkgs.stdenv.hostPlatform.system;
+      # Resolved through the emptiness guard rather than after it. flake-parts
+      # forces this inside the mkIf condition below, so reading `.${checkHost}`
+      # off an empty attrset would throw attribute-missing first and leave a
+      # guard in the check body unreachable.
+      checkSystem =
+        if config.flake.nixosConfigurations == { } then
+          throw "bootstrap-substituter-parity: no nixosConfigurations to compare against; the check would pass vacuously"
+        else
+          config.flake.nixosConfigurations.${checkHost}.pkgs.stdenv.hostPlatform.system;
 
       missing = lib.concatLists (
         lib.mapAttrsToList (
@@ -101,14 +112,11 @@ in
     {
       checks = lib.mkIf (checkSystem == system) {
         bootstrap-substituter-parity =
-          # Both sides of the comparison need a floor. An empty parse means the
-          # arrays were renamed or reshaped; an empty host set means there is
-          # nothing to compare against. Either one passes vacuously otherwise,
-          # which is the failure mode this check exists to close. check.yml
-          # treats an empty host list as a failure for the same reason.
-          if config.flake.nixosConfigurations == { } then
-            throw "bootstrap-substituter-parity: no nixosConfigurations to compare against; the check would pass vacuously"
-          else if bootstrapSubstituters == [ ] || bootstrapKeys == [ ] then
+          # Both sides of the comparison need a floor, or the check passes
+          # vacuously, which is the failure mode it exists to close. check.yml
+          # treats an empty host list as a failure for the same reason; that
+          # side is caught above, when checkSystem resolves.
+          if bootstrapSubstituters == [ ] || bootstrapKeys == [ ] then
             throw "bootstrap-substituter-parity: parsed no BOOTSTRAP_SUBSTITUTERS or BOOTSTRAP_TRUSTED_KEYS entries out of build.sh; a rename would make this comparison vacuous"
           else if missing != [ ] then
             throw (

--- a/modules/meta/bootstrap-substituter-parity.nix
+++ b/modules/meta/bootstrap-substituter-parity.nix
@@ -9,9 +9,13 @@
   because the build still succeeds. It just rebuilds locally everything the
   missing cache would have served.
 
-  The comparison is directional. Every substituter and key the primary host
-  trusts must appear in the bootstrap arrays; the reverse is not required,
-  since build.sh also carries region mirrors for other networks.
+  The comparison is directional and covers every registered host. build.sh
+  bootstraps whichever host it runs on (`TARGET_HOST="$(hostname)"`, with a
+  `--host` override), so a cache that reaches only one host's nix.settings,
+  through a host-specific module or an app that per-host apps-enable.nix turns
+  on for one host and not the other, still has to be in the arrays. Every
+  substituter and key any host trusts must appear there; the reverse is not
+  required, since build.sh also carries region mirrors for other networks.
 
   extra-substituters counts the same as substituters. configure_nix_config
   replaces the whole list, so a cache that reaches the daemon through
@@ -21,7 +25,9 @@
 */
 { config, lib, ... }:
 let
-  primaryHost = "system76";
+  # Only decides which perSystem instance carries the check. The comparison
+  # below reads every registered host.
+  checkHost = "system76";
 
   buildScriptLines = lib.splitString "\n" (builtins.readFile ../../build.sh);
 
@@ -76,30 +82,33 @@ in
   perSystem =
     { pkgs, system, ... }:
     let
-      hostConfig = config.flake.nixosConfigurations.${primaryHost}.config;
-      hostSystem = config.flake.nixosConfigurations.${primaryHost}.pkgs.stdenv.hostPlatform.system;
+      checkSystem = config.flake.nixosConfigurations.${checkHost}.pkgs.stdenv.hostPlatform.system;
 
-      missingSubstituters = lib.subtractLists bootstrapSubstituters (
-        map normalize (
-          hostConfig.nix.settings.substituters ++ (hostConfig.nix.settings.extra-substituters or [ ])
-        )
-      );
-      missingKeys = lib.subtractLists bootstrapKeys (
-        hostConfig.nix.settings.trusted-public-keys
-        ++ (hostConfig.nix.settings.extra-trusted-public-keys or [ ])
+      missing = lib.concatLists (
+        lib.mapAttrsToList (
+          host: node:
+          let
+            settings = node.config.nix.settings;
+            substituters = map normalize (settings.substituters ++ (settings.extra-substituters or [ ]));
+            keys = settings.trusted-public-keys ++ (settings.extra-trusted-public-keys or [ ]);
+          in
+          map (entry: "${host} trusts ${entry}") (
+            lib.subtractLists bootstrapSubstituters substituters ++ lib.subtractLists bootstrapKeys keys
+          )
+        ) config.flake.nixosConfigurations
       );
     in
     {
-      checks = lib.mkIf (hostSystem == system) {
+      checks = lib.mkIf (checkSystem == system) {
         bootstrap-substituter-parity =
           # An empty parse means the arrays were renamed or reshaped. That must
           # fail rather than compare nothing and pass.
           if bootstrapSubstituters == [ ] || bootstrapKeys == [ ] then
             throw "bootstrap-substituter-parity: parsed no BOOTSTRAP_SUBSTITUTERS or BOOTSTRAP_TRUSTED_KEYS entries out of build.sh; a rename would make this comparison vacuous"
-          else if missingSubstituters != [ ] || missingKeys != [ ] then
+          else if missing != [ ] then
             throw (
-              "bootstrap-substituter-parity: ${primaryHost} trusts "
-              + lib.concatStringsSep ", " (missingSubstituters ++ missingKeys)
+              "bootstrap-substituter-parity: "
+              + lib.concatStringsSep "; " missing
               + " but build.sh omits it. configure_nix_config replaces the substituter list rather than "
               + "extending it, so build.sh --bootstrap cannot substitute from that cache. Add it to "
               + "BOOTSTRAP_SUBSTITUTERS and BOOTSTRAP_TRUSTED_KEYS."

--- a/modules/meta/bootstrap-substituter-parity.nix
+++ b/modules/meta/bootstrap-substituter-parity.nix
@@ -1,0 +1,91 @@
+/*
+  Bootstrap substituter parity (issue #382)
+
+  `configure_nix_config` in build.sh writes `substituters = ...`, replacing the
+  daemon's list rather than extending it, so a cache hosts trust through
+  modules/hosts/common/nix-substituters.nix but that BOOTSTRAP_SUBSTITUTERS
+  omits is unreachable for the one build that runs before that module is
+  active: a fresh machine with nothing in its store. The drift is silent,
+  because the build still succeeds. It just rebuilds locally everything the
+  missing cache would have served.
+
+  The comparison is directional. Every substituter and key the primary host
+  trusts must appear in the bootstrap arrays; the reverse is not required,
+  since build.sh also carries region mirrors and the caches that app modules
+  append through extra-substituters.
+*/
+{ config, lib, ... }:
+let
+  primaryHost = "system76";
+
+  buildScriptLines = lib.splitString "\n" (builtins.readFile ../../build.sh);
+
+  # Quoted entries between `<name>=(` and its closing `)`. A commented-out
+  # entry starts with `#`, so the quote match fails and a disabled mirror does
+  # not count as configured.
+  arrayEntries =
+    name:
+    let
+      step =
+        state: line:
+        if state.done then
+          state
+        else if !state.inside then
+          state // { inside = line == "${name}=("; }
+        else if line == ")" then
+          state
+          // {
+            inside = false;
+            done = true;
+          }
+        else
+          let
+            m = builtins.match "[[:space:]]*\"([^\"]+)\".*" line;
+          in
+          if m == null then state else state // { entries = state.entries ++ [ (lib.head m) ]; };
+    in
+    (lib.foldl' step {
+      inside = false;
+      done = false;
+      entries = [ ];
+    } buildScriptLines).entries;
+
+  # The NixOS module default contributes cache.nixos.org with a trailing slash
+  # and build.sh spells it without one; they address the same store.
+  normalize = lib.removeSuffix "/";
+
+  bootstrapSubstituters = map normalize (arrayEntries "BOOTSTRAP_SUBSTITUTERS");
+  bootstrapKeys = arrayEntries "BOOTSTRAP_TRUSTED_KEYS";
+in
+{
+  perSystem =
+    { pkgs, system, ... }:
+    let
+      hostConfig = config.flake.nixosConfigurations.${primaryHost}.config;
+      hostSystem = config.flake.nixosConfigurations.${primaryHost}.pkgs.stdenv.hostPlatform.system;
+
+      missingSubstituters = lib.subtractLists bootstrapSubstituters (
+        map normalize hostConfig.nix.settings.substituters
+      );
+      missingKeys = lib.subtractLists bootstrapKeys hostConfig.nix.settings.trusted-public-keys;
+    in
+    {
+      checks = lib.mkIf (hostSystem == system) {
+        bootstrap-substituter-parity =
+          # An empty parse means the arrays were renamed or reshaped. That must
+          # fail rather than compare nothing and pass.
+          if bootstrapSubstituters == [ ] || bootstrapKeys == [ ] then
+            throw "bootstrap-substituter-parity: parsed no BOOTSTRAP_SUBSTITUTERS or BOOTSTRAP_TRUSTED_KEYS entries out of build.sh; a rename would make this comparison vacuous"
+          else if missingSubstituters != [ ] || missingKeys != [ ] then
+            throw (
+              "bootstrap-substituter-parity: ${primaryHost} trusts "
+              + lib.concatStringsSep ", " (missingSubstituters ++ missingKeys)
+              + " but build.sh omits it. configure_nix_config replaces the substituter list rather than "
+              + "extending it, so build.sh --bootstrap cannot substitute from that cache. Add it to "
+              + "BOOTSTRAP_SUBSTITUTERS and BOOTSTRAP_TRUSTED_KEYS."
+            )
+          else
+            pkgs.runCommand "bootstrap-substituter-parity" { } "touch $out";
+      };
+    };
+}

--- a/modules/meta/bootstrap-substituter-parity.nix
+++ b/modules/meta/bootstrap-substituter-parity.nix
@@ -74,8 +74,8 @@ let
   # Spellings that address the same store must compare equal. The NixOS module
   # default contributes cache.nixos.org with a trailing slash while build.sh
   # writes it without one, and per-substituter priority is set through a URL
-  # parameter, which is how this array spelled its garnix entry
-  # (`?priority=38`) before it was removed.
+  # parameter, so `https://example.cachix.org?priority=38` and a bare
+  # `https://example.cachix.org` name the same cache.
   normalize = url: lib.removeSuffix "/" (lib.head (lib.splitString "?" url));
 
   bootstrapSubstituters = map normalize (arrayEntries "BOOTSTRAP_SUBSTITUTERS");

--- a/modules/meta/bootstrap-substituter-parity.nix
+++ b/modules/meta/bootstrap-substituter-parity.nix
@@ -92,6 +92,8 @@ in
       checkSystem =
         if config.flake.nixosConfigurations == { } then
           throw "bootstrap-substituter-parity: no nixosConfigurations to compare against; the check would pass vacuously"
+        else if !(lib.hasAttr checkHost config.flake.nixosConfigurations) then
+          throw "bootstrap-substituter-parity: anchor host ${checkHost} is not registered; point checkHost at a registered host so the check keeps landing on a perSystem instance"
         else
           config.flake.nixosConfigurations.${checkHost}.pkgs.stdenv.hostPlatform.system;
 

--- a/modules/meta/bootstrap-substituter-parity.nix
+++ b/modules/meta/bootstrap-substituter-parity.nix
@@ -11,8 +11,13 @@
 
   The comparison is directional. Every substituter and key the primary host
   trusts must appear in the bootstrap arrays; the reverse is not required,
-  since build.sh also carries region mirrors and the caches that app modules
-  append through extra-substituters.
+  since build.sh also carries region mirrors for other networks.
+
+  extra-substituters counts the same as substituters. configure_nix_config
+  replaces the whole list, so a cache that reaches the daemon through
+  `nix.settings.extra-substituters` (how modules/apps/doom-emacs.nix and
+  modules/apps/logseq.nix wire theirs) is exactly as unreachable during
+  bootstrap as one reaching it through `substituters`.
 */
 { config, lib, ... }:
 let
@@ -23,6 +28,12 @@ let
   # Quoted entries between `<name>=(` and its closing `)`. A commented-out
   # entry starts with `#`, so the quote match fails and a disabled mirror does
   # not count as configured.
+  #
+  # An array that is never opened or never closed throws. Without that, a
+  # closing paren gaining a comment would leave the fold collecting quoted
+  # lines to EOF, yielding a strict superset of the real array: every
+  # comparison below would then find nothing missing and pass forever. The
+  # emptiness guard cannot catch that, because the over-wide list is large.
   arrayEntries =
     name:
     let
@@ -32,7 +43,7 @@ let
           state
         else if !state.inside then
           state // { inside = line == "${name}=("; }
-        else if line == ")" then
+        else if lib.hasPrefix ")" line then
           state
           // {
             inside = false;
@@ -43,12 +54,16 @@ let
             m = builtins.match "[[:space:]]*\"([^\"]+)\".*" line;
           in
           if m == null then state else state // { entries = state.entries ++ [ (lib.head m) ]; };
+      parsed = lib.foldl' step {
+        inside = false;
+        done = false;
+        entries = [ ];
+      } buildScriptLines;
     in
-    (lib.foldl' step {
-      inside = false;
-      done = false;
-      entries = [ ];
-    } buildScriptLines).entries;
+    if parsed.done then
+      parsed.entries
+    else
+      throw "bootstrap-substituter-parity: build.sh has no closed ${name}=( ... ) array; the comparison would otherwise run against an over-wide list";
 
   # The NixOS module default contributes cache.nixos.org with a trailing slash
   # and build.sh spells it without one; they address the same store.
@@ -65,9 +80,14 @@ in
       hostSystem = config.flake.nixosConfigurations.${primaryHost}.pkgs.stdenv.hostPlatform.system;
 
       missingSubstituters = lib.subtractLists bootstrapSubstituters (
-        map normalize hostConfig.nix.settings.substituters
+        map normalize (
+          hostConfig.nix.settings.substituters ++ (hostConfig.nix.settings.extra-substituters or [ ])
+        )
       );
-      missingKeys = lib.subtractLists bootstrapKeys hostConfig.nix.settings.trusted-public-keys;
+      missingKeys = lib.subtractLists bootstrapKeys (
+        hostConfig.nix.settings.trusted-public-keys
+        ++ (hostConfig.nix.settings.extra-trusted-public-keys or [ ])
+      );
     in
     {
       checks = lib.mkIf (hostSystem == system) {

--- a/modules/meta/bootstrap-substituter-parity.nix
+++ b/modules/meta/bootstrap-substituter-parity.nix
@@ -101,9 +101,14 @@ in
     {
       checks = lib.mkIf (checkSystem == system) {
         bootstrap-substituter-parity =
-          # An empty parse means the arrays were renamed or reshaped. That must
-          # fail rather than compare nothing and pass.
-          if bootstrapSubstituters == [ ] || bootstrapKeys == [ ] then
+          # Both sides of the comparison need a floor. An empty parse means the
+          # arrays were renamed or reshaped; an empty host set means there is
+          # nothing to compare against. Either one passes vacuously otherwise,
+          # which is the failure mode this check exists to close. check.yml
+          # treats an empty host list as a failure for the same reason.
+          if config.flake.nixosConfigurations == { } then
+            throw "bootstrap-substituter-parity: no nixosConfigurations to compare against; the check would pass vacuously"
+          else if bootstrapSubstituters == [ ] || bootstrapKeys == [ ] then
             throw "bootstrap-substituter-parity: parsed no BOOTSTRAP_SUBSTITUTERS or BOOTSTRAP_TRUSTED_KEYS entries out of build.sh; a rename would make this comparison vacuous"
           else if missing != [ ] then
             throw (

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -152,10 +152,18 @@ in
               m = builtins.match "[[:space:]]*([^#[:space:]]+).*" line;
             in
             if m == null then null else lib.head m;
+          globs = lib.filter (glob: glob != null) (
+            map globOf (lib.splitString "\n" (builtins.readFile ../../scripts/cache-coverage-allowlist.txt))
+          );
         in
-        lib.filter (glob: glob != null) (
-          map globOf (lib.splitString "\n" (builtins.readFile ../../scripts/cache-coverage-allowlist.txt))
-        );
+        # This is a second parser of a format whose only other reader is
+        # scripts/cache-coverage.sh. A format change this regex stops matching
+        # would empty the glob list and turn the guard green rather than red,
+        # so an empty parse is the failure, not a pass.
+        if globs == [ ] then
+          throw "cache-roots: parsed no globs out of scripts/cache-coverage-allowlist.txt; the disjointness guard would pass vacuously"
+        else
+          globs;
 
       globMatches =
         name: glob:

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -93,46 +93,81 @@ in
           pkg
         else
           throw "cache-roots: ${name} is not free or redistributable; refusing to publish it to the public cache";
+      entries =
+        map (name: {
+          inherit name;
+          path = assertFree name hostPkgs.${name};
+        }) hostPackageNames
+        ++ lib.mapAttrsToList (
+          name: optionPath:
+          let
+            enablePath = lib.init optionPath ++ [ "enable" ];
+          in
+          {
+            inherit name;
+            path =
+              if lib.getAttrFromPath enablePath hostConfig then
+                assertFree name (lib.getAttrFromPath optionPath hostConfig)
+              else
+                throw "cache-roots: ${name} is sourced from ${lib.concatStringsSep "." optionPath}, but that module is disabled on ${primaryHost}";
+          }
+        ) hostFinalPackagePaths
+        ++ map (name: {
+          inherit name;
+          path = assertFree name self'.packages.${name};
+        }) perSystemPackageNames
+        ++ [
+          # modules/agents/mcp.nix resolves MCP server packages from the
+          # mcp-servers-nix input; hostPkgs carries a same-named but
+          # different context7-mcp derivation no consumer runs.
+          {
+            name = "context7-mcp";
+            path = assertFree "context7-mcp" inputs'.mcp-servers-nix.packages.context7-mcp;
+          }
+          {
+            name = "codex";
+            path = assertFree "codex" inputs'.llm-agents.packages.codex;
+          }
+        ];
+
+      # A glob in scripts/cache-coverage-allowlist.txt accepts a permanent local
+      # build; a name here publishes the package instead. Holding both leaves a
+      # glob that matches nothing, which then silently absorbs the next real
+      # divergence on that name at --max-count 0. Names are read back off
+      # `entries` so the guard cannot fall behind the linkFarm. The failure is a
+      # throw rather than a failing runCommand so that
+      # `nix flake check --no-build` still catches it.
+      allowlistGlobs =
+        let
+          globOf =
+            line:
+            let
+              m = builtins.match "[[:space:]]*([^#[:space:]]+).*" line;
+            in
+            if m == null then null else lib.head m;
+        in
+        lib.filter (glob: glob != null) (
+          map globOf (lib.splitString "\n" (builtins.readFile ../../scripts/cache-coverage-allowlist.txt))
+        );
+
+      globMatches =
+        name: glob:
+        builtins.match (builtins.replaceStrings [ "." "+" "*" "?" ] [ "\\." "\\+" ".*" "." ] glob) name
+        != null;
+
+      allowlistedPublished = lib.filter (entry: lib.any (globMatches entry.name) allowlistGlobs) entries;
     in
     {
       packages = lib.mkIf (hostPkgs.stdenv.hostPlatform.system == system) {
-        cache-roots = pkgs.linkFarm "cache-roots" (
-          map (name: {
-            inherit name;
-            path = assertFree name hostPkgs.${name};
-          }) hostPackageNames
-          ++ lib.mapAttrsToList (
-            name: optionPath:
-            let
-              enablePath = lib.init optionPath ++ [ "enable" ];
-            in
-            {
-              inherit name;
-              path =
-                if lib.getAttrFromPath enablePath hostConfig then
-                  assertFree name (lib.getAttrFromPath optionPath hostConfig)
-                else
-                  throw "cache-roots: ${name} is sourced from ${lib.concatStringsSep "." optionPath}, but that module is disabled on ${primaryHost}";
-            }
-          ) hostFinalPackagePaths
-          ++ map (name: {
-            inherit name;
-            path = assertFree name self'.packages.${name};
-          }) perSystemPackageNames
-          ++ [
-            # modules/agents/mcp.nix resolves MCP server packages from the
-            # mcp-servers-nix input; hostPkgs carries a same-named but
-            # different context7-mcp derivation no consumer runs.
-            {
-              name = "context7-mcp";
-              path = assertFree "context7-mcp" inputs'.mcp-servers-nix.packages.context7-mcp;
-            }
-            {
-              name = "codex";
-              path = assertFree "codex" inputs'.llm-agents.packages.codex;
-            }
-          ]
-        );
+        cache-roots = pkgs.linkFarm "cache-roots" entries;
       };
+
+      checks.cache-roots-allowlist-disjoint =
+        if allowlistedPublished == [ ] then
+          pkgs.runCommand "cache-roots-allowlist-disjoint" { } "touch $out"
+        else
+          throw "cache-roots: ${
+            lib.concatMapStringsSep ", " (entry: entry.name) allowlistedPublished
+          } is published by cache-roots.nix and also matched by a glob in scripts/cache-coverage-allowlist.txt; allowlisting and caching are mutually exclusive dispositions. Delete the glob (docs/reference/cache-coverage.md).";
     };
 }

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -144,6 +144,11 @@ in
       # version: the key alone would miss `proton-vpn-[0-9]*` against a
       # `proton-vpn-4.16.5` derivation, and version-anchored globs are already
       # the file's convention for wrapper entries.
+      #
+      # The domain is the entries, not the closure members cache-push also
+      # serves: that closure does not exist at evaluation time. A glob written
+      # against a closure member (nemo-[0-9]* under nemo-with-extensions) still
+      # passes here; https://github.com/Bad3r/nixos/issues/428 covers it from CI.
       allowlistGlobs =
         let
           globOf =

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -137,6 +137,13 @@ in
       # `entries` so the guard cannot fall behind the linkFarm. The failure is a
       # throw rather than a failing runCommand so that
       # `nix flake check --no-build` still catches it.
+      #
+      # Each entry is matched on all three strings the glob could have been
+      # written against, because scripts/cache-coverage.sh matches derivation
+      # name and pname while the linkFarm key is hand-chosen and carries no
+      # version: the key alone would miss `proton-vpn-[0-9]*` against a
+      # `proton-vpn-4.16.5` derivation, and version-anchored globs are already
+      # the file's convention for wrapper entries.
       allowlistGlobs =
         let
           globOf =
@@ -155,19 +162,31 @@ in
         builtins.match (builtins.replaceStrings [ "." "+" "*" "?" ] [ "\\." "\\+" ".*" "." ] glob) name
         != null;
 
-      allowlistedPublished = lib.filter (entry: lib.any (globMatches entry.name) allowlistGlobs) entries;
+      allowlistedPublished = lib.filter (
+        entry:
+        lib.any (candidate: lib.any (globMatches candidate) allowlistGlobs) (
+          [ entry.name ]
+          ++ lib.optional (entry.path ? name) entry.path.name
+          ++ lib.optional (entry.path ? pname) entry.path.pname
+        )
+      ) entries;
     in
     {
       packages = lib.mkIf (hostPkgs.stdenv.hostPlatform.system == system) {
         cache-roots = pkgs.linkFarm "cache-roots" entries;
       };
 
-      checks.cache-roots-allowlist-disjoint =
-        if allowlistedPublished == [ ] then
-          pkgs.runCommand "cache-roots-allowlist-disjoint" { } "touch $out"
-        else
-          throw "cache-roots: ${
-            lib.concatMapStringsSep ", " (entry: entry.name) allowlistedPublished
-          } is published by cache-roots.nix and also matched by a glob in scripts/cache-coverage-allowlist.txt; allowlisting and caching are mutually exclusive dispositions. Delete the glob (docs/reference/cache-coverage.md).";
+      # Gated with packages above: the guard reads each entry's derivation, so
+      # it belongs on the system that publishes them rather than resolving the
+      # primary host's package set under every other perSystem instance.
+      checks = lib.mkIf (hostPkgs.stdenv.hostPlatform.system == system) {
+        cache-roots-allowlist-disjoint =
+          if allowlistedPublished == [ ] then
+            pkgs.runCommand "cache-roots-allowlist-disjoint" { } "touch $out"
+          else
+            throw "cache-roots: ${
+              lib.concatMapStringsSep ", " (entry: entry.name) allowlistedPublished
+            } is published by cache-roots.nix and also matched by a glob in scripts/cache-coverage-allowlist.txt; allowlisting and caching are mutually exclusive dispositions. Delete the glob (docs/reference/cache-coverage.md).";
+      };
     };
 }

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -138,12 +138,15 @@ in
       # throw rather than a failing runCommand so that
       # `nix flake check --no-build` still catches it.
       #
-      # Each entry is matched on all three strings the glob could have been
-      # written against, because scripts/cache-coverage.sh matches derivation
-      # name and pname while the linkFarm key is hand-chosen and carries no
-      # version: the key alone would miss `proton-vpn-[0-9]*` against a
-      # `proton-vpn-4.16.5` derivation, and version-anchored globs are already
-      # the file's convention for wrapper entries.
+      # Matched on the derivation name and pname, which is what
+      # scripts/cache-coverage.sh matches globs against: the linkFarm key is
+      # hand-chosen and carries no version, so the key alone would miss
+      # `proton-vpn-[0-9]*` against a `proton-vpn-4.16.5` derivation, and
+      # version-anchored globs are already the file's convention for wrapper
+      # entries. The key is checked too. The detector never sees it, so a glob
+      # spelled that way suppresses nothing, but it states the same disposition
+      # this rule forbids, and it is the one candidate guaranteed to exist when
+      # a path exposes neither name nor pname.
       #
       # The domain is the entries, not the closure members cache-push also
       # serves: that closure does not exist at evaluation time. A glob written

--- a/scripts/cache-coverage-allowlist.txt
+++ b/scripts/cache-coverage-allowlist.txt
@@ -10,7 +10,8 @@
 # exclusive: this file accepts a permanent local build, that list publishes
 # the package instead. Adding a name there means deleting the glob here in
 # the same change, or the dead glob absorbs the next regression on that name.
-# See docs/reference/cache-coverage.md.
+# The cache-roots-allowlist-disjoint flake check fails evaluation when a name
+# appears in both. See docs/reference/cache-coverage.md.
 
 # Fork or version pins carried as custom overlays
 # (modules/custom-overlays/<name>.nix).

--- a/scripts/cache-coverage-allowlist.txt
+++ b/scripts/cache-coverage-allowlist.txt
@@ -5,14 +5,17 @@
 #
 # Keep every entry tied to its owning module and remove the entry together
 # with the override so real regressions stay visible.
+#
+# A glob here and a name in modules/meta/cache-roots.nix are mutually
+# exclusive: this file accepts a permanent local build, that list publishes
+# the package instead. Adding a name there means deleting the glob here in
+# the same change, or the dead glob absorbs the next regression on that name.
+# See docs/reference/cache-coverage.md.
 
 # Fork or version pins carried as custom overlays
 # (modules/custom-overlays/<name>.nix).
 age-plugin-fido2prf*
-electron-mail*
-firefoxpwa* # covers firefoxpwa and firefoxpwa-unwrapped
 librepods*
-proton-vpn*
 snixembed*
 subjack*
 


### PR DESCRIPTION
## Summary

Remove Garnix from this configuration and replan the cache coverage it was
supposed to provide.

Garnix shut down on 2026-07-15 per https://garnix.io/blog/shutting-down/,
deleted every stored build artifact, and open sourced its CI with no public
successor instance. `cache.garnix.io` answers HTTP 502 from garnix's own nginx
(`x-garnix-backend: garnix-server1`). Keeping the endpoint configured blocks
builds instead of letting the remaining substituters or the local build
fallback proceed.

Removal:

- Drop `cache.garnix.io` from the common NixOS substituter list and the
  `build.sh` bootstrap list.
- Drop the retired signing key
  `cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g=`.
- Collapse the Garnix audit section in `docs/reference/binary-cache-coverage.md`
  to a single retired note. Garnix now appears nowhere else in the repo.

Replan:

Garnix needs no replacement service. Attic and Harmonia reintroduce a server
to operate, which is the dependency issue #382 removed; FlakeHub Cache is paid
and pairs with Determinate Nix while hosts here run Lix. The mechanism that
resolves #382 is already running: `modules/meta/cache-roots.nix` builds the
custom closure, `.github/workflows/cache-push.yml` pushes it to
`bad3r-nixos.cachix.org`, and `update-flake.yml` keeps the pushed revision in
step with the lock hosts evaluate. The "Push closure to Cachix" step concludes
`success` on merges to `main`, and the cache serves `Priority: 41`.

What Garnix would have contributed is output enumeration, not hosting. It built
flake outputs on its own; `cache-roots.nix` publishes a list typed by hand,
while `scripts/cache-coverage-allowlist.txt` separately suppresses divergences
(age-plugin-fido2prf, librepods, snixembed, subjack, cewl, normcap, zap,
system76-power, nixos-icons, nixos-option) that `cache-roots.nix` never
publishes. The docs now record that gap and state that allowlisting and caching
are mutually exclusive dispositions, so the two lists stop drifting apart. The
RAR-enabled p7zip and the configuration wrappers stay permanently allowlisted
under that rule rather than counting as reconciliation debt.
`docs/reference/cache-coverage.md` and
`docs/reference/binary-cache-coverage.md` describe one mechanism and now
cross-link as detector and publisher.

Reconciliation:

`electron-mail*`, `firefoxpwa*`, and `proton-vpn*` sat in the allowlist while
`cache-roots.nix` publishes all three through `hostPackageNames`, so the tree
contradicted the rule this branch adds. Those globs are deleted here, and the
allowlist header now carries the rule at the point it is enforced.

Deleting them surfaced a failure the `proton-vpn*` glob was masking. `cachix
push` uploads the runtime closure of the cache-roots `linkFarm`, so only an
entry's default output reaches the cache: `proton-vpn`'s `out` answers 200 from
`bad3r-nixos.cachix.org` while its `dist` answers 404 everywhere, and `nemo`
behaves the same way across `out` and `dev`. The detector probes every output,
so both classify as `unexpected-local`. That is recorded as coverage gap 4 and
tracked in https://github.com/Bad3r/nixos/issues/426, because the candidate
fixes (publish every output, push the build-time closure, or narrow the
detector to referenced outputs) are separate design decisions. Neither name is
re-allowlisted: a glob would restore coverage on paper and suppress the next
real divergence on that package.

Enforcement:

The mutual-exclusivity rule was stated in prose and enforced by nothing, and
the three violating globs above were found by a hand-run cross-check. That
check now lives in the repo: `cache-roots-allowlist-disjoint` in
`modules/meta/cache-roots.nix` parses the allowlist, converts each glob to a
regex, and matches it against every published entry's derivation `name` and
`pname`, which are the strings the detector matches globs against, plus the
`linkFarm` key, which suppresses nothing but declares the disposition the rule
forbids. The entries
are read off the list the `linkFarm` is built from, so the guard cannot fall
behind the published set. The failure is a throw rather
than a failing `runCommand`, because `nix flake check --no-build` computes
derivations without building them and a fail-drv would not gate CI. An empty
parse of the allowlist throws instead of comparing nothing, so a format change
cannot turn the guard green, matching the vacuity guard in
`modules/meta/ci-lix-parity.nix`. The guard's domain is the published entries;
the closure members the push also serves do not exist at evaluation time, and
covering them from CI is
https://github.com/Bad3r/nixos/issues/428.

The same treatment is applied to the invariant the bootstrap fix below relies
on. `modules/meta/bootstrap-substituter-parity.nix` parses
`BOOTSTRAP_SUBSTITUTERS` and `BOOTSTRAP_TRUSTED_KEYS` out of `build.sh` and
throws when a substituter or key the primary host trusts is absent from them.
It covers every registered host, not just the primary, because `build.sh`
bootstraps whichever host it runs on, and `extra-substituters` counts the same
as `substituters` because the bootstrap write replaces the whole list. The
comparison is directional, so region mirrors for other networks do not trip it;
commented-out entries do not count as configured; `cache.nixos.org` is compared
with its trailing slash stripped because the NixOS module default spells it
with one; and an array that is missing, unclosed, or empty throws rather than
comparing against an over-wide or empty list.

Both guards are throws inside `perSystem.checks`, which enforce nothing unless
something forces `checks.<system>`. `check.yml` was `workflow_dispatch` only and
the sole `pull_request` workflow is the review bot, so it now also runs on
`pull_request`: its "Check flake" step already forces every
`checks.x86_64-linux` drvPath, so the trigger was the only missing piece.
`pull_request` rather than `pull_request_target`, after auditing the workflow
for untrusted interpolation: no `github.event` field reaches any `run:` step, so
a fork PR runs with a read-only token and no injection surface.

Bootstrap trust:

`configure_nix_config` in `build.sh` writes `substituters =`, replacing the list
rather than extending it, and `BOOTSTRAP_SUBSTITUTERS` never carried
`https://bad3r-nixos.cachix.org`. The one path that runs on a machine with
nothing in its store therefore had the repo's own cache unreachable and rebuilt
the cache-roots closure locally, which is what `cache-push.yml` exists to
prevent. The URL and its signing key are added here, matching
`modules/hosts/common/nix-substituters.nix` and the `publicSigningKeys` the
Cachix API reports for the cache. The sibling repo-owned cache
`nix-logseq-git-flake.cachix.org` was already in both arrays, so the omission
was an oversight rather than a deliberate exclusion.

Follow-up work is tracked rather than bundled here:

- https://github.com/Bad3r/nixos/issues/422 derive the publish set from the
  coverage report instead of a hand-maintained list
- https://github.com/Bad3r/nixos/issues/423 source cache-roots from every
  registered host, not just the primary
- https://github.com/Bad3r/nixos/issues/424 gate cache coverage in `check.yml`
- https://github.com/Bad3r/nixos/issues/426 publish every output of a
  multi-output cache-roots entry
- https://github.com/Bad3r/nixos/issues/428 extend the disjointness guard to
  the pushed closure members, which evaluation cannot see
- https://github.com/Bad3r/nixos/issues/430 fail bootstrap parity on
  substituters no host trusts, once the four surplus entries are dispositioned

Issue https://github.com/Bad3r/nixos/issues/382 is rewritten to match: its
Phase 1 was entirely a Garnix coverage audit and is now void.

## Test plan

- `bash -n build.sh`
- `nix develop path:. -c pre-commit run --files build.sh ...` (shellcheck,
  treefmt, typos passed)
- Parity check: every cachix URL and trusted key in
  `modules/hosts/common/nix-substituters.nix` is present in `build.sh`.
- `nix-instantiate --parse modules/hosts/common/nix-substituters.nix`
- Evaluated `config.nix.settings.substituters` and trusted keys per host with
  `nix eval --offline`; no `cache.garnix.io` entry and no retired key remains.
- `nix run path:.#formatter.x86_64-linux -- docs/reference/binary-cache-coverage.md docs/reference/cache-coverage.md scripts/cache-coverage-allowlist.txt`
- `nix develop path:. -c pre-commit run --files docs/reference/binary-cache-coverage.md docs/reference/cache-coverage.md`
  (treefmt, typos passed)
- `scripts/cache-coverage.sh --host system76`: FAIL, 2 unexpected-local (nemo
  7.5M, proton-vpn 3.0M).
- `scripts/cache-coverage.sh --host system76 --allowlist <pre-change copy>`:
  FAIL, 1 unexpected-local (nemo 7.5M). The gate was already red on `main`;
  this branch adds only proton-vpn, which the deleted glob was hiding.
- `curl` narinfo probes against `cache.nixos.org` and `bad3r-nixos.cachix.org`
  for `proton-vpn` `out`/`dist` and `nemo` `out`/`dev`: `out` 200 on
  bad3r-nixos, `dist` and `dev` 404 on both.
- `nix flake check path:. --accept-flake-config --no-build --offline`: exit 0.
- `pre-commit run --files .github/workflows/check.yml` (actionlint, yamllint,
  treefmt, typos passed); `yq` reports the triggers as `workflow_dispatch,
  pull_request`.
- Prioritized spelling `https://bad3r-nixos.cachix.org?priority=41` resolves to
  the same check drvPath rather than reading as absent, and deleting the entry
  outright still throws.
- Same command with `proton-vpn*` reintroduced into the allowlist: exit 1 with
  `cache-roots: proton-vpn is published by cache-roots.nix and also matched by
  a glob`, proving the new check gates a `--no-build` run. Allowlist restored
  and confirmed identical afterwards.
- Glob translation checked against `firefox-esr`, which `firefox-[0-9]*` must
  not match, and against zap, p7zip, and nixos-option, which their globs must.
- `proton-vpn-[0-9]*` appended to the allowlist: eval throws for proton-vpn,
  covering the version-anchored spelling the detector matches.
- Allowlist reduced to comments: eval throws the vacuity error rather than
  passing.
- `bad3r-nixos.cachix.org` deleted from `BOOTSTRAP_SUBSTITUTERS`: eval throws
  `system76 trusts https://bad3r-nixos.cachix.org but build.sh omits it`,
  reproducing the bug this PR fixes.
- `BOOTSTRAP_SUBSTITUTERS` renamed: eval throws `has no closed
  BOOTSTRAP_SUBSTITUTERS=( ... ) array`.
- Closing paren changed to `) # trailing comment`: parses to the identical
  check drvPath, so the fail-open widening path is gone.
- `bad3r-nixos.cachix.org` removed: the throw names both hosts
  (`system76 trusts ...; tpnix trusts ...`), confirming every registered host
  is read.
- `build.sh` and the allowlist restored and confirmed byte-identical after
  every negative run.
- `cache-roots` still resolves to the same 13 entries after the `entries`
  extraction (codeburn, codex, context7-mcp, electron-mail, firefoxpwa, john,
  nemo-with-extensions, planify, proton-vpn, restringer, tweakcc, upscayl,
  wappalyzer-next).
- Pre-push hooks passed: apps-catalog-sync, flake-checker, gitleaks,
  managed-files-drift.
- `git diff --check`
- `rg -ni garnix` confirms mentions are confined to the retired note.

Shutdown evidence, in case the marketing site's continued availability is
misleading: `curl -i https://cache.garnix.io/nix-cache-info` returns 502, and
the migration wave is visible in argumentcomputer/ix#493, obeli-sk/obelisk#691,
codgician/nur-packages#288, and bashfulrobot/nixerator#334.

No host closure was rebuilt for this PR: the changes are a substituter list
edit, an allowlist edit, a guard that adds a check output without touching the
published set, and documentation. The removed cache served nothing.