### PR TITLE
fix(packages): run updaters under Lix instead of the CppNix nix shebang

### DIFF
--- a/docs/guides/custom-packages-style-guide.md
+++ b/docs/guides/custom-packages-style-guide.md
@@ -38,6 +38,15 @@ packages/
 
 Use `hashes.json` when a package has multiple update-managed pins, such as `version`, `srcHash`, and `cargoHash`. Add `update.py` when the package can be updated mechanically from upstream release metadata. Expose it from the derivation with `passthru.updateScript = ./update.py;`.
 
+Start `update.py` with a `nix-shell` shebang so the script stays runnable on its own:
+
+```python
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
+```
+
+Lix implements no `#!/usr/bin/env nix` shebang, so the CppNix `#! nix shell ...` form fails with `is not a recognised command`. The shebang requests only `python3`; `nix` and `nix-prefetch-url` come from the ambient Lix that runs the shebang.
+
 ## Package Template
 
 Use the appropriate builder for your package type. All packages must include a `meta` attribute set.

--- a/docs/guides/custom-packages-style-guide.md
+++ b/docs/guides/custom-packages-style-guide.md
@@ -45,7 +45,7 @@ Start `update.py` with a `nix-shell` shebang so the script stays runnable on its
 #! nix-shell -i python3 --packages python3
 ```
 
-Lix implements no `#!/usr/bin/env nix` shebang, so the CppNix `#! nix shell ...` form fails with `is not a recognised command`. The shebang requests only `python3`; `nix` and `nix-prefetch-url` come from the ambient Lix that runs the shebang.
+Lix implements no `#!/usr/bin/env nix` shebang, so the CppNix `#! nix shell ...` form fails with `is not a recognised command`. The shebang requests `python3`; `nix` and `nix-prefetch-url` come from the ambient Lix that runs the shebang. An updater that invokes another command directly must add its package to `--packages`, such as `yq-go` for `packages/webcrack/update.py`; otherwise it depends on the caller's `PATH`.
 
 ## Package Template
 

--- a/docs/guides/custom-packages-style-guide.md
+++ b/docs/guides/custom-packages-style-guide.md
@@ -47,6 +47,8 @@ Start `update.py` with a `nix-shell` shebang so the script stays runnable on its
 
 Lix implements no `#!/usr/bin/env nix` shebang, so the CppNix `#! nix shell ...` form fails with `is not a recognised command`. The shebang requests `python3`; `nix` and `nix-prefetch-url` come from the ambient Lix that runs the shebang. An updater that invokes another command directly must add its package to `--packages`, such as `yq-go` for `packages/webcrack/update.py`; otherwise it depends on the caller's `PATH`.
 
+`--packages` resolves `<nixpkgs>` from the Nix search path rather than from this flake's inputs. Hosts configured by this repository provide it through `nix.nixPath` (`modules/base/nixpkgs.nix`, which also disables channels), so updaters run only where that path is set; on an unconfigured machine they fail with `file 'nixpkgs' was not found in the Nix search path`. Do not try to pin the flake input instead: Lix `nix-shell` rejects the CppNix `--inputs-from` flag.
+
 ## Package Template
 
 Use the appropriate builder for your package type. All packages must include a `meta` attribute set.

--- a/packages/age-plugin-fido2prf/update.py
+++ b/packages/age-plugin-fido2prf/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for age-plugin-fido2prf."""
 
 from __future__ import annotations

--- a/packages/azd/update.py
+++ b/packages/azd/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for azd."""
 
 from __future__ import annotations

--- a/packages/brave-origin/update.py
+++ b/packages/brave-origin/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for brave-origin."""
 
 from __future__ import annotations

--- a/packages/charles/update.py
+++ b/packages/charles/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for Charles."""
 
 from __future__ import annotations

--- a/packages/codeburn/update.py
+++ b/packages/codeburn/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for codeburn."""
 
 from __future__ import annotations

--- a/packages/electron-mail/update.py
+++ b/packages/electron-mail/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for electron-mail."""
 
 from __future__ import annotations

--- a/packages/gitlawb/update.py
+++ b/packages/gitlawb/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for gitlawb."""
 
 from __future__ import annotations

--- a/packages/malimite/update.py
+++ b/packages/malimite/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for malimite."""
 
 from __future__ import annotations

--- a/packages/opendirectorydownloader/update.py
+++ b/packages/opendirectorydownloader/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for opendirectorydownloader."""
 
 from __future__ import annotations

--- a/packages/restringer/update.py
+++ b/packages/restringer/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for restringer."""
 
 from __future__ import annotations

--- a/packages/searchfox-cli/update.py
+++ b/packages/searchfox-cli/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for searchfox-cli."""
 
 from __future__ import annotations

--- a/packages/source-map-explorer/update.py
+++ b/packages/source-map-explorer/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for source-map-explorer."""
 
 from __future__ import annotations

--- a/packages/tweakcc/update.py
+++ b/packages/tweakcc/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell --inputs-from .# nixpkgs#python3 --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 
 """Update script for tweakcc.
 

--- a/packages/wakaru/update.py
+++ b/packages/wakaru/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for wakaru.
 
 Upstream migrated the project from a pnpm JavaScript monorepo (``cli-v*`` tags,

--- a/packages/wappalyzer-next/update.py
+++ b/packages/wappalyzer-next/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for wappalyzer-next."""
 
 from __future__ import annotations

--- a/packages/webcrack/update.py
+++ b/packages/webcrack/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix nixpkgs#yq-go --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for webcrack."""
 
 from __future__ import annotations

--- a/packages/webcrack/update.py
+++ b/packages/webcrack/update.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#! nix-shell -i python3 --packages python3
+#! nix-shell -i python3 --packages python3 yq-go
 """Update script for webcrack."""
 
 from __future__ import annotations

--- a/packages/wfuzz/update.py
+++ b/packages/wfuzz/update.py
@@ -1,5 +1,5 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#python3 nixpkgs#nix --command python3
+#!/usr/bin/env nix-shell
+#! nix-shell -i python3 --packages python3
 """Update script for wfuzz."""
 
 from __future__ import annotations

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -18,8 +18,8 @@ repository-wide workflow, commit, PR, safety, and Nix module rules.
 - `prune-stale-worktrees.sh`: prunes branches with gone upstreams and their
   worktrees; wrapped by the `worktree-prune` Home Manager timer. Tests live in
   `tests/prune-stale-worktrees/run.sh`; see `docs/reference/worktree-prune.md`.
-- `tests/run-packages-updaters/run.sh`: fixture coverage for updater-runner
-  arguments, empty roots, exit-code propagation, and fail-fast dispatch.
+- `run-packages-updaters.sh`: runs package updaters from the repository root;
+  fixture coverage lives in `../tests/run-packages-updaters/run.sh`.
 - Top-level scripts are task-specific entrypoints. Keep them runnable from the
   repository root and avoid hidden dependencies on the current shell session.
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -17,9 +17,9 @@ repository-wide workflow, commit, PR, safety, and Nix module rules.
   CppNix-only `nix hash convert`.
 - `prune-stale-worktrees.sh`: prunes branches with gone upstreams and their
   worktrees; wrapped by the `worktree-prune` Home Manager timer. Tests live in
-  `tests/prune-stale-worktrees/run.sh`; see `docs/reference/worktree-prune.md`.
+  `./tests/prune-stale-worktrees/run.sh`; see `./docs/reference/worktree-prune.md`.
 - `run-packages-updaters.sh`: runs package updaters from the repository root;
-  fixture coverage lives in `../tests/run-packages-updaters/run.sh`.
+  fixture coverage lives in `./tests/run-packages-updaters/run.sh`.
 - Top-level scripts are task-specific entrypoints. Keep them runnable from the
   repository root and avoid hidden dependencies on the current shell session.
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -17,9 +17,9 @@ repository-wide workflow, commit, PR, safety, and Nix module rules.
   CppNix-only `nix hash convert`.
 - `prune-stale-worktrees.sh`: prunes branches with gone upstreams and their
   worktrees; wrapped by the `worktree-prune` Home Manager timer. Tests live in
-  `./tests/prune-stale-worktrees/run.sh`; see `./docs/reference/worktree-prune.md`.
+  `tests/prune-stale-worktrees/run.sh`; see `docs/reference/worktree-prune.md`.
 - `run-packages-updaters.sh`: runs package updaters from the repository root;
-  fixture coverage lives in `./tests/run-packages-updaters/run.sh`.
+  fixture coverage lives in `tests/run-packages-updaters/run.sh`.
 - Top-level scripts are task-specific entrypoints. Keep them runnable from the
   repository root and avoid hidden dependencies on the current shell session.
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -33,7 +33,8 @@ For scripts with inline dependencies, use the `uv run --script` metadata block
 pattern already used by `url-catalog-add.py`. Package updaters under
 `packages/*/update.py` instead use a `nix-shell` shebang
 (`#! nix-shell -i python3 --packages python3`) because Lix has no
-`#!/usr/bin/env nix` shebang.
+`#!/usr/bin/env nix` shebang. Add packages for commands invoked directly,
+such as `yq-go` in `packages/webcrack/update.py`.
 
 ## Validation Commands
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -13,6 +13,8 @@ repository-wide workflow, commit, PR, safety, and Nix module rules.
 - `hooks/`: generated-hook installation and sync helpers used by the dev shell.
 - `updater/`: shared Python library for package updater scripts. Reuse these
   helpers instead of duplicating HTTP, hash, Nix, npm, or version parsing logic.
+  Nix invocations must use spellings Lix implements: `nix hash to-sri`, not the
+  CppNix-only `nix hash convert`.
 - `prune-stale-worktrees.sh`: prunes branches with gone upstreams and their
   worktrees; wrapped by the `worktree-prune` Home Manager timer. Tests live in
   `tests/prune-stale-worktrees/run.sh`; see `docs/reference/worktree-prune.md`.
@@ -28,7 +30,10 @@ commands. Prefer clear exit codes and stderr diagnostics over silent fallback.
 Python scripts should keep side effects behind `main()` style entrypoints,
 raise explicit exceptions for malformed upstream data, and use typed helpers.
 For scripts with inline dependencies, use the `uv run --script` metadata block
-pattern already used by `url-catalog-add.py`.
+pattern already used by `url-catalog-add.py`. Package updaters under
+`packages/*/update.py` instead use a `nix-shell` shebang
+(`#! nix-shell -i python3 --packages python3`) because Lix has no
+`#!/usr/bin/env nix` shebang.
 
 ## Validation Commands
 

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -18,6 +18,8 @@ repository-wide workflow, commit, PR, safety, and Nix module rules.
 - `prune-stale-worktrees.sh`: prunes branches with gone upstreams and their
   worktrees; wrapped by the `worktree-prune` Home Manager timer. Tests live in
   `tests/prune-stale-worktrees/run.sh`; see `docs/reference/worktree-prune.md`.
+- `tests/run-packages-updaters/run.sh`: fixture coverage for updater-runner
+  arguments, empty roots, exit-code propagation, and fail-fast dispatch.
 - Top-level scripts are task-specific entrypoints. Keep them runnable from the
   repository root and avoid hidden dependencies on the current shell session.
 

--- a/scripts/run-packages-updaters.sh
+++ b/scripts/run-packages-updaters.sh
@@ -4,7 +4,7 @@
 set -euo pipefail
 
 usage() {
-  printf 'Usage: %s\n\nRuns every packages/*/update.py from the repository root.\n' "${0##*/}"
+  printf 'Usage: %s [-h|--help]\n\nRuns packages/*/update.py in order from the repository root, stopping at the\nfirst updater that fails and exiting with its status.\n' "${0##*/}"
 }
 
 if [ "$#" -gt 0 ]; then

--- a/scripts/run-packages-updaters.sh
+++ b/scripts/run-packages-updaters.sh
@@ -1,15 +1,16 @@
-#!/usr/bin/env nix
-#! nix shell nixpkgs#dash --command dash
-# shellcheck shell=dash
+#!/usr/bin/env bash
+# shellcheck shell=bash
 
-set -eu
+set -euo pipefail
 
-total=0
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
 
-for updater in packages/*/update.py; do
-  [ -f "$updater" ] || continue
-  total=$((total + 1))
-done
+shopt -s nullglob
+updaters=(packages/*/update.py)
+shopt -u nullglob
+
+total=${#updaters[@]}
 
 if [ "$total" -eq 0 ]; then
   printf 'No package updaters found.\n'
@@ -20,8 +21,7 @@ index=0
 
 printf 'Package updaters: %s\n' "$total"
 
-for updater in packages/*/update.py; do
-  [ -f "$updater" ] || continue
+for updater in "${updaters[@]}"; do
   index=$((index + 1))
 
   printf '\n[%s/%s] %s\n' "$index" "$total" "$updater"

--- a/scripts/run-packages-updaters.sh
+++ b/scripts/run-packages-updaters.sh
@@ -3,6 +3,27 @@
 
 set -euo pipefail
 
+usage() {
+  printf 'Usage: %s\n\nRuns every packages/*/update.py from the repository root.\n' "${0##*/}"
+}
+
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+  -h | --help)
+    if [ "$#" -ne 1 ]; then
+      usage >&2
+      exit 2
+    fi
+    usage
+    exit 0
+    ;;
+  *)
+    usage >&2
+    exit 2
+    ;;
+  esac
+fi
+
 repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
@@ -13,8 +34,8 @@ shopt -u nullglob
 total=${#updaters[@]}
 
 if [ "$total" -eq 0 ]; then
-  printf 'No package updaters found.\n'
-  exit 0
+  printf 'No package updaters found under %s/packages.\n' "$repo_root" >&2
+  exit 1
 fi
 
 index=0

--- a/scripts/updater/nix.py
+++ b/scripts/updater/nix.py
@@ -216,7 +216,7 @@ def nix_prefetch_url(url: str, *, unpack: bool = False) -> str:
     # nix-prefetch-url returns base32-encoded hash, convert to SRI
     hash_b32 = result.stdout.strip()
 
-    # Convert to SRI format by using nix hash convert
-    convert_args = ["hash", "convert", "--hash-algo", "sha256", hash_b32]
+    # `nix hash convert` is CppNix-only; Lix spells this `nix hash to-sri`.
+    convert_args = ["hash", "to-sri", "--type", "sha256", hash_b32]
     convert_result = nix_command(convert_args)
     return convert_result.stdout.strip()

--- a/tests/run-packages-updaters/run.sh
+++ b/tests/run-packages-updaters/run.sh
@@ -100,13 +100,16 @@ write_updater() {
 test_help_exits_before_discovery() {
   local err out
   make_fixture help
+  export RUN_LOG="${fixture_root}/run.log"
+  write_updater 01-first first 0
   out="${tmpdir}/help.out"
   err="${tmpdir}/help.err"
   run_sut "${out}" "${err}" --help
 
   [[ ${sut_status} -eq 0 ]] || fail "help: expected exit 0, got ${sut_status}" "${err}"
   assert_contains "${out}" 'Usage: run-packages-updaters.sh [-h|--help]' 'help'
-  assert_not_contains "${out}" 'No package updaters found' 'help'
+  assert_not_contains "${out}" 'Package updaters:' 'help'
+  [[ ! -e ${RUN_LOG} ]] || fail 'help: an updater was executed' "${out}"
   assert_empty "${err}" 'help stderr'
   pass
 }
@@ -114,6 +117,8 @@ test_help_exits_before_discovery() {
 test_rejects_unknown_argument() {
   local err out
   make_fixture unknown
+  export RUN_LOG="${fixture_root}/run.log"
+  write_updater 01-first first 0
   out="${tmpdir}/unknown.out"
   err="${tmpdir}/unknown.err"
   run_sut "${out}" "${err}" --unexpected
@@ -121,12 +126,15 @@ test_rejects_unknown_argument() {
   [[ ${sut_status} -eq 2 ]] || fail "unknown: expected exit 2, got ${sut_status}" "${err}"
   assert_empty "${out}" 'unknown stdout'
   assert_contains "${err}" 'Usage: run-packages-updaters.sh [-h|--help]' 'unknown'
+  [[ ! -e ${RUN_LOG} ]] || fail 'unknown: an updater was executed' "${out}"
   pass
 }
 
 test_rejects_extra_help_argument() {
   local err out
   make_fixture extra-help
+  export RUN_LOG="${fixture_root}/run.log"
+  write_updater 01-first first 0
   out="${tmpdir}/extra-help.out"
   err="${tmpdir}/extra-help.err"
   run_sut "${out}" "${err}" --help extra
@@ -134,6 +142,7 @@ test_rejects_extra_help_argument() {
   [[ ${sut_status} -eq 2 ]] || fail "extra-help: expected exit 2, got ${sut_status}" "${err}"
   assert_empty "${out}" 'extra-help stdout'
   assert_contains "${err}" 'Usage: run-packages-updaters.sh [-h|--help]' 'extra-help'
+  [[ ! -e ${RUN_LOG} ]] || fail 'extra-help: an updater was executed' "${out}"
   pass
 }
 

--- a/tests/run-packages-updaters/run.sh
+++ b/tests/run-packages-updaters/run.sh
@@ -48,7 +48,7 @@ run_sut() {
   out="$1"
   err="$2"
   shift 2
-  if "${fixture_root}/scripts/run-packages-updaters.sh" "$@" >"${out}" 2>"${err}"; then
+  if (cd "${tmpdir}" && "${fixture_root}/scripts/run-packages-updaters.sh" "$@") >"${out}" 2>"${err}"; then
     sut_status=0
   else
     sut_status=$?

--- a/tests/run-packages-updaters/run.sh
+++ b/tests/run-packages-updaters/run.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+set -euo pipefail
+export LC_ALL=C
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="${SCRIPT_DIR}/../../scripts/run-packages-updaters.sh"
+
+if [[ ! -x ${SUT} ]]; then
+  printf 'run.sh: SUT not executable at %s\n' "${SUT}" >&2
+  exit 2
+fi
+
+tmpdir="$(mktemp -d)"
+cleanup() {
+  if [[ -d ${tmpdir} ]]; then
+    chmod -R u+w "${tmpdir}"
+    rm -r "${tmpdir}"
+  fi
+}
+trap cleanup EXIT
+
+tests_passed=0
+
+pass() {
+  tests_passed=$((tests_passed + 1))
+}
+
+fail() {
+  printf 'FAIL: %s\n' "$1" >&2
+  if [[ -n ${2:-} && -f ${2:-} ]]; then
+    printf '%s\n' '--- SUT output ---' >&2
+    cat "$2" >&2
+    printf '%s\n' '------------------' >&2
+  fi
+  exit 1
+}
+
+make_fixture() {
+  fixture_root="${tmpdir}/$1"
+  mkdir -p "${fixture_root}/scripts"
+  cp "${SUT}" "${fixture_root}/scripts/run-packages-updaters.sh"
+  chmod +x "${fixture_root}/scripts/run-packages-updaters.sh"
+}
+
+run_sut() {
+  local out
+  out="$1"
+  shift
+  if "${fixture_root}/scripts/run-packages-updaters.sh" "$@" >"${out}" 2>&1; then
+    sut_status=0
+  else
+    sut_status=$?
+  fi
+}
+
+assert_contains() {
+  local file pattern label
+  file="$1"
+  pattern="$2"
+  label="$3"
+  grep -Fq -- "${pattern}" "${file}" ||
+    fail "${label}: output does not contain '${pattern}'" "${file}"
+}
+
+assert_not_contains() {
+  local file pattern label
+  file="$1"
+  pattern="$2"
+  label="$3"
+  if grep -Fq -- "${pattern}" "${file}"; then
+    fail "${label}: output unexpectedly contains '${pattern}'" "${file}"
+  fi
+}
+
+write_updater() {
+  local name label status updater
+  name="$1"
+  label="$2"
+  status="$3"
+  updater="${fixture_root}/packages/${name}/update.py"
+
+  mkdir -p "$(dirname "${updater}")"
+  printf '%s\n' \
+    '#!/usr/bin/env bash' \
+    'set -euo pipefail' \
+    "printf '%s\\n' '${label}' >> \"\${RUN_LOG}\"" \
+    "exit ${status}" >"${updater}"
+  chmod +x "${updater}"
+}
+
+test_help_exits_before_discovery() {
+  local out
+  make_fixture help
+  out="${tmpdir}/help.out"
+  run_sut "${out}" --help
+
+  [[ ${sut_status} -eq 0 ]] || fail "help: expected exit 0, got ${sut_status}" "${out}"
+  assert_contains "${out}" 'Usage: run-packages-updaters.sh [-h|--help]' 'help'
+  assert_not_contains "${out}" 'No package updaters found' 'help'
+  pass
+}
+
+test_rejects_unknown_argument() {
+  local out
+  make_fixture unknown
+  out="${tmpdir}/unknown.out"
+  run_sut "${out}" --unexpected
+
+  [[ ${sut_status} -eq 2 ]] || fail "unknown: expected exit 2, got ${sut_status}" "${out}"
+  assert_contains "${out}" 'Usage: run-packages-updaters.sh [-h|--help]' 'unknown'
+  assert_not_contains "${out}" 'Package updaters:' 'unknown'
+  pass
+}
+
+test_rejects_extra_help_argument() {
+  local out
+  make_fixture extra-help
+  out="${tmpdir}/extra-help.out"
+  run_sut "${out}" --help extra
+
+  [[ ${sut_status} -eq 2 ]] || fail "extra-help: expected exit 2, got ${sut_status}" "${out}"
+  assert_contains "${out}" 'Usage: run-packages-updaters.sh [-h|--help]' 'extra-help'
+  pass
+}
+
+test_empty_package_root_fails() {
+  local out expected
+  make_fixture empty
+  out="${tmpdir}/empty.out"
+  expected="No package updaters found under ${fixture_root}/packages."
+  run_sut "${out}"
+
+  [[ ${sut_status} -eq 1 ]] || fail "empty: expected exit 1, got ${sut_status}" "${out}"
+  assert_contains "${out}" "${expected}" 'empty'
+  pass
+}
+
+test_stops_after_first_failure() {
+  local out actual
+  make_fixture fail-fast
+  export RUN_LOG="${fixture_root}/run.log"
+  write_updater 01-first first 0
+  write_updater 02-failing second 7
+  write_updater 03-unreached third 0
+  out="${tmpdir}/fail-fast.out"
+  run_sut "${out}"
+
+  [[ ${sut_status} -eq 7 ]] || fail "fail-fast: expected exit 7, got ${sut_status}" "${out}"
+  assert_contains "${out}" 'Package updaters: 3' 'fail-fast'
+  assert_contains "${out}" 'failed with exit code 7' 'fail-fast'
+  [[ -f ${RUN_LOG} ]] || fail 'fail-fast: updater log was not created' "${out}"
+  actual="$(<"${RUN_LOG}")"
+  [[ ${actual} == $'first\nsecond' ]] ||
+    fail "fail-fast: expected first and second updaters only, got '${actual}'" "${out}"
+  assert_not_contains "${out}" '03-unreached' 'fail-fast'
+  pass
+}
+
+test_help_exits_before_discovery
+test_rejects_unknown_argument
+test_rejects_extra_help_argument
+test_empty_package_root_fails
+test_stops_after_first_failure
+
+printf '%d passed\n' "${tests_passed}"

--- a/tests/run-packages-updaters/run.sh
+++ b/tests/run-packages-updaters/run.sh
@@ -44,10 +44,11 @@ make_fixture() {
 }
 
 run_sut() {
-  local out
+  local err out
   out="$1"
-  shift
-  if "${fixture_root}/scripts/run-packages-updaters.sh" "$@" >"${out}" 2>&1; then
+  err="$2"
+  shift 2
+  if "${fixture_root}/scripts/run-packages-updaters.sh" "$@" >"${out}" 2>"${err}"; then
     sut_status=0
   else
     sut_status=$?
@@ -73,6 +74,13 @@ assert_not_contains() {
   fi
 }
 
+assert_empty() {
+  local file label
+  file="$1"
+  label="$2"
+  [[ ! -s ${file} ]] || fail "${label}: output was not empty" "${file}"
+}
+
 write_updater() {
   local name label status updater
   name="$1"
@@ -90,65 +98,73 @@ write_updater() {
 }
 
 test_help_exits_before_discovery() {
-  local out
+  local err out
   make_fixture help
   out="${tmpdir}/help.out"
-  run_sut "${out}" --help
+  err="${tmpdir}/help.err"
+  run_sut "${out}" "${err}" --help
 
-  [[ ${sut_status} -eq 0 ]] || fail "help: expected exit 0, got ${sut_status}" "${out}"
+  [[ ${sut_status} -eq 0 ]] || fail "help: expected exit 0, got ${sut_status}" "${err}"
   assert_contains "${out}" 'Usage: run-packages-updaters.sh [-h|--help]' 'help'
   assert_not_contains "${out}" 'No package updaters found' 'help'
+  assert_empty "${err}" 'help stderr'
   pass
 }
 
 test_rejects_unknown_argument() {
-  local out
+  local err out
   make_fixture unknown
   out="${tmpdir}/unknown.out"
-  run_sut "${out}" --unexpected
+  err="${tmpdir}/unknown.err"
+  run_sut "${out}" "${err}" --unexpected
 
-  [[ ${sut_status} -eq 2 ]] || fail "unknown: expected exit 2, got ${sut_status}" "${out}"
-  assert_contains "${out}" 'Usage: run-packages-updaters.sh [-h|--help]' 'unknown'
-  assert_not_contains "${out}" 'Package updaters:' 'unknown'
+  [[ ${sut_status} -eq 2 ]] || fail "unknown: expected exit 2, got ${sut_status}" "${err}"
+  assert_empty "${out}" 'unknown stdout'
+  assert_contains "${err}" 'Usage: run-packages-updaters.sh [-h|--help]' 'unknown'
   pass
 }
 
 test_rejects_extra_help_argument() {
-  local out
+  local err out
   make_fixture extra-help
   out="${tmpdir}/extra-help.out"
-  run_sut "${out}" --help extra
+  err="${tmpdir}/extra-help.err"
+  run_sut "${out}" "${err}" --help extra
 
-  [[ ${sut_status} -eq 2 ]] || fail "extra-help: expected exit 2, got ${sut_status}" "${out}"
-  assert_contains "${out}" 'Usage: run-packages-updaters.sh [-h|--help]' 'extra-help'
+  [[ ${sut_status} -eq 2 ]] || fail "extra-help: expected exit 2, got ${sut_status}" "${err}"
+  assert_empty "${out}" 'extra-help stdout'
+  assert_contains "${err}" 'Usage: run-packages-updaters.sh [-h|--help]' 'extra-help'
   pass
 }
 
 test_empty_package_root_fails() {
-  local out expected
+  local err expected out
   make_fixture empty
   out="${tmpdir}/empty.out"
+  err="${tmpdir}/empty.err"
   expected="No package updaters found under ${fixture_root}/packages."
-  run_sut "${out}"
+  run_sut "${out}" "${err}"
 
-  [[ ${sut_status} -eq 1 ]] || fail "empty: expected exit 1, got ${sut_status}" "${out}"
-  assert_contains "${out}" "${expected}" 'empty'
+  [[ ${sut_status} -eq 1 ]] || fail "empty: expected exit 1, got ${sut_status}" "${err}"
+  assert_empty "${out}" 'empty stdout'
+  assert_contains "${err}" "${expected}" 'empty'
   pass
 }
 
 test_stops_after_first_failure() {
-  local out actual
+  local actual err out
   make_fixture fail-fast
   export RUN_LOG="${fixture_root}/run.log"
   write_updater 01-first first 0
   write_updater 02-failing second 7
   write_updater 03-unreached third 0
   out="${tmpdir}/fail-fast.out"
-  run_sut "${out}"
+  err="${tmpdir}/fail-fast.err"
+  run_sut "${out}" "${err}"
 
-  [[ ${sut_status} -eq 7 ]] || fail "fail-fast: expected exit 7, got ${sut_status}" "${out}"
+  [[ ${sut_status} -eq 7 ]] || fail "fail-fast: expected exit 7, got ${sut_status}" "${err}"
   assert_contains "${out}" 'Package updaters: 3' 'fail-fast'
-  assert_contains "${out}" 'failed with exit code 7' 'fail-fast'
+  assert_contains "${err}" 'failed with exit code 7' 'fail-fast'
   [[ -f ${RUN_LOG} ]] || fail 'fail-fast: updater log was not created' "${out}"
   actual="$(<"${RUN_LOG}")"
   [[ ${actual} == $'first\nsecond' ]] ||

--- a/tests/run-packages-updaters/run.sh
+++ b/tests/run-packages-updaters/run.sh
@@ -173,10 +173,32 @@ test_stops_after_first_failure() {
   pass
 }
 
+test_runs_all_updaters() {
+  local actual err out
+  make_fixture all-pass
+  export RUN_LOG="${fixture_root}/run.log"
+  write_updater 01-first first 0
+  write_updater 02-second second 0
+  out="${tmpdir}/all-pass.out"
+  err="${tmpdir}/all-pass.err"
+  run_sut "${out}" "${err}"
+
+  [[ ${sut_status} -eq 0 ]] || fail "all-pass: expected exit 0, got ${sut_status}" "${err}"
+  assert_contains "${out}" 'Package updaters: 2' 'all-pass'
+  assert_contains "${out}" 'done: packages/02-second/update.py' 'all-pass'
+  assert_empty "${err}" 'all-pass stderr'
+  [[ -f ${RUN_LOG} ]] || fail 'all-pass: updater log was not created' "${out}"
+  actual="$(<"${RUN_LOG}")"
+  [[ ${actual} == $'first\nsecond' ]] ||
+    fail "all-pass: expected both updaters, got '${actual}'" "${out}"
+  pass
+}
+
 test_help_exits_before_discovery
 test_rejects_unknown_argument
 test_rejects_extra_help_argument
 test_empty_package_root_fails
 test_stops_after_first_failure
+test_runs_all_updaters
 
 printf '%d passed\n' "${tests_passed}"


### PR DESCRIPTION
## Summary

`./scripts/run-packages-updaters.sh` and every `packages/*/update.py` failed with
`is not a recognised command` because they carry the CppNix-only
`#!/usr/bin/env nix` + `#! nix shell ...` shebang, which Lix does not implement.
The repository runs Lix 2.95.2 (RFC issue #282), so the whole updater fleet has
been unrunnable since the cutover.

- Package updaters now use the `nix-shell` shebang Lix implements:
  `#!/usr/bin/env nix-shell` plus `#! nix-shell -i python3 --packages python3`.
  `packages/webcrack/update.py` additionally requests `yq-go` because it
  invokes `yq` to parse the upstream pnpm lockfile.
- `nixpkgs#nix` is dropped from the shebang closure, so `nix`, `nix fmt`, and
  `nix-prefetch-url` resolve to the ambient Lix instead of CppNix 2.34.8 from
  nixpkgs.
- `updater.nix.nix_prefetch_url` used `nix hash convert`, another CppNix-only
  command that aborted hashing with `error: 'convert' is not a recognised command`.
  It now uses the Lix spelling `nix hash to-sri --type sha256`.
- `scripts/run-packages-updaters.sh` moves from dash to bash per
  `scripts/AGENTS.md`, anchors itself to the repository root, accepts only
  `-h|--help`, rejects invalid arguments before execution, stops at the first
  updater failure, and reports an empty updater set as an error.
- `docs/guides/custom-packages-style-guide.md` and `scripts/AGENTS.md` record the
  shebang form, the Lix-only Nix CLI spellings, the direct-command dependency rule,
  the nix.nixPath precondition for `nix-shell --packages`, and the committed runner
  regression suite with separate stream and cwd assertions.
- Configured hosts provide the flake's nixpkgs source through `nix.nixPath`; Lix
  `nix-shell` does not implement the old `--inputs-from .#` flag, so that CppNix
  option is not carried into the Lix-compatible shebang. Unconfigured hosts fail
  when `<nixpkgs>` is absent from the Nix search path.

## Test plan

- `bash -n scripts/run-packages-updaters.sh`
- `shellcheck scripts/run-packages-updaters.sh`
- `./scripts/run-packages-updaters.sh --help`
- `tests/run-packages-updaters/run.sh` (successful all-updater execution, help,
  invalid and extra arguments with no-dispatch assertions, empty roots,
  exit-code propagation, stop-at-first-failure ordering, stdout/stderr routing,
  and unrelated-cwd anchoring)
- `--help` launch of every `packages/*/update.py` (all start under the new shebang)
- pure `nix-shell` smoke test confirms `yq-go` provides `yq` for webcrack
- `./packages/age-plugin-fido2prf/update.py --check-release` (release metadata valid)
- `updater.nix.nix_prefetch_url` against a known archive returns an SRI hash
- `uv run ruff check scripts/updater packages/*/update.py`
- `uv run pyright scripts/updater/nix.py`
- `nix develop path:. -c pre-commit run --files <changed files>`

Refreshing the pins themselves is intentionally not part of this PR.