### PR TITLE
feat(cache-roots): publish unfree packages, source entries from every host, and add three free packages

### DIFF
--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -370,14 +370,17 @@ and a host actually installs it. License is no longer a criterion; see
   - `self'.packages`, when only the devshell surface consumes it;
   - the owning flake input, when a module consumes the input's package
     directly (context7-mcp);
-  - the option that holds the resolved package, listed in
-    `hostOptionPackages`, when the bare package-set attribute never produces
-    it or it never reaches `environment.systemPackages`
-    (nemo-with-extensions, nvidia-x11). Give the entry an `installed`
-    predicate naming the condition under which the host installs it; do not
-    assume a sibling `enable` exists, because upstream options such as
-    `hardware.nvidia.package` carry a default and stay defined on hosts that
-    never use them.
+  - the host config, listed in `hostOptionPackages`, when the bare
+    package-set attribute never produces it or it never reaches
+    `environment.systemPackages` (nemo-with-extensions, nvidia-x11). Write
+    `path` as a `hostConfig: package` function, not an option path: it may
+    reach past the option into a derivation hanging off the package
+    (`hardware.nvidia.package.settings`) or choose between derivations by
+    another option's value (`hardware.nvidia.open`). Give the entry an
+    `installed` predicate naming the condition under which the host installs
+    it; do not assume a sibling `enable` exists, because upstream options such
+    as `hardware.nvidia.package` carry a default and stay defined on hosts
+    that never use them.
 - A name enabled on no host aborts evaluation rather than publishing nothing,
   so a rename or a last-host disable fails `nix flake check` instead of leaving
   a dead entry.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -62,7 +62,12 @@ derivations built locally per full system build. Three groups remain:
 ## Build surface
 
 `packages.<system>.cache-roots` is a `linkFarm` over an explicit list of the
-packages hosts would otherwise build locally:
+packages hosts would otherwise build locally. Every output of each entry is
+linked, not just the default one: `cache-push.yml` pushes the closure of the
+built `result`, and a multi-output derivation's `outPath` does not reach its
+siblings, so those outputs would be built on CI and then dropped. `nvidia-x11`
+alone splits into `out`, `lib32`, `bin`, `modsrc`, and `firmware`. Links are
+keyed `<host>/<package>/<output>`.
 
 - Host-sourced entries read `programs.<name>.extended.package` on each host,
   which is the value those modules install, so custom overlays (firefoxpwa
@@ -82,9 +87,14 @@ packages hosts would otherwise build locally:
   `nix build --dry-run "path:.#cache-roots"` on a host that has switched
   recently should report no unexpected package rebuilds; that is the
   derivation-parity check.
-- Option-sourced entries (`hostOptionPackages`) read the option holding the
-  resolved package, for packages the bare package-set attribute never produces
-  or that never reach `environment.systemPackages` at all. Each entry carries
+- Option-sourced entries (`hostOptionPackages`) read the attribute path holding
+  the resolved package, for packages the bare package-set attribute never
+  produces or that never reach `environment.systemPackages` at all. A path may
+  reach past the option into the value it holds, for derivations that hang off
+  a package rather than being an output of it: `hardware.nvidia.package.mod` is
+  the kernel module built against `boot.kernelPackages` and installed through
+  `boot.extraModulePackages`, and `hardware.nvidia.package.settings` is
+  nvidia-settings. Linking every output does not reach either. Each entry carries
   its own `installed` predicate rather than deriving a sibling `enable` from
   the option path, because these options do not share one shape:
   `programs.nemo.extended.finalPackage` is assigned inside
@@ -167,11 +177,18 @@ enables the last six.
 Option-sourced entries, resolved from the option that holds the installed
 package:
 
-| Package              | Option                                | Hosts           |
-| -------------------- | ------------------------------------- | --------------- |
-| nemo-with-extensions | `programs.nemo.extended.finalPackage` | system76, tpnix |
-| nvidia-x11           | `hardware.nvidia.package`             | system76, tpnix |
-| steam                | `programs.steam.package`              | system76        |
+| Package               | Option                                | Hosts           |
+| --------------------- | ------------------------------------- | --------------- |
+| nemo-with-extensions  | `programs.nemo.extended.finalPackage` | system76, tpnix |
+| nvidia-x11            | `hardware.nvidia.package`             | system76, tpnix |
+| nvidia-kernel-modules | `hardware.nvidia.package.mod`         | system76, tpnix |
+| nvidia-settings       | `hardware.nvidia.package.settings`    | system76, tpnix |
+| steam                 | `programs.steam.package`              | system76        |
+
+`nvidia-kernel-modules` is gated on `hardware.nvidia.open != true`, matching
+upstream's `boot.extraModulePackages = if useOpenModules then [ nvidia_x11.open ] else [ nvidia_x11.mod ]`, and `nvidia-settings` on
+`hardware.nvidia.nvidiaSettings`. Both hosts set `open = false` and
+`nvidiaSettings = true`, so both publish both.
 
 `steam` is option-sourced because `modules/apps/steam.nix` installs nothing
 itself: it sets `programs.steam.enable` with `extraCompatPackages` and

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -61,112 +61,139 @@ derivations built locally per full system build. Three groups remain:
 
 ## Build surface
 
-`packages.<system>.cache-roots` is a `linkFarm` over an explicit allowlist
-of free, redistribution-safe packages:
+`packages.<system>.cache-roots` is a `linkFarm` over an explicit list of the
+packages hosts would otherwise build locally:
 
-- Host-sourced entries come from the primary host's package set so custom
+- Host-sourced entries come from each host's own package set so custom
   overlays (firefoxpwa policy injection, john patches) and nixpkgs config
-  produce exactly the derivations a host switch evaluates. Every entry's
-  app must be enabled on that host: overlays are gated on
-  `programs.<name>.extended.enable`, and a disabled app resolves to the
-  stock nixpkgs attr that no host consumes (which is why wfuzz is not
-  listed).
+  produce exactly the derivations a host switch evaluates. Every registered
+  host that builds for the current system contributes its own entries, keyed
+  `<host>/<package>`, so an app only a sibling host enables still reaches the
+  cache and each host's distinct closure is published separately (nvidia-x11
+  is 580.173.02 on system76 and 595.84 on tpnix).
+  Entries are gated per host on `programs.<name>.extended.enable`, so a host
+  that turns an app off contributes nothing for it and the cache never carries
+  a closure that host will not install (which is why wfuzz is not listed).
   `nix build --dry-run "path:.#cache-roots"` on a host that has switched
   recently should report no unexpected package rebuilds; that is the
   derivation-parity check.
-- Option-sourced entries (`hostFinalPackagePaths`) read the owning module's
-  read-only resolved-package option on the primary host, for modules that
-  install a configured variant the bare package-set attribute never produces
-  (nemo-with-extensions, via `programs.nemo.extended.finalPackage`). The
-  enable invariant holds here through the option's shape: `finalPackage` is
-  declared with no default and assigned inside `config = lib.mkIf cfg.enable`,
-  so a disabled module leaves it undefined rather than resolving to a closure
-  no host installs. `cache-roots.nix` reads the sibling `enable` as well, so
-  the failure names the entry, the option path, and the host instead of
-  surfacing a bare "was accessed but has no value defined".
+- Option-sourced entries (`hostOptionPackages`) read the option holding the
+  resolved package, for packages the bare package-set attribute never produces
+  or that never reach `environment.systemPackages` at all. Each entry carries
+  its own `installed` predicate rather than deriving a sibling `enable` from
+  the option path, because these options do not share one shape:
+  `programs.nemo.extended.finalPackage` is assigned inside
+  `config = lib.mkIf cfg.enable` and is undefined when the module is off, so
+  its sibling `enable` is the real signal, while `hardware.nvidia.package`
+  carries an upstream default and stays defined on hosts that never load the
+  driver, so `services.xserver.videoDrivers` is what actually installs it.
 - perSystem-sourced entries (codeburn, restringer) are consumed through
   the devshell surface and build from the perSystem nixpkgs instance.
 - Input-sourced entries (context7-mcp, mcp-server-sequential-thinking, codex)
   come from the flake input the consuming module resolves them from, because
-  the host package set can carry a same-named but different derivation.
+  host package sets can carry a same-named but different derivation.
 
-The allowlist is explicit because `cachix push` publishes the full runtime
-closure to a public cache. Every entry's closure must be redistributable. An
-`assertFree` guard aborts evaluation for any entry whose `meta.license` is
-missing or is neither free nor redistributable, so a license-violating addition
-fails `nix flake check` (the check `modules/package-checks.nix` mirrors from
-this output) instead of reaching the cache. The guard reads the entry's own
-`meta.license` only; it does not walk the closure, so a wrapper that pulls in
-separately licensed packages still needs the manual check under
-"Extending the allowlist".
+The list names the attribute hosts install, which is not always the attribute
+that shares the app's common name: `vscode-fhs` and `ventoy-full` are what
+`modules/apps/` enables, while the bare `vscode` and `ventoy` attributes are
+different derivations no host consumes. `vscode` still reaches the cache as a
+dependency of the `vscode-fhs` closure.
 
-## Classification (2026-07-17 and 2026-08-03 build logs)
+A name listed but enabled on no host aborts evaluation instead of quietly
+publishing nothing, so renaming an app or disabling it on the last host that
+had it fails `nix flake check` rather than leaving a dead entry behind.
 
-License fields read from each package's `meta.license` on the surface that
-entry is sourced from, per the rule under "Extending the allowlist": the
-primary host's package set for host-sourced entries,
-`programs.nemo.extended.finalPackage` for nemo-with-extensions, the owning
-flake input for context7-mcp, mcp-server-sequential-thinking, and codex, and
-`self'.packages` for codeburn and restringer.
+There is no license gate. `cachix push` publishes the full runtime closure,
+and the cache is operator-private in use, so unfree packages are published
+alongside free ones and redistribution is not evaluated at build time. See
+"License posture" below for what that assumes.
 
-Cached via cache-roots (free, redistributable):
+## License posture
 
-| Package                        | License            |
-| ------------------------------ | ------------------ |
-| codeburn                       | MIT                |
-| codex                          | Apache-2.0         |
-| context7-mcp                   | MIT                |
-| electron-mail                  | GPL-3.0            |
-| firefoxpwa                     | MPL-2.0            |
-| john                           | GPL-2.0-or-later   |
-| mcp-server-sequential-thinking | MIT                |
-| nemo-with-extensions           | GPL-2.0 + LGPL-2.0 |
-| planify                        | GPL-3.0-or-later   |
-| proton-vpn                     | GPL-3.0-only       |
-| restringer                     | MIT                |
-| searchfox-cli                  | Apache-2.0 + MIT   |
-| source-map-explorer            | Apache-2.0         |
-| tweakcc                        | MIT                |
-| upscayl                        | AGPL-3.0-or-later  |
-| wappalyzer-next                | GPL-3.0-only       |
+The cache carries unfree packages. This rests on the cache being consumed by
+its operator alone, not on any redistribution grant: most entries below
+(vscode, google-chrome, webex, charles, obsidian, veracrypt, ventoy-full,
+discord, dropbox, nomachine-client, burpsuite) are `unfree` with
+`redistributable = false` in nixpkgs, so publishing them to an audience would
+violate their licenses. `nvidia-x11`, `firefox-bin`, and `steam` are the only
+unfree entries nixpkgs marks redistributable.
+
+That assumption is not enforced by anything in this repo. `bad3r-nixos.cachix.org`
+is a public cache: `modules/hosts/common/nix-substituters.nix` reads it with no
+token and `nix-cache-info` answers anonymously, so the store paths are reachable
+by anyone who knows the cache name. Making the Cachix cache private is what would
+make the posture match the mechanism.
+
+An earlier `assertFree` guard aborted evaluation for any entry that was neither
+free nor redistributable. It was removed with this policy; nothing now checks a
+license at build time, so adding an entry is purely an operator decision.
+
+## Inventory (2026-07-17, 2026-08-03, and 2026-08-04 build logs)
+
+Host-sourced entries, published per host that enables them. Only system76
+enables the last six.
+
+| Package             | Hosts           |
+| ------------------- | --------------- |
+| burpsuite           | system76, tpnix |
+| charles             | system76, tpnix |
+| electron-mail       | system76, tpnix |
+| firefoxpwa          | system76, tpnix |
+| google-chrome       | system76, tpnix |
+| john                | system76, tpnix |
+| nomachine-client    | system76, tpnix |
+| obsidian            | system76, tpnix |
+| planify             | system76, tpnix |
+| proton-vpn          | system76, tpnix |
+| searchfox-cli       | system76, tpnix |
+| source-map-explorer | system76, tpnix |
+| tweakcc             | system76, tpnix |
+| vscode-fhs          | system76, tpnix |
+| wappalyzer-next     | system76, tpnix |
+| webex               | system76, tpnix |
+| discord             | system76        |
+| dropbox             | system76        |
+| steam               | system76        |
+| upscayl             | system76        |
+| ventoy-full         | system76        |
+| veracrypt           | system76        |
+
+Option-sourced entries, resolved from the option that holds the installed
+package:
+
+| Package              | Option                                | Hosts           |
+| -------------------- | ------------------------------------- | --------------- |
+| nemo-with-extensions | `programs.nemo.extended.finalPackage` | system76, tpnix |
+| nvidia-x11           | `hardware.nvidia.package`             | system76, tpnix |
+
+perSystem-sourced (codeburn, restringer) and input-sourced (context7-mcp,
+mcp-server-sequential-thinking, codex) entries are published once, not per
+host, because no host package set shapes them.
 
 context7-mcp and mcp-server-sequential-thinking are sourced from the
 `mcp-servers-nix` input, matching the consumer in `modules/agents/mcp.nix`,
 which resolves every server's package through
-`inputs.mcp-servers-nix.packages.<system>`; the host package set carries
+`inputs.mcp-servers-nix.packages.<system>`; host package sets carry
 same-named but different derivations no consumer runs. nemo-with-extensions
 is sourced from `programs.nemo.extended.finalPackage` for the same reason:
 `modules/apps/nemo.nix` re-wraps nemo with an explicit extension list, so
 the bare `pkgs.nemo-with-extensions` attribute is a derivation no host
 installs, and its closure omits nemo-preview and nemo-seahorse. For entries built
 through `buildFHSEnv` or wrapper derivations (electron-mail, upscayl,
-nemo-with-extensions), the outer wrapper sets `allowSubstitutes = false`
-and always rebuilds locally; that is trivial assembly work, and the heavy
-dependency closure underneath substitutes normally.
+vscode-fhs, nemo-with-extensions), the outer wrapper sets
+`allowSubstitutes = false` and always rebuilds locally; that is trivial
+assembly work, and the heavy dependency closure underneath substitutes
+normally.
 
-Intentionally local, unfree with redistribution not permitted or unclear
-(publishing these to a public cache would violate their licenses):
+Deliberately absent:
 
-| Package       | License note                       |
-| ------------- | ---------------------------------- |
-| charles       | unfree                             |
-| discord       | unfree                             |
-| dropbox       | unfree                             |
-| google-chrome | unfree                             |
-| kiro          | Amazon Software License            |
-| veracrypt     | TrueCrypt-derived, unfree          |
-| ventoy        | unfree (vendored blobs)            |
-| vscode        | unfree (Microsoft product license) |
-| webex         | unfree                             |
-
-Unfree but marked redistributable in nixpkgs; candidates for a later
-operator decision, kept local until then:
-
-| Package     | License note                               |
-| ----------- | ------------------------------------------ |
-| firefox-bin | Firefox trademark license, redistributable |
-| nvidia-x11  | unfreeRedistributable                      |
-| steam       | unfreeRedistributable                      |
+- firefox-bin: no host installs it as an entry would publish it. Both hosts
+  install `firefox-153.0.1`, which wraps the source-built `firefox-unwrapped`,
+  and that wrapper is dispositioned as an accepted local build by the
+  `firefox-[0-9]*` glob in `scripts/cache-coverage-allowlist.txt`. The
+  `firefox-bin` closure is pushed anyway, as a member of the dropbox FHS
+  rootfs, so listing it would add an entry and no coverage.
+- kiro, tor-browser, mullvad-browser: see the residual-local-builds list below.
 
 Residual local builds accepted with reasons:
 
@@ -180,9 +207,8 @@ Residual local builds accepted with reasons:
   backfill here.
 - pentest wrappers (`pentest-*`): the wrapper derivations embed the flake
   self path and change on every commit; their heavy runtime payloads are
-  either Hydra-built (metasploit, nmap, sqlmap, ...), covered by
-  cache-roots entries (john, wappalyzer-next), or unfree (burpsuite,
-  charles) and excluded by license.
+  either Hydra-built (metasploit, nmap, sqlmap, ...) or covered by
+  cache-roots entries (john, wappalyzer-next, burpsuite, charles).
 - nix-index-with-full-db: fetch-dominated assembly of a prebuilt database,
   negligible build cost.
 - host config and systemd unit text derivations: cheap by design.
@@ -246,13 +272,16 @@ the remaining work. Four gaps carry it.
    name added to the publisher leaves behind a dead glob that absorbs the next
    regression on it. The allowlist's other entries are permanent dispositions
    `docs/reference/cache-coverage.md` accepts rather than reconciliation debt:
-   the RAR-enabled p7zip is unfree while the cache is public, and the
-   configuration wrappers are too cheap to be worth the CI time.
-2. Only the primary host sources entries
-   (https://github.com/Bad3r/nixos/issues/423). `cache-roots.nix` hardcodes
-   `primaryHost`, so apps a sibling host enables and the primary does not
-   (`modules/tpnix/apps-enable.nix` turns on projectlibre and thinkfan) never
-   reach the cache, and neither do that host's distinct wrapper closures.
+   the configuration wrappers are too cheap to be worth the CI time. The
+   RAR-enabled p7zip is no longer among them on license grounds and is now an
+   unclaimed candidate.
+2. ~~Only the primary host sources entries~~ (closed,
+   https://github.com/Bad3r/nixos/issues/423). `cache-roots.nix` iterates every
+   registered host that builds for the current system and keys entries
+   `<host>/<package>`, so a sibling host's apps and its distinct closures are
+   published too. This is what pulls tpnix's nvidia-x11 595.84 into the cache
+   alongside system76's 580.173.02; before the change, evaluating the flake
+   fetched that 595.84 driver and then published nothing for it.
 3. Nothing gates coverage in CI
    (https://github.com/Bad3r/nixos/issues/424). `scripts/cache-coverage.sh`
    is reachable only through `build.sh --cache-coverage` and `nix run`, and
@@ -269,72 +298,63 @@ the remaining work. Four gaps carry it.
    restore coverage on paper and suppress the next real divergence on that
    package.
 
-The unfree group remains the issue's phase 2 and stays out of scope while the
-cache is public: serving it needs a private or authenticated cache with the
-token provisioned to hosts through sops.
+The issue's phase 2 is now partly inverted: the unfree group is served, but the
+private or authenticated cache it was meant to be served from does not exist
+yet. Provisioning a Cachix read token to hosts through sops is what would close
+the gap between the posture under "License posture" and the mechanism.
 
 Before-and-after measurement of switch time belongs to the detector, not to a
 manual log diff. Once gap 3 lands, the report's own class counts are the
 metric.
 
-## Extending the allowlist
+## Extending the list
 
-Add a package to `modules/meta/cache-roots.nix` when it shows up in build
-logs and its full runtime closure is redistributable:
+Add a package to `modules/meta/cache-roots.nix` when it shows up in build logs
+and a host actually installs it. License is no longer a criterion; see
+"License posture".
 
+- Name the attribute a host installs, not the one that shares the app's common
+  name. `pkgs.vscode` and `pkgs.ventoy` are derivations no host consumes; the
+  installed attributes are `vscode-fhs` and `ventoy-full`. Confirm with
+  `nix eval` that the attribute's `outPath` appears in the host's
+  `environment.systemPackages` or Home Manager `home.packages`, or that it is a
+  dependency of the wrapper that does.
 - Source it from the surface that owns the derivation:
   - the host package set, when a custom overlay or host nixpkgs config
-    shapes it;
+    shapes it. `hostPackageNames` entries are gated per host on
+    `programs.<name>.extended.enable`, so the app must be wired through
+    `modules/hosts/common/apps-enable.nix` or a per-host override;
   - `self'.packages`, when only the devshell surface consumes it;
   - the owning flake input, when a module consumes the input's package
     directly (context7-mcp);
-  - the owning module's read-only resolved-package option, listed in
-    `hostFinalPackagePaths`, when the module installs a configured variant
-    rather than the bare package-set attribute (nemo-with-extensions).
-    Declare that option with no default and assign it inside
-    `config = lib.mkIf cfg.enable`, next to a sibling `enable` that
-    `cache-roots.nix` reads; `modules/browsers/ungoogled-chromium/apps.nix`
-    and `modules/apps/nemo.nix` are the reference shape.
-- Verify the license on the surface the entry is sourced from, not on the
-  host package set by default, because the bare `pkgs.<name>` attribute can
-  be a different derivation than the one that gets published:
-  - host-sourced:
-    `nix eval "path:.#nixosConfigurations.<host>.pkgs.<name>.meta.license"`
-  - option-sourced:
-    `nix eval "path:.#nixosConfigurations.<host>.config.<option-path>.meta.license"`
-  - perSystem- and input-sourced: the matching `self'.packages.<name>` or
-    flake-input attribute.
-- For a wrapper-style entry, check the packages it wraps as well. `meta.license`
-  on the wrapper describes the wrapper alone, and `assertFree` reads that same
-  field, so neither covers what the wrapper pulls into the published closure:
-  `nemo-with-extensions` reports GPL-2.0 and LGPL-2.0 while carrying
-  nemo-preview, nemo-seahorse, nemo-python, nemo-fileroller (GPL-2.0-or-later),
-  nemo-emblems, and folder-color-switcher (GPL-3.0-only).
+  - the option that holds the resolved package, listed in
+    `hostOptionPackages`, when the bare package-set attribute never produces
+    it or it never reaches `environment.systemPackages`
+    (nemo-with-extensions, nvidia-x11). Give the entry an `installed`
+    predicate naming the condition under which the host installs it; do not
+    assume a sibling `enable` exists, because upstream options such as
+    `hardware.nvidia.package` carry a default and stay defined on hosts that
+    never use them.
+- A name enabled on no host aborts evaluation rather than publishing nothing,
+  so a rename or a last-host disable fails `nix flake check` instead of leaving
+  a dead entry.
 - Verify the heavy derivation substitutes: a derivation that sets
   `allowSubstitutes = false` (check `drvAttrs.allowSubstitutes`) never hits
   the cache itself, so what matters is whether that derivation is the
   expensive one. An entry belongs in the list when the non-substitutable
   derivation is thin assembly over a substitutable dependency closure
-  (electron-mail, upscayl, nemo-with-extensions all set it on the outer
-  wrapper). It does not belong when the non-substitutable derivation is
+  (electron-mail, upscayl, vscode-fhs, nemo-with-extensions all set it on the
+  outer wrapper). It does not belong when the non-substitutable derivation is
   itself the expensive build (tor-browser, mullvad-browser).
 - Drop the matching glob from `scripts/cache-coverage-allowlist.txt` in the
   same change. That file records divergences accepted as permanent local
   builds; a package the cache now serves is no longer one, and leaving the
   glob behind hides the next regression on that name. The
   `cache-roots-allowlist-disjoint` check enforces this: it matches every
-  published entry against the file's globs, on the `linkFarm` key and on the
+  published entry against the file's globs, on the entry name and on the
   derivation `name` and `pname`, and aborts evaluation naming the offender. So
   forgetting the deletion fails `nix flake check` rather than surfacing as a
   silently dead glob later.
 - Confirm derivation parity with
   `nix build --dry-run "path:.#cache-roots"` on a recently switched host:
   the new entry must not introduce rebuilds of paths the host already has.
-
-Unfree packages must never enter the allowlist while the cache is public.
-Serving them requires the issue's phase 2: a private or authenticated
-cache with the token provisioned to hosts via sops. The `assertFree` guard
-in `cache-roots.nix` backstops this: a package whose license is missing or
-non-redistributable aborts evaluation. Unfree-but-redistributable packages
-(firefox-bin, nvidia-x11, steam) pass the guard's legal check but stay out of
-the allowlist until that phase-2 operator decision.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -87,14 +87,16 @@ keyed `<host>/<package>/<output>`.
   `nix build --dry-run "path:.#cache-roots"` on a host that has switched
   recently should report no unexpected package rebuilds; that is the
   derivation-parity check.
-- Option-sourced entries (`hostOptionPackages`) read the attribute path holding
-  the resolved package, for packages the bare package-set attribute never
-  produces or that never reach `environment.systemPackages` at all. A path may
-  reach past the option into the value it holds, for derivations that hang off
-  a package rather than being an output of it: `hardware.nvidia.package.mod` is
-  the kernel module built against `boot.kernelPackages` and installed through
-  `boot.extraModulePackages`, and `hardware.nvidia.package.settings` is
-  nvidia-settings. Linking every output does not reach either. Each entry carries
+- Option-sourced entries (`hostOptionPackages`) resolve the package from the
+  host config, for packages the bare package-set attribute never produces or
+  that never reach `environment.systemPackages` at all. Resolution is a
+  function rather than an option path, because it can mean reaching past the
+  option into the value it holds, or choosing between derivations by another
+  option's value: `hardware.nvidia.package.mod` is the kernel module built
+  against `boot.kernelPackages` and installed through
+  `boot.extraModulePackages`, `hardware.nvidia.package.settings` is
+  nvidia-settings, and neither is an output, so linking every output does not
+  reach them. Each entry carries
   its own `installed` predicate rather than deriving a sibling `enable` from
   the option path, because these options do not share one shape:
   `programs.nemo.extended.finalPackage` is assigned inside
@@ -175,21 +177,27 @@ enables the last six.
 | ventoy-full         | system76        |
 | veracrypt           | system76        |
 
-Option-sourced entries, resolved from the option that holds the installed
+Option-sourced entries, resolved from the host config that holds the installed
 package:
 
-| Package               | Option                                | Hosts           |
+| Package               | Resolved from                         | Hosts           |
 | --------------------- | ------------------------------------- | --------------- |
 | nemo-with-extensions  | `programs.nemo.extended.finalPackage` | system76, tpnix |
 | nvidia-x11            | `hardware.nvidia.package`             | system76, tpnix |
-| nvidia-kernel-modules | `hardware.nvidia.package.mod`         | system76, tpnix |
+| nvidia-kernel-modules | `hardware.nvidia.package.{open,mod}`  | system76, tpnix |
 | nvidia-settings       | `hardware.nvidia.package.settings`    | system76, tpnix |
 | steam                 | `programs.steam.package`              | system76        |
 
-`nvidia-kernel-modules` is gated on `hardware.nvidia.open != true`, matching
-upstream's `boot.extraModulePackages = if useOpenModules then [ nvidia_x11.open ] else [ nvidia_x11.mod ]`, and `nvidia-settings` on
-`hardware.nvidia.nvidiaSettings`. Both hosts set `open = false` and
-`nvidiaSettings = true`, so both publish both.
+`nvidia-kernel-modules` selects the module flavor the host installs rather than
+gating on one of them, mirroring upstream's
+`boot.extraModulePackages = if useOpenModules then [ nvidia_x11.open ] else [ nvidia_x11.mod ]`
+with `useOpenModules = cfg.open == true`. Gating on one flavor would drop
+coverage silently on a host that flips `hardware.nvidia.open`, which
+`modules/hardware/nvidia-gpu.nix` documents as required on Blackwell and newer,
+and a symmetric second entry cannot exist while no host sets it: the
+unused-name throw would abort on it. `nvidia-settings` is gated on
+`hardware.nvidia.nvidiaSettings`. Both hosts currently set `open = false` and
+`nvidiaSettings = true`.
 
 `steam` is option-sourced because `modules/apps/steam.nix` installs nothing
 itself: it sets `programs.steam.enable` with `extraCompatPackages` and

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -86,9 +86,9 @@ of free, redistribution-safe packages:
   surfacing a bare "was accessed but has no value defined".
 - perSystem-sourced entries (codeburn, restringer) are consumed through
   the devshell surface and build from the perSystem nixpkgs instance.
-- Input-sourced entries (context7-mcp, codex) come from the flake input the
-  consuming module resolves them from, because the host package set can
-  carry a same-named but different derivation.
+- Input-sourced entries (context7-mcp, mcp-server-sequential-thinking, codex)
+  come from the flake input the consuming module resolves them from, because
+  the host package set can carry a same-named but different derivation.
 
 The allowlist is explicit because `cachix push` publishes the full runtime
 closure to a public cache. Every entry's closure must be redistributable. An
@@ -100,36 +100,41 @@ this output) instead of reaching the cache. The guard reads the entry's own
 separately licensed packages still needs the manual check under
 "Extending the allowlist".
 
-## Classification (2026-07-17 build logs)
+## Classification (2026-07-17 and 2026-08-03 build logs)
 
 License fields read from each package's `meta.license` on the surface that
 entry is sourced from, per the rule under "Extending the allowlist": the
 primary host's package set for host-sourced entries,
 `programs.nemo.extended.finalPackage` for nemo-with-extensions, the owning
-flake input for context7-mcp and codex, and `self'.packages` for codeburn
-and restringer.
+flake input for context7-mcp, mcp-server-sequential-thinking, and codex, and
+`self'.packages` for codeburn and restringer.
 
 Cached via cache-roots (free, redistributable):
 
-| Package              | License            |
-| -------------------- | ------------------ |
-| codeburn             | MIT                |
-| codex                | Apache-2.0         |
-| context7-mcp         | MIT                |
-| electron-mail        | GPL-3.0            |
-| firefoxpwa           | MPL-2.0            |
-| john                 | GPL-2.0-or-later   |
-| nemo-with-extensions | GPL-2.0 + LGPL-2.0 |
-| planify              | GPL-3.0-or-later   |
-| proton-vpn           | GPL-3.0-only       |
-| restringer           | MIT                |
-| tweakcc              | MIT                |
-| upscayl              | AGPL-3.0-or-later  |
-| wappalyzer-next      | GPL-3.0-only       |
+| Package                        | License            |
+| ------------------------------ | ------------------ |
+| codeburn                       | MIT                |
+| codex                          | Apache-2.0         |
+| context7-mcp                   | MIT                |
+| electron-mail                  | GPL-3.0            |
+| firefoxpwa                     | MPL-2.0            |
+| john                           | GPL-2.0-or-later   |
+| mcp-server-sequential-thinking | MIT                |
+| nemo-with-extensions           | GPL-2.0 + LGPL-2.0 |
+| planify                        | GPL-3.0-or-later   |
+| proton-vpn                     | GPL-3.0-only       |
+| restringer                     | MIT                |
+| searchfox-cli                  | Apache-2.0 + MIT   |
+| source-map-explorer            | Apache-2.0         |
+| tweakcc                        | MIT                |
+| upscayl                        | AGPL-3.0-or-later  |
+| wappalyzer-next                | GPL-3.0-only       |
 
-context7-mcp is sourced from the `mcp-servers-nix` input, matching the
-consumer in `modules/agents/mcp.nix`; the host package set carries a
-same-named but different derivation no consumer runs. nemo-with-extensions
+context7-mcp and mcp-server-sequential-thinking are sourced from the
+`mcp-servers-nix` input, matching the consumer in `modules/agents/mcp.nix`,
+which resolves every server's package through
+`inputs.mcp-servers-nix.packages.<system>`; the host package set carries
+same-named but different derivations no consumer runs. nemo-with-extensions
 is sourced from `programs.nemo.extended.finalPackage` for the same reason:
 `modules/apps/nemo.nix` re-wraps nemo with an explicit extension list, so
 the bare `pkgs.nemo-with-extensions` attribute is a derivation no host

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -64,9 +64,14 @@ derivations built locally per full system build. Three groups remain:
 `packages.<system>.cache-roots` is a `linkFarm` over an explicit list of the
 packages hosts would otherwise build locally:
 
-- Host-sourced entries come from each host's own package set so custom
-  overlays (firefoxpwa policy injection, john patches) and nixpkgs config
-  produce exactly the derivations a host switch evaluates. Every registered
+- Host-sourced entries read `programs.<name>.extended.package` on each host,
+  which is the value those modules install, so custom overlays (firefoxpwa
+  policy injection, john patches), nixpkgs config, and any per-host override
+  of that option produce exactly the derivations a host switch evaluates.
+  Reading the bare package-set attribute instead would desync silently: an
+  override keeps `extended.enable = true`, so the gate stays green while the
+  published derivation is one nobody builds, and the symptom is a cache miss
+  rather than an error. Every registered
   host that builds for the current system contributes its own entries, keyed
   `<host>/<package>`, so an app only a sibling host enables still reaches the
   cache and each host's distinct closure is published separately (nvidia-x11
@@ -93,8 +98,8 @@ packages hosts would otherwise build locally:
   come from the flake input the consuming module resolves them from, because
   host package sets can carry a same-named but different derivation.
 
-The list names the attribute hosts install, which is not always the attribute
-that shares the app's common name: `vscode-fhs` and `ventoy-full` are what
+The list names the module hosts enable, which is not always the attribute that
+shares the app's common name: `vscode-fhs` and `ventoy-full` are what
 `modules/apps/` enables, while the bare `vscode` and `ventoy` attributes are
 different derivations no host consumes. `vscode` still reaches the cache as a
 dependency of the `vscode-fhs` closure.

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -89,9 +89,10 @@ packages hosts would otherwise build locally:
   the option path, because these options do not share one shape:
   `programs.nemo.extended.finalPackage` is assigned inside
   `config = lib.mkIf cfg.enable` and is undefined when the module is off, so
-  its sibling `enable` is the real signal, while `hardware.nvidia.package`
-  carries an upstream default and stays defined on hosts that never load the
-  driver, so `services.xserver.videoDrivers` is what actually installs it.
+  its sibling `enable` is the real signal, while `hardware.nvidia.package` and
+  `programs.steam.package` carry upstream defaults and stay defined on hosts
+  that never install them, so `services.xserver.videoDrivers` and the upstream
+  `programs.steam.enable` are what actually install them.
 - perSystem-sourced entries (codeburn, restringer) are consumed through
   the devshell surface and build from the perSystem nixpkgs instance.
 - Input-sourced entries (context7-mcp, mcp-server-sequential-thinking, codex)
@@ -136,7 +137,7 @@ license at build time, so adding an entry is purely an operator decision.
 ## Inventory (2026-07-17, 2026-08-03, and 2026-08-04 build logs)
 
 Host-sourced entries, published per host that enables them. Only system76
-enables the last six.
+enables the last five.
 
 | Package             | Hosts           |
 | ------------------- | --------------- |
@@ -158,7 +159,6 @@ enables the last six.
 | webex               | system76, tpnix |
 | discord             | system76        |
 | dropbox             | system76        |
-| steam               | system76        |
 | upscayl             | system76        |
 | ventoy-full         | system76        |
 | veracrypt           | system76        |
@@ -170,6 +170,17 @@ package:
 | -------------------- | ------------------------------------- | --------------- |
 | nemo-with-extensions | `programs.nemo.extended.finalPackage` | system76, tpnix |
 | nvidia-x11           | `hardware.nvidia.package`             | system76, tpnix |
+| steam                | `programs.steam.package`              | system76        |
+
+`steam` is option-sourced because `modules/apps/steam.nix` installs nothing
+itself: it sets `programs.steam.enable` with `extraCompatPackages` and
+`extraPackages`, and upstream's `programs.steam.package` carries an `apply`
+that re-`override`s the FHS env with both lists. The applied value is what
+upstream puts in `environment.systemPackages`, and proton-ge-bin, dwarfs,
+fuse-overlayfs, and protonup-rs live inside it. On system76 the applied
+derivation is `steam-1.0.0.87` at a different store path than
+`pkgs.steam`, so the bare attribute published a closure no host substitutes
+from.
 
 perSystem-sourced (codeburn, restringer) and input-sourced (context7-mcp,
 mcp-server-sequential-thinking, codex) entries are published once, not per

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -77,10 +77,10 @@ keyed `<host>/<package>/<output>`.
   override keeps `extended.enable = true`, so the gate stays green while the
   published derivation is one nobody builds, and the symptom is a cache miss
   rather than an error. Every registered
-  host that builds for the current system contributes its own entries, keyed
-  `<host>/<package>`, so an app only a sibling host enables still reaches the
-  cache and each host's distinct closure is published separately (nvidia-x11
-  is 580.173.02 on system76 and 595.84 on tpnix).
+  host that builds for the current system contributes its own entries, so an
+  app only a sibling host enables still reaches the cache and each host's
+  distinct closure is published separately (nvidia-x11 is 580.173.02 on
+  system76 and 595.84 on tpnix).
   Entries are gated per host on `programs.<name>.extended.enable`, so a host
   that turns an app off contributes nothing for it and the cache never carries
   a closure that host will not install (which is why wfuzz is not listed).
@@ -159,6 +159,7 @@ enables the last six.
 | john                | system76, tpnix |
 | nomachine-client    | system76, tpnix |
 | obsidian            | system76, tpnix |
+| p7zip-rar           | system76, tpnix |
 | planify             | system76, tpnix |
 | proton-vpn          | system76, tpnix |
 | searchfox-cli       | system76, tpnix |

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -137,7 +137,7 @@ license at build time, so adding an entry is purely an operator decision.
 ## Inventory (2026-07-17, 2026-08-03, and 2026-08-04 build logs)
 
 Host-sourced entries, published per host that enables them. Only system76
-enables the last five.
+enables the last six.
 
 | Package             | Hosts           |
 | ------------------- | --------------- |
@@ -159,6 +159,7 @@ enables the last five.
 | webex               | system76, tpnix |
 | discord             | system76        |
 | dropbox             | system76        |
+| kiro-fhs            | system76        |
 | upscayl             | system76        |
 | ventoy-full         | system76        |
 | veracrypt           | system76        |
@@ -195,7 +196,7 @@ is sourced from `programs.nemo.extended.finalPackage` for the same reason:
 `modules/apps/nemo.nix` re-wraps nemo with an explicit extension list, so
 the bare `pkgs.nemo-with-extensions` attribute is a derivation no host
 installs, and its closure omits nemo-preview and nemo-seahorse. For entries built
-through `buildFHSEnv` or wrapper derivations (electron-mail, upscayl,
+through `buildFHSEnv` or wrapper derivations (electron-mail, kiro-fhs, upscayl,
 vscode-fhs, nemo-with-extensions), the outer wrapper sets
 `allowSubstitutes = false` and always rebuilds locally; that is trivial
 assembly work, and the heavy dependency closure underneath substitutes
@@ -209,7 +210,7 @@ Deliberately absent:
   `firefox-[0-9]*` glob in `scripts/cache-coverage-allowlist.txt`. The
   `firefox-bin` closure is pushed anyway, as a member of the dropbox FHS
   rootfs, so listing it would add an entry and no coverage.
-- kiro, tor-browser, mullvad-browser: see the residual-local-builds list below.
+- tor-browser and mullvad-browser: see the residual-local-builds list below.
 
 Residual local builds accepted with reasons:
 

--- a/docs/reference/binary-cache-coverage.md
+++ b/docs/reference/binary-cache-coverage.md
@@ -316,13 +316,13 @@ the remaining work. Four gaps carry it.
    regression on it. The allowlist's other entries are permanent dispositions
    `docs/reference/cache-coverage.md` accepts rather than reconciliation debt:
    the configuration wrappers are too cheap to be worth the CI time. The
-   RAR-enabled p7zip is no longer among them on license grounds and is now an
-   unclaimed candidate.
+   RAR-enabled p7zip left the file for the opposite reason: `cache-roots.nix`
+   publishes it as `p7zip-rar` now, so its glob was deleted in the same change.
 2. ~~Only the primary host sources entries~~ (closed,
    https://github.com/Bad3r/nixos/issues/423). `cache-roots.nix` iterates every
-   registered host that builds for the current system and keys entries
-   `<host>/<package>`, so a sibling host's apps and its distinct closures are
-   published too. This is what pulls tpnix's nvidia-x11 595.84 into the cache
+   registered host that builds for the current system and keys links
+   `<host>/<package>/<output>`, so a sibling host's apps and its distinct
+   closures are published too. This is what pulls tpnix's nvidia-x11 595.84 into the cache
    alongside system76's 580.173.02; before the change, evaluating the flake
    fetched that 595.84 driver and then published nothing for it.
 3. Nothing gates coverage in CI

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -112,7 +112,8 @@ glob such as `proton-vpn-[0-9]*` is caught the same as `proton-vpn*`. The
 entry's package name is checked as well: a glob spelled that way suppresses
 nothing here, since that name never reaches this report, but it declares the
 same disposition the rule forbids. The host-qualified `linkFarm` key
-(`<host>/<package>`) is not checked, because no glob is written that way. Its
+(`<host>/<package>/<output>`) is not checked, because no glob is written that
+way. Its
 domain is the published entries, not the closure
 members the push also serves, because that closure does not exist at evaluation
 time; extending the check to them is

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -101,7 +101,7 @@ allowlist only when the package cannot be cached: `allowSubstitutes = false`
 on the expensive derivation (tor-browser, mullvad-browser), or a wrapper cheap
 enough that publishing it costs more CI time than it saves. A license is not a
 reason; `cache-roots.nix` publishes unfree packages too, so the RAR-enabled
-p7zip is now an unclaimed candidate rather than a permanent local build.
+p7zip belongs there, and its glob left this file in the same change.
 Everything else belongs in `cache-roots.nix`, and adding it there
 means deleting the glob here in the same change. That is enforced rather than
 left to memory: the `cache-roots-allowlist-disjoint` flake check in

--- a/docs/reference/cache-coverage.md
+++ b/docs/reference/cache-coverage.md
@@ -98,19 +98,22 @@ Allowlisting and caching are mutually exclusive dispositions, not a
 preference. A glob here declares that the divergence is a permanent local
 build; a name in `cache-roots.nix` declares that CI publishes it. Choose the
 allowlist only when the package cannot be cached: `allowSubstitutes = false`
-on the expensive derivation (tor-browser, mullvad-browser), an unfree or
-non-redistributable license while the cache is public (the RAR-enabled
-p7zip), or a wrapper cheap enough that publishing it costs more CI time than
-it saves. Everything else belongs in `cache-roots.nix`, and adding it there
+on the expensive derivation (tor-browser, mullvad-browser), or a wrapper cheap
+enough that publishing it costs more CI time than it saves. A license is not a
+reason; `cache-roots.nix` publishes unfree packages too, so the RAR-enabled
+p7zip is now an unclaimed candidate rather than a permanent local build.
+Everything else belongs in `cache-roots.nix`, and adding it there
 means deleting the glob here in the same change. That is enforced rather than
 left to memory: the `cache-roots-allowlist-disjoint` flake check in
 `modules/meta/cache-roots.nix` reads this file and aborts evaluation naming the
 offender. It matches each published entry on the derivation `name` and `pname`,
 which are the strings this report matches globs against, so a version-anchored
 glob such as `proton-vpn-[0-9]*` is caught the same as `proton-vpn*`. The
-`linkFarm` key is checked as well: a glob spelled that way suppresses nothing
-here, since the key never reaches this report, but it declares the same
-disposition the rule forbids. Its domain is the published entries, not the closure
+entry's package name is checked as well: a glob spelled that way suppresses
+nothing here, since that name never reaches this report, but it declares the
+same disposition the rule forbids. The host-qualified `linkFarm` key
+(`<host>/<package>`) is not checked, because no glob is written that way. Its
+domain is the published entries, not the closure
 members the push also serves, because that closure does not exist at evaluation
 time; extending the check to them is
 https://github.com/Bad3r/nixos/issues/428. It throws

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -72,10 +72,11 @@ let
   nvidiaLoaded = hostConfig: lib.elem "nvidia" hostConfig.services.xserver.videoDrivers;
 
   # Packages the bare package-set attribute never produces, or that never
-  # reach environment.systemPackages at all. Each entry names the attribute
-  # path holding the resolved package and the condition under which the host
-  # actually installs it. A path may reach past the option into the value it
-  # holds, for derivations that hang off a package rather than being one.
+  # reach environment.systemPackages at all. Each entry resolves the package
+  # from the host config and states the condition under which the host
+  # actually installs it. `path` is a function rather than an option path
+  # because resolving can mean reaching past the option into the value it
+  # holds, or choosing between derivations by another option's value.
   #
   # The condition is explicit rather than derived from the option path
   # because these options do not share one shape. nemo.extended.finalPackage
@@ -87,44 +88,39 @@ let
   # upstream programs.steam.enable are what actually install them.
   hostOptionPackages = {
     nemo-with-extensions = {
-      path = [
-        "programs"
-        "nemo"
-        "extended"
-        "finalPackage"
-      ];
+      path = hostConfig: hostConfig.programs.nemo.extended.finalPackage;
       installed = hostConfig: hostConfig.programs.nemo.extended.enable;
     };
     nvidia-x11 = {
-      path = [
-        "hardware"
-        "nvidia"
-        "package"
-      ];
+      path = hostConfig: hostConfig.hardware.nvidia.package;
       installed = nvidiaLoaded;
     };
     # Two derivations hanging off hardware.nvidia.package rather than outputs
-    # of it, so linking every output does not reach them. `mod` is the kernel
-    # module built against boot.kernelPackages, which upstream puts in
-    # boot.extraModulePackages whenever hardware.nvidia.open is not true, and
-    # is the expensive half of the driver. `settings` is nvidia-settings,
-    # added to environment.systemPackages under hardware.nvidia.nvidiaSettings.
+    # of it, so linking every output does not reach them.
+    #
+    # The kernel module is the expensive half of the driver, and which
+    # derivation carries it depends on the module flavor: upstream's
+    # `useOpenModules = cfg.open == true` selects `open` over `mod` for
+    # boot.extraModulePackages. Selecting the same way keeps the entry
+    # publishing whatever the host installs. Gating on one flavor instead would
+    # drop coverage silently on a host that flips
+    # `hardware.nvidia.open`, which modules/hardware/nvidia-gpu.nix documents as
+    # required on Blackwell and newer, and a symmetric second entry cannot exist
+    # while no host sets it: the unused-name throw below would abort on it.
+    #
+    # `settings` is nvidia-settings, which upstream adds to
+    # environment.systemPackages under hardware.nvidia.nvidiaSettings.
     nvidia-kernel-modules = {
-      path = [
-        "hardware"
-        "nvidia"
-        "package"
-        "mod"
-      ];
-      installed = hostConfig: nvidiaLoaded hostConfig && hostConfig.hardware.nvidia.open != true;
+      path =
+        hostConfig:
+        if hostConfig.hardware.nvidia.open == true then
+          hostConfig.hardware.nvidia.package.open
+        else
+          hostConfig.hardware.nvidia.package.mod;
+      installed = nvidiaLoaded;
     };
     nvidia-settings = {
-      path = [
-        "hardware"
-        "nvidia"
-        "package"
-        "settings"
-      ];
+      path = hostConfig: hostConfig.hardware.nvidia.package.settings;
       installed = hostConfig: nvidiaLoaded hostConfig && hostConfig.hardware.nvidia.nvidiaSettings;
     };
     # modules/apps/steam.nix installs nothing itself: it sets
@@ -135,11 +131,7 @@ let
     # and protonup-rs live inside it; pkgs.steam is a different derivation
     # missing exactly the part that costs a switch.
     steam = {
-      path = [
-        "programs"
-        "steam"
-        "package"
-      ];
+      path = hostConfig: hostConfig.programs.steam.package;
       installed = hostConfig: hostConfig.programs.steam.enable;
     };
   };
@@ -183,7 +175,7 @@ in
         ++ lib.mapAttrsToList (name: entry: {
           key = "${hostName}/${name}";
           pkgName = name;
-          path = lib.getAttrFromPath entry.path hostConfig;
+          path = entry.path hostConfig;
         }) (lib.filterAttrs (_: entry: entry.installed hostConfig) hostOptionPackages);
 
       hostConfigs = map (nixos: nixos.config) (lib.attrValues hosts);

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -58,7 +58,6 @@ let
     "proton-vpn"
     "searchfox-cli"
     "source-map-explorer"
-    "steam"
     "tweakcc"
     "upscayl"
     "ventoy-full"
@@ -77,9 +76,10 @@ let
   # because these options do not share one shape. nemo.extended.finalPackage
   # is assigned inside `config = lib.mkIf cfg.enable` and is undefined when
   # the module is off, so its sibling `enable` is the real signal.
-  # hardware.nvidia.package carries an upstream default and stays defined on
-  # hosts that never load the driver, so a sibling `enable` would not exist
-  # to read; services.xserver.videoDrivers is what actually installs it.
+  # hardware.nvidia.package and programs.steam.package carry upstream defaults
+  # and stay defined on hosts that never install them, so no sibling
+  # extended.enable is readable there; services.xserver.videoDrivers and the
+  # upstream programs.steam.enable are what actually install them.
   hostOptionPackages = {
     nemo-with-extensions = {
       path = [
@@ -97,6 +97,21 @@ let
         "package"
       ];
       installed = hostConfig: lib.elem "nvidia" hostConfig.services.xserver.videoDrivers;
+    };
+    # modules/apps/steam.nix installs nothing itself: it sets
+    # programs.steam.enable with extraCompatPackages and extraPackages, and
+    # upstream's programs.steam.package carries an `apply` that re-overrides
+    # the FHS env with both lists. The applied value is what upstream puts in
+    # environment.systemPackages, and proton-ge-bin, dwarfs, fuse-overlayfs,
+    # and protonup-rs live inside it; pkgs.steam is a different derivation
+    # missing exactly the part that costs a switch.
+    steam = {
+      path = [
+        "programs"
+        "steam"
+        "package"
+      ];
+      installed = hostConfig: hostConfig.programs.steam.enable;
     };
   };
 

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -35,9 +35,9 @@ let
   # tor-browser and mullvad-browser stay out: nixpkgs sets
   # allowSubstitutes = false on the derivation that carries the build, so
   # hosts rebuild them whatever the cache holds. Entries whose outer wrapper
-  # sets the same flag over a substitutable closure (electron-mail, upscayl,
-  # vscode-fhs) belong here, because the closure underneath is the expensive
-  # half.
+  # sets the same flag over a substitutable closure (electron-mail, kiro-fhs,
+  # upscayl, vscode-fhs) belong here, because the closure underneath is the
+  # expensive half.
   #
   # Names are the attributes hosts install, which is not always the attribute
   # that shares the app's common name: vscode-fhs and ventoy-full are what
@@ -52,6 +52,7 @@ let
     "firefoxpwa"
     "google-chrome"
     "john"
+    "kiro-fhs"
     "nomachine-client"
     "obsidian"
     "planify"

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -1,64 +1,100 @@
 /*
   Cache Roots (issue #382)
 
-  Aggregates the heavy custom derivations that every host switch would
-  otherwise build locally into one buildable flake output,
-  `packages.<system>.cache-roots`. The cache-push workflow builds this
-  output on CI and pushes its closure to the binary cache, so hosts
-  substitute these packages instead of rebuilding them after each
-  nixpkgs bump.
+  Aggregates the heavy derivations that a host switch would otherwise build
+  locally into one buildable flake output, `packages.<system>.cache-roots`.
+  The cache-push workflow builds this output on CI and pushes its closure to
+  the binary cache, so hosts substitute these packages instead of rebuilding
+  them after each nixpkgs bump.
 
-  A cache hit requires the exact derivation a consumer evaluates, so
-  each entry is sourced from the package set that owns it: host-enabled
-  overlay packages (firefoxpwa policy injection, john patches, ...)
-  come from the primary host's pkgs, and devshell-consumed packages
-  come from the perSystem instance that `nix develop` uses. The lists
-  are explicit allowlists because the pushed closure lands on a public
-  cache: every entry must be free software whose redistribution is
-  permitted. Unfree repacks (vscode, webex, kiro, ...) stay out; see
-  docs/reference/binary-cache-coverage.md for the per-package
-  classification and the operator runbook.
+  A cache hit requires the exact derivation a consumer evaluates, so each
+  entry is sourced from the package set that owns it: host apps come from
+  each host's own pkgs, and devshell-consumed packages come from the
+  perSystem instance that `nix develop` uses. Every registered host on the
+  building system contributes its own entries (issue #423), so an app a
+  sibling host enables and the primary does not still reaches the cache, and
+  a host that turns an app off contributes nothing for it.
+
+  The cache is operator-private in use, so unfree packages are published
+  alongside free ones; see docs/reference/binary-cache-coverage.md for the
+  per-package inventory and the operator runbook.
 */
 { config, lib, ... }:
 let
-  primaryHost = "system76";
-
+  # Apps published for every host that enables them, gated on
+  # programs.<name>.extended.enable. A name enabled on no host is a throw
+  # below rather than a silently absent entry.
+  #
   # tor-browser and mullvad-browser stay out: nixpkgs sets
-  # allowSubstitutes = false, so hosts rebuild them whatever the cache holds.
+  # allowSubstitutes = false on the derivation that carries the build, so
+  # hosts rebuild them whatever the cache holds. Entries whose outer wrapper
+  # sets the same flag over a substitutable closure (electron-mail, upscayl,
+  # vscode-fhs) belong here, because the closure underneath is the expensive
+  # half.
+  #
+  # Names are the attributes hosts install, which is not always the attribute
+  # that shares the app's common name: vscode-fhs and ventoy-full are what
+  # modules/apps/ enables, and the bare vscode and ventoy attributes are
+  # derivations no host consumes.
   hostPackageNames = [
+    "burpsuite"
+    "charles"
+    "discord"
+    "dropbox"
     "electron-mail"
     "firefoxpwa"
+    "google-chrome"
     "john"
+    "nomachine-client"
+    "obsidian"
     "planify"
     "proton-vpn"
     "searchfox-cli"
     "source-map-explorer"
+    "steam"
     "tweakcc"
     "upscayl"
+    "ventoy-full"
+    "veracrypt"
+    "vscode-fhs"
     "wappalyzer-next"
+    "webex"
   ];
 
-  # Modules that install a configured variant evaluate a derivation the bare
-  # package-set attribute never produces, so pushing the attribute caches a
-  # closure no host requests. nemo.extended wraps nemo with an explicit
-  # extension list (useDefaultExtensions = false), which is what pulls
-  # nemo-preview and nemo-seahorse in; neither is published by Hydra.
-  # Each path must address a read-only resolved-package option with a sibling
-  # `enable`. Owning modules define these options under `config` rather than as
-  # an option default, so a disabled module leaves the option undefined; the
-  # sibling `enable` is read here anyway, both to name the entry and host in the
-  # error and to catch an owning module that grows a default later.
-  hostFinalPackagePaths = {
-    nemo-with-extensions = [
-      "programs"
-      "nemo"
-      "extended"
-      "finalPackage"
-    ];
+  # Packages the bare package-set attribute never produces, or that never
+  # reach environment.systemPackages at all. Each entry names the option
+  # holding the resolved package and the condition under which the host
+  # actually installs it.
+  #
+  # The condition is explicit rather than derived from the option path
+  # because these options do not share one shape. nemo.extended.finalPackage
+  # is assigned inside `config = lib.mkIf cfg.enable` and is undefined when
+  # the module is off, so its sibling `enable` is the real signal.
+  # hardware.nvidia.package carries an upstream default and stays defined on
+  # hosts that never load the driver, so a sibling `enable` would not exist
+  # to read; services.xserver.videoDrivers is what actually installs it.
+  hostOptionPackages = {
+    nemo-with-extensions = {
+      path = [
+        "programs"
+        "nemo"
+        "extended"
+        "finalPackage"
+      ];
+      installed = hostConfig: hostConfig.programs.nemo.extended.enable;
+    };
+    nvidia-x11 = {
+      path = [
+        "hardware"
+        "nvidia"
+        "package"
+      ];
+      installed = hostConfig: lib.elem "nvidia" hostConfig.services.xserver.videoDrivers;
+    };
   };
 
   # Built through the perSystem nixpkgs instance (devshell surface),
-  # not enabled as host apps; same redistribution constraint applies.
+  # not enabled as host apps.
   perSystemPackageNames = [
     "codeburn"
     "restringer"
@@ -74,68 +110,82 @@ in
       ...
     }:
     let
-      hostPkgs = config.flake.nixosConfigurations.${primaryHost}.pkgs;
-      hostConfig = config.flake.nixosConfigurations.${primaryHost}.config;
+      # Only hosts this system can build for. A host on another platform
+      # belongs to that platform's cache-roots, not this one.
+      hosts = lib.filterAttrs (
+        _: nixos: nixos.pkgs.stdenv.hostPlatform.system == system
+      ) config.flake.nixosConfigurations;
 
-      # The pushed closure lands on a public cache, so the allowlist above is
-      # only safe while every entry stays redistributable. This aborts
-      # evaluation (and therefore the nix flake check that
-      # modules/package-checks.nix mirrors from this output) when an entry has
-      # no meta.license or carries a license that is neither free nor
-      # redistributable, instead of silently publishing a license violation.
-      assertFree =
-        name: pkg:
+      appEnabled =
+        hostConfig: name: ((hostConfig.programs.${name} or { }).extended or { }).enable or false;
+
+      hostEntries =
+        hostName: nixos:
         let
-          licenses = lib.toList (pkg.meta.license or [ ]);
-          redistributable =
-            licenses != [ ]
-            && lib.all (license: (license.free or false) || (license.redistributable or false)) licenses;
+          hostPkgs = nixos.pkgs;
+          hostConfig = nixos.config;
         in
-        if redistributable then
-          pkg
-        else
-          throw "cache-roots: ${name} is not free or redistributable; refusing to publish it to the public cache";
-      entries =
         map (name: {
-          inherit name;
-          path = assertFree name hostPkgs.${name};
-        }) hostPackageNames
-        ++ lib.mapAttrsToList (
-          name: optionPath:
-          let
-            enablePath = lib.init optionPath ++ [ "enable" ];
-          in
-          {
-            inherit name;
-            path =
-              if lib.getAttrFromPath enablePath hostConfig then
-                assertFree name (lib.getAttrFromPath optionPath hostConfig)
-              else
-                throw "cache-roots: ${name} is sourced from ${lib.concatStringsSep "." optionPath}, but that module is disabled on ${primaryHost}";
-          }
-        ) hostFinalPackagePaths
-        ++ map (name: {
-          inherit name;
-          path = assertFree name self'.packages.${name};
-        }) perSystemPackageNames
-        ++ [
-          # modules/agents/mcp.nix resolves MCP server packages from the
-          # mcp-servers-nix input; hostPkgs carries same-named but different
-          # context7-mcp and mcp-server-sequential-thinking derivations no
-          # consumer runs.
-          {
-            name = "context7-mcp";
-            path = assertFree "context7-mcp" inputs'.mcp-servers-nix.packages.context7-mcp;
-          }
-          {
-            name = "mcp-server-sequential-thinking";
-            path = assertFree "mcp-server-sequential-thinking" inputs'.mcp-servers-nix.packages.mcp-server-sequential-thinking;
-          }
-          {
-            name = "codex";
-            path = assertFree "codex" inputs'.llm-agents.packages.codex;
-          }
-        ];
+          key = "${hostName}/${name}";
+          pkgName = name;
+          path = hostPkgs.${name};
+        }) (lib.filter (appEnabled hostConfig) hostPackageNames)
+        ++ lib.mapAttrsToList (name: entry: {
+          key = "${hostName}/${name}";
+          pkgName = name;
+          path = lib.getAttrFromPath entry.path hostConfig;
+        }) (lib.filterAttrs (_: entry: entry.installed hostConfig) hostOptionPackages);
+
+      hostConfigs = map (nixos: nixos.config) (lib.attrValues hosts);
+
+      # A name no host enables publishes nothing, so the list would carry it
+      # forever while the cache stayed unchanged. That is the failure mode
+      # this whole file exists to prevent, so it aborts rather than thins the
+      # output silently. Renaming an app or turning it off on the last host
+      # that had it lands here.
+      unusedAppNames = lib.filter (
+        name: !(lib.any (hostConfig: appEnabled hostConfig name) hostConfigs)
+      ) hostPackageNames;
+
+      unusedOptionNames = lib.attrNames (
+        lib.filterAttrs (
+          _: entry: !(lib.any (hostConfig: entry.installed hostConfig) hostConfigs)
+        ) hostOptionPackages
+      );
+
+      unused = unusedAppNames ++ unusedOptionNames;
+
+      entries =
+        if unused != [ ] then
+          throw "cache-roots: ${lib.concatStringsSep ", " unused} is listed in cache-roots.nix but enabled on no host that builds for ${system}; publishing it is a no-op. Drop the name or enable the app."
+        else
+          lib.concatLists (lib.mapAttrsToList hostEntries hosts)
+          ++ map (name: {
+            key = name;
+            pkgName = name;
+            path = self'.packages.${name};
+          }) perSystemPackageNames
+          ++ [
+            # modules/agents/mcp.nix resolves MCP server packages from the
+            # mcp-servers-nix input; host package sets carry same-named but
+            # different context7-mcp and mcp-server-sequential-thinking
+            # derivations no consumer runs.
+            {
+              key = "context7-mcp";
+              pkgName = "context7-mcp";
+              path = inputs'.mcp-servers-nix.packages.context7-mcp;
+            }
+            {
+              key = "mcp-server-sequential-thinking";
+              pkgName = "mcp-server-sequential-thinking";
+              path = inputs'.mcp-servers-nix.packages.mcp-server-sequential-thinking;
+            }
+            {
+              key = "codex";
+              pkgName = "codex";
+              path = inputs'.llm-agents.packages.codex;
+            }
+          ];
 
       # A glob in scripts/cache-coverage-allowlist.txt accepts a permanent local
       # build; a name here publishes the package instead. Holding both leaves a
@@ -146,14 +196,15 @@ in
       # `nix flake check --no-build` still catches it.
       #
       # Matched on the derivation name and pname, which is what
-      # scripts/cache-coverage.sh matches globs against: the linkFarm key is
-      # hand-chosen and carries no version, so the key alone would miss
+      # scripts/cache-coverage.sh matches globs against: the entry name is
+      # hand-chosen and carries no version, so it alone would miss
       # `proton-vpn-[0-9]*` against a `proton-vpn-4.16.5` derivation, and
       # version-anchored globs are already the file's convention for wrapper
-      # entries. The key is checked too. The detector never sees it, so a glob
-      # spelled that way suppresses nothing, but it states the same disposition
-      # this rule forbids, and it is the one candidate guaranteed to exist when
-      # a path exposes neither name nor pname.
+      # entries. The entry name is checked too. The detector never sees it, so a
+      # glob spelled that way suppresses nothing, but it states the same
+      # disposition this rule forbids, and it is the one candidate guaranteed to
+      # exist when a path exposes neither name nor pname. The host-qualified
+      # linkFarm key is not checked, because no glob is written that way.
       #
       # The domain is the entries, not the closure members cache-push also
       # serves: that closure does not exist at evaluation time. A glob written
@@ -188,27 +239,37 @@ in
       allowlistedPublished = lib.filter (
         entry:
         lib.any (candidate: lib.any (globMatches candidate) allowlistGlobs) (
-          [ entry.name ]
+          [ entry.pkgName ]
           ++ lib.optional (entry.path ? name) entry.path.name
           ++ lib.optional (entry.path ? pname) entry.path.pname
         )
       ) entries;
+
+      # Hosts share most apps, so the same derivation arrives under several
+      # host-qualified keys. linkFarm rejects duplicate keys, not duplicate
+      # paths, and the keys already differ; the closure counts each path once.
+      linkFarmEntries = map (entry: {
+        inherit (entry) path;
+        name = entry.key;
+      }) entries;
+
+      buildsHere = hosts != { };
     in
     {
-      packages = lib.mkIf (hostPkgs.stdenv.hostPlatform.system == system) {
-        cache-roots = pkgs.linkFarm "cache-roots" entries;
+      packages = lib.mkIf buildsHere {
+        cache-roots = pkgs.linkFarm "cache-roots" linkFarmEntries;
       };
 
       # Gated with packages above: the guard reads each entry's derivation, so
-      # it belongs on the system that publishes them rather than resolving the
-      # primary host's package set under every other perSystem instance.
-      checks = lib.mkIf (hostPkgs.stdenv.hostPlatform.system == system) {
+      # it belongs on the system that publishes them rather than resolving every
+      # host's package set under every other perSystem instance.
+      checks = lib.mkIf buildsHere {
         cache-roots-allowlist-disjoint =
           if allowlistedPublished == [ ] then
             pkgs.runCommand "cache-roots-allowlist-disjoint" { } "touch $out"
           else
             throw "cache-roots: ${
-              lib.concatMapStringsSep ", " (entry: entry.name) allowlistedPublished
+              lib.concatMapStringsSep ", " (entry: entry.pkgName) allowlistedPublished
             } is published by cache-roots.nix and also matched by a glob in scripts/cache-coverage-allowlist.txt; allowlisting and caching are mutually exclusive dispositions. Delete the glob (docs/reference/cache-coverage.md).";
       };
     };

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -55,6 +55,7 @@ let
     "kiro-fhs"
     "nomachine-client"
     "obsidian"
+    "p7zip-rar"
     "planify"
     "proton-vpn"
     "searchfox-cli"

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -31,6 +31,8 @@ let
     "john"
     "planify"
     "proton-vpn"
+    "searchfox-cli"
+    "source-map-explorer"
     "tweakcc"
     "upscayl"
     "wappalyzer-next"
@@ -118,11 +120,16 @@ in
         }) perSystemPackageNames
         ++ [
           # modules/agents/mcp.nix resolves MCP server packages from the
-          # mcp-servers-nix input; hostPkgs carries a same-named but
-          # different context7-mcp derivation no consumer runs.
+          # mcp-servers-nix input; hostPkgs carries same-named but different
+          # context7-mcp and mcp-server-sequential-thinking derivations no
+          # consumer runs.
           {
             name = "context7-mcp";
             path = assertFree "context7-mcp" inputs'.mcp-servers-nix.packages.context7-mcp;
+          }
+          {
+            name = "mcp-server-sequential-thinking";
+            path = assertFree "mcp-server-sequential-thinking" inputs'.mcp-servers-nix.packages.mcp-server-sequential-thinking;
           }
           {
             name = "codex";

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -8,8 +8,8 @@
   them after each nixpkgs bump.
 
   A cache hit requires the exact derivation a consumer evaluates, so each
-  entry is sourced from the package set that owns it: host apps come from
-  each host's own pkgs, and devshell-consumed packages come from the
+  entry is sourced where that consumer resolves it: host apps come from the
+  option each host installs, and devshell-consumed packages come from the
   perSystem instance that `nix develop` uses. Every registered host on the
   building system contributes its own entries (issue #423), so an app a
   sibling host enables and the primary does not still reaches the cache, and
@@ -22,8 +22,15 @@
 { config, lib, ... }:
 let
   # Apps published for every host that enables them, gated on
-  # programs.<name>.extended.enable. A name enabled on no host is a throw
+  # programs.<name>.extended.enable and resolved through
+  # programs.<name>.extended.package. A name enabled on no host is a throw
   # below rather than a silently absent entry.
+  #
+  # Each of these modules installs its own extended.package, so that option
+  # and not the bare package-set attribute is what a host evaluates. A host
+  # overriding it keeps extended.enable = true, so reading the attribute
+  # instead would leave the gate green while publishing a derivation nobody
+  # builds, and the symptom would be a cache miss rather than an error.
   #
   # tor-browser and mullvad-browser stay out: nixpkgs sets
   # allowSubstitutes = false on the derivation that carries the build, so
@@ -122,13 +129,12 @@ in
       hostEntries =
         hostName: nixos:
         let
-          hostPkgs = nixos.pkgs;
           hostConfig = nixos.config;
         in
         map (name: {
           key = "${hostName}/${name}";
           pkgName = name;
-          path = hostPkgs.${name};
+          path = hostConfig.programs.${name}.extended.package;
         }) (lib.filter (appEnabled hostConfig) hostPackageNames)
         ++ lib.mapAttrsToList (name: entry: {
           key = "${hostName}/${name}";

--- a/modules/meta/cache-roots.nix
+++ b/modules/meta/cache-roots.nix
@@ -68,10 +68,13 @@ let
     "webex"
   ];
 
+  nvidiaLoaded = hostConfig: lib.elem "nvidia" hostConfig.services.xserver.videoDrivers;
+
   # Packages the bare package-set attribute never produces, or that never
-  # reach environment.systemPackages at all. Each entry names the option
-  # holding the resolved package and the condition under which the host
-  # actually installs it.
+  # reach environment.systemPackages at all. Each entry names the attribute
+  # path holding the resolved package and the condition under which the host
+  # actually installs it. A path may reach past the option into the value it
+  # holds, for derivations that hang off a package rather than being one.
   #
   # The condition is explicit rather than derived from the option path
   # because these options do not share one shape. nemo.extended.finalPackage
@@ -97,7 +100,31 @@ let
         "nvidia"
         "package"
       ];
-      installed = hostConfig: lib.elem "nvidia" hostConfig.services.xserver.videoDrivers;
+      installed = nvidiaLoaded;
+    };
+    # Two derivations hanging off hardware.nvidia.package rather than outputs
+    # of it, so linking every output does not reach them. `mod` is the kernel
+    # module built against boot.kernelPackages, which upstream puts in
+    # boot.extraModulePackages whenever hardware.nvidia.open is not true, and
+    # is the expensive half of the driver. `settings` is nvidia-settings,
+    # added to environment.systemPackages under hardware.nvidia.nvidiaSettings.
+    nvidia-kernel-modules = {
+      path = [
+        "hardware"
+        "nvidia"
+        "package"
+        "mod"
+      ];
+      installed = hostConfig: nvidiaLoaded hostConfig && hostConfig.hardware.nvidia.open != true;
+    };
+    nvidia-settings = {
+      path = [
+        "hardware"
+        "nvidia"
+        "package"
+        "settings"
+      ];
+      installed = hostConfig: nvidiaLoaded hostConfig && hostConfig.hardware.nvidia.nvidiaSettings;
     };
     # modules/apps/steam.nix installs nothing itself: it sets
     # programs.steam.enable with extraCompatPackages and extraPackages, and
@@ -270,10 +297,19 @@ in
       # Hosts share most apps, so the same derivation arrives under several
       # host-qualified keys. linkFarm rejects duplicate keys, not duplicate
       # paths, and the keys already differ; the closure counts each path once.
-      linkFarmEntries = map (entry: {
-        inherit (entry) path;
-        name = entry.key;
-      }) entries;
+      #
+      # Every output is linked, not just the default one. cache-push walks the
+      # closure of this linkFarm, and a multi-output derivation's outPath does
+      # not reach its siblings, so those outputs would be built on CI and then
+      # dropped. nvidia-x11 alone splits into out, lib32, bin, modsrc, and
+      # firmware.
+      linkFarmEntries = lib.concatMap (
+        entry:
+        map (output: {
+          name = "${entry.key}/${output}";
+          path = entry.path.${output};
+        }) (entry.path.outputs or [ "out" ])
+      ) entries;
 
       buildsHere = hosts != { };
     in

--- a/scripts/cache-coverage-allowlist.txt
+++ b/scripts/cache-coverage-allowlist.txt
@@ -26,7 +26,6 @@ normcap* # modules/apps/normcap.nix
 zap* # modules/apps/zap.nix
 
 # Deliberate feature or environment overrides.
-p7zip* # modules/apps/p7zip-rar.nix enables the unfree RAR codec
 system76-power* # modules/system76/system76-power-overlay.nix patch
 nixos-icons* # stylix.targets.nixos-icons recolors the logo source (leaf package)
 nixos-option* # rebuilt against the host nix package (Lix, modules/base/nix-package.nix)


### PR DESCRIPTION
## Summary

Three changes to `packages.<system>.cache-roots`, the output `cache-push.yml` builds and pushes to
`bad3r-nixos.cachix.org`.

### 1. New free entries from the 2026-08-03 build log

`searchfox-cli` 0.18.0, `source-map-explorer` 2.5.3, and `mcp-server-sequential-thinking` 2026.7.10 rebuilt locally on
every switch. The MCP server is sourced from the `mcp-servers-nix` input rather than `hostPkgs`, because
`modules/agents/mcp.nix` resolves every server through `inputs.mcp-servers-nix.packages.<system>` and host package sets
carry a same-named but different derivation.

### 2. License gate removed

The `assertFree` guard and the free-or-redistributable precondition are gone. The cache is consumed by its operator
alone, so redistribution is no longer evaluated at build time. Added: `burpsuite`, `charles`, `discord`, `dropbox`,
`google-chrome`, `kiro-fhs`, `nomachine-client`, `obsidian`, `steam`, `veracrypt`, `ventoy-full`, `vscode-fhs`,
`webex`, and `nvidia-x11`.

Entries resolve through the option each host installs, not the bare package-set attribute: host apps read
`programs.<name>.extended.package`, verified by `outPath` against `environment.systemPackages` and Home Manager
`home.packages`. `vscode-fhs` and `ventoy-full` are what `modules/apps/` enables; the bare `vscode` and `ventoy`
attributes are different derivations no host consumes. `vscode` still reaches the cache inside the `vscode-fhs`
closure.

`firefox-bin` is excluded: no host installs it (both install `firefox-153.0.1`, wrapping source-built
`firefox-unwrapped`, and that wrapper is an accepted local build via the `firefox-[0-9]*` glob). Its closure is pushed
anyway as a member of the dropbox FHS rootfs, so an entry would add no coverage.

### 3. Every host sources entries (closes #423)

`cache-roots.nix` no longer hardcodes `primaryHost`. It iterates every registered host that builds for the current
system and keys entries `<host>/<package>`, gated per host on `programs.<name>.extended.enable`.

| | Entries |
| --- | --- |
| system76 | 28 |
| tpnix | 21 (no discord, dropbox, kiro-fhs, steam, upscayl, ventoy-full, veracrypt) |
| shared (perSystem + input) | 5 |

54 entries expand to 72 `linkFarm` links, because every output of a multi-output entry is linked, not just the
default one.

This publishes tpnix's `nvidia-x11` 595.84 alongside system76's 580.173.02. Previously, evaluating the flake fetched
that 595.84 driver (visible as `NVIDIA-Linux-x86_64-595.84.run` in `build-20260803-104051-779170.log`) and published
nothing for it.

`hostFinalPackagePaths` becomes `hostOptionPackages` and carries an explicit `installed` predicate per entry rather
than deriving a sibling `enable` by string surgery on the option path. The options do not share a shape:
`programs.nemo.extended.finalPackage` is assigned inside `config = lib.mkIf cfg.enable` and is undefined when the
module is off, so its sibling `enable` is the real signal; `hardware.nvidia.package` and `programs.steam.package` carry
upstream defaults and stay defined on hosts that never install them (confirmed: both evaluate on both hosts), so no
sibling `enable` exists and `services.xserver.videoDrivers` and the upstream `programs.steam.enable` are the conditions
that actually install them.

A name enabled on no host now aborts evaluation instead of silently publishing nothing.

## Note on the license posture

`bad3r-nixos.cachix.org` is a **public** cache: `modules/hosts/common/nix-substituters.nix` reads it with no token and
`nix-cache-info` answers anonymously. Most of the newly added entries are `unfree` with `redistributable = false` in
nixpkgs, so the operator-only assumption rests on usage, not on access control. Making the Cachix cache private is
what would align the mechanism with the posture. This is stated explicitly under "License posture" in
`docs/reference/binary-cache-coverage.md` rather than left implicit.

## Test plan

- `nix flake check --accept-flake-config --no-build --offline path:.` passes (exit 0), covering
  `cache-roots-allowlist-disjoint` and the new enabled-on-no-host guard.
- `nix build --dry-run path:.#cache-roots`: 54 entries resolve over 72 links. 70 derivations to build and 42 paths to
  fetch (634.32 MiB), which is the first-push cost of repacks and FHS wrappers no cache serves. Verified against
  `cache.nixos.org`, `nixpkgs-unfree.cachix.org`, and `bad3r-nixos.cachix.org` that every added unfree package is
  currently 404 on all three. The dry run needs `--option substituters` to drop `cache.garnix.io`, which is
  returning HTTP 502 on narinfo requests; that outage is unrelated to this branch.
- Per-name `outPath` comparison of `programs.<name>.extended.package` against `nixos.pkgs.<name>` on both hosts:
  identical for all 38 enabled host-name pairs, so option-sourcing changes no published derivation today.
- `nix fmt` reports no formatting diffs.
- Pre-commit and pre-push hooks pass, including `gitleaks`, `treefmt`, `statix`, `deadnix`, and `managed-files-drift`.

Docs updated in the same change: `binary-cache-coverage.md` (build surface, license posture, per-host inventory,
extension rules, gap 2 closed) and `cache-coverage.md` (license is no longer a reason to allowlist; the RAR-enabled
p7zip becomes an unclaimed candidate).

## Review round 1

Three inline findings accepted, one commit each, after verifying every claim against the tree:

- `731ce249`: `steam` published `pkgs.steam` while system76 installs the value `programs.steam.package` produces
  through its `apply` (`kw3zrg2d...` vs `hji33hvb...`), so the entry cost a CI build and returned no coverage, and
  proton-ge-bin, dwarfs, fuse-overlayfs, and protonup-rs never entered the push. Moved to `hostOptionPackages`.
- `2a9b3cfb`: host entries now resolve through `programs.<name>.extended.package`. A host override of that option
  keeps `extended.enable = true`, so reading the bare attribute would leave the gate green while publishing a
  derivation nobody evaluates, failing as a cache miss rather than an error.
- `a8e48e26`: `kiro-fhs` is published instead of pointing at a residual-local-builds list that has no kiro entry. It
  is `kiro-0.12.333` with `allowSubstitutes = false` and `preferLocalBuild = true`, the same shape as `vscode-fhs`,
  and no allowlist glob matches it.

## Review round 2

Two further inline findings accepted:

- `ad1182ae`: only each entry's default output was linked, so `cache-push` built every sibling output on CI and then
  dropped it. `nvidia_x11` splits five ways (`out`, `lib32`, `bin`, `modsrc`, `firmware`). Worse, the kernel module is
  `nvidia_x11.mod`, a derivation hanging off the package rather than an output of it, so linking outputs alone would
  not reach it: `boot.extraModulePackages` on system76 is
  `nvidia-kernel-modules-580.173.02-7.1.4`, which appeared nowhere in the pushed closure despite the nvidia entry
  being added for exactly that cost. `linkFarmEntries` now expands over `path.outputs`, and
  `hardware.nvidia.package.mod` and `hardware.nvidia.package.settings` are entries of their own.
- `d8ea05de`: this branch deleted the license reason for `p7zip*` in `scripts/cache-coverage-allowlist.txt` without
  deleting the glob, leaving a detector suppression with no accepted rationale. `p7zip-rar` is published and the glob
  is gone, in the same change, as the file's own rule requires.