### PR TITLE
fix(apps): register an absolute-argv Jupyter kernelspec for external clients

### DIFF
--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -21,7 +21,7 @@
     * `jupyter-all` is `jupyter.override` from nixpkgs that swaps the default kernel definition set for the Clojure, Octave, R, and Ruby ones.
     * The Wolfram kernel is intentionally excluded upstream because it is unfree.
     * Every kernelspec the wrapper can reach is re-exported on JUPYTER_PATH so external clients such as the VS Code Jupyter extension can launch them.
-    * JUPYTER_PATH precedes the user data dir in `jupyter_path()` and the first kernelspec of a given name wins, so this `python3` shadows a user-installed `~/.local/share/jupyter/kernels/python3`.
+    * JUPYTER_PATH precedes both the user data dir and `sys.prefix/share/jupyter` in `jupyter_path()`, and the first kernelspec of a given name wins, so this `python3` shadows both a user-installed `~/.local/share/jupyter/kernels/python3` and the `python3` spec `pip install ipykernel` writes into an active virtualenv.
 */
 _:
 let
@@ -160,6 +160,39 @@ in
 
             if [ "$(find "$kernels" -mindepth 1 -maxdepth 1 -not -name python3 | wc -l)" -eq 0 ]; then
               echo "only python3 reached $kernels; the override kernels were not re-exported" >&2
+              exit 1
+            fi
+
+            touch $out
+          '';
+
+      # The other branch of mkKernelspecs: a package whose definitions supply
+      # their own python3 keeps that kernelspec verbatim. Byte comparison
+      # rather than a field check, so any reappearance of the unconditional
+      # rewrite fails. Eval-only for the same reason as the check above.
+      checks.jupyter-kernelspecs-preserved =
+        let
+          package = pkgs.jupyter;
+          specs = mkKernelspecs pkgs package;
+        in
+        pkgs.runCommand "jupyter-kernelspecs-preserved"
+          {
+            nativeBuildInputs = [ pkgs.jq ];
+          }
+          ''
+            wrapperData=$(${package}/bin/jupyter --paths --json | jq -r '.data[0]')
+            wrapperSpec="$wrapperData/kernels/python3/kernel.json"
+            emitted=${specs}/share/jupyter/kernels/python3/kernel.json
+
+            if [ ! -e "$wrapperSpec" ]; then
+              echo "jupyter-kernel.default no longer supplies python3, so this check asserts nothing" >&2
+              exit 1
+            fi
+
+            if ! cmp -s "$wrapperSpec" "$emitted"; then
+              echo "the wrapper's python3 kernelspec was rewritten instead of preserved" >&2
+              echo "wrapper:  $(jq -c . "$wrapperSpec")" >&2
+              echo "emitted:  $(jq -c . "$emitted")" >&2
               exit 1
             fi
 

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -7,7 +7,7 @@
 
   Summary:
     * Provides a single environment with `jupyter`, `jupyter-lab`, `jupyter-notebook`, `jupyter-console`, `jupyter-nbconvert`, and `ipython` entry points.
-    * Ships Clojure (Clojupyter), Octave, R (Ark), and Ruby (IRuby) kernels in addition to the default Python kernel via the nixpkgs override.
+    * Ships Clojure (Clojupyter), Octave, R (Ark), and Ruby (IRuby) kernels through the nixpkgs override; the Python kernelspec comes from ipykernel in the environment itself, not from the override.
 
   Options:
     notebook: Launch the classic web-based Jupyter Notebook server.
@@ -57,17 +57,18 @@ let
 
             wrapperData=$(${cfg.package}/bin/jupyter --paths --json | jq -r '.data[0]')
 
+            # jupyter_path() lists JUPYTER_PATH ahead of sys.prefix, so data[0]
+            # landing on the environment itself means the injected entry is
+            # gone and the copy below would re-export ipykernel's relative-argv
+            # spec and nothing else.
+            if [ "$wrapperData" = "${cfg.package}/share/jupyter" ]; then
+              echo "jupyter --paths resolved data[0] to the environment ($wrapperData), not the wrapper kernel dir" >&2
+              exit 1
+            fi
+
             install -d "$out/share/jupyter"
             cp -R "$wrapperData/kernels" "$out/share/jupyter/kernels"
             chmod -R u+w "$out/share/jupyter/kernels"
-
-            # The override output holds only the non-Python kernels, so a
-            # python3-only tree means .data[0] resolved to the environment's
-            # own share/jupyter and the override kernels were missed.
-            if [ "$(find "$out/share/jupyter/kernels" -mindepth 1 -maxdepth 1 -not -name python3 | wc -l)" -eq 0 ]; then
-              echo "no non-Python kernelspec under $wrapperData/kernels" >&2
-              exit 1
-            fi
 
             install -d "$out/share/jupyter/kernels/python3"
             jq --arg interpreter '${cfg.package}/bin/python' '.argv[0] = $interpreter' \
@@ -99,9 +100,11 @@ let
           # reachable only through the wrapped `jupyter` binary, which sets
           # JUPYTER_PATH itself. Exported through sessionVariables
           # (PAM-initialised) rather than variables (shell-profile only) so
-          # editors started from the desktop inherit it.
+          # editors started from the desktop inherit it. A singleton list so a
+          # second definition merges into the colon-joined value instead of
+          # conflicting.
           pathsToLink = [ "/share/jupyter" ];
-          sessionVariables.JUPYTER_PATH = "/run/current-system/sw/share/jupyter";
+          sessionVariables.JUPYTER_PATH = [ "/run/current-system/sw/share/jupyter" ];
         };
       };
     };

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -45,8 +45,6 @@ let
         nativeBuildInputs = [ pkgs.jq ];
       }
       ''
-        ${package}/bin/python -c 'import ipykernel_launcher'
-
         wrapperData=$(${package}/bin/jupyter --paths --json | jq -r '.data[0]')
 
         # jupyter_path() lists JUPYTER_PATH ahead of sys.prefix, so data[0]
@@ -67,6 +65,7 @@ let
         # and env, and jupyter-kernel.create already writes it with an
         # absolute argv.
         if [ ! -e "$out/share/jupyter/kernels/python3/kernel.json" ]; then
+          ${package}/bin/python -c 'import ipykernel_launcher'
           install -d "$out/share/jupyter/kernels/python3"
           jq --arg interpreter '${package}/bin/python' '.argv[0] = $interpreter' \
             ${package}/share/jupyter/kernels/python3/kernel.json \

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -106,13 +106,15 @@ let
 
           # NixOS links no /share/jupyter by default, so kernelspecs stay
           # reachable only through the wrapped `jupyter` binary, which sets
-          # JUPYTER_PATH itself. Exported through sessionVariables
-          # (PAM-initialised) rather than variables (shell-profile only) so
-          # editors started from the desktop inherit it. A singleton list so a
-          # second definition merges into the colon-joined value instead of
-          # conflicting.
+          # JUPYTER_PATH itself. profileRelativeSessionVariables expands the
+          # suffix over environment.profiles, so a kernel installed through
+          # home.packages is exported alongside the system one, and it feeds
+          # both /etc/pam/environment (so editors started from the desktop
+          # inherit it) and profileRelativeEnvVars for shells. Profiles that
+          # ship no kernels cost nothing: _list_kernels_in skips a path that
+          # is not a directory.
           pathsToLink = [ "/share/jupyter" ];
-          sessionVariables.JUPYTER_PATH = [ "/run/current-system/sw/share/jupyter" ];
+          profileRelativeSessionVariables.JUPYTER_PATH = [ "/share/jupyter" ];
         };
       };
     };

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -35,9 +35,9 @@ let
   # jupyter-kernel.default and its absolute interpreter argv, leaving
   # ipykernel's own kernelspec, whose argv[0] is the bare string "python".
   # That resolves through PATH, and outside the wrapper PATH yields
-  # programs.python.extended's hiPrio pkgs.python3, which has no ipykernel. Only
-  # kernel.json needs rewriting; buildEnv unfolds the python3 directory and
-  # links ipykernel's logos next to it.
+  # programs.python.extended's hiPrio pkgs.python3, which has no ipykernel.
+  # Only kernel.json needs rewriting; buildEnv unfolds the python3 directory
+  # and links ipykernel's logos next to it.
   mkKernelspecs =
     pkgs: package:
     pkgs.runCommand "jupyter-all-kernelspecs"
@@ -104,22 +104,23 @@ let
             (lib.hiPrio kernelspecs)
           ];
 
-          # NixOS links no /share/jupyter by default, so kernelspecs stay
-          # reachable only through the wrapped `jupyter` binary, which sets
-          # JUPYTER_PATH itself. profileRelativeSessionVariables expands the
-          # suffix over environment.profiles, so a kernel installed through
-          # home.packages is exported alongside the system one, and it feeds
-          # both /etc/pam/environment (so editors started from the desktop
-          # inherit it) and profileRelativeEnvVars for shells. Profiles that
-          # ship no kernels cost nothing: _list_kernels_in skips a path that
-          # is not a directory.
-          # Only kernels: cfg.package's share/jupyter also carries
+          # Kernels only: cfg.package's share/jupyter also carries
           # labextensions and nbconvert/templates, both resolved through
           # jupyter_path(), and exporting those would outrank a virtualenv's
           # own copies for `jupyter lab` and `jupyter nbconvert`. buildEnv
           # still creates the intermediate share/jupyter that JUPYTER_PATH
           # names.
           pathsToLink = [ "/share/jupyter/kernels" ];
+
+          # NixOS links nothing under /share/jupyter by default, so kernelspecs
+          # stay reachable only through the wrapped `jupyter` binary, which
+          # sets JUPYTER_PATH itself. profileRelativeSessionVariables expands
+          # the suffix over environment.profiles, so a kernel installed through
+          # home.packages is exported alongside the system one, and it feeds
+          # both /etc/pam/environment (so editors started from the desktop
+          # inherit it) and profileRelativeEnvVars for shells. Profiles that
+          # ship no kernels cost nothing: _list_kernels_in skips a path that is
+          # not a directory.
           profileRelativeSessionVariables.JUPYTER_PATH = [ "/share/jupyter" ];
         };
       };

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -62,10 +62,16 @@ let
         cp -R "$wrapperData/kernels" "$out/share/jupyter/kernels"
         chmod -R u+w "$out/share/jupyter/kernels"
 
-        install -d "$out/share/jupyter/kernels/python3"
-        jq --arg interpreter '${package}/bin/python' '.argv[0] = $interpreter' \
-          ${package}/share/jupyter/kernels/python3/kernel.json \
-          > "$out/share/jupyter/kernels/python3/kernel.json"
+        # Only when the wrapper set has no python3 of its own. A definition
+        # that supplies one carries a deliberate interpreter, display name,
+        # and env, and jupyter-kernel.create already writes it with an
+        # absolute argv.
+        if [ ! -e "$out/share/jupyter/kernels/python3/kernel.json" ]; then
+          install -d "$out/share/jupyter/kernels/python3"
+          jq --arg interpreter '${package}/bin/python' '.argv[0] = $interpreter' \
+            ${package}/share/jupyter/kernels/python3/kernel.json \
+            > "$out/share/jupyter/kernels/python3/kernel.json"
+        fi
       '';
 
   JupyterAllModule =

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -20,6 +20,7 @@
   Notes:
     * `jupyter-all` is `jupyter.override` from nixpkgs that registers Clojure (clojupyter) and Octave kernels alongside the Python kernel.
     * The Wolfram kernel is intentionally excluded upstream because it is unfree.
+    * Kernelspecs are re-exported on JUPYTER_PATH so external clients such as the VS Code Jupyter extension can launch them.
 */
 _:
 let
@@ -32,6 +33,29 @@ let
     }:
     let
       cfg = config.programs."jupyter-all".extended;
+
+      # jupyter-all replaces the jupyter-kernel definition set instead of
+      # extending it, so upstream drops jupyter-kernel.default.python3 and its
+      # absolute interpreter argv. The only surviving Python kernelspec is
+      # ipykernel's own, whose argv[0] is the bare string "python". That
+      # resolves through PATH, and outside the wrapped `jupyter` binary PATH
+      # yields programs.python.extended's hiPrio python313, which has no
+      # ipykernel.
+      kernelspecs =
+        pkgs.runCommand "jupyter-all-kernelspecs"
+          {
+            nativeBuildInputs = [ pkgs.jq ];
+          }
+          ''
+            ${cfg.package}/bin/python -c 'import ipykernel_launcher'
+
+            install -d "$out/share/jupyter/kernels/python3"
+            install -m444 -t "$out/share/jupyter/kernels/python3" \
+              ${cfg.package}/share/jupyter/kernels/python3/logo-*
+            jq --arg interpreter '${cfg.package}/bin/python' '.argv[0] = $interpreter' \
+              ${cfg.package}/share/jupyter/kernels/python3/kernel.json \
+              > "$out/share/jupyter/kernels/python3/kernel.json"
+          '';
     in
     {
       options.programs."jupyter-all".extended = {
@@ -45,7 +69,22 @@ let
       };
 
       config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
+        environment = {
+          # hiPrio so the absolute-argv kernel.json wins the system-path
+          # collision against the copy bundled in cfg.package.
+          systemPackages = [
+            cfg.package
+            (lib.hiPrio kernelspecs)
+          ];
+
+          # NixOS links no /share/jupyter by default, so kernelspecs stay
+          # reachable only through the wrapped `jupyter` binary, which sets
+          # JUPYTER_PATH itself. Exported through sessionVariables
+          # (PAM-initialised) rather than variables (shell-profile only) so
+          # editors started from the desktop inherit it.
+          pathsToLink = [ "/share/jupyter" ];
+          sessionVariables.JUPYTER_PATH = "/run/current-system/sw/share/jupyter";
+        };
       };
     };
 in

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -35,7 +35,7 @@ let
   # jupyter-kernel.default and its absolute interpreter argv, leaving
   # ipykernel's own kernelspec, whose argv[0] is the bare string "python".
   # That resolves through PATH, and outside the wrapper PATH yields
-  # programs.python.extended's hiPrio python313, which has no ipykernel. Only
+  # programs.python.extended's hiPrio pkgs.python3, which has no ipykernel. Only
   # kernel.json needs rewriting; buildEnv unfolds the python3 directory and
   # links ipykernel's logos next to it.
   mkKernelspecs =

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -25,6 +25,14 @@
 */
 _:
 let
+  # Kernels only: cfg.package's share/jupyter also carries labextensions and
+  # nbconvert/templates, both resolved through jupyter_path(), and exporting
+  # those would outrank a virtualenv's own copies for `jupyter lab` and
+  # `jupyter nbconvert`. buildEnv still creates the intermediate share/jupyter
+  # that JUPYTER_PATH names. Shared with checks.jupyter-all-kernelspecs, which
+  # only asserts anything while it reproduces the real merge.
+  kernelspecPathsToLink = [ "/share/jupyter/kernels" ];
+
   # The kernels named in the override land in a standalone
   # jupyter-kernel.create output that only the wrapped `jupyter` binary knows
   # about, through its own JUPYTER_PATH. Resolve that directory through the
@@ -108,13 +116,7 @@ let
             (lib.hiPrio kernelspecs)
           ];
 
-          # Kernels only: cfg.package's share/jupyter also carries
-          # labextensions and nbconvert/templates, both resolved through
-          # jupyter_path(), and exporting those would outrank a virtualenv's
-          # own copies for `jupyter lab` and `jupyter nbconvert`. buildEnv
-          # still creates the intermediate share/jupyter that JUPYTER_PATH
-          # names.
-          pathsToLink = [ "/share/jupyter/kernels" ];
+          pathsToLink = kernelspecPathsToLink;
 
           # NixOS links nothing under /share/jupyter by default, so kernelspecs
           # stay reachable only through the wrapped `jupyter` binary, which
@@ -151,7 +153,7 @@ in
               package
               (pkgs.lib.hiPrio (mkKernelspecs pkgs package))
             ];
-            pathsToLink = [ "/share/jupyter/kernels" ];
+            pathsToLink = kernelspecPathsToLink;
             ignoreCollisions = false;
           };
         in

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -21,9 +21,53 @@
     * `jupyter-all` is `jupyter.override` from nixpkgs that swaps the default kernel definition set for the Clojure, Octave, R, and Ruby ones.
     * The Wolfram kernel is intentionally excluded upstream because it is unfree.
     * Every kernelspec the wrapper can reach is re-exported on JUPYTER_PATH so external clients such as the VS Code Jupyter extension can launch them.
+    * JUPYTER_PATH precedes the user data dir in `jupyter_path()` and the first kernelspec of a given name wins, so this `python3` shadows a user-installed `~/.local/share/jupyter/kernels/python3`.
 */
 _:
 let
+  # The kernels named in the override land in a standalone
+  # jupyter-kernel.create output that only the wrapped `jupyter` binary knows
+  # about, through its own JUPYTER_PATH. Resolve that directory through the
+  # wrapper instead of restating upstream's definition list.
+  #
+  # python3 is absent from that set when the override supplies no python
+  # definition: replacing the definitions rather than extending them drops
+  # jupyter-kernel.default and its absolute interpreter argv, leaving
+  # ipykernel's own kernelspec, whose argv[0] is the bare string "python".
+  # That resolves through PATH, and outside the wrapper PATH yields
+  # programs.python.extended's hiPrio python313, which has no ipykernel. Only
+  # kernel.json needs rewriting; buildEnv unfolds the python3 directory and
+  # links ipykernel's logos next to it.
+  mkKernelspecs =
+    pkgs: package:
+    pkgs.runCommand "jupyter-all-kernelspecs"
+      {
+        nativeBuildInputs = [ pkgs.jq ];
+      }
+      ''
+        ${package}/bin/python -c 'import ipykernel_launcher'
+
+        wrapperData=$(${package}/bin/jupyter --paths --json | jq -r '.data[0]')
+
+        # jupyter_path() lists JUPYTER_PATH ahead of sys.prefix, so data[0]
+        # landing on the environment itself means the injected entry is gone
+        # and the copy below would re-export ipykernel's relative-argv spec
+        # and nothing else.
+        if [ "$wrapperData" = "${package}/share/jupyter" ]; then
+          echo "jupyter --paths resolved data[0] to the environment ($wrapperData), not the wrapper kernel dir" >&2
+          exit 1
+        fi
+
+        install -d "$out/share/jupyter"
+        cp -R "$wrapperData/kernels" "$out/share/jupyter/kernels"
+        chmod -R u+w "$out/share/jupyter/kernels"
+
+        install -d "$out/share/jupyter/kernels/python3"
+        jq --arg interpreter '${package}/bin/python' '.argv[0] = $interpreter' \
+          ${package}/share/jupyter/kernels/python3/kernel.json \
+          > "$out/share/jupyter/kernels/python3/kernel.json"
+      '';
+
   JupyterAllModule =
     {
       config,
@@ -33,48 +77,7 @@ let
     }:
     let
       cfg = config.programs."jupyter-all".extended;
-
-      # The kernels named in the override land in a standalone
-      # jupyter-kernel.create output that only the wrapped `jupyter` binary
-      # knows about, through its own JUPYTER_PATH. Resolve that directory
-      # through the wrapper instead of restating upstream's definition list.
-      #
-      # python3 is absent from that set: jupyter-all replaces the definitions
-      # instead of extending them, so upstream drops jupyter-kernel.default
-      # and its absolute interpreter argv. The only surviving Python
-      # kernelspec is ipykernel's own, whose argv[0] is the bare string
-      # "python". That resolves through PATH, and outside the wrapper PATH
-      # yields programs.python.extended's hiPrio python313, which has no
-      # ipykernel. Only kernel.json needs rewriting; buildEnv unfolds the
-      # python3 directory and links ipykernel's logos next to it.
-      kernelspecs =
-        pkgs.runCommand "jupyter-all-kernelspecs"
-          {
-            nativeBuildInputs = [ pkgs.jq ];
-          }
-          ''
-            ${cfg.package}/bin/python -c 'import ipykernel_launcher'
-
-            wrapperData=$(${cfg.package}/bin/jupyter --paths --json | jq -r '.data[0]')
-
-            # jupyter_path() lists JUPYTER_PATH ahead of sys.prefix, so data[0]
-            # landing on the environment itself means the injected entry is
-            # gone and the copy below would re-export ipykernel's relative-argv
-            # spec and nothing else.
-            if [ "$wrapperData" = "${cfg.package}/share/jupyter" ]; then
-              echo "jupyter --paths resolved data[0] to the environment ($wrapperData), not the wrapper kernel dir" >&2
-              exit 1
-            fi
-
-            install -d "$out/share/jupyter"
-            cp -R "$wrapperData/kernels" "$out/share/jupyter/kernels"
-            chmod -R u+w "$out/share/jupyter/kernels"
-
-            install -d "$out/share/jupyter/kernels/python3"
-            jq --arg interpreter '${cfg.package}/bin/python' '.argv[0] = $interpreter' \
-              ${cfg.package}/share/jupyter/kernels/python3/kernel.json \
-              > "$out/share/jupyter/kernels/python3/kernel.json"
-          '';
+      kernelspecs = mkKernelspecs pkgs cfg.package;
     in
     {
       options.programs."jupyter-all".extended = {
@@ -111,4 +114,51 @@ let
 in
 {
   flake.nixosModules.apps.jupyter-all = JupyterAllModule;
+
+  perSystem =
+    { pkgs, ... }:
+    {
+      # system.path merges with ignoreCollisions = true, so a lost hiPrio race
+      # degrades to a scrolled-past warning and a relative-argv kernel.json,
+      # which is the bug this module exists to fix. Rebuild the same merge with
+      # collisions fatal and assert the outcome. No runtimeCheck: realising the
+      # merge pulls jupyter-all's 2.7 GiB closure, which is the weight
+      # check.yml excludes host toplevels for.
+      checks.jupyter-all-kernelspecs =
+        let
+          package = pkgs.jupyter-all;
+          merged = pkgs.buildEnv {
+            name = "jupyter-all-kernelspec-merge";
+            paths = [
+              package
+              (pkgs.lib.hiPrio (mkKernelspecs pkgs package))
+            ];
+            pathsToLink = [ "/share/jupyter" ];
+            ignoreCollisions = false;
+          };
+        in
+        pkgs.runCommand "jupyter-all-kernelspecs-valid"
+          {
+            nativeBuildInputs = [ pkgs.jq ];
+          }
+          ''
+            kernels=${merged}/share/jupyter/kernels
+
+            argv0=$(jq -r '.argv[0]' "$kernels/python3/kernel.json")
+            case "$argv0" in
+              ${builtins.storeDir}/*) ;;
+              *)
+                echo "python3 argv[0] is '$argv0': the merge kept the relative-argv kernel.json from ${package.name}" >&2
+                exit 1
+                ;;
+            esac
+
+            if [ "$(find "$kernels" -mindepth 1 -maxdepth 1 -not -name python3 | wc -l)" -eq 0 ]; then
+              echo "only python3 reached $kernels; the override kernels were not re-exported" >&2
+              exit 1
+            fi
+
+            touch $out
+          '';
+    };
 }

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -21,7 +21,7 @@
     * `jupyter-all` is `jupyter.override` from nixpkgs that swaps the default kernel definition set for the Clojure, Octave, R, and Ruby ones.
     * The Wolfram kernel is intentionally excluded upstream because it is unfree.
     * Every kernelspec the wrapper can reach is re-exported on JUPYTER_PATH so external clients such as the VS Code Jupyter extension can launch them.
-    * JUPYTER_PATH precedes both the user data dir and `sys.prefix/share/jupyter` in `jupyter_path()`, and the first kernelspec of a given name wins, so this `python3` shadows both a user-installed `~/.local/share/jupyter/kernels/python3` and the `python3` spec `pip install ipykernel` writes into an active virtualenv.
+    * JUPYTER_PATH precedes both the user data dir and `sys.prefix/share/jupyter` in `jupyter_path()`, and the first kernelspec of a given name wins, so this `python3` shadows both a user-installed `~/.local/share/jupyter/kernels/python3` and the `python3` spec `pip install ipykernel` writes into an active virtualenv. It is labelled `Python 3 (jupyter-all)` so the substitution is visible in a client's kernel picker.
 */
 _:
 let
@@ -67,7 +67,11 @@ let
         if [ ! -e "$out/share/jupyter/kernels/python3/kernel.json" ]; then
           ${package}/bin/python -c 'import ipykernel_launcher'
           install -d "$out/share/jupyter/kernels/python3"
-          jq --arg interpreter '${package}/bin/python' '.argv[0] = $interpreter' \
+          # Relabelled because the spec this shadows carries ipykernel's own
+          # "Python 3 (ipykernel)", so without it the two are indistinguishable
+          # in a client's kernel picker.
+          jq --arg interpreter '${package}/bin/python' \
+            '.argv[0] = $interpreter | .display_name = "Python 3 (jupyter-all)"' \
             ${package}/share/jupyter/kernels/python3/kernel.json \
             > "$out/share/jupyter/kernels/python3/kernel.json"
         fi

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -113,7 +113,13 @@ let
           # inherit it) and profileRelativeEnvVars for shells. Profiles that
           # ship no kernels cost nothing: _list_kernels_in skips a path that
           # is not a directory.
-          pathsToLink = [ "/share/jupyter" ];
+          # Only kernels: cfg.package's share/jupyter also carries
+          # labextensions and nbconvert/templates, both resolved through
+          # jupyter_path(), and exporting those would outrank a virtualenv's
+          # own copies for `jupyter lab` and `jupyter nbconvert`. buildEnv
+          # still creates the intermediate share/jupyter that JUPYTER_PATH
+          # names.
+          pathsToLink = [ "/share/jupyter/kernels" ];
           profileRelativeSessionVariables.JUPYTER_PATH = [ "/share/jupyter" ];
         };
       };
@@ -140,7 +146,7 @@ in
               package
               (pkgs.lib.hiPrio (mkKernelspecs pkgs package))
             ];
-            pathsToLink = [ "/share/jupyter" ];
+            pathsToLink = [ "/share/jupyter/kernels" ];
             ignoreCollisions = false;
           };
         in

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -171,6 +171,16 @@ in
                 ;;
             esac
 
+            # Compared against the spec the rewrite reads from rather than a
+            # literal, so the assertion tracks whatever label ipykernel writes
+            # into a user or virtualenv install.
+            label=$(jq -r '.display_name' "$kernels/python3/kernel.json")
+            shadowed=$(jq -r '.display_name' ${package}/share/jupyter/kernels/python3/kernel.json)
+            if [ "$label" = "$shadowed" ]; then
+              echo "python3 display_name is '$label', the label ipykernel installs: the exported spec is indistinguishable in a kernel picker from the user and virtualenv specs it shadows" >&2
+              exit 1
+            fi
+
             if [ "$(find "$kernels" -mindepth 1 -maxdepth 1 -not -name python3 | wc -l)" -eq 0 ]; then
               echo "only python3 reached $kernels; the override kernels were not re-exported" >&2
               exit 1

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -83,6 +83,22 @@ let
             ${package}/share/jupyter/kernels/python3/kernel.json \
             > "$out/share/jupyter/kernels/python3/kernel.json"
         fi
+
+        # The property this derivation exists to establish, asserted for
+        # whatever `package` supplies rather than only for the two the checks
+        # pin. The guard above is a string comparison, so it misses a data[0]
+        # that lands on an environment whose prefix differs from `package`:
+        # cp -R would land ipykernel's relative-argv spec, the rewrite would
+        # then be skipped because that file exists, and argv[0] would resolve
+        # through PATH outside the wrapper.
+        argv0=$(jq -r '.argv[0]' "$out/share/jupyter/kernels/python3/kernel.json")
+        case "$argv0" in
+          ${builtins.storeDir}/*) ;;
+          *)
+            echo "python3 argv[0] is '$argv0', not a store path: it would resolve through PATH outside the wrapper" >&2
+            exit 1
+            ;;
+        esac
       '';
 
   JupyterAllModule =

--- a/modules/apps/jupyter-all.nix
+++ b/modules/apps/jupyter-all.nix
@@ -7,7 +7,7 @@
 
   Summary:
     * Provides a single environment with `jupyter`, `jupyter-lab`, `jupyter-notebook`, `jupyter-console`, `jupyter-nbconvert`, and `ipython` entry points.
-    * Ships additional Clojure (Clojupyter) and Octave kernels in addition to the default Python kernel via the nixpkgs override.
+    * Ships Clojure (Clojupyter), Octave, R (Ark), and Ruby (IRuby) kernels in addition to the default Python kernel via the nixpkgs override.
 
   Options:
     notebook: Launch the classic web-based Jupyter Notebook server.
@@ -18,9 +18,9 @@
     server: Run only the headless Jupyter server backend without a UI.
 
   Notes:
-    * `jupyter-all` is `jupyter.override` from nixpkgs that registers Clojure (clojupyter) and Octave kernels alongside the Python kernel.
+    * `jupyter-all` is `jupyter.override` from nixpkgs that swaps the default kernel definition set for the Clojure, Octave, R, and Ruby ones.
     * The Wolfram kernel is intentionally excluded upstream because it is unfree.
-    * Kernelspecs are re-exported on JUPYTER_PATH so external clients such as the VS Code Jupyter extension can launch them.
+    * Every kernelspec the wrapper can reach is re-exported on JUPYTER_PATH so external clients such as the VS Code Jupyter extension can launch them.
 */
 _:
 let
@@ -34,13 +34,19 @@ let
     let
       cfg = config.programs."jupyter-all".extended;
 
-      # jupyter-all replaces the jupyter-kernel definition set instead of
-      # extending it, so upstream drops jupyter-kernel.default.python3 and its
-      # absolute interpreter argv. The only surviving Python kernelspec is
-      # ipykernel's own, whose argv[0] is the bare string "python". That
-      # resolves through PATH, and outside the wrapped `jupyter` binary PATH
+      # The kernels named in the override land in a standalone
+      # jupyter-kernel.create output that only the wrapped `jupyter` binary
+      # knows about, through its own JUPYTER_PATH. Resolve that directory
+      # through the wrapper instead of restating upstream's definition list.
+      #
+      # python3 is absent from that set: jupyter-all replaces the definitions
+      # instead of extending them, so upstream drops jupyter-kernel.default
+      # and its absolute interpreter argv. The only surviving Python
+      # kernelspec is ipykernel's own, whose argv[0] is the bare string
+      # "python". That resolves through PATH, and outside the wrapper PATH
       # yields programs.python.extended's hiPrio python313, which has no
-      # ipykernel.
+      # ipykernel. Only kernel.json needs rewriting; buildEnv unfolds the
+      # python3 directory and links ipykernel's logos next to it.
       kernelspecs =
         pkgs.runCommand "jupyter-all-kernelspecs"
           {
@@ -49,9 +55,21 @@ let
           ''
             ${cfg.package}/bin/python -c 'import ipykernel_launcher'
 
+            wrapperData=$(${cfg.package}/bin/jupyter --paths --json | jq -r '.data[0]')
+
+            install -d "$out/share/jupyter"
+            cp -R "$wrapperData/kernels" "$out/share/jupyter/kernels"
+            chmod -R u+w "$out/share/jupyter/kernels"
+
+            # The override output holds only the non-Python kernels, so a
+            # python3-only tree means .data[0] resolved to the environment's
+            # own share/jupyter and the override kernels were missed.
+            if [ "$(find "$out/share/jupyter/kernels" -mindepth 1 -maxdepth 1 -not -name python3 | wc -l)" -eq 0 ]; then
+              echo "no non-Python kernelspec under $wrapperData/kernels" >&2
+              exit 1
+            fi
+
             install -d "$out/share/jupyter/kernels/python3"
-            install -m444 -t "$out/share/jupyter/kernels/python3" \
-              ${cfg.package}/share/jupyter/kernels/python3/logo-*
             jq --arg interpreter '${cfg.package}/bin/python' '.argv[0] = $interpreter' \
               ${cfg.package}/share/jupyter/kernels/python3/kernel.json \
               > "$out/share/jupyter/kernels/python3/kernel.json"


### PR DESCRIPTION
## Summary

VS Code notebooks cannot start a Python kernel on this configuration. The extension reports:

```
error: The interpreter at /nix/store/...-python3-3.14.6 is externally managed
[error] Error managing packages Failed to run uv pip install --python /nix/store/...-system-path/bin/python3.14 ipykernel
Error: The kernel died. Error: .../bin/python3.14: No module named ipykernel_launcher
```

Three facts combine into that failure:

1. `jupyter-all` in nixpkgs passes a fresh `definitions` set to `jupyter.override` instead of extending
   `jupyter-kernel.default`, so the default `python3` definition and its absolute `env.interpreter` argv are
   dropped. The only surviving Python kernelspec is ipykernel's own, whose `argv[0]` is the bare string `python`.
2. NixOS links nothing under `/share/jupyter` through `environment.pathsToLink`, and `JUPYTER_PATH` is not in
   the session environment, so that kernelspec is reachable only through the wrapped `jupyter` binary, which
   sets `JUPYTER_PATH` for itself.
3. With no kernelspec to launch, `ms-toolsai.jupyter` falls through to `installMissingDependencies` and shells out
   to `uv pip install` against an immutable store path.

This links `/share/jupyter/kernels` into the profiles, exports `JUPYTER_PATH` through
`profileRelativeSessionVariables` (which reaches both `/etc/pam/environment`, so desktop-launched editors
inherit it, and `profileRelativeEnvVars` for shells, and covers `home.packages` profiles as well as the system
one), and registers a kernelspec derivation that carries every kernel the wrapper can reach.

The absolute path matters twice over. `ms-toolsai.jupyter` gates the `uv pip install` path on `argv[0]` being
`python`, `python3`, `python.exe`, or `python3.exe`, so an absolute path skips it and the kernel launches verbatim.
Independently, `programs.python.extended` installs `pkgs.python3` at `hiPrio`, so a bare `python` argv resolves
to a plain interpreter with no ipykernel even once the kernelspec becomes visible.

The `hiPrio` on the kernelspec derivation is what makes the absolute-argv `kernel.json` win the `system-path`
collision against the relative-argv copy bundled inside `cfg.package`.

### Non-Python kernels

`python3` is not the only kernelspec that was invisible. The kernels named in the override (clojupyter,
octave-kernel, ark, iruby) are built into a standalone `jupyter-kernel.create` derivation that reaches the wrapper
only through `makeWrapperArgs = [ "--prefix JUPYTER_PATH : <jupyterPath>" ]`; it is not in
`environment.systemPackages`, and `cfg.package/share/jupyter/kernels` is just a symlink to ipykernel's own kernels
directory. Linking `/share/jupyter/kernels` alone would therefore have exported exactly one kernelspec.

The derivation resolves that directory through `jupyter --paths --json` rather than restating upstream's
definition list, then copies its `kernels/` tree. Both ways that resolution can degrade are fatal:
`jupyter_path()` lists `JUPYTER_PATH` ahead of `sys.prefix`, so `data[0]` matching
`${cfg.package}/share/jupyter` means the injected entry is gone and the build stops; if the entry disappears
entirely, `data[0]` becomes `$HOME/.local/share/jupyter` and the copy fails on the missing path.

A post-condition on the emitted `python3/kernel.json` closes the residual gap. That guard is a string
comparison, so it misses a `package` whose `bin/jupyter` execs an interpreter with a different `sys.prefix`:
`data[0]` would land on that environment, `cp -R` would copy ipykernel's relative-argv spec, and the rewrite
would be skipped because the file now exists. The post-condition asserts `argv[0]` is a store path for
whatever `package` supplies, covering both branches on the host rather than only the two packages the checks
pin.

Only `kernel.json` is written for `python3`, and only when the wrapper set has no `python3` of its own. Both
`cfg.package` and this derivation contribute `share/jupyter/kernels/python3`, so `buildEnv` unfolds that
directory and links ipykernel's logos from `cfg.package` anyway. A `package` whose definitions do supply a
python kernel (`pkgs.jupyter`, or any custom `definitions.python3`) keeps that kernelspec verbatim:
`jupyter-kernel.create` already writes it with an absolute `env.interpreter` argv.

One consequence worth knowing about: `jupyter_path()` documents `$JUPYTER_PATH` as "always highest priority",
ahead of both the user data dir and `sys.prefix/share/jupyter`, and `KernelSpecManager.find_kernel_specs` keeps
the first spec per name. So the exported `python3` shadows both a user-installed
`~/.local/share/jupyter/kernels/python3` and the spec `pip install ipykernel` writes into an active
virtualenv. That is recorded in the module header, and the exported spec is relabelled
`Python 3 (jupyter-all)` so the substitution is visible in a client's kernel picker: `ipykernel install` writes
`Python 3 (ipykernel)`, which is exactly what the unrelabelled spec carried.

### Regression checks

`kernelspecs` moved out of the NixOS module into `mkKernelspecs pkgs package`, so the checks and the module
share one definition. One check per branch:

- `checks.jupyter-all-kernelspecs` — `config.system.path` merges with `ignoreCollisions = true`, so the
  `hiPrio` that makes this module's `kernel.json` outrank the copy in `cfg.package` was an unverified
  assertion: if the resolution flipped, the closure would still build and degrade to a warning plus
  `argv[0] = "python"`. The check rebuilds that merge with `ignoreCollisions = false`, narrowed to
  `pathsToLink = [ "/share/jupyter/kernels" ]`, and asserts `argv[0]` is a store path, that `display_name`
  differs from the label ipykernel installs, and that a kernelspec other than `python3` survived.
- `checks.jupyter-kernelspecs-preserved` — runs `mkKernelspecs` against `pkgs.jupyter` and byte-compares the
  emitted `python3/kernel.json` against the wrapper's own, so any reappearance of an unconditional rewrite
  fails. It also fails if `jupyter-kernel.default` ever stops supplying `python3`, which would make the
  comparison vacuous.

Neither carries `passthru.runtimeCheck`. Realising a merge that includes `jupyter-all` pulls a 2.71 GiB
closure, which is the runner-disk weight `check.yml` excludes host toplevels for. CI forces the drvPaths; the
assertions run under a full local `nix flake check`.

## Test plan

- `nix build` of the `jupyter-all-kernelspecs` derivation. When the rewrite runs, an `import ipykernel_launcher`
  step gates it, so the derivation fails if the environment ever loses ipykernel.
- `buildEnv` probe over the host's `environment.pathsToLink` with both `cfg.package` and the kernelspec derivation,
  run with `ignoreCollisions = false`: no conflicting subpath, `share/jupyter` holds `kernels` and nothing else,
  `kernels` holds `clojure`, `octave`, `python3`, `r`, and `ruby`, and `python3/` resolves `kernel.json` to the
  `hiPrio` absolute-argv copy while `logo-32x32.png`, `logo-64x64.png`, and `logo-svg.svg` resolve to
  `cfg.package`.
- `jupyter_client` from an unwrapped `python3.withPackages [ jupyter-client ]` (no injected `JUPYTER_PATH`, the
  external-client case), with `PATH` limited to the `hiPrio` `pkgs.python3` (confirmed to raise
  `ModuleNotFoundError: No module named 'ipykernel_launcher'`) and `JUPYTER_PATH` pointed at the probe:
  `get_all_specs()` reports all five kernels, `start_new_kernel("python3")` executes `print(6*7)`, emits `42`, and
  returns `status: ok`.
- Same `nix build` against `pkgs.jupyter` (upstream's `jupyter-kernel.default`), covering a `package` override
  whose kernel set is legitimately python3-only.
- `nix build` of both checks, each with a negative control: the merge assertion against a `buildEnv` with
  `hiPrio` dropped takes the failure branch (`argv[0]=python`), the label assertion against a derivation with
  the relabel dropped takes its own (`display_name='Python 3 (ipykernel)'`), and the byte comparison against a
  derivation with the rewrite made unconditional again detects the rewrite.
- `nix flake check --accept-flake-config --no-build --offline`
- `nix eval` of `config.environment.etc."pam/environment".text` and a build of
  `config.system.build.setEnvironment`: both carry the profile-expanded `JUPYTER_PATH`, user profiles first and
  `/run/current-system/sw/share/jupyter` last.

Requires a switch plus re-login, since these variables are read at session start.