### PR TITLE
feat(browsers): install the Microsoft 365 web apps through firefoxpwa

### DIFF
--- a/docs/architecture/04-home-manager.md
+++ b/docs/architecture/04-home-manager.md
@@ -91,7 +91,7 @@ defaultAppImports = [
 
 ### Browser Modules
 
-Browsers register under `flake.homeManagerModules.browsers.<name>` from `modules/browsers/<name>/home.nix`. `modules/hosts/common/home-manager-apps.nix` resolves the shared browser set from that namespace directly into `home-manager.sharedModules`; browser names never go through `extraAppImports`, which only resolves the `apps` namespace and the `modules/hm-apps/` fallback path. A sibling file can extend the same `browsers.<name>` key, merged the same way `apps.stylix-gui` is above: `modules/browsers/firefoxpwa/home.nix` pins the userdata directory for every firefoxpwa site, and `modules/browsers/firefoxpwa/dmail.nix` layers the DMail-specific install onto the same `browsers.firefoxpwa` key.
+Browsers register under `flake.homeManagerModules.browsers.<name>` from `modules/browsers/<name>/home.nix`. `modules/hosts/common/home-manager-apps.nix` resolves the shared browser set from that namespace directly into `home-manager.sharedModules`; browser names never go through `extraAppImports`, which only resolves the `apps` namespace and the `modules/hm-apps/` fallback path. A sibling file can extend the same `browsers.<name>` key, merged the same way `apps.stylix-gui` is above: `modules/browsers/firefoxpwa/home.nix` pins the userdata directory for every firefoxpwa site, while `modules/browsers/firefoxpwa/dmail.nix` and `modules/browsers/firefoxpwa/m365.nix` layer the DMail and Microsoft 365 site installs onto the same `browsers.firefoxpwa` key.
 
 ### Per-Host Divergences
 

--- a/modules/browsers/firefoxpwa/_m365-apps.nix
+++ b/modules/browsers/firefoxpwa/_m365-apps.nix
@@ -1,0 +1,54 @@
+/*
+  firefoxpwa: Microsoft 365 web app catalog
+
+  Default for programs.firefoxpwa.m365.apps in ./apps.nix, and the fixture
+  ./m365-check.nix asserts against, so both move together.
+
+  Start URLs are bare origins. The installed manifest scope is the origin (see
+  packages/firefoxpwa-m365-install), and the landing paths Microsoft redirects
+  to are locale- or tenant-dependent (/en-us/, /mail/, /tasks/), so pinning one
+  ages out while the origin does not.
+
+  Left out on purpose, all verified 2026-08-04:
+    * teams.cloud.microsoft redirects to /v2/unsupported-browser on Gecko.
+    * visio.cloud.microsoft redirects to m365.cloud.microsoft, a different
+      origin, so it would leave its own scope on first load.
+    * clipchamp.cloud.microsoft does not resolve.
+*/
+[
+  {
+    key = "m365";
+    name = "Microsoft 365";
+    url = "https://m365.cloud.microsoft/";
+  }
+  {
+    key = "word";
+    name = "Word";
+    url = "https://word.cloud.microsoft/";
+  }
+  {
+    key = "excel";
+    name = "Excel";
+    url = "https://excel.cloud.microsoft/";
+  }
+  {
+    key = "powerpoint";
+    name = "PowerPoint";
+    url = "https://powerpoint.cloud.microsoft/";
+  }
+  {
+    key = "outlook";
+    name = "Outlook";
+    url = "https://outlook.cloud.microsoft/";
+  }
+  {
+    key = "onenote";
+    name = "OneNote";
+    url = "https://onenote.cloud.microsoft/";
+  }
+  {
+    key = "onedrive";
+    name = "OneDrive";
+    url = "https://onedrive.cloud.microsoft/";
+  }
+]

--- a/modules/browsers/firefoxpwa/apps-check.nix
+++ b/modules/browsers/firefoxpwa/apps-check.nix
@@ -59,8 +59,11 @@
       # The url type rejects by throwing rather than by failing an assertion, so
       # the two need different observations. Forced through the app list, since
       # a type only applies when its value is forced.
-      accepts =
-        url:
+      acceptsApp =
+        {
+          key,
+          url,
+        }:
         (builtins.tryEval (
           builtins.deepSeq
             (evalWith {
@@ -69,7 +72,7 @@
                 enable = true;
                 apps = [
                   {
-                    key = "probe";
+                    inherit key;
                     name = "Probe";
                     inherit url;
                   }
@@ -78,6 +81,12 @@
             }).programs.firefoxpwa.m365.apps
             true
         )).success;
+      accepts =
+        url:
+        acceptsApp {
+          key = "probe";
+          inherit url;
+        };
       failsWith = evaled: fragment: lib.any (a: lib.hasInfix fragment a.message) (failures evaled);
 
       # The launcher name is the idempotency key in a config.json every site
@@ -192,6 +201,12 @@
         assert lib.assertMsg (
           !accepts "word.cloud.microsoft"
         ) "browsers/firefoxpwa-apps-eval: a scheme-less start URL must be rejected";
+        assert lib.assertMsg (
+          !acceptsApp {
+            key = "Word_1";
+            url = "https://probe.example/";
+          }
+        ) "browsers/firefoxpwa-apps-eval: a key outside the path-safe alphabet must be rejected";
         pkgs.runCommand "firefoxpwa-apps-eval" { } ''
           echo "the firefoxpwa option module's assertions evaluate and fire" >"$out"
         '';

--- a/modules/browsers/firefoxpwa/apps-check.nix
+++ b/modules/browsers/firefoxpwa/apps-check.nix
@@ -1,0 +1,139 @@
+/*
+  Check: the firefoxpwa NixOS-scope option module (./apps.nix).
+
+  ./module-check.nix forces the Home Manager side. This forces the other half,
+  which nothing else evaluates either: no host enables programs.firefoxpwa.m365,
+  so its assertions and the launcher-name registry they read are unforced
+  everywhere, and an assertion that never evaluates is indistinguishable from
+  one that never fires.
+
+  Evaluated through lib.evalModules with the handful of NixOS options this
+  module writes to declared as stubs, rather than a full nixosSystem: the
+  subject is the module's own options and assertions, and a stub that goes
+  missing fails loudly by naming the option.
+
+  ./apps.nix is imported directly, the way ./m365-check.nix imports
+  ./_m365-apps.nix and the installers it drives. flake.nixosModules.browsers is
+  one deferred module rather than an attrset, so the module cannot be reached
+  through it by name, and flake.lib.nixosBrowsers, which does flatten it, must
+  not be read from perSystem.
+*/
+{
+  lib,
+  ...
+}:
+{
+  perSystem =
+    { pkgs, ... }:
+    let
+      evalWith =
+        firefoxpwa:
+        (lib.evalModules {
+          modules = [
+            (import ./apps.nix { }).flake.nixosModules.browsers.firefoxpwa
+            {
+              options = {
+                environment.systemPackages = lib.mkOption {
+                  type = lib.types.listOf lib.types.package;
+                  default = [ ];
+                };
+                assertions = lib.mkOption {
+                  type = lib.types.listOf lib.types.unspecified;
+                  default = [ ];
+                };
+                warnings = lib.mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ ];
+                };
+              };
+              config = {
+                _module.args.pkgs = pkgs;
+                programs.firefoxpwa = firefoxpwa;
+              };
+            }
+          ];
+        }).config;
+
+      failures = evaled: lib.filter (a: !a.assertion) evaled.assertions;
+      failsWith = evaled: fragment: lib.any (a: lib.hasInfix fragment a.message) (failures evaled);
+
+      # The launcher name is the idempotency key in a config.json every site
+      # installer shares, so this is the collision the registry exists for: one
+      # site's name claimed by another's entry.
+      collides = evalWith {
+        extended.enable = true;
+        dmail.enable = true;
+        m365 = {
+          enable = true;
+          apps = [
+            {
+              key = "work-mail";
+              name = "DMail";
+              url = "https://mail.example/";
+            }
+          ];
+        };
+      };
+
+      # The same pair without the collision: the shipped catalog alongside the
+      # DMail site, which is what a host enabling both actually gets.
+      shipped = evalWith {
+        extended.enable = true;
+        dmail.enable = true;
+        m365.enable = true;
+      };
+
+      # Registered only while the site is enabled, or a disabled installer would
+      # reserve a name nothing installs.
+      dmailOff = evalWith {
+        extended.enable = true;
+        m365 = {
+          enable = true;
+          apps = [
+            {
+              key = "work-mail";
+              name = "DMail";
+              url = "https://mail.example/";
+            }
+          ];
+        };
+      };
+
+      duplicateKeys = evalWith {
+        extended.enable = true;
+        m365 = {
+          enable = true;
+          apps = [
+            {
+              key = "word";
+              name = "Word";
+              url = "https://word.example/";
+            }
+            {
+              key = "word";
+              name = "Excel";
+              url = "https://excel.example/";
+            }
+          ];
+        };
+      };
+    in
+    {
+      checks."browsers/firefoxpwa-apps-eval" =
+        assert lib.assertMsg (failsWith collides "same launcher name")
+          "browsers/firefoxpwa-apps-eval: an m365 entry claiming the DMail site's launcher name must fail an assertion";
+        assert lib.assertMsg (
+          failures shipped == [ ]
+        ) "browsers/firefoxpwa-apps-eval: the shipped catalog alongside DMail must not fail an assertion";
+        assert lib.assertMsg (
+          failures dmailOff == [ ]
+        ) "browsers/firefoxpwa-apps-eval: a name is only claimed while its site is enabled";
+        assert lib.assertMsg (failsWith duplicateKeys "duplicate keys")
+          "browsers/firefoxpwa-apps-eval: two m365 entries sharing a key must fail an assertion";
+        assert lib.assertMsg (lib.elem "DMail" shipped.programs.firefoxpwa.siteNames)
+          "browsers/firefoxpwa-apps-eval: an enabled site must register its launcher name";
+        pkgs.runCommand "firefoxpwa-apps-eval" { } ''
+          echo "the firefoxpwa option module's assertions evaluate and fire" >"$out"
+        '';
+    };
+}

--- a/modules/browsers/firefoxpwa/apps-check.nix
+++ b/modules/browsers/firefoxpwa/apps-check.nix
@@ -153,6 +153,28 @@
         ) "browsers/firefoxpwa-apps-eval: a name is only claimed while its site is enabled";
         assert lib.assertMsg (failsWith duplicateKeys "duplicate keys")
           "browsers/firefoxpwa-apps-eval: two m365 entries sharing a key must fail an assertion";
+        # The m365-only duplicate-name assertion was dropped as subsumed by the
+        # union above; this is the intra-list case it used to cover, and it
+        # reaches the union only through siteNames = m365Names in ./apps.nix.
+        assert lib.assertMsg (failsWith (evalWith {
+          extended.enable = true;
+          m365 = {
+            enable = true;
+            apps = [
+              {
+                key = "word";
+                name = "Word";
+                url = "https://word.example/";
+              }
+              {
+                key = "word-2";
+                name = "Word";
+                url = "https://word-2.example/";
+              }
+            ];
+          };
+        }) "same launcher name")
+          "browsers/firefoxpwa-apps-eval: two m365 entries sharing a name must fail an assertion";
         assert lib.assertMsg (lib.elem "DMail" shipped.programs.firefoxpwa.siteNames)
           "browsers/firefoxpwa-apps-eval: an enabled site must register its launcher name";
         assert lib.assertMsg (accepts "https://word.cloud.microsoft/")

--- a/modules/browsers/firefoxpwa/apps-check.nix
+++ b/modules/browsers/firefoxpwa/apps-check.nix
@@ -156,25 +156,27 @@
         # The m365-only duplicate-name assertion was dropped as subsumed by the
         # union above; this is the intra-list case it used to cover, and it
         # reaches the union only through siteNames = m365Names in ./apps.nix.
-        assert lib.assertMsg (failsWith (evalWith {
-          extended.enable = true;
-          m365 = {
-            enable = true;
-            apps = [
-              {
-                key = "word";
-                name = "Word";
-                url = "https://word.example/";
-              }
-              {
-                key = "word-2";
-                name = "Word";
-                url = "https://word-2.example/";
-              }
-            ];
-          };
-        }) "same launcher name")
-          "browsers/firefoxpwa-apps-eval: two m365 entries sharing a name must fail an assertion";
+        assert lib.assertMsg (failsWith
+          (evalWith {
+            extended.enable = true;
+            m365 = {
+              enable = true;
+              apps = [
+                {
+                  key = "word";
+                  name = "Word";
+                  url = "https://word.example/";
+                }
+                {
+                  key = "word-2";
+                  name = "Word";
+                  url = "https://word-2.example/";
+                }
+              ];
+            };
+          })
+          "same launcher name"
+        ) "browsers/firefoxpwa-apps-eval: two m365 entries sharing a name must fail an assertion";
         assert lib.assertMsg (lib.elem "DMail" shipped.programs.firefoxpwa.siteNames)
           "browsers/firefoxpwa-apps-eval: an enabled site must register its launcher name";
         assert lib.assertMsg (accepts "https://word.cloud.microsoft/")

--- a/modules/browsers/firefoxpwa/apps-check.nix
+++ b/modules/browsers/firefoxpwa/apps-check.nix
@@ -157,6 +157,11 @@
         assert lib.assertMsg (
           failures shipped == [ ]
         ) "browsers/firefoxpwa-apps-eval: the shipped catalog alongside DMail must not fail an assertion";
+        # The assertions above reach only key and name, so nothing applies the
+        # url type to ./_m365-apps.nix. Forced whole, so every field of every
+        # shipped entry goes through its own option type.
+        assert lib.assertMsg (builtins.deepSeq shipped.programs.firefoxpwa.m365.apps true)
+          "browsers/firefoxpwa-apps-eval: every shipped catalog entry must satisfy its option types";
         assert lib.assertMsg (
           failures dmailOff == [ ]
         ) "browsers/firefoxpwa-apps-eval: a name is only claimed while its site is enabled";

--- a/modules/browsers/firefoxpwa/apps-check.nix
+++ b/modules/browsers/firefoxpwa/apps-check.nix
@@ -55,6 +55,29 @@
         }).config;
 
       failures = evaled: lib.filter (a: !a.assertion) evaled.assertions;
+
+      # The url type rejects by throwing rather than by failing an assertion, so
+      # the two need different observations. Forced through the app list, since
+      # a type only applies when its value is forced.
+      accepts =
+        url:
+        (builtins.tryEval (
+          builtins.deepSeq
+            (evalWith {
+              extended.enable = true;
+              m365 = {
+                enable = true;
+                apps = [
+                  {
+                    key = "probe";
+                    name = "Probe";
+                    inherit url;
+                  }
+                ];
+              };
+            }).programs.firefoxpwa.m365.apps
+            true
+        )).success;
       failsWith = evaled: fragment: lib.any (a: lib.hasInfix fragment a.message) (failures evaled);
 
       # The launcher name is the idempotency key in a config.json every site
@@ -132,6 +155,19 @@
           "browsers/firefoxpwa-apps-eval: two m365 entries sharing a key must fail an assertion";
         assert lib.assertMsg (lib.elem "DMail" shipped.programs.firefoxpwa.siteNames)
           "browsers/firefoxpwa-apps-eval: an enabled site must register its launcher name";
+        assert lib.assertMsg (accepts "https://word.cloud.microsoft/")
+          "browsers/firefoxpwa-apps-eval: a plain https start URL must be accepted";
+        assert lib.assertMsg (accepts "https://word.cloud.microsoft/a/b?q=1@2")
+          "browsers/firefoxpwa-apps-eval: an @ outside the authority must be accepted";
+        # Refused at runtime by the installer because the scope derived from it
+        # drops the userinfo and could then never contain the start URL. These
+        # are static strings, so the refusal belongs at eval.
+        assert lib.assertMsg (
+          !accepts "https://user:pass@word.cloud.microsoft/"
+        ) "browsers/firefoxpwa-apps-eval: a start URL embedding credentials must be rejected";
+        assert lib.assertMsg (
+          !accepts "word.cloud.microsoft"
+        ) "browsers/firefoxpwa-apps-eval: a scheme-less start URL must be rejected";
         pkgs.runCommand "firefoxpwa-apps-eval" { } ''
           echo "the firefoxpwa option module's assertions evaluate and fire" >"$out"
         '';

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -136,11 +136,13 @@ let
               place. Moving it to another origin is not: the manifest scope is
               fixed at install time and `firefoxpwa site update` cannot rewrite
               it, so the installer refuses that entry until the site is removed
-              with `firefoxpwa site uninstall`. The user service then reports
-              failure on the switch that moves the entry, on each of the bounded
-              restarts that follow it, and at every login after that. The
-              remaining entries are still installed, so one refusal does not hold
-              up the rest of the suite.
+              with `firefoxpwa site uninstall`. The installer logs the refusal
+              and exits `EX_CONFIG` (78), which the user service treats as a
+              successful, non-restarting exit: the unit stays active rather than
+              failing, does not consume its restart burst, and repeats the
+              refusal at every login until the entry is fixed. The remaining
+              entries are still installed, so one refusal does not hold up the
+              rest of the suite.
 
               Renaming an entry while keeping its `key` is refused on the same
               terms. `name` is the idempotency key, so the installer would

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -133,7 +133,11 @@ let
                     '';
                   };
                   url = lib.mkOption {
-                    type = lib.types.str;
+                    # Constrained to a scheme the installer can parse an origin
+                    # from: a scheme-less or misspelled entry is otherwise
+                    # accepted here and only surfaces as a refusal in a user
+                    # unit's journal after a switch.
+                    type = lib.types.strMatching "https?://[^[:space:]]+";
                     description = ''
                       Start URL. The installed manifest scope is its origin, so
                       same-origin navigation stays inside the app and anything

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -147,6 +147,13 @@ let
               otherwise register a second site under the new name and overwrite
               the record naming the first, leaving the original app and its
               launcher entry with nothing pointing at them.
+
+              Editing `key` and `name` together is not refused. Both lookups then
+              miss the old site, so the installer treats the entry as new and
+              registers a second site while leaving the original app and its
+              launcher entry orphaned. Uninstall the old site before changing
+              both fields. Editing only one field while the old site remains is
+              refused.
             '';
           };
 

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -109,6 +109,12 @@ let
               restarts that follow it, and at every login after that. The
               remaining entries are still installed, so one refusal does not hold
               up the rest of the suite.
+
+              Renaming an entry while keeping its `key` is refused on the same
+              terms. `name` is the idempotency key, so the installer would
+              otherwise register a second site under the new name and overwrite
+              the record naming the first, leaving the original app and its
+              launcher entry with nothing pointing at them.
             '';
           };
 

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -175,6 +175,12 @@ let
                       `firefoxpwa site uninstall`, which destroys its PWA profile
                       and session state. The `m365-<old-key>-*` records are left
                       behind and have to be deleted by hand.
+
+                      That refusal holds only while `name` is unchanged. Editing
+                      both fields makes every lookup miss the installed site, so
+                      it is registered a second time and the original app and
+                      its launcher entry are orphaned with no message. Uninstall
+                      the old site before changing both.
                     '';
                   };
                   name = lib.mkOption {

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -24,6 +24,7 @@ let
     }:
     let
       cfg = config.programs.firefoxpwa.extended;
+      dmailCfg = config.programs.firefoxpwa.dmail;
       m365Cfg = config.programs.firefoxpwa.m365;
       m365Keys = map (app: app.key) m365Cfg.apps;
       m365Names = map (app: app.name) m365Cfg.apps;
@@ -41,10 +42,36 @@ let
           package = lib.mkPackageOption pkgs "firefoxpwa" { };
         };
 
+        # Every site installer shares one config.json and looks a site up by
+        # its launcher name (.sites.<ulid>.config.name), so two claiming the
+        # same name collide there rather than at eval: the second finds a site
+        # no record of its own accounts for and refuses it on every run, with a
+        # remedy that destroys the first one's PWA profile. Each site registers
+        # the names it claims here and the assertion below is one check over all
+        # of them, so a site added later joins it by contributing rather than by
+        # anyone remembering to widen a comparison.
+        siteNames = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          internal = true;
+          description = "Launcher names claimed by the enabled firefoxpwa site installers.";
+        };
+
         # Per-site install toggles are declared here (NixOS scope) so the common
         # app catalog and per-host apps-enable files can layer them like any other
         # app, and the Home Manager installer in ./dmail.nix can read them through
         # `osConfig`.
+        dmail.name = lib.mkOption {
+          type = lib.types.str;
+          default = "DMail";
+          description = ''
+            Launcher name for the DMail site, and its idempotency key: the
+            installer finds the site it installed by matching this against
+            `.sites.<ulid>.config.name`. Declared rather than fixed in
+            ./dmail.nix so it takes part in the collision check above.
+          '';
+        };
+
         dmail.enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
@@ -187,22 +214,31 @@ let
           environment.systemPackages = [ cfg.package ];
         })
 
+        (lib.mkIf dmailCfg.enable { programs.firefoxpwa.siteNames = [ dmailCfg.name ]; })
+
         (lib.mkIf m365Cfg.enable {
-          # Both collisions are silent at install time and only surface as a
-          # site the installer then refuses to adopt: two entries sharing a
-          # name race for the same idempotency key, and two sharing a key
-          # overwrite each other's install records.
+          programs.firefoxpwa.siteNames = m365Names;
+
+          # Silent at install time and surfacing only as a site the installer
+          # then refuses to adopt: two entries sharing a key overwrite each
+          # other's install records. Names are checked across every site
+          # installer instead, below.
           assertions = [
             {
               assertion = duplicates m365Keys == [ ];
               message = "programs.firefoxpwa.m365.apps has duplicate keys: ${lib.concatStringsSep ", " (duplicates m365Keys)}";
             }
-            {
-              assertion = duplicates m365Names == [ ];
-              message = "programs.firefoxpwa.m365.apps has duplicate names: ${lib.concatStringsSep ", " (duplicates m365Names)}";
-            }
           ];
         })
+
+        {
+          assertions = [
+            {
+              assertion = duplicates config.programs.firefoxpwa.siteNames == [ ];
+              message = "firefoxpwa site installers claim the same launcher name, which they would fight over in one config.json: ${lib.concatStringsSep ", " (duplicates config.programs.firefoxpwa.siteNames)}";
+            }
+          ];
+        }
       ];
     };
 in

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -143,7 +143,10 @@ let
               counts each start, including corrective switches, within its
               bounded five-start window, so the refusal remains visible while
               leaving room to fix the entry without an immediate rate-limit
-              lockout. The remaining entries are still installed, so one
+              lockout. The status is for the whole run: if another entry has a
+              retryable fault, the run exits 1 instead, the unit restarts on
+              its bounded schedule, and the refusal is logged again on each
+              restart. The remaining entries are still installed, so one
               refusal does not hold up the rest of the suite.
 
               Renaming an entry while keeping its `key` is refused on the same

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -103,10 +103,12 @@ let
               Changing an entry's `url` within its installed origin is applied in
               place. Moving it to another origin is not: the manifest scope is
               fixed at install time and `firefoxpwa site update` cannot rewrite
-              it, so the installer refuses that entry, and the user service
-              reports failure on every switch and login until the site is removed
-              with `firefoxpwa site uninstall`. The remaining entries are still
-              installed, so one refusal does not hold up the rest of the suite.
+              it, so the installer refuses that entry until the site is removed
+              with `firefoxpwa site uninstall`. The user service then reports
+              failure on the switch that moves the entry, on each of the bounded
+              restarts that follow it, and at every login after that. The
+              remaining entries are still installed, so one refusal does not hold
+              up the rest of the suite.
             '';
           };
 

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -69,6 +69,11 @@ let
             installer finds the site it installed by matching this against
             `.sites.<ulid>.config.name`. Declared rather than fixed in
             ./dmail.nix so it takes part in the collision check above.
+
+            Editing it is not a rename. The installer no longer finds the site
+            it installed under the old name, so it refuses the entry until that
+            site is removed with `firefoxpwa site uninstall`, which destroys its
+            PWA profile and session state.
           '';
         };
 

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -139,10 +139,12 @@ let
               with `firefoxpwa site uninstall`. The installer logs the refusal
               and exits `EX_CONFIG` (78), which the user service treats as a
               successful, non-restarting exit: the unit stays active rather than
-              failing, does not consume its restart burst, and repeats the
-              refusal at every login until the entry is fixed. The remaining
-              entries are still installed, so one refusal does not hold up the
-              rest of the suite.
+              failing and does not trigger automatic retries. The unit still
+              counts each start, including corrective switches, within its
+              bounded five-start window, so the refusal remains visible while
+              leaving room to fix the entry without an immediate rate-limit
+              lockout. The remaining entries are still installed, so one
+              refusal does not hold up the rest of the suite.
 
               Renaming an entry while keeping its `key` is refused on the same
               terms. `name` is the idempotency key, so the installer would

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -128,6 +128,14 @@ let
                       Slug for this entry's install records under the firefoxpwa
                       data directory. Constrained to a path-safe alphabet because
                       it is interpolated into those file names.
+
+                      Editing it is not a rename. The records move with the slug,
+                      so the installer finds the installed site with nothing
+                      recording the origin it was installed at, and refuses that
+                      entry until the site is removed with
+                      `firefoxpwa site uninstall`, which destroys its PWA profile
+                      and session state. The `m365-<old-key>-*` records are left
+                      behind and have to be deleted by hand.
                     '';
                   };
                   name = lib.mkOption {

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -180,10 +180,13 @@ let
                   };
                   url = lib.mkOption {
                     # Constrained to a scheme the installer can parse an origin
-                    # from: a scheme-less or misspelled entry is otherwise
-                    # accepted here and only surfaces as a refusal in a user
-                    # unit's journal after a switch.
-                    type = lib.types.strMatching "https?://[^[:space:]]+";
+                    # from, and to an authority without userinfo: both are
+                    # otherwise accepted here and surface only as a refusal in a
+                    # user unit's journal after a switch. Unlike the DMail URL,
+                    # which is a rotating secret nothing can check at eval, these
+                    # are static strings. `@` is excluded from the authority
+                    # only, so a path or query may still carry one.
+                    type = lib.types.strMatching "https?://[^[:space:]/?#@]+([/?#][^[:space:]]*)?";
                     description = ''
                       Start URL. The installed manifest scope is its origin, so
                       same-origin navigation stays inside the app and anything

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -149,6 +149,13 @@ let
               restart. The remaining entries are still installed, so one
               refusal does not hold up the rest of the suite.
 
+              Removing a refused site does not rerun the unit by itself. The
+              unit remains `active (exited)` because `RemainAfterExit` and exit
+              status 78 make the refusal successful, and its text is unchanged,
+              so neither `sd-switch` nor `Restart=on-failure` starts it. After
+              the removal, the reinstall runs at the next login or after
+              `systemctl --user restart firefoxpwa-m365`.
+
               Renaming an entry while keeping its `key` is refused on the same
               terms. `name` is the idempotency key, so the installer would
               otherwise register a second site under the new name and overwrite
@@ -180,8 +187,11 @@ let
                       recording the origin it was installed at, and refuses that
                       entry until the site is removed with
                       `firefoxpwa site uninstall`, which destroys its PWA profile
-                      and session state. The `m365-<old-key>-*` records are left
-                      behind and have to be deleted by hand.
+                      and session state. After the removal, the reinstall runs at
+                      the next login or after
+                      `systemctl --user restart firefoxpwa-m365`. The
+                      `m365-<old-key>-*` records are left behind and have to be
+                      deleted by hand.
 
                       That refusal holds only while `name` is unchanged. Editing
                       both fields makes every lookup miss the installed site, so

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -156,6 +156,15 @@ let
               the removal, the reinstall runs at the next login or after
               `systemctl --user restart firefoxpwa-m365`.
 
+              A retryable fault is bounded differently. Five starts inside the
+              unit's `StartLimitIntervalSec` leave it failed with
+              `start-limit-hit`; while those starts remain in the window, later
+              starts can be refused with "start request repeated too quickly",
+              including a corrective `sd-switch` or an explicit restart. After
+              fixing the fault, run
+              `systemctl --user reset-failed firefoxpwa-m365` before restarting
+              the unit to clear the start counter.
+
               Renaming an entry while keeping its `key` is refused on the same
               terms. `name` is the idempotency key, so the installer would
               otherwise register a second site under the new name and overwrite

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -24,63 +24,166 @@ let
     }:
     let
       cfg = config.programs.firefoxpwa.extended;
+      m365Cfg = config.programs.firefoxpwa.m365;
+      m365Keys = map (app: app.key) m365Cfg.apps;
+      m365Names = map (app: app.name) m365Cfg.apps;
+      duplicates = xs: lib.unique (lib.filter (x: lib.count (y: y == x) xs > 1) xs);
     in
     {
-      options.programs.firefoxpwa.extended = {
-        enable = lib.mkOption {
-          type = lib.types.bool;
-          default = false;
-          description = "Whether to enable Progressive Web Apps for Firefox.";
+      options.programs.firefoxpwa = {
+        extended = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Whether to enable Progressive Web Apps for Firefox.";
+          };
+
+          package = lib.mkPackageOption pkgs "firefoxpwa" { };
         };
 
-        package = lib.mkPackageOption pkgs "firefoxpwa" { };
+        # Per-site install toggles are declared here (NixOS scope) so the common
+        # app catalog and per-host apps-enable files can layer them like any other
+        # app, and the Home Manager installer in ./dmail.nix can read them through
+        # `osConfig`.
+        dmail.enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = ''
+            Install the primary user's work mail Progressive Web App (DMail)
+            through firefoxpwa. The start URL is read at runtime from the
+            SOPS-encrypted gecko work-bookmark secret. Requires
+            programs.firefoxpwa.extended.enable.
+
+            One-way. Setting this back to false stops managing the site but does
+            not uninstall it. Removing the site is a manual
+            `firefoxpwa site uninstall`, which deletes the PWA profile and the
+            launcher entry but none of this module's own records: the
+            dmail-applied-url, dmail-applied-origin, dmail-applied-ulid and
+            dmail-installing files under `''${xdg.dataHome}/firefoxpwa` have to
+            be deleted separately, and a leftover dmail-applied-ulid makes the
+            next site to carry this name refused rather than adopted. Not
+            automated, because an automatic uninstall would destroy the PWA
+            profile and its session state.
+
+            Rotating the secret to a URL on a different origin is also not
+            applied automatically. The manifest scope is fixed at install time
+            and `firefoxpwa site update` cannot rewrite it, so the installer
+            refuses the rotation and the user service fails on every switch and
+            login until the site is removed with `firefoxpwa site uninstall`.
+            Rotations within the same origin are applied in place.
+
+            A secret whose URL embeds credentials (`https://user:pass@host/...`)
+            is refused outright, before any site lookup, because the manifest
+            scope derived from it drops the userinfo and could then never contain
+            the start URL. `firefoxpwa site uninstall` does not clear that one:
+            the secret itself has to be stored without the credentials.
+          '';
+        };
+
+        m365 = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = ''
+              Install the Microsoft 365 web apps listed in
+              `programs.firefoxpwa.m365.apps` as Progressive Web Apps through
+              firefoxpwa. Requires programs.firefoxpwa.extended.enable.
+
+              One-way, on the same terms as
+              `programs.firefoxpwa.dmail.enable`: setting this back to false, or
+              dropping an entry from the list, stops managing those sites but
+              does not uninstall them, and `firefoxpwa site uninstall` clears
+              neither the `m365-<key>-applied-url`,
+              `m365-<key>-applied-origin`, `m365-<key>-applied-ulid` nor
+              `m365-<key>-installing` records under
+              `''${xdg.dataHome}/firefoxpwa`. A leftover
+              `m365-<key>-applied-ulid` makes the next site to carry that entry's
+              name refused rather than adopted.
+
+              Changing an entry's `url` within its installed origin is applied in
+              place. Moving it to another origin is not: the manifest scope is
+              fixed at install time and `firefoxpwa site update` cannot rewrite
+              it, so the installer refuses that entry, and the user service
+              reports failure on every switch and login until the site is removed
+              with `firefoxpwa site uninstall`. The remaining entries are still
+              installed, so one refusal does not hold up the rest of the suite.
+            '';
+          };
+
+          apps = lib.mkOption {
+            type = lib.types.listOf (
+              lib.types.submodule {
+                options = {
+                  key = lib.mkOption {
+                    type = lib.types.strMatching "[a-z0-9][a-z0-9-]*";
+                    description = ''
+                      Slug for this entry's install records under the firefoxpwa
+                      data directory. Constrained to a path-safe alphabet because
+                      it is interpolated into those file names.
+                    '';
+                  };
+                  name = lib.mkOption {
+                    type = lib.types.str;
+                    description = ''
+                      Launcher name. Also the idempotency key: firefoxpwa stores
+                      it at `.sites.<ulid>.config.name`, which is how the
+                      installer finds an entry it already installed.
+                    '';
+                  };
+                  url = lib.mkOption {
+                    type = lib.types.str;
+                    description = ''
+                      Start URL. The installed manifest scope is its origin, so
+                      same-origin navigation stays inside the app and anything
+                      else opens in the default browser.
+                    '';
+                  };
+                };
+              }
+            );
+            default = import ./_m365-apps.nix;
+            example = lib.literalExpression ''
+              [
+                {
+                  key = "excel";
+                  name = "Excel";
+                  url = "https://excel.cloud.microsoft/";
+                }
+              ]
+            '';
+            description = ''
+              Microsoft 365 web apps to install. Defaults to the suite in
+              `modules/browsers/firefoxpwa/_m365-apps.nix`.
+            '';
+          };
+        };
       };
 
-      # Per-site install toggles are declared here (NixOS scope) so the common
-      # app catalog and per-host apps-enable files can layer them like any other
-      # app, and the Home Manager installer in ./dmail.nix can read them through
-      # `osConfig`.
-      options.programs.firefoxpwa.dmail.enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Install the primary user's work mail Progressive Web App (DMail)
-          through firefoxpwa. The start URL is read at runtime from the
-          SOPS-encrypted gecko work-bookmark secret. Requires
-          programs.firefoxpwa.extended.enable.
+      config = lib.mkMerge [
+        (lib.mkIf cfg.enable {
+          # The connector is launched via the native-messaging manifest's absolute
+          # path, but the `firefoxpwa` CLI must also be on PATH so the management
+          # extension can detect it and so sites install/launch from a shell.
+          environment.systemPackages = [ cfg.package ];
+        })
 
-          One-way. Setting this back to false stops managing the site but does
-          not uninstall it. Removing the site is a manual
-          `firefoxpwa site uninstall`, which deletes the PWA profile and the
-          launcher entry but none of this module's own records: the
-          dmail-applied-url, dmail-applied-origin, dmail-applied-ulid and
-          dmail-installing files under `''${xdg.dataHome}/firefoxpwa` have to
-          be deleted separately, and a leftover dmail-applied-ulid makes the
-          next site to carry this name refused rather than adopted. Not
-          automated, because an automatic uninstall would destroy the PWA
-          profile and its session state.
-
-          Rotating the secret to a URL on a different origin is also not
-          applied automatically. The manifest scope is fixed at install time
-          and `firefoxpwa site update` cannot rewrite it, so the installer
-          refuses the rotation and the user service fails on every switch and
-          login until the site is removed with `firefoxpwa site uninstall`.
-          Rotations within the same origin are applied in place.
-
-          A secret whose URL embeds credentials (`https://user:pass@host/...`)
-          is refused outright, before any site lookup, because the manifest
-          scope derived from it drops the userinfo and could then never contain
-          the start URL. `firefoxpwa site uninstall` does not clear that one:
-          the secret itself has to be stored without the credentials.
-        '';
-      };
-
-      config = lib.mkIf cfg.enable {
-        # The connector is launched via the native-messaging manifest's absolute
-        # path, but the `firefoxpwa` CLI must also be on PATH so the management
-        # extension can detect it and so sites install/launch from a shell.
-        environment.systemPackages = [ cfg.package ];
-      };
+        (lib.mkIf m365Cfg.enable {
+          # Both collisions are silent at install time and only surface as a
+          # site the installer then refuses to adopt: two entries sharing a
+          # name race for the same idempotency key, and two sharing a key
+          # overwrite each other's install records.
+          assertions = [
+            {
+              assertion = duplicates m365Keys == [ ];
+              message = "programs.firefoxpwa.m365.apps has duplicate keys: ${lib.concatStringsSep ", " (duplicates m365Keys)}";
+            }
+            {
+              assertion = duplicates m365Names == [ ];
+              message = "programs.firefoxpwa.m365.apps has duplicate names: ${lib.concatStringsSep ", " (duplicates m365Names)}";
+            }
+          ];
+        })
+      ];
     };
 in
 {

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -921,6 +921,7 @@
               echo "PASS  marker write leaves no temporary"
             fi
 
+            echo
             echo "-- the installer uses the directory it is given --"
             if [ -e "$XDG_DATA_HOME/firefoxpwa" ]; then
               echo "FAIL  installer re-derived a path under XDG_DATA_HOME"

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -253,6 +253,12 @@
             # Matched with case, not piped into grep: under pipefail, grep -q
             # exiting on first match can SIGPIPE the producer and flip a real
             # match into a reported failure.
+            #
+            # A matching fragment with the wrong status leaves the case arm, and
+            # so the case, returning 1, which does not trip errexit: bash
+            # ignores -e for the left side of an && list and the enclosing
+            # compound inherits that, so the FAIL branch below still reports the
+            # mismatch and the assertions after it still run.
             expect() {
               local label="$1" want_rc="$2" want_text="$3" out rc=0 ok=1
               out=$("$installer" 2>&1) || rc=$?

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -220,6 +220,7 @@
             nativeBuildInputs = [
               pkgs.jq
               pkgs.coreutils
+              pkgs.gnugrep
             ];
           }
           ''
@@ -919,6 +920,20 @@
               failures=$((failures + 1))
             else
               echo "PASS  marker write leaves no temporary"
+            fi
+
+            echo
+            echo "-- the installer is built through the shared site installer --"
+            # ./site-lock-check.nix proves the builder serializes, but nothing
+            # there names this derivation: rewriting default.nix back to a
+            # direct writeShellApplication would keep that check green while
+            # losing the mutual exclusion it exists to provide. The lock path is
+            # the tie, since it is the shared resource rather than the mechanism.
+            if grep -q '\.config-lock' "$installer"; then
+              echo "PASS  takes the shared site lock"
+            else
+              echo "FAIL  no shared site lock in the installer text; it was not built through packages/firefoxpwa-site-installer"
+              failures=$((failures + 1))
             fi
 
             echo

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -281,7 +281,7 @@
               if [ "$ok" = 0 ]; then
                 echo "PASS  $label"
               else
-                echo "FAIL  $label (rc=$rc, expected $want_rc)"
+                echo "FAIL  $label (rc=$rc, expected $want_rc; wanted output containing '$want_text')"
                 printf '%s\n' "$out" | sed 's/^/      /'
                 failures=$((failures + 1))
               fi

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -229,6 +229,7 @@
               pkgs.jq
               pkgs.coreutils
               pkgs.gnugrep
+              pkgs.gnused
             ];
           }
           ''

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -947,6 +947,16 @@
             # both of those read identically either way.
             assert_equal "the installed site still carries the original name" \
               "$(jq -r '.sites["01STUB"].config.name' "$config_file")" "DMail"
+            # config.json gone entirely rather than the site removed from it:
+            # the rename guard reads that file, so it has to tell "no file" from
+            # "cannot read this file" and let the first install.
+            rm -f "$config_file"
+            expect "a config.json that is gone does not block the install" 0 "installed" "$renamed"
+
+            reset
+            set_url 'https://mail.example.com/a'
+            "$installer" >/dev/null
+            expect "rename still refused after the reset" 1 "is a new name for the site this unit installed" "$renamed"
             # An uninstall leaves the same record but takes the site, and that
             # case must still install: the guard is on the site being there.
             jq 'del(.sites["01STUB"])' "$config_file" >"$config_file.next"

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -941,8 +941,12 @@
             expect "rename refused" 1 "is a new name for the site this unit installed" "$renamed"
             assert_equal "no second site registered under the new name" \
               "$(jq -r '(.sites // {}) | length' "$config_file")" 1
-            assert_equal "the ulid record still names the original site" \
-              "$(cat "$data_dir/dmail-applied-ulid")" "01STUB"
+            # The site's own name, not the count or the ulid record: this stub
+            # writes every install to .sites["01STUB"], so without the guard the
+            # renamed run overwrites the original rather than adding one, and
+            # both of those read identically either way.
+            assert_equal "the installed site still carries the original name" \
+              "$(jq -r '.sites["01STUB"].config.name' "$config_file")" "DMail"
             # An uninstall leaves the same record but takes the site, and that
             # case must still install: the guard is on the site being there.
             jq 'del(.sites["01STUB"])' "$config_file" >"$config_file.next"

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -951,7 +951,10 @@
             # the rename guard reads that file, so it has to tell "no file" from
             # "cannot read this file" and let the first install.
             rm -f "$config_file"
-            expect "a config.json that is gone does not block the install" 0 "installed" "$renamed"
+            # The full message, not just "installed": that substring also matches
+            # "already installed with current URL", so the loose form pins
+            # neither the branch that ran nor the name it installed under.
+            expect "a config.json that is gone does not block the install" 0 "installed 'Work Mail'" "$renamed"
 
             reset
             set_url 'https://mail.example.com/a'
@@ -961,7 +964,9 @@
             # case must still install: the guard is on the site being there.
             jq 'del(.sites["01STUB"])' "$config_file" >"$config_file.next"
             mv "$config_file.next" "$config_file"
-            expect "an uninstalled site is reinstalled under the new name" 0 "installed" "$renamed"
+            expect "an uninstalled site is reinstalled under the new name" 0 "installed 'Work Mail'" "$renamed"
+            assert_equal "the reinstalled site carries the new name" \
+              "$(jq -r '.sites["01STUB"].config.name' "$config_file")" "Work Mail"
 
             echo
             echo "-- the installer is built through the shared site installer --"

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -191,15 +191,23 @@
       # through unread.
       pinnedXdgDataHome = "${secretDir}/xdg-pinned";
 
-      installer = (pkgs.callPackage ../../../packages/firefoxpwa-dmail-install { }) {
-        firefoxpwa = stub;
-        urlPath = "${secretDir}/url";
-        xdgDataHome = pinnedXdgDataHome;
-        inherit dataDir;
-        # Exercises the retry loop's control flow without three real 5-second
-        # sleeps per check run.
-        retryDelay = 0;
-      };
+      mkInstaller =
+        appName:
+        (pkgs.callPackage ../../../packages/firefoxpwa-dmail-install { }) {
+          firefoxpwa = stub;
+          urlPath = "${secretDir}/url";
+          xdgDataHome = pinnedXdgDataHome;
+          inherit dataDir appName;
+          # Exercises the retry loop's control flow without three real 5-second
+          # sleeps per check run.
+          retryDelay = 0;
+        };
+
+      installer = mkInstaller "DMail";
+      # programs.firefoxpwa.dmail.name edited on a host that already installed
+      # the site: the records keep their fixed dmail-* paths, so the lookup
+      # misses and nothing but the guard stops a second site being registered.
+      renamed = mkInstaller "Work Mail";
     in
     {
       checks."browsers/firefoxpwa-dmail" =
@@ -241,6 +249,7 @@
             install -d "$HOME" "$XDG_DATA_HOME" "$secret_dir"
 
             installer=${lib.getExe installer}
+            renamed=${lib.getExe renamed}
             failures=0
 
             reset() {
@@ -261,8 +270,10 @@
             # compound inherits that, so the FAIL branch below still reports the
             # mismatch and the assertions after it still run.
             expect() {
-              local label="$1" want_rc="$2" want_text="$3" out rc=0 ok=1
-              out=$("$installer" 2>&1) || rc=$?
+              # Fourth argument, defaulting to the DMail installer: a variant
+              # built with another launcher name drives the same assertions.
+              local label="$1" want_rc="$2" want_text="$3" runner="''${4:-$installer}" out rc=0 ok=1
+              out=$("$runner" 2>&1) || rc=$?
               case "$out" in
                 *"$want_text"*) [ "$rc" = "$want_rc" ] && ok=0 ;;
               esac
@@ -921,6 +932,22 @@
             else
               echo "PASS  marker write leaves no temporary"
             fi
+
+            echo
+            echo "-- renaming the site is refused rather than orphaning it --"
+            reset
+            set_url 'https://mail.example.com/a'
+            "$installer" >/dev/null
+            expect "rename refused" 1 "is a new name for the site this unit installed" "$renamed"
+            assert_equal "no second site registered under the new name" \
+              "$(jq -r '(.sites // {}) | length' "$config_file")" 1
+            assert_equal "the ulid record still names the original site" \
+              "$(cat "$data_dir/dmail-applied-ulid")" "01STUB"
+            # An uninstall leaves the same record but takes the site, and that
+            # case must still install: the guard is on the site being there.
+            jq 'del(.sites["01STUB"])' "$config_file" >"$config_file.next"
+            mv "$config_file.next" "$config_file"
+            expect "an uninstalled site is reinstalled under the new name" 0 "installed" "$renamed"
 
             echo
             echo "-- the installer is built through the shared site installer --"

--- a/modules/browsers/firefoxpwa/dmail-check.nix
+++ b/modules/browsers/firefoxpwa/dmail-check.nix
@@ -586,6 +586,13 @@
             expect "unreadable config.json refuses rather than risking a duplicate" 1 \
               "not installing a second"
 
+            reset
+            set_url 'https://mail.example.com/x'
+            "$installer" >/dev/null
+            : >"$config_file"
+            expect "zero-byte config.json refuses rather than risking a duplicate" 1 \
+              "not installing a second"
+
             # Following the refusal's own remedy: installed at A, rotated to B,
             # site uninstalled, then the reinstall registers and fails. The
             # applied URL still names A while the origin record names B, so

--- a/modules/browsers/firefoxpwa/dmail.nix
+++ b/modules/browsers/firefoxpwa/dmail.nix
@@ -86,6 +86,12 @@ _: {
             Service = {
               Type = "oneshot";
               RemainAfterExit = true;
+              # Past the default 90s, which a legitimate wait can exceed: the
+              # installers share one lock (packages/firefoxpwa-site-installer)
+              # and this unit is the one with no Restart=, so a run killed while
+              # queued behind another would sit failed until the next switch.
+              # Still a bound, so a genuine hang fails rather than sits.
+              TimeoutStartSec = 900;
               # FFPWA_USERDATA (the userdata tree, ProjectDirs) and
               # XDG_DATA_HOME (system integration's applications/ directory,
               # BaseDirs) are exported by the installer itself from the same

--- a/modules/browsers/firefoxpwa/dmail.nix
+++ b/modules/browsers/firefoxpwa/dmail.nix
@@ -46,8 +46,10 @@ _: {
 
       # The launcher name doubles as the idempotency key. firefoxpwa stores it in
       # config.json at .sites.<ulid>.config.name, so an existing site with this
-      # name means the app is already installed.
-      appName = "DMail";
+      # name means the app is already installed. Read from the option rather
+      # than written here, so ./apps.nix can register it among the names every
+      # site installer claims and catch a collision at eval.
+      appName = osConfig.programs.firefoxpwa.dmail.name or "DMail";
 
       # Owned by ./home.nix, which pins and hardens it to 0700. Read rather
       # than re-derived: a second rule drifts from it as soon as either side

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -402,18 +402,24 @@ assert lib.assertMsg (lib.all (
             else
               echo "PASS  nothing written outside the configured data directory"
             fi
-            # Globbed rather than matched with compgen, which the builder's
-            # bash does not provide and which fails open: a "command not found"
-            # takes the else branch and reports a pass.
-            shopt -s nullglob
-            leftover=("$data_dir"/*.next)
-            shopt -u nullglob
-            if [ "''${#leftover[@]}" -ne 0 ]; then
-              echo "FAIL  record temporary file left behind: ''${leftover[*]}"
-              failures=$((failures + 1))
-            else
-              echo "PASS  record writes leave no temporary"
-            fi
+            # Globbed rather than matched with compgen: the bash a runCommand
+            # builder runs is built without programmable completion, so the
+            # first form of this assertion reported "command not found" into
+            # the else branch and passed on every run. Planted against a real
+            # temporary first, because an assertion nothing proves can fail is
+            # what made that defect invisible.
+            leftover_temps() {
+              local found=()
+              shopt -s nullglob
+              found=("$data_dir"/*.next)
+              shopt -u nullglob
+              printf '%s\n' "''${found[@]##*/}"
+            }
+            : >"$data_dir/planted.next"
+            assert_equal "leftover detector reports a planted temporary" \
+              "$(leftover_temps)" "planted.next"
+            rm -f "$data_dir/planted.next"
+            assert_equal "record writes leave no temporary" "$(leftover_temps)" ""
 
             echo
             if [ "$failures" -ne 0 ]; then

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -248,6 +248,12 @@ assert lib.assertMsg (lib.all (
             # Matched with case, not piped into grep: under pipefail, grep -q
             # exiting on first match can SIGPIPE the producer and flip a real
             # match into a reported failure.
+            #
+            # A matching fragment with the wrong status leaves the case arm, and
+            # so the case, returning 1, which does not trip errexit: bash
+            # ignores -e for the left side of an && list and the enclosing
+            # compound inherits that, so the FAIL branch below still reports the
+            # mismatch and the assertions after it still run.
             expect() {
               local label="$1" installer="$2" want_rc="$3" want_text="$4" out rc=0 ok=1
               out=$("$installer" 2>&1) || rc=$?

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -291,6 +291,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
               pkgs.jq
               pkgs.coreutils
               pkgs.gnugrep
+              pkgs.gnused
             ];
           }
           ''

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -340,7 +340,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
               if [ "$ok" = 0 ]; then
                 echo "PASS  $label"
               else
-                echo "FAIL  $label (rc=$rc, expected $want_rc)"
+                echo "FAIL  $label (rc=$rc, expected $want_rc; wanted output containing '$want_text')"
                 printf '%s\n' "$out" | sed 's/^/      /'
                 failures=$((failures + 1))
               fi

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -255,6 +255,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             nativeBuildInputs = [
               pkgs.jq
               pkgs.coreutils
+              pkgs.gnugrep
             ];
           }
           ''
@@ -494,6 +495,20 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             expect "catalog rerun" "$shipped" 0 ""
             assert_equal "catalog rerun adds nothing" \
               "$(site_count)" ${toString (builtins.length catalog)}
+
+            echo
+            echo "-- the installer is built through the shared site installer --"
+            # ./site-lock-check.nix proves the builder serializes, but nothing
+            # there names this derivation: rewriting default.nix back to a
+            # direct writeShellApplication would keep that check green while
+            # losing the mutual exclusion it exists to provide. The lock path is
+            # the tie, since it is the shared resource rather than the mechanism.
+            if grep -q '\.config-lock' "$declared"; then
+              echo "PASS  takes the shared site lock"
+            else
+              echo "FAIL  no shared site lock in the installer text; it was not built through packages/firefoxpwa-site-installer"
+              failures=$((failures + 1))
+            fi
 
             echo
             echo "-- the installer uses the directories it is given --"

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -383,6 +383,38 @@ assert lib.assertMsg (lib.all (
               "$(cat "$data_dir/m365-alpha-applied-url")" "https://alpha.example/"
 
             echo
+            echo "-- a record write that fails stops the run instead of reporting an install --"
+            reset
+            # A directory where the record's temporary goes: the redirection
+            # fails, which is what a full or read-only filesystem does to this
+            # write, without needing either. Planted on the ulid record because
+            # that is the write whose silent failure is unrecoverable: the
+            # pending record is removed on the next line, and without either
+            # record every later run refuses the entry as foreign.
+            mkdir -p "$data_dir/m365-alpha-applied-ulid.next"
+            # Aborts rather than counting a refusal: a failed record is a
+            # filesystem fault, not a state this installer decided not to act
+            # on. Asserting the message text would only prove bash still names
+            # the file it could not open; what has to hold is that the run
+            # stopped and left the entry repairable.
+            expect "failed record write is fatal" "$declared" 1 "m365-alpha-applied-ulid.next"
+            assert_equal "the entry after the fault was never attempted" "$(site_count)" 1
+            if [ -s "$data_dir/m365-alpha-installing" ]; then
+              echo "PASS  pending record survives a failed ulid write"
+            else
+              echo "FAIL  pending record cleared despite the failed ulid write"
+              failures=$((failures + 1))
+            fi
+            rmdir "$data_dir/m365-alpha-applied-ulid.next"
+            # The pending record is the whole point of the assertion above: it
+            # is what lets the adopt branch recognize the registered site as
+            # this unit's own instead of refusing it forever.
+            expect "the next run adopts the site the fault left behind" "$declared" 0 "installed 'Beta'"
+            assert_equal "no second Alpha registered" "$(site_count)" 2
+            assert_equal "alpha ulid recorded on the recovery run" \
+              "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB0"
+
+            echo
             echo "-- the shipped catalog installs end to end --"
             reset
             expect "catalog install" "$shipped" 0 "installed 'Word'"

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -179,6 +179,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
           # 5-second sleeps per entry.
           retryDelay = 0;
         };
+      inherit (mkInstaller [ ]) refusalExitStatus;
 
       declared = mkInstaller [
         {
@@ -448,7 +449,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
 
             echo
             echo "-- an entry moved across origins is refused, the rest are not --"
-            expect "cross-origin move" "$cross_origin" 78 "uninstall the site so this unit can reinstall it at the new origin"
+            expect "cross-origin move" "$cross_origin" ${toString refusalExitStatus} "uninstall the site so this unit can reinstall it at the new origin"
             assert_equal "no site added for the new origin" "$(site_count)" 2
             assert_equal "alpha still points at the installed origin" \
               "$(start_url_of Alpha)" "https://alpha.example/"
@@ -459,7 +460,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             echo "-- renaming an entry is refused rather than orphaning its site --"
             reset
             "$declared" >/dev/null
-            expect "rename refused" "$renamed" 78 "is a new name for the site this unit installed"
+            expect "rename refused" "$renamed" ${toString refusalExitStatus} "is a new name for the site this unit installed"
             assert_equal "no second site registered under the new name" "$(site_count)" 2
             assert_equal "the ulid record still names the original site" \
               "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB0"
@@ -476,7 +477,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
 
             reset
             "$declared" >/dev/null
-            expect "rename still refused after the reset" "$renamed" 78 "is a new name for the site this unit installed"
+            expect "rename still refused after the reset" "$renamed" ${toString refusalExitStatus} "is a new name for the site this unit installed"
             # An uninstall leaves the same stale record but takes the site, and
             # that case must still reinstall: the guard is on the site being
             # there, not on the record existing.
@@ -491,7 +492,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             # Documented on the option as destructive: the remedy the message
             # names destroys a working PWA profile, so what must not happen is
             # the installer deciding that for itself.
-            expect "key edit refused" "$rekeyed" 78 "nothing records the origin it was installed at"
+            expect "key edit refused" "$rekeyed" ${toString refusalExitStatus} "nothing records the origin it was installed at"
             assert_equal "no site added under the new slug" "$(site_count)" 2
             assert_equal "the old slug's records are left for the user to clear" \
               "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB0"
@@ -505,12 +506,12 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             echo
             echo "-- a start URL with credentials is refused before any site lookup --"
             reset
-            expect "credentials refused" "$credentials" 78 "embeds credentials"
+            expect "credentials refused" "$credentials" ${toString refusalExitStatus} "embeds credentials"
             assert_equal "only the other entry was installed" "$(site_count)" 1
             assert_equal "beta installed anyway" "$(cat "$data_dir/m365-beta-applied-url")" "https://beta.example/"
-            # A retryable fault must outrank a permanent refusal: 78 is a
-            # successful exit for the user service, so the wrong precedence
-            # would leave the transient fault with no rerun.
+            # A retryable fault must outrank a permanent refusal: the refusal
+            # is a successful exit for the user service, so the wrong
+            # precedence would leave the transient fault with no rerun.
             reset
             export STUB_FAIL_NAME=Beta STUB_FAIL_BEFORE_REGISTER=1
             expect "a retryable fault outranks a permanent refusal" "$credentials" 1 "failed after 3 attempts"
@@ -527,7 +528,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             jq '.sites["01STUB0"].config.manifest_url = "https://alpha.example/manifest.json"' \
               "$config_file" >"$config_file.next"
             mv "$config_file.next" "$config_file"
-            expect "foreign site refused" "$declared" 78 "is not the site this unit installed"
+            expect "foreign site refused" "$declared" ${toString refusalExitStatus} "is not the site this unit installed"
             assert_equal "no second Alpha registered" "$(site_count)" 2
 
             echo

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -37,6 +37,16 @@ assert lib.assertMsg (
 assert lib.assertMsg (lib.all (
   app: lib.hasPrefix "https://" app.url
 ) catalog) "browsers/firefoxpwa-m365: every _m365-apps.nix start URL must be https";
+# The catalog is the option's default, and an option's type is checked only
+# when its value is forced: ./m365.nix reaches apps behind `m365Enabled &&`,
+# no host sets that, and ./module-check.nix passes osConfig as a plain attrset,
+# so nothing anywhere applies the key's strMatching to these entries. Restated
+# rather than read back from the option because reaching the type needs a NixOS
+# evaluation this file does not do; a widened alphabet fails here loudly, which
+# is the safe direction for the drift.
+assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key != null)
+  catalog
+) "browsers/firefoxpwa-m365: every _m365-apps.nix key must match the option's path-safe alphabet";
 {
   perSystem =
     { pkgs, ... }:

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -112,11 +112,19 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
               [ ! -f "$seq_file" ] || seq=$(<"$seq_file")
               ulid="01STUB$seq"
               printf '%s' "$((seq + 1))" >"$seq_file"
+              # Decoded from the manifest the installer actually built, the way
+              # ./dmail-check.nix's stub does. Taking it from --document-url
+              # would make manifest.scope a copy of a field the installer passes
+              # separately, so the scope assertion could not see a manifest built
+              # with the wrong one, which is the invariant the whole design rests
+              # on: scope is fixed at install time and must be the bare origin.
+              scope=$(printf '%s' "''${manifest_url#*base64,}" | base64 -d | jq -r .scope)
               jq --arg u "$ulid" --arg n "$name" --arg m "$manifest_url" \
                 --arg s "$(normalize "$start_url")" --arg d "$(normalize "$document_url")" \
+                --arg sc "$(normalize "$scope")" \
                 '.sites[$u] = {
                    config: {name: $n, start_url: $s, document_url: $d, manifest_url: $m},
-                   manifest: {scope: $d}
+                   manifest: {scope: $sc}
                  }' "$config_file" >"$config_file.next"
               mv "$config_file.next" "$config_file"
               # Reproduces an install that registers the site and then fails,
@@ -195,6 +203,18 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
           key = "beta";
           name = "Beta";
           url = "https://beta.example/";
+        }
+      ];
+      # Alpha installed straight at a deep URL rather than moved there. The
+      # discriminating case for scope: a start URL equal to its own origin
+      # normalizes to the same string either way, so only an entry installed
+      # below its origin can show whether the manifest carries the origin or the
+      # start URL.
+      deep = mkInstaller [
+        {
+          key = "alpha";
+          name = "Alpha";
+          url = "https://alpha.example/deep/link";
         }
       ];
       # Alpha moved to another origin: refused, because scope is immutable.
@@ -290,6 +310,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             moved=${lib.getExe moved}
             cross_origin=${lib.getExe crossOrigin}
             renamed=${lib.getExe renamed}
+            deep=${lib.getExe deep}
             rekeyed=${lib.getExe rekeyed}
             credentials=${lib.getExe credentials}
             failures=0
@@ -361,6 +382,20 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             else
               echo "PASS  pending record cleared after a successful install"
             fi
+
+            echo
+            echo "-- an entry installed below its origin still scopes to the origin --"
+            reset
+            expect "deep install" "$deep" 0 "installed 'Alpha'"
+            # Scope is fixed at install time and site update cannot rewrite it,
+            # so a manifest built from the start URL rather than the origin
+            # would push every same-origin navigation into the external browser.
+            assert_equal "scope is the origin, not the start URL" \
+              "$(scope_of Alpha)" "https://alpha.example/"
+            assert_equal "the start URL is still the declared one" \
+              "$(start_url_of Alpha)" "https://alpha.example/deep/link"
+            reset
+            "$declared" >/dev/null
 
             echo
             echo "-- rerunning the same generation changes nothing --"

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -102,9 +102,16 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
               if [ "''${STUB_FAIL_NAME:-}" = "$name" ] && [ -n "''${STUB_FAIL_BEFORE_REGISTER:-}" ]; then
                 exit 1
               fi
-              # Sites are keyed by insertion order, so several can coexist and
-              # a check can tell one entry's site from another's.
-              ulid="01STUB$(jq -r '(.sites // {}) | length' "$config_file")"
+              # Allocated from a counter rather than the site count, so several
+              # can coexist, a check can tell one entry's site from another's,
+              # and an id is never handed out twice: a real ulid is unique for
+              # the life of the profile, while a count reuses the id of a site
+              # that was uninstalled and would silently overwrite its successor.
+              seq_file="$userdata/.stub-ulid-seq"
+              seq=0
+              [ ! -f "$seq_file" ] || seq=$(<"$seq_file")
+              ulid="01STUB$seq"
+              printf '%s' "$((seq + 1))" >"$seq_file"
               jq --arg u "$ulid" --arg n "$name" --arg m "$manifest_url" \
                 --arg s "$(normalize "$start_url")" --arg d "$(normalize "$document_url")" \
                 '.sites[$u] = {
@@ -207,6 +214,21 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
       # is the only thing that proves the catalog survives escapeShellArg,
       # shellcheck and a real run, since no host enables the toggle yet.
       shipped = mkInstaller catalog;
+      # Alpha's launcher name edited while its key stays: the lookup misses the
+      # site the key installed, so the fresh-install branch has to refuse rather
+      # than register a second one.
+      renamed = mkInstaller [
+        {
+          key = "alpha";
+          name = "Alpha Renamed";
+          url = "https://alpha.example/";
+        }
+        {
+          key = "beta";
+          name = "Beta";
+          url = "https://beta.example/";
+        }
+      ];
       credentials = mkInstaller [
         {
           key = "alpha";
@@ -251,6 +273,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             shipped=${lib.getExe shipped}
             moved=${lib.getExe moved}
             cross_origin=${lib.getExe crossOrigin}
+            renamed=${lib.getExe renamed}
             credentials=${lib.getExe credentials}
             failures=0
 
@@ -359,6 +382,23 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
               "$(start_url_of Alpha)" "https://alpha.example/"
             assert_equal "beta record untouched" \
               "$(cat "$data_dir/m365-beta-applied-url")" "https://beta.example/"
+
+            echo
+            echo "-- renaming an entry is refused rather than orphaning its site --"
+            reset
+            "$declared" >/dev/null
+            expect "rename refused" "$renamed" 1 "is a new name for the site this unit installed"
+            assert_equal "no second site registered under the new name" "$(site_count)" 2
+            assert_equal "the ulid record still names the original site" \
+              "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB0"
+            assert_equal "the applied record still names the original entry" \
+              "$(cat "$data_dir/m365-alpha-applied-url")" "https://alpha.example/"
+            # An uninstall leaves the same stale record but takes the site, and
+            # that case must still reinstall: the guard is on the site being
+            # there, not on the record existing.
+            jq 'del(.sites["01STUB0"])' "$config_file" >"$config_file.next"
+            mv "$config_file.next" "$config_file"
+            expect "an uninstalled site is reinstalled under the new name" "$renamed" 0 "installed 'Alpha Renamed'"
 
             echo
             echo "-- a start URL with credentials is refused before any site lookup --"

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -1,0 +1,426 @@
+/*
+  Check: Microsoft 365 installer behaviour (packages/firefoxpwa-m365-install).
+
+  The installer is a shell script whose interesting branches only appear after
+  firefoxpwa has rewritten config.json, which parsing and shellcheck cannot
+  see. This builds the real derivation against a stub firefoxpwa and drives it
+  through the states that matter for a multi-entry install:
+
+  - the url crate normalizes what it stores (a bare origin comes back with a
+    path), so any check comparing a declared URL against a value read back from
+    config.json is wrong,
+  - site update accepts neither --document-url nor --manifest-url, so those
+    fields are immutable and a moved entry must be refused rather than patched,
+  - one entry that cannot be installed must not cost the others theirs.
+
+  The stub is passed as the firefoxpwa package rather than placed on PATH:
+  writeShellApplication prepends runtimeInputs, so a PATH stub would be
+  shadowed by the real binary.
+*/
+{
+  lib,
+  ...
+}:
+let
+  catalog = import ./_m365-apps.nix;
+  catalogKeys = map (app: app.key) catalog;
+  catalogNames = map (app: app.name) catalog;
+in
+# The shipped catalog is a default no host has to restate, so nothing else
+# would notice these until a site was installed under a colliding record.
+assert lib.assertMsg (
+  lib.unique catalogKeys == catalogKeys
+) "browsers/firefoxpwa-m365: _m365-apps.nix has duplicate keys";
+assert lib.assertMsg (
+  lib.unique catalogNames == catalogNames
+) "browsers/firefoxpwa-m365: _m365-apps.nix has duplicate names";
+assert lib.assertMsg (lib.all (
+  app: lib.hasPrefix "https://" app.url
+) catalog) "browsers/firefoxpwa-m365: every _m365-apps.nix start URL must be https";
+{
+  perSystem =
+    { pkgs, ... }:
+    let
+      stub = pkgs.writeShellApplication {
+        name = "firefoxpwa";
+        runtimeInputs = [
+          pkgs.jq
+          pkgs.coreutils
+        ];
+        text = ''
+          # Resolved the way the real binary does (native/src/directories.rs):
+          # FFPWA_USERDATA if set, else the XDG data directory plus a firefoxpwa
+          # suffix. The stub must not be told the path directly, or it would
+          # agree with an installer that picked its own and hide the mismatch.
+          userdata="''${FFPWA_USERDATA:-''${XDG_DATA_HOME:-$HOME/.local/share}/firefoxpwa}"
+          mkdir -p "$userdata"
+          # Recorded so a check can assert this equals the xdgDataHome the
+          # installer was given, proving it pins system integration's directory
+          # from that parameter rather than from the caller's environment.
+          printf '%s' "$XDG_DATA_HOME" >"$userdata/.xdg-data-home-seen"
+          config_file="$userdata/config.json"
+          [ -f "$config_file" ] || echo '{"sites":{}}' >"$config_file"
+
+          # The url crate fills in an empty path, so a bare origin is stored
+          # with a trailing slash. The stub only has to be wrong in the same
+          # way the real one is.
+          normalize() {
+            if [[ $1 =~ ^[A-Za-z][A-Za-z0-9+.-]*://[^/?#]+$ ]]; then
+              printf '%s/' "$1"
+            else
+              printf '%s' "$1"
+            fi
+          }
+
+          [ "''${1:-}" = "site" ] || exit 64
+
+          case "''${2:-}" in
+            install)
+              manifest_url="$3"
+              start_url="" document_url="" name=""
+              while [ $# -gt 0 ]; do
+                case "$1" in
+                  --start-url) start_url="$2" ;;
+                  --document-url) document_url="$2" ;;
+                  --name) name="$2" ;;
+                esac
+                shift
+              done
+              # Reproduces an install that fails before storage.write ever
+              # runs, for example a network error: the site is never
+              # registered, unlike STUB_FAIL_AFTER_REGISTER.
+              if [ "''${STUB_FAIL_NAME:-}" = "$name" ] && [ -n "''${STUB_FAIL_BEFORE_REGISTER:-}" ]; then
+                exit 1
+              fi
+              # Sites are keyed by insertion order, so several can coexist and
+              # a check can tell one entry's site from another's.
+              ulid="01STUB$(jq -r '(.sites // {}) | length' "$config_file")"
+              jq --arg u "$ulid" --arg n "$name" --arg m "$manifest_url" \
+                --arg s "$(normalize "$start_url")" --arg d "$(normalize "$document_url")" \
+                '.sites[$u] = {
+                   config: {name: $n, start_url: $s, document_url: $d, manifest_url: $m},
+                   manifest: {scope: $d}
+                 }' "$config_file" >"$config_file.next"
+              mv "$config_file.next" "$config_file"
+              # Reproduces an install that registers the site and then fails,
+              # for example on desktop integration.
+              if [ "''${STUB_FAIL_NAME:-}" = "$name" ] && [ -n "''${STUB_FAIL_AFTER_REGISTER:-}" ]; then
+                exit 1
+              fi
+              ;;
+            update)
+              ulid="$3"
+              start_url=""
+              while [ $# -gt 0 ]; do
+                case "$1" in
+                  # The real binary takes neither: accepting them here would
+                  # hide an installer trying to rewrite an immutable field.
+                  --document-url | --manifest-url) exit 64 ;;
+                  --start-url) start_url="$2" ;;
+                esac
+                shift
+              done
+              jq -e --arg u "$ulid" '.sites[$u]' "$config_file" >/dev/null
+              jq --arg u "$ulid" --arg s "$(normalize "$start_url")" \
+                '.sites[$u].config.start_url = $s' "$config_file" >"$config_file.next"
+              mv "$config_file.next" "$config_file"
+              ;;
+            *) exit 64 ;;
+          esac
+        '';
+      };
+
+      # Deliberately not $XDG_DATA_HOME/firefoxpwa: passing a directory the
+      # script could not have guessed proves it uses the parameter rather than
+      # re-deriving a path of its own. Relative, so it lands in the build
+      # directory rather than a fixed path two concurrent builds would share.
+      dataDir = "firefoxpwa-m365-check/data";
+      # A third, distinct path: the build environment's own XDG_DATA_HOME (set
+      # below) is deliberately wrong, so asserting the stub sees this value
+      # proves the installer's own export takes effect.
+      pinnedXdgDataHome = "firefoxpwa-m365-check/xdg-pinned";
+
+      mkInstaller =
+        apps:
+        (pkgs.callPackage ../../../packages/firefoxpwa-m365-install { }) {
+          firefoxpwa = stub;
+          xdgDataHome = pinnedXdgDataHome;
+          inherit dataDir apps;
+          # Exercises the retry loop's control flow without three real
+          # 5-second sleeps per entry.
+          retryDelay = 0;
+        };
+
+      declared = mkInstaller [
+        {
+          key = "alpha";
+          name = "Alpha";
+          url = "https://alpha.example/";
+        }
+        {
+          key = "beta";
+          name = "Beta";
+          url = "https://beta.example/";
+        }
+      ];
+      # Alpha moved within its own origin: applied in place.
+      moved = mkInstaller [
+        {
+          key = "alpha";
+          name = "Alpha";
+          url = "https://alpha.example/deep/link";
+        }
+        {
+          key = "beta";
+          name = "Beta";
+          url = "https://beta.example/";
+        }
+      ];
+      # Alpha moved to another origin: refused, because scope is immutable.
+      crossOrigin = mkInstaller [
+        {
+          key = "alpha";
+          name = "Alpha";
+          url = "https://alpha.example.net/";
+        }
+        {
+          key = "beta";
+          name = "Beta";
+          url = "https://beta.example/";
+        }
+      ];
+      # The shipped default, built and driven like any other list: writing it
+      # is the only thing that proves the catalog survives escapeShellArg,
+      # shellcheck and a real run, since no host enables the toggle yet.
+      shipped = mkInstaller catalog;
+      credentials = mkInstaller [
+        {
+          key = "alpha";
+          name = "Alpha";
+          url = "https://user:pass@alpha.example/";
+        }
+        {
+          key = "beta";
+          name = "Beta";
+          url = "https://beta.example/";
+        }
+      ];
+    in
+    {
+      checks."browsers/firefoxpwa-m365" =
+        pkgs.runCommand "firefoxpwa-m365-check"
+          {
+            # Opts this check into the build step in .github/workflows/check.yml;
+            # its assertions run in the derivation, so forcing drvPath proves
+            # nothing. passthru, not a plain attr: runCommand's second argument
+            # becomes derivationArgs, so a plain attr would be an unread build
+            # environment variable and part of the derivation hash.
+            passthru.runtimeCheck = true;
+            nativeBuildInputs = [
+              pkgs.jq
+              pkgs.coreutils
+            ];
+          }
+          ''
+            set -o errexit -o nounset -o pipefail
+
+            export HOME="$PWD/home"
+            # Points somewhere the installer must not use: it pins both
+            # FFPWA_USERDATA and XDG_DATA_HOME itself.
+            export XDG_DATA_HOME="$PWD/xdg"
+            data_dir=${lib.escapeShellArg dataDir}
+            pinned_xdg_data_home=${lib.escapeShellArg pinnedXdgDataHome}
+            config_file="$data_dir/config.json"
+            install -d "$HOME" "$XDG_DATA_HOME"
+
+            declared=${lib.getExe declared}
+            shipped=${lib.getExe shipped}
+            moved=${lib.getExe moved}
+            cross_origin=${lib.getExe crossOrigin}
+            credentials=${lib.getExe credentials}
+            failures=0
+
+            reset() {
+              rm -rf "$data_dir" "$pinned_xdg_data_home"
+              install -d -m 700 "$data_dir"
+            }
+
+            # Matched with case, not piped into grep: under pipefail, grep -q
+            # exiting on first match can SIGPIPE the producer and flip a real
+            # match into a reported failure.
+            expect() {
+              local label="$1" installer="$2" want_rc="$3" want_text="$4" out rc=0 ok=1
+              out=$("$installer" 2>&1) || rc=$?
+              case "$out" in
+                *"$want_text"*) [ "$rc" = "$want_rc" ] && ok=0 ;;
+              esac
+              if [ "$ok" = 0 ]; then
+                echo "PASS  $label"
+              else
+                echo "FAIL  $label (rc=$rc, expected $want_rc)"
+                printf '%s\n' "$out" | sed 's/^/      /'
+                failures=$((failures + 1))
+              fi
+            }
+
+            assert_equal() {
+              if [ "$2" = "$3" ]; then
+                echo "PASS  $1"
+              else
+                echo "FAIL  $1: got '$2', expected '$3'"
+                failures=$((failures + 1))
+              fi
+            }
+
+            site_count() { jq -r '(.sites // {}) | length' "$config_file"; }
+            start_url_of() {
+              jq -r --arg n "$1" \
+                'first((.sites // {}) | to_entries[] | select(.value.config.name == $n) | .value.config.start_url) // ""' \
+                "$config_file"
+            }
+            scope_of() {
+              jq -r --arg n "$1" \
+                'first((.sites // {}) | to_entries[] | select(.value.config.name == $n) | .value.manifest.scope) // ""' \
+                "$config_file"
+            }
+
+            echo "-- a fresh run installs every declared entry --"
+            reset
+            expect "fresh install" "$declared" 0 "installed 'Alpha'"
+            assert_equal "both sites registered" "$(site_count)" 2
+            assert_equal "alpha start URL stored normalized" "$(start_url_of Alpha)" "https://alpha.example/"
+            assert_equal "alpha scope is the bare origin" "$(scope_of Alpha)" "https://alpha.example/"
+            assert_equal "alpha applied record is the declared URL" \
+              "$(cat "$data_dir/m365-alpha-applied-url")" "https://alpha.example/"
+            assert_equal "alpha origin recorded" \
+              "$(cat "$data_dir/m365-alpha-applied-origin")" "https://alpha.example"
+            assert_equal "alpha ulid recorded" "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB0"
+            if [ -e "$data_dir/m365-alpha-installing" ]; then
+              echo "FAIL  pending record left behind after a successful install"
+              failures=$((failures + 1))
+            else
+              echo "PASS  pending record cleared after a successful install"
+            fi
+
+            echo
+            echo "-- rerunning the same generation changes nothing --"
+            expect "idempotent rerun" "$declared" 0 ""
+            assert_equal "no duplicate sites" "$(site_count)" 2
+
+            echo
+            echo "-- an entry moved within its origin is applied in place --"
+            expect "same-origin move" "$moved" 0 "refreshing start URL for 'Alpha'"
+            assert_equal "still no duplicate sites" "$(site_count)" 2
+            assert_equal "alpha start URL updated" "$(start_url_of Alpha)" "https://alpha.example/deep/link"
+            assert_equal "alpha applied record updated" \
+              "$(cat "$data_dir/m365-alpha-applied-url")" "https://alpha.example/deep/link"
+            # The declared URL is a bare origin while config.json holds the
+            # url crate's trailing-slash form, so a no-op here would mean the
+            # installer compared against config.json instead of its record.
+            expect "move back to the origin" "$declared" 0 "refreshing start URL for 'Alpha'"
+            assert_equal "alpha start URL restored" "$(start_url_of Alpha)" "https://alpha.example/"
+
+            echo
+            echo "-- an entry moved across origins is refused, the rest are not --"
+            expect "cross-origin move" "$cross_origin" 1 "uninstall the site so this unit can reinstall it at the new origin"
+            assert_equal "no site added for the new origin" "$(site_count)" 2
+            assert_equal "alpha still points at the installed origin" \
+              "$(start_url_of Alpha)" "https://alpha.example/"
+            assert_equal "beta record untouched" \
+              "$(cat "$data_dir/m365-beta-applied-url")" "https://beta.example/"
+
+            echo
+            echo "-- a start URL with credentials is refused before any site lookup --"
+            reset
+            expect "credentials refused" "$credentials" 1 "embeds credentials"
+            assert_equal "only the other entry was installed" "$(site_count)" 1
+            assert_equal "beta installed anyway" "$(cat "$data_dir/m365-beta-applied-url")" "https://beta.example/"
+
+            echo
+            echo "-- a same-named site this unit did not install is refused --"
+            reset
+            "$declared" >/dev/null
+            # What an uninstall followed by a browser-extension install leaves:
+            # the site carries the managed name but not the manifest URL this
+            # installer would have given it, and its ulid record is gone.
+            rm -f "$data_dir/m365-alpha-applied-ulid"
+            jq '.sites["01STUB0"].config.manifest_url = "https://alpha.example/manifest.json"' \
+              "$config_file" >"$config_file.next"
+            mv "$config_file.next" "$config_file"
+            expect "foreign site refused" "$declared" 1 "is not the site this unit installed"
+            assert_equal "no second Alpha registered" "$(site_count)" 2
+
+            echo
+            echo "-- an entry that never registers does not stop the others --"
+            reset
+            # Exported rather than prefixed onto the call: the stub reads them
+            # from its environment, and a prefix on a shell function is not
+            # reliably scoped to that call.
+            export STUB_FAIL_NAME=Alpha STUB_FAIL_BEFORE_REGISTER=1
+            expect "failing entry reported" "$declared" 1 "failed after 3 attempts"
+            unset STUB_FAIL_NAME STUB_FAIL_BEFORE_REGISTER
+            assert_equal "the other entry installed" "$(site_count)" 1
+            assert_equal "beta installed" "$(cat "$data_dir/m365-beta-applied-url")" "https://beta.example/"
+            for record in applied-url applied-origin applied-ulid installing; do
+              if [ -e "$data_dir/m365-alpha-$record" ]; then
+                echo "FAIL  m365-alpha-$record survived an install that registered nothing"
+                failures=$((failures + 1))
+              else
+                echo "PASS  m365-alpha-$record cleared"
+              fi
+            done
+
+            echo
+            echo "-- an install that registers the site and then fails is repaired, not duplicated --"
+            reset
+            export STUB_FAIL_NAME=Alpha STUB_FAIL_AFTER_REGISTER=1
+            expect "registered-then-failed reported" "$declared" 1 "was registered by a failed install"
+            unset STUB_FAIL_NAME STUB_FAIL_AFTER_REGISTER
+            assert_equal "exactly one Alpha registered" "$(site_count)" 2
+            expect "next run repairs it" "$declared" 0 "refreshing start URL for 'Alpha'"
+            assert_equal "still exactly one Alpha" "$(site_count)" 2
+            assert_equal "alpha applied record recovered" \
+              "$(cat "$data_dir/m365-alpha-applied-url")" "https://alpha.example/"
+
+            echo
+            echo "-- the shipped catalog installs end to end --"
+            reset
+            expect "catalog install" "$shipped" 0 "installed 'Word'"
+            assert_equal "every catalog entry installed" \
+              "$(site_count)" ${toString (builtins.length catalog)}
+            expect "catalog rerun" "$shipped" 0 ""
+            assert_equal "catalog rerun adds nothing" \
+              "$(site_count)" ${toString (builtins.length catalog)}
+
+            echo
+            echo "-- the installer uses the directories it is given --"
+            assert_equal "system integration directory pinned" \
+              "$(cat "$data_dir/.xdg-data-home-seen")" "$pinned_xdg_data_home"
+            if [ -e "$XDG_DATA_HOME/firefoxpwa" ]; then
+              echo "FAIL  installer re-derived a path under XDG_DATA_HOME"
+              failures=$((failures + 1))
+            else
+              echo "PASS  nothing written outside the configured data directory"
+            fi
+            # Globbed rather than matched with compgen, which the builder's
+            # bash does not provide and which fails open: a "command not found"
+            # takes the else branch and reports a pass.
+            shopt -s nullglob
+            leftover=("$data_dir"/*.next)
+            shopt -u nullglob
+            if [ "''${#leftover[@]}" -ne 0 ]; then
+              echo "FAIL  record temporary file left behind: ''${leftover[*]}"
+              failures=$((failures + 1))
+            else
+              echo "PASS  record writes leave no temporary"
+            fi
+
+            echo
+            if [ "$failures" -ne 0 ]; then
+              echo "$failures assertion(s) failed"
+              exit 1
+            fi
+            echo "all assertions passed" >"$out"
+          '';
+    };
+}

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -532,6 +532,13 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             assert_equal "no second Alpha registered" "$(site_count)" 2
 
             echo
+            echo "-- a truncated config.json is retryable rather than a second install --"
+            reset
+            "$declared" >/dev/null
+            : >"$config_file"
+            expect "zero-byte config.json is retryable" "$declared" 1 "not installing a second"
+
+            echo
             echo "-- an entry that never registers does not stop the others --"
             reset
             # Exported rather than prefixed onto the call: the stub reads them

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -508,6 +508,13 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             expect "credentials refused" "$credentials" 78 "embeds credentials"
             assert_equal "only the other entry was installed" "$(site_count)" 1
             assert_equal "beta installed anyway" "$(cat "$data_dir/m365-beta-applied-url")" "https://beta.example/"
+            # A retryable fault must outrank a permanent refusal: 78 is a
+            # successful exit for the user service, so the wrong precedence
+            # would leave the transient fault with no rerun.
+            reset
+            export STUB_FAIL_NAME=Beta STUB_FAIL_BEFORE_REGISTER=1
+            expect "a retryable fault outranks a permanent refusal" "$credentials" 1 "failed after 3 attempts"
+            unset STUB_FAIL_NAME STUB_FAIL_BEFORE_REGISTER
 
             echo
             echo "-- a same-named site this unit did not install is refused --"

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -448,7 +448,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
 
             echo
             echo "-- an entry moved across origins is refused, the rest are not --"
-            expect "cross-origin move" "$cross_origin" 1 "uninstall the site so this unit can reinstall it at the new origin"
+            expect "cross-origin move" "$cross_origin" 78 "uninstall the site so this unit can reinstall it at the new origin"
             assert_equal "no site added for the new origin" "$(site_count)" 2
             assert_equal "alpha still points at the installed origin" \
               "$(start_url_of Alpha)" "https://alpha.example/"
@@ -459,7 +459,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             echo "-- renaming an entry is refused rather than orphaning its site --"
             reset
             "$declared" >/dev/null
-            expect "rename refused" "$renamed" 1 "is a new name for the site this unit installed"
+            expect "rename refused" "$renamed" 78 "is a new name for the site this unit installed"
             assert_equal "no second site registered under the new name" "$(site_count)" 2
             assert_equal "the ulid record still names the original site" \
               "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB0"
@@ -476,7 +476,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
 
             reset
             "$declared" >/dev/null
-            expect "rename still refused after the reset" "$renamed" 1 "is a new name for the site this unit installed"
+            expect "rename still refused after the reset" "$renamed" 78 "is a new name for the site this unit installed"
             # An uninstall leaves the same stale record but takes the site, and
             # that case must still reinstall: the guard is on the site being
             # there, not on the record existing.
@@ -491,7 +491,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             # Documented on the option as destructive: the remedy the message
             # names destroys a working PWA profile, so what must not happen is
             # the installer deciding that for itself.
-            expect "key edit refused" "$rekeyed" 1 "nothing records the origin it was installed at"
+            expect "key edit refused" "$rekeyed" 78 "nothing records the origin it was installed at"
             assert_equal "no site added under the new slug" "$(site_count)" 2
             assert_equal "the old slug's records are left for the user to clear" \
               "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB0"
@@ -505,7 +505,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             echo
             echo "-- a start URL with credentials is refused before any site lookup --"
             reset
-            expect "credentials refused" "$credentials" 1 "embeds credentials"
+            expect "credentials refused" "$credentials" 78 "embeds credentials"
             assert_equal "only the other entry was installed" "$(site_count)" 1
             assert_equal "beta installed anyway" "$(cat "$data_dir/m365-beta-applied-url")" "https://beta.example/"
 
@@ -520,7 +520,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             jq '.sites["01STUB0"].config.manifest_url = "https://alpha.example/manifest.json"' \
               "$config_file" >"$config_file.next"
             mv "$config_file.next" "$config_file"
-            expect "foreign site refused" "$declared" 1 "is not the site this unit installed"
+            expect "foreign site refused" "$declared" 78 "is not the site this unit installed"
             assert_equal "no second Alpha registered" "$(site_count)" 2
 
             echo

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -445,6 +445,18 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
               "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB0"
             assert_equal "the applied record still names the original entry" \
               "$(cat "$data_dir/m365-alpha-applied-url")" "https://alpha.example/"
+            # config.json gone entirely rather than the site removed from it:
+            # the rename guard reads that file, so it has to tell "no file" from
+            # "cannot read this file" and let the first install.
+            rm -f "$config_file"
+            expect "a config.json that is gone does not block the install" "$renamed" 0 "installed 'Alpha Renamed'"
+            # 01STUB2, not 01STUB0: only config.json was removed, so the stub's
+            # ulid counter survives and the reinstall is a genuinely new site.
+            assert_equal "alpha ulid re-recorded" "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB2"
+
+            reset
+            "$declared" >/dev/null
+            expect "rename still refused after the reset" "$renamed" 1 "is a new name for the site this unit installed"
             # An uninstall leaves the same stale record but takes the site, and
             # that case must still reinstall: the guard is on the site being
             # there, not on the record existing.

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -640,6 +640,15 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             assert_equal "record writes leave no temporary" "$(leftover_temps)" ""
 
             echo
+            echo "-- the installer creates the data directory it is given --"
+            # reset pre-creates the directory for every other scenario, so this
+            # is the first-run path that proves the shared builder owns it.
+            rm -rf "$data_dir" "$pinned_xdg_data_home"
+            expect "install into a missing data directory" "$declared" 0 "installed 'Alpha'"
+            assert_equal "the data directory is created 0700" \
+              "$(stat -c %a "$data_dir")" 700
+
+            echo
             if [ "$failures" -ne 0 ]; then
               echo "$failures assertion(s) failed"
               exit 1

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -344,6 +344,25 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
               fi
             }
 
+            # A rerun that changed nothing prints nothing, so silence is the
+            # observable. expect with an empty fragment pins only the exit
+            # status, which a run that calls site update on every entry also
+            # satisfies: without the installer's no-op fast path the rerun still
+            # exits 0 with the same site count, and every other assertion in
+            # this check requires "refreshing start URL" rather than forbidding
+            # it, so nothing would notice.
+            expect_silent() {
+                local label="$1" installer="$2" out rc=0
+                out=$("$installer" 2>&1) || rc=$?
+                if [ "$rc" = 0 ] && [ -z "$out" ]; then
+                  echo "PASS  $label"
+                else
+                  echo "FAIL  $label (rc=$rc, expected 0 and no output)"
+                  printf '%s\n' "$out" | sed 's/^/      /'
+                  failures=$((failures + 1))
+                fi
+            }
+
             assert_equal() {
               if [ "$2" = "$3" ]; then
                 echo "PASS  $1"
@@ -399,7 +418,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
 
             echo
             echo "-- rerunning the same generation changes nothing --"
-            expect "idempotent rerun" "$declared" 0 ""
+            expect_silent "idempotent rerun" "$declared"
             assert_equal "no duplicate sites" "$(site_count)" 2
 
             echo
@@ -573,7 +592,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             expect "catalog install" "$shipped" 0 "installed 'Word'"
             assert_equal "every catalog entry installed" \
               "$(site_count)" ${toString (builtins.length catalog)}
-            expect "catalog rerun" "$shipped" 0 ""
+            expect_silent "catalog rerun" "$shipped"
             assert_equal "catalog rerun adds nothing" \
               "$(site_count)" ${toString (builtins.length catalog)}
 

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -214,6 +214,21 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
       # is the only thing that proves the catalog survives escapeShellArg,
       # shellcheck and a real run, since no host enables the toggle yet.
       shipped = mkInstaller catalog;
+      # Alpha's key edited while its name stays: the lookup still finds the
+      # site, but every record moved to the new slug, so nothing can show the
+      # site is still at the origin it was installed at.
+      rekeyed = mkInstaller [
+        {
+          key = "alpha-2";
+          name = "Alpha";
+          url = "https://alpha.example/";
+        }
+        {
+          key = "beta";
+          name = "Beta";
+          url = "https://beta.example/";
+        }
+      ];
       # Alpha's launcher name edited while its key stays: the lookup misses the
       # site the key installed, so the fresh-install branch has to refuse rather
       # than register a second one.
@@ -275,6 +290,7 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             moved=${lib.getExe moved}
             cross_origin=${lib.getExe crossOrigin}
             renamed=${lib.getExe renamed}
+            rekeyed=${lib.getExe rekeyed}
             credentials=${lib.getExe credentials}
             failures=0
 
@@ -400,6 +416,24 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             jq 'del(.sites["01STUB0"])' "$config_file" >"$config_file.next"
             mv "$config_file.next" "$config_file"
             expect "an uninstalled site is reinstalled under the new name" "$renamed" 0 "installed 'Alpha Renamed'"
+
+            echo
+            echo "-- editing an entry's key is refused, not silently reinstalled --"
+            reset
+            "$declared" >/dev/null
+            # Documented on the option as destructive: the remedy the message
+            # names destroys a working PWA profile, so what must not happen is
+            # the installer deciding that for itself.
+            expect "key edit refused" "$rekeyed" 1 "nothing records the origin it was installed at"
+            assert_equal "no site added under the new slug" "$(site_count)" 2
+            assert_equal "the old slug's records are left for the user to clear" \
+              "$(cat "$data_dir/m365-alpha-applied-ulid")" "01STUB0"
+            if [ -e "$data_dir/m365-alpha-2-applied-ulid" ]; then
+              echo "FAIL  a record was written under the new slug for a refused entry"
+              failures=$((failures + 1))
+            else
+              echo "PASS  nothing recorded under the new slug"
+            fi
 
             echo
             echo "-- a start URL with credentials is refused before any site lookup --"

--- a/modules/browsers/firefoxpwa/m365-check.nix
+++ b/modules/browsers/firefoxpwa/m365-check.nix
@@ -120,6 +120,10 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
               ;;
             update)
               ulid="$3"
+              # Reproduces an update that fails without touching the site, the
+              # one failure the installer counts as a refusal rather than a
+              # fault, and the repair every other branch defers to.
+              [ -z "''${STUB_FAIL_UPDATE:-}" ] || exit 1
               start_url=""
               while [ $# -gt 0 ]; do
                 case "$1" in
@@ -330,6 +334,17 @@ assert lib.assertMsg (lib.all (app: builtins.match "[a-z0-9][a-z0-9-]*" app.key 
             assert_equal "alpha start URL updated" "$(start_url_of Alpha)" "https://alpha.example/deep/link"
             assert_equal "alpha applied record updated" \
               "$(cat "$data_dir/m365-alpha-applied-url")" "https://alpha.example/deep/link"
+            # A failed update must leave the applied record where it was: the
+            # record is what the no-op fast path compares against, so advancing
+            # it here would make the next run agree the URL is already applied
+            # and never retry. The move back below is that retry.
+            export STUB_FAIL_UPDATE=1
+            expect "failed update refused" "$declared" 1 "failed to update start URL for 'Alpha'"
+            unset STUB_FAIL_UPDATE
+            assert_equal "alpha applied record not advanced past a failed update" \
+              "$(cat "$data_dir/m365-alpha-applied-url")" "https://alpha.example/deep/link"
+            assert_equal "alpha start URL untouched by a failed update" \
+              "$(start_url_of Alpha)" "https://alpha.example/deep/link"
             # The declared URL is a bare origin while config.json holds the
             # url crate's trailing-slash form, so a no-op here would mean the
             # installer compared against config.json instead of its record.

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -87,10 +87,11 @@ _: {
               # Bounds the Restart= below, so an entry this unit refuses
               # permanently (a site moved across origins, a foreign site under
               # a managed name) stops after three tries instead of restarting
-              # for the rest of the session. Short enough that the window in
-              # which a later `systemctl --user start` is refused with "start
-              # request repeated too quickly" closes on its own.
-              StartLimitIntervalSec = 600;
+              # for the rest of the session. Sized beyond
+              # 3 * (TimeoutStartSec + RestartSec), so a run killed at the
+              # 900-second timeout still counts toward the burst rather than
+              # landing alone in a shorter sliding window.
+              StartLimitIntervalSec = 3600;
               StartLimitBurst = 3;
             };
             Service = {

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -94,7 +94,7 @@ _: {
               # 5 * (TimeoutStartSec + RestartSec), so a run killed at the
               # 900-second timeout still counts toward the burst rather than
               # landing alone in a shorter sliding window.
-              StartLimitIntervalSec = 5400;
+              StartLimitIntervalSec = 10800;
               StartLimitBurst = 5;
             };
             Service = {
@@ -105,7 +105,10 @@ _: {
               # this is what makes a failed one reachable again, since nothing
               # else reruns the unit while the app table is unchanged.
               Restart = "on-failure";
-              RestartSec = 120;
+              # Pace fast failures across the start window too: the counter
+              # counts starts, so the five automatic attempts must not all
+              # consume the budget before a corrective switch can be made.
+              RestartSec = 1080;
               # The installer returns EX_CONFIG (78) for a permanent refusal
               # that needs user action. Treating it as successful prevents
               # Restart=on-failure from burning the retry window automatically

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -29,7 +29,7 @@
   whenever the app table does, and
   systemd.user.startServices = "sd-switch" (modules/home-manager/base.nix)
   restarts it on the switch that changes it. That is the only switch it runs
-  on, which is why a failed run retries itself rather than waiting: sd-switch
+  on, which is why a retryable failed run retries itself rather than waiting: sd-switch
   restarts a unit only when the unit's own text changed, so a run that failed
   with an unchanged app table would otherwise sit failed until the next login,
   and the install branch that returns non-zero expecting a rerun to repair a
@@ -84,10 +84,9 @@ _: {
               # exist when its toggle is off, and an After= naming an absent
               # unit is ignored rather than fatal.
               After = [ "firefoxpwa-dmail.service" ];
-              # Bounds the Restart= below, so an entry this unit refuses
-              # permanently (a site moved across origins, a foreign site under
-              # a managed name) stops after three tries instead of restarting
-              # for the rest of the session. Sized beyond
+              # Bounds the Restart= below, so a retryable fault stops after
+              # three tries instead of restarting for the rest of the session.
+              # Sized beyond
               # 3 * (TimeoutStartSec + RestartSec), so a run killed at the
               # 900-second timeout still counts toward the burst rather than
               # landing alone in a shorter sliding window.
@@ -103,6 +102,13 @@ _: {
               # else reruns the unit while the app table is unchanged.
               Restart = "on-failure";
               RestartSec = 120;
+              # The installer returns EX_CONFIG (78) for a permanent refusal
+              # that needs user action. Treating it as successful prevents
+              # Restart=on-failure from burning the retry window before the
+              # user can fix the entry and switch again. Filesystem, firefoxpwa
+              # and timeout faults retain status 1 and the bounded retry.
+              SuccessExitStatus = "78";
+              RestartPreventExitStatus = "78";
               # Past the default 90s, which a legitimate wait can exceed: the
               # installer holds the shared site lock for its whole run, and the
               # queued unit is the one that pays. Being killed there costs the

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -21,8 +21,12 @@
     * firefoxpwa system integration writes the launcher .desktop entry, making
       each app discoverable from the desktop menu.
 
-  Unlike ./dmail.nix there is no secret to wait for, so the unit is ordered
-  against nothing: its ExecStart path changes whenever the app table does, and
+  Unlike ./dmail.nix there is no secret to wait for, so the only ordering this
+  unit carries is the After= on ./dmail.nix's unit below, which waits on nothing
+  it needs: what keeps the two installers off config.json is the lock every one
+  of them takes (../../../packages/firefoxpwa-site-installer), and the ordering
+  only keeps the common case from reaching it. Its ExecStart path changes
+  whenever the app table does, and
   systemd.user.startServices = "sd-switch" (modules/home-manager/base.nix)
   restarts it on the switch that changes it. That is the only switch it runs
   on, which is why a failed run retries itself rather than waiting: sd-switch

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -67,12 +67,18 @@ _: {
           systemd.user.services.firefoxpwa-m365 = {
             Unit = {
               Description = "Install the Microsoft 365 web apps (firefoxpwa)";
-              # firefoxpwa rewrites the whole of config.json with no lock, so
-              # this unit and ./dmail.nix's, both pulled in by default.target,
-              # would race at login and the later writer would drop the other's
-              # site. Ordering only: the dmail unit does not exist when its
-              # toggle is off, and an After= naming an absent unit is ignored
-              # rather than fatal, so this needs no condition on that toggle.
+              # Both units are pulled in by default.target and firefoxpwa
+              # rewrites the whole of config.json with no lock, so at login they
+              # would otherwise start together. What keeps them apart is the
+              # lock every site installer takes
+              # (../../../packages/firefoxpwa-site-installer); ordering cannot,
+              # because Home Manager activates sd-switch before the sops-nix
+              # step, so a switch starts this unit and only then restarts the
+              # dmail one through PartOf, the direction this After= does not
+              # constrain. Kept because it costs nothing and keeps the common
+              # case from reaching the lock at all: the dmail unit does not
+              # exist when its toggle is off, and an After= naming an absent
+              # unit is ignored rather than fatal.
               After = [ "firefoxpwa-dmail.service" ];
               # Bounds the Restart= below, so an entry this unit refuses
               # permanently (a site moved across origins, a foreign site under

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -67,6 +67,13 @@ _: {
           systemd.user.services.firefoxpwa-m365 = {
             Unit = {
               Description = "Install the Microsoft 365 web apps (firefoxpwa)";
+              # firefoxpwa rewrites the whole of config.json with no lock, so
+              # this unit and ./dmail.nix's, both pulled in by default.target,
+              # would race at login and the later writer would drop the other's
+              # site. Ordering only: the dmail unit does not exist when its
+              # toggle is off, and an After= naming an absent unit is ignored
+              # rather than fatal, so this needs no condition on that toggle.
+              After = [ "firefoxpwa-dmail.service" ];
               # Bounds the Restart= below, so an entry this unit refuses
               # permanently (a site moved across origins, a foreign site under
               # a managed name) stops after three tries instead of restarting

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -1,0 +1,93 @@
+/*
+  firefoxpwa: Microsoft 365 web apps
+  Description: Installs the Microsoft 365 web apps declared in
+    programs.firefoxpwa.m365.apps as standalone Progressive Web Apps through
+    the firefoxpwa CLI, so the suite is reproduced from the configuration
+    instead of clicked together in the browser extension. The userdata
+    directory these sites share with every other firefoxpwa site is pinned and
+    hardened by ./home.nix, not here.
+
+  Mechanism:
+    * A oneshot user service runs `firefoxpwa site install` once per entry with
+      a synthetic data: manifest, so a site installs without Microsoft having
+      to serve a web manifest to an unauthenticated request.
+    * The install is idempotent, but only for the sites this unit installed:
+      the ulid firefoxpwa assigned each one, its origin and its applied URL are
+      recorded next to config.json, and a site merely carrying a managed name
+      that those records do not account for is refused rather than adopted.
+    * Editing an entry's URL within its recorded origin is applied in place;
+      one that crosses origins is refused, because the manifest scope is fixed
+      at install time.
+    * firefoxpwa system integration writes the launcher .desktop entry, making
+      each app discoverable from the desktop menu.
+
+  Unlike ./dmail.nix there is no secret to wait for, so the unit is ordered
+  against nothing: its ExecStart path changes whenever the app table does, and
+  systemd.user.startServices = "sd-switch" (modules/home-manager/base.nix)
+  restarts it on the switch that changes it.
+*/
+_: {
+  flake.homeManagerModules.browsers.firefoxpwa =
+    {
+      config,
+      lib,
+      pkgs,
+      osConfig,
+      ...
+    }:
+    let
+      # Per-host toggle declared at NixOS scope in ./apps.nix.
+      m365Enabled = osConfig.programs.firefoxpwa.m365.enable or false;
+      firefoxpwaEnabled = osConfig.programs.firefoxpwa.extended.enable or false;
+      firefoxpwaPackage = osConfig.programs.firefoxpwa.extended.package or pkgs.firefoxpwa;
+      apps = osConfig.programs.firefoxpwa.m365.apps or [ ];
+
+      # Owned by ./home.nix, which pins and hardens it to 0700. Read rather
+      # than re-derived: a second rule drifts from it as soon as either side is
+      # edited, leaving the records and config.json outside the directory the
+      # hardening applies to.
+      inherit (config.programs.firefoxpwa) dataDir;
+
+      installScript = (pkgs.callPackage ../../../packages/firefoxpwa-m365-install { }) {
+        firefoxpwa = firefoxpwaPackage;
+        xdgDataHome = config.xdg.dataHome;
+        inherit dataDir apps;
+      };
+    in
+    {
+      config = lib.mkMerge [
+        (lib.mkIf (m365Enabled && firefoxpwaEnabled && apps != [ ]) {
+          systemd.user.services.firefoxpwa-m365 = {
+            Unit.Description = "Install the Microsoft 365 web apps (firefoxpwa)";
+            Service = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              # Both are exported by the installer itself from the same
+              # dataDir/xdgDataHome passed to it, so the binary and the script
+              # agree by construction rather than through this unit. Set here
+              # too so a manual `systemctl --user start` outside a session that
+              # has the Home Manager session variables behaves identically.
+              Environment = [
+                "FFPWA_USERDATA=${dataDir}"
+                "XDG_DATA_HOME=${config.xdg.dataHome}"
+              ];
+              ExecStart = lib.getExe installScript;
+            };
+            Install.WantedBy = [ "default.target" ];
+          };
+        })
+
+        (lib.mkIf (m365Enabled && !firefoxpwaEnabled) {
+          warnings = [
+            "programs.firefoxpwa.m365.enable is true but programs.firefoxpwa.extended.enable is false; skipping the Microsoft 365 PWA installs."
+          ];
+        })
+
+        (lib.mkIf (m365Enabled && firefoxpwaEnabled && apps == [ ]) {
+          warnings = [
+            "programs.firefoxpwa.m365.enable is true but programs.firefoxpwa.m365.apps is empty; skipping the Microsoft 365 PWA installs."
+          ];
+        })
+      ];
+    };
+}

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -91,10 +91,10 @@ _: {
               # EX_CONFIG refusal is a successful start and still consumes a
               # slot, as does each sd-switch restart the user triggers while
               # fixing the entry. Sized beyond
-              # 5 * (TimeoutStartSec + RestartSec), so a run killed at the
-              # 900-second timeout still counts toward the burst rather than
-              # landing alone in a shorter sliding window.
-              StartLimitIntervalSec = 10800;
+              # 5 * (TimeoutStartSec + RestartMaxDelaySec), so a run killed at
+              # the 900-second timeout still counts toward the burst rather
+              # than landing alone in a shorter sliding window.
+              StartLimitIntervalSec = 6000;
               StartLimitBurst = 5;
             };
             Service = {
@@ -105,12 +105,15 @@ _: {
               # this is what makes a failed one reachable again, since nothing
               # else reruns the unit while the app table is unchanged.
               Restart = "on-failure";
-              # Pace the automatic retries across the start window rather than
-              # burning the whole budget in minutes. Restart=on-failure retries
-              # until the burst is spent, so a corrective switch after
-              # start-limit-hit needs `systemctl --user reset-failed
-              # firefoxpwa-m365` first, as documented in apps.nix.
-              RestartSec = 1080;
+              # Back off automatic retries: the likely config.json race clears
+              # in milliseconds, while slow faults still need pacing across
+              # the start window. Restart=on-failure retries until the burst
+              # is spent, so a corrective switch after start-limit-hit needs
+              # `systemctl --user reset-failed firefoxpwa-m365` first, as
+              # documented in apps.nix.
+              RestartSec = 10;
+              RestartSteps = 4;
+              RestartMaxDelaySec = 300;
               # The installer returns EX_CONFIG (78) for a permanent refusal
               # that needs user action. Treating it as successful prevents
               # Restart=on-failure from burning the retry window automatically

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -24,7 +24,14 @@
   Unlike ./dmail.nix there is no secret to wait for, so the unit is ordered
   against nothing: its ExecStart path changes whenever the app table does, and
   systemd.user.startServices = "sd-switch" (modules/home-manager/base.nix)
-  restarts it on the switch that changes it.
+  restarts it on the switch that changes it. That is the only switch it runs
+  on, which is why a failed run retries itself rather than waiting: sd-switch
+  restarts a unit only when the unit's own text changed, so a run that failed
+  with an unchanged app table would otherwise sit failed until the next login,
+  and the install branch that returns non-zero expecting a rerun to repair a
+  registered-but-unfinished site would never get one. ./dmail.nix has no such
+  need: PartOf = sops-nix.service, which sops-nix restarts on every switch,
+  gives that unit a rerun for free.
 */
 _: {
   flake.homeManagerModules.browsers.firefoxpwa =
@@ -58,10 +65,26 @@ _: {
       config = lib.mkMerge [
         (lib.mkIf (m365Enabled && firefoxpwaEnabled && apps != [ ]) {
           systemd.user.services.firefoxpwa-m365 = {
-            Unit.Description = "Install the Microsoft 365 web apps (firefoxpwa)";
+            Unit = {
+              Description = "Install the Microsoft 365 web apps (firefoxpwa)";
+              # Bounds the Restart= below, so an entry this unit refuses
+              # permanently (a site moved across origins, a foreign site under
+              # a managed name) stops after three tries instead of restarting
+              # for the rest of the session. Short enough that the window in
+              # which a later `systemctl --user start` is refused with "start
+              # request repeated too quickly" closes on its own.
+              StartLimitIntervalSec = 600;
+              StartLimitBurst = 3;
+            };
             Service = {
               Type = "oneshot";
               RemainAfterExit = true;
+              # Permitted for Type=oneshot (only always and on-success are
+              # not). RemainAfterExit keeps a successful run from repeating;
+              # this is what makes a failed one reachable again, since nothing
+              # else reruns the unit while the app table is unchanged.
+              Restart = "on-failure";
+              RestartSec = 120;
               # Both are exported by the installer itself from the same
               # dataDir/xdgDataHome passed to it, so the binary and the script
               # agree by construction rather than through this unit. Set here

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -105,9 +105,11 @@ _: {
               # this is what makes a failed one reachable again, since nothing
               # else reruns the unit while the app table is unchanged.
               Restart = "on-failure";
-              # Pace fast failures across the start window too: the counter
-              # counts starts, so the five automatic attempts must not all
-              # consume the budget before a corrective switch can be made.
+              # Pace the automatic retries across the start window rather than
+              # burning the whole budget in minutes. Restart=on-failure retries
+              # until the burst is spent, so a corrective switch after
+              # start-limit-hit needs `systemctl --user reset-failed
+              # firefoxpwa-m365` first, as documented in apps.nix.
               RestartSec = 1080;
               # The installer returns EX_CONFIG (78) for a permanent refusal
               # that needs user action. Treating it as successful prevents

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -64,6 +64,7 @@ _: {
         xdgDataHome = config.xdg.dataHome;
         inherit dataDir apps;
       };
+      refusalExitStatus = toString installScript.refusalExitStatus;
     in
     {
       config = lib.mkMerge [
@@ -112,8 +113,8 @@ _: {
               # still count toward the five-start budget above. Filesystem,
               # firefoxpwa and timeout faults retain status 1 and the bounded
               # retry.
-              SuccessExitStatus = "78";
-              RestartPreventExitStatus = "78";
+              SuccessExitStatus = refusalExitStatus;
+              RestartPreventExitStatus = refusalExitStatus;
               # Past the default 90s, which a legitimate wait can exceed: the
               # installer holds the shared site lock for its whole run, and the
               # queued unit is the one that pays. Being killed there costs the

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -85,13 +85,16 @@ _: {
               # unit is ignored rather than fatal.
               After = [ "firefoxpwa-dmail.service" ];
               # Bounds the Restart= below, so a retryable fault stops after
-              # three tries instead of restarting for the rest of the session.
-              # Sized beyond
-              # 3 * (TimeoutStartSec + RestartSec), so a run killed at the
+              # five tries instead of restarting for the rest of the session.
+              # The burst counts every start, not only failed ones: an
+              # EX_CONFIG refusal is a successful start and still consumes a
+              # slot, as does each sd-switch restart the user triggers while
+              # fixing the entry. Sized beyond
+              # 5 * (TimeoutStartSec + RestartSec), so a run killed at the
               # 900-second timeout still counts toward the burst rather than
               # landing alone in a shorter sliding window.
-              StartLimitIntervalSec = 3600;
-              StartLimitBurst = 3;
+              StartLimitIntervalSec = 5400;
+              StartLimitBurst = 5;
             };
             Service = {
               Type = "oneshot";
@@ -104,9 +107,11 @@ _: {
               RestartSec = 120;
               # The installer returns EX_CONFIG (78) for a permanent refusal
               # that needs user action. Treating it as successful prevents
-              # Restart=on-failure from burning the retry window before the
-              # user can fix the entry and switch again. Filesystem, firefoxpwa
-              # and timeout faults retain status 1 and the bounded retry.
+              # Restart=on-failure from burning the retry window automatically
+              # before the user can fix the entry and switch again. The starts
+              # still count toward the five-start budget above. Filesystem,
+              # firefoxpwa and timeout faults retain status 1 and the bounded
+              # retry.
               SuccessExitStatus = "78";
               RestartPreventExitStatus = "78";
               # Past the default 90s, which a legitimate wait can exceed: the

--- a/modules/browsers/firefoxpwa/m365.nix
+++ b/modules/browsers/firefoxpwa/m365.nix
@@ -98,6 +98,12 @@ _: {
               # else reruns the unit while the app table is unchanged.
               Restart = "on-failure";
               RestartSec = 120;
+              # Past the default 90s, which a legitimate wait can exceed: the
+              # installer holds the shared site lock for its whole run, and the
+              # queued unit is the one that pays. Being killed there costs the
+              # run for a reason that is not a fault, so the bound is generous;
+              # it is still a bound, so a genuine hang fails rather than sits.
+              TimeoutStartSec = 900;
               # Both are exported by the installer itself from the same
               # dataDir/xdgDataHome passed to it, so the binary and the script
               # agree by construction rather than through this unit. Set here

--- a/modules/browsers/firefoxpwa/module-check.nix
+++ b/modules/browsers/firefoxpwa/module-check.nix
@@ -157,10 +157,10 @@
           in
           lib.assertMsg
             (
-              m365Unit.Unit.StartLimitIntervalSec
-              >= m365Unit.Unit.StartLimitBurst * (m365Unit.Service.TimeoutStartSec + m365Unit.Service.RestartSec)
+              m365Unit.Unit.StartLimitIntervalSec >= m365Unit.Unit.StartLimitBurst
+              * (m365Unit.Service.TimeoutStartSec + m365Unit.Service.RestartMaxDelaySec)
             )
-            "browsers/firefoxpwa-module-eval: StartLimitIntervalSec must cover StartLimitBurst * (TimeoutStartSec + RestartSec)";
+            "browsers/firefoxpwa-module-eval: StartLimitIntervalSec must cover StartLimitBurst * (TimeoutStartSec + RestartMaxDelaySec)";
         builtins.deepSeq {
           # The whole unit, not selected attributes: a removed binding in its
           # Unit or Install blocks must fail this check too.

--- a/modules/browsers/firefoxpwa/module-check.nix
+++ b/modules/browsers/firefoxpwa/module-check.nix
@@ -148,6 +148,19 @@
             && hm.config.systemd.user.services.firefoxpwa-m365.Service.RestartPreventExitStatus == "78"
           )
           "browsers/firefoxpwa-module-eval: a permanent m365 refusal must exit EX_CONFIG 78, which no installer fault produces";
+        # Keep the retry window long enough for every bounded attempt to count
+        # toward StartLimitBurst. Otherwise a timeout can land alone in the
+        # sliding window and the unit retries for the rest of the session.
+        assert
+          let
+            m365Unit = hm.config.systemd.user.services.firefoxpwa-m365;
+          in
+          lib.assertMsg
+            (
+              m365Unit.Unit.StartLimitIntervalSec
+              >= m365Unit.Unit.StartLimitBurst * (m365Unit.Service.TimeoutStartSec + m365Unit.Service.RestartSec)
+            )
+            "browsers/firefoxpwa-module-eval: StartLimitIntervalSec must cover StartLimitBurst * (TimeoutStartSec + RestartSec)";
         builtins.deepSeq {
           # The whole unit, not selected attributes: a removed binding in its
           # Unit or Install blocks must fail this check too.

--- a/modules/browsers/firefoxpwa/module-check.nix
+++ b/modules/browsers/firefoxpwa/module-check.nix
@@ -137,9 +137,10 @@
           execStart = hm.config.systemd.user.services.firefoxpwa-dmail.Service.ExecStart;
           environment = hm.config.systemd.user.services.firefoxpwa-dmail.Service.Environment;
           secretPath = hm.config.sops.secrets."firefoxpwa/dmail/url".path;
-          m365 = {
-            inherit (hm.config.systemd.user.services.firefoxpwa-m365.Service) ExecStart Environment;
-          };
+          # The whole unit, not the two attributes dmail names above: this one
+          # also carries the restart policy that gives a failed run its rerun,
+          # and no host enables the toggle, so nothing else would force it.
+          m365 = hm.config.systemd.user.services.firefoxpwa-m365;
           sessionVariables = {
             inherit (hm.config.home.sessionVariables) FFPWA_USERDATA XDG_DATA_HOME;
           };

--- a/modules/browsers/firefoxpwa/module-check.nix
+++ b/modules/browsers/firefoxpwa/module-check.nix
@@ -142,6 +142,12 @@
         assert lib.assertMsg
           (lib.elem "firefoxpwa-dmail.service" hm.config.systemd.user.services.firefoxpwa-m365.Unit.After)
           "browsers/firefoxpwa-module-eval: the m365 unit must be ordered after the dmail unit";
+        assert lib.assertMsg
+          (hm.config.systemd.user.services.firefoxpwa-m365.Service.SuccessExitStatus == "78")
+          "browsers/firefoxpwa-module-eval: a permanent m365 refusal must be a successful non-restarting service exit";
+        assert lib.assertMsg (
+          hm.config.systemd.user.services.firefoxpwa-m365.Service.RestartPreventExitStatus == "78"
+        ) "browsers/firefoxpwa-module-eval: a permanent m365 refusal must not consume the restart burst";
         builtins.deepSeq {
           # The whole unit, not selected attributes: a removed binding in its
           # Unit or Install blocks must fail this check too.

--- a/modules/browsers/firefoxpwa/module-check.nix
+++ b/modules/browsers/firefoxpwa/module-check.nix
@@ -133,6 +133,15 @@
         assert lib.assertMsg (
           hm.config.warnings == [ ]
         ) "browsers/firefoxpwa-module-eval: the enabled configuration must not warn";
+        # Forcing the unit below proves the attribute evaluates, not that it
+        # names the right unit, and systemd ignores an After= on a unit that
+        # does not exist rather than reporting it: a typo here would be silent
+        # at switch and at login. The installers' shared lock is what actually
+        # keeps the two apart, so this only has to hold the ordering that keeps
+        # the common case off the lock.
+        assert lib.assertMsg
+          (lib.elem "firefoxpwa-dmail.service" hm.config.systemd.user.services.firefoxpwa-m365.Unit.After)
+          "browsers/firefoxpwa-module-eval: the m365 unit must be ordered after the dmail unit";
         builtins.deepSeq {
           execStart = hm.config.systemd.user.services.firefoxpwa-dmail.Service.ExecStart;
           environment = hm.config.systemd.user.services.firefoxpwa-dmail.Service.Environment;

--- a/modules/browsers/firefoxpwa/module-check.nix
+++ b/modules/browsers/firefoxpwa/module-check.nix
@@ -11,6 +11,9 @@
   removed binding inside them would reach main and fail only at the next real
   switch.
 
+  m365.nix has the same gap for a different reason: no host enables
+  programs.firefoxpwa.m365 yet, so its mkIf blocks are unforced everywhere.
+
   Builds a standalone Home Manager configuration the same way
   modules/home-manager/checks.nix does, with osConfig stubbed to enable both
   toggles and secretsRoot pointed at module-check-fixtures (an in-repo,
@@ -62,22 +65,43 @@
                 inherit secretsRoot;
               };
             };
+          # osConfig is a plain attrset here, not an evaluated NixOS
+          # configuration, so the option default in ./apps.nix does not apply
+          # and the catalog has to be named. Imported rather than restated, so
+          # this evaluates the list hosts actually get.
+          m365 = {
+            enable = true;
+            apps = import ./_m365-apps.nix;
+          };
           hm = mkHm {
             firefoxpwaConfig = {
               extended.enable = true;
               dmail.enable = true;
+              inherit m365;
             };
           };
           noFirefoxpwa = mkHm {
             firefoxpwaConfig = {
               extended.enable = false;
               dmail.enable = true;
+              inherit m365;
+            };
+          };
+          noM365Apps = mkHm {
+            firefoxpwaConfig = {
+              extended.enable = true;
+              dmail.enable = false;
+              m365 = {
+                enable = true;
+                apps = [ ];
+              };
             };
           };
           noGecko = mkHm {
             firefoxpwaConfig = {
               extended.enable = true;
               dmail.enable = true;
+              m365.enable = false;
             };
             secretsRoot = "${./module-check-fixtures}/missing";
           };
@@ -96,6 +120,16 @@
         assert lib.assertMsg (
           !builtins.hasAttr "firefoxpwa/dmail/url" noGecko.config.sops.secrets
         ) "browsers/firefoxpwa-module-eval: a missing gecko.yaml must not declare the sops secret";
+        assert lib.assertMsg (lib.any (lib.hasInfix "m365.apps is empty") noM365Apps.config.warnings)
+          "browsers/firefoxpwa-module-eval: m365.enable with an empty app list must warn";
+        assert lib.assertMsg (!builtins.hasAttr "firefoxpwa-m365" noFirefoxpwa.config.systemd.user.services)
+          "browsers/firefoxpwa-module-eval: m365.enable without extended.enable must not declare the install unit";
+        assert lib.assertMsg (
+          !builtins.hasAttr "firefoxpwa-m365" noM365Apps.config.systemd.user.services
+        ) "browsers/firefoxpwa-module-eval: an empty app list must not declare the install unit";
+        assert lib.assertMsg (
+          !builtins.hasAttr "firefoxpwa-m365" noGecko.config.systemd.user.services
+        ) "browsers/firefoxpwa-module-eval: m365.enable = false must not declare the install unit";
         assert lib.assertMsg (
           hm.config.warnings == [ ]
         ) "browsers/firefoxpwa-module-eval: the enabled configuration must not warn";
@@ -103,6 +137,9 @@
           execStart = hm.config.systemd.user.services.firefoxpwa-dmail.Service.ExecStart;
           environment = hm.config.systemd.user.services.firefoxpwa-dmail.Service.Environment;
           secretPath = hm.config.sops.secrets."firefoxpwa/dmail/url".path;
+          m365 = {
+            inherit (hm.config.systemd.user.services.firefoxpwa-m365.Service) ExecStart Environment;
+          };
           sessionVariables = {
             inherit (hm.config.home.sessionVariables) FFPWA_USERDATA XDG_DATA_HOME;
           };
@@ -110,6 +147,7 @@
           warnings = {
             enabled = hm.config.warnings;
             noFirefoxpwa = noFirefoxpwa.config.warnings;
+            noM365Apps = noM365Apps.config.warnings;
             noGecko = noGecko.config.warnings;
           };
         } hm.config.home-files;

--- a/modules/browsers/firefoxpwa/module-check.nix
+++ b/modules/browsers/firefoxpwa/module-check.nix
@@ -143,11 +143,11 @@
           (lib.elem "firefoxpwa-dmail.service" hm.config.systemd.user.services.firefoxpwa-m365.Unit.After)
           "browsers/firefoxpwa-module-eval: the m365 unit must be ordered after the dmail unit";
         assert lib.assertMsg
-          (hm.config.systemd.user.services.firefoxpwa-m365.Service.SuccessExitStatus == "78")
-          "browsers/firefoxpwa-module-eval: a permanent m365 refusal must be a successful non-restarting service exit";
-        assert lib.assertMsg (
-          hm.config.systemd.user.services.firefoxpwa-m365.Service.RestartPreventExitStatus == "78"
-        ) "browsers/firefoxpwa-module-eval: a permanent m365 refusal must not consume the restart burst";
+          (
+            hm.config.systemd.user.services.firefoxpwa-m365.Service.SuccessExitStatus
+            == hm.config.systemd.user.services.firefoxpwa-m365.Service.RestartPreventExitStatus
+          )
+          "browsers/firefoxpwa-module-eval: a permanent m365 refusal must use one shared non-restarting status";
         builtins.deepSeq {
           # The whole unit, not selected attributes: a removed binding in its
           # Unit or Install blocks must fail this check too.

--- a/modules/browsers/firefoxpwa/module-check.nix
+++ b/modules/browsers/firefoxpwa/module-check.nix
@@ -144,10 +144,10 @@
           "browsers/firefoxpwa-module-eval: the m365 unit must be ordered after the dmail unit";
         assert lib.assertMsg
           (
-            hm.config.systemd.user.services.firefoxpwa-m365.Service.SuccessExitStatus
-            == hm.config.systemd.user.services.firefoxpwa-m365.Service.RestartPreventExitStatus
+            hm.config.systemd.user.services.firefoxpwa-m365.Service.SuccessExitStatus == "78"
+            && hm.config.systemd.user.services.firefoxpwa-m365.Service.RestartPreventExitStatus == "78"
           )
-          "browsers/firefoxpwa-module-eval: a permanent m365 refusal must use one shared non-restarting status";
+          "browsers/firefoxpwa-module-eval: a permanent m365 refusal must exit EX_CONFIG 78, which no installer fault produces";
         builtins.deepSeq {
           # The whole unit, not selected attributes: a removed binding in its
           # Unit or Install blocks must fail this check too.

--- a/modules/browsers/firefoxpwa/module-check.nix
+++ b/modules/browsers/firefoxpwa/module-check.nix
@@ -143,12 +143,13 @@
           (lib.elem "firefoxpwa-dmail.service" hm.config.systemd.user.services.firefoxpwa-m365.Unit.After)
           "browsers/firefoxpwa-module-eval: the m365 unit must be ordered after the dmail unit";
         builtins.deepSeq {
-          execStart = hm.config.systemd.user.services.firefoxpwa-dmail.Service.ExecStart;
-          environment = hm.config.systemd.user.services.firefoxpwa-dmail.Service.Environment;
+          # The whole unit, not selected attributes: a removed binding in its
+          # Unit or Install blocks must fail this check too.
+          dmail = hm.config.systemd.user.services.firefoxpwa-dmail;
           secretPath = hm.config.sops.secrets."firefoxpwa/dmail/url".path;
-          # The whole unit, not the two attributes dmail names above: this one
-          # also carries the restart policy that gives a failed run its rerun,
-          # and no host enables the toggle, so nothing else would force it.
+          # The whole unit also carries the restart policy that gives a failed
+          # run its rerun, and no host enables the toggle, so nothing else would
+          # force it.
           m365 = hm.config.systemd.user.services.firefoxpwa-m365;
           sessionVariables = {
             inherit (hm.config.home.sessionVariables) FFPWA_USERDATA XDG_DATA_HOME;

--- a/modules/browsers/firefoxpwa/site-lock-check.nix
+++ b/modules/browsers/firefoxpwa/site-lock-check.nix
@@ -131,11 +131,13 @@ _: {
               sleep 0.1
             done
             exec 8>&-
-            wait "$queued"
-            if [ "$announced" = 1 ]; then
+            queued_rc=0
+            wait "$queued" || queued_rc=$?
+            if [ "$announced" = 1 ] && [ "$queued_rc" -eq 0 ]; then
               echo "PASS  the queued installer names the lock it is waiting on"
             else
-              echo "FAIL  the queued installer blocked silently on the lock"
+              echo "FAIL  the queued installer blocked silently on the lock (rc=$queued_rc)"
+              cat "$PWD/wait.log" >&2
               failures=$((failures + 1))
             fi
 

--- a/modules/browsers/firefoxpwa/site-lock-check.nix
+++ b/modules/browsers/firefoxpwa/site-lock-check.nix
@@ -94,8 +94,13 @@ _: {
               local first=$!
               "$2" &
               local second=$!
-              wait "$first"
-              wait "$second"
+              local first_rc=0 second_rc=0
+              wait "$first" || first_rc=$?
+              wait "$second" || second_rc=$?
+              if [ "$first_rc" -ne 0 ] || [ "$second_rc" -ne 0 ]; then
+                echo "installer exited non-zero (rc=$first_rc/$second_rc)"
+                return 0
+              fi
               cat "$data_dir/counter"
             }
 

--- a/modules/browsers/firefoxpwa/site-lock-check.nix
+++ b/modules/browsers/firefoxpwa/site-lock-check.nix
@@ -104,6 +104,37 @@ _: {
               failures=$((failures + 1))
             fi
 
+            # The announce before the blocking acquire, which is what makes a
+            # unit killed at TimeoutStartSec attributable to the lock rather
+            # than to an unexplained timeout. Held here rather than by a peer
+            # installer: which of two peers blocks is a scheduling outcome, and
+            # this way the queued run is guaranteed to wait.
+            rm -rf "$data_dir"
+            install -d -m 700 "$data_dir"
+            printf '0' >"$data_dir/counter"
+            exec 8>"$data_dir/.config-lock"
+            flock 8
+            ${pkgs.lib.getExe (locked "site-lock-a")} 2>"$PWD/wait.log" &
+            queued=$!
+            announced=0
+            for _ in $(seq 100); do
+              case "$(cat "$PWD/wait.log")" in
+                *.config-lock*)
+                  announced=1
+                  break
+                  ;;
+              esac
+              sleep 0.1
+            done
+            exec 8>&-
+            wait "$queued"
+            if [ "$announced" = 1 ]; then
+              echo "PASS  the queued installer names the lock it is waiting on"
+            else
+              echo "FAIL  the queued installer blocked silently on the lock"
+              failures=$((failures + 1))
+            fi
+
             got=$(run_pair ${pkgs.lib.getExe (unlocked "site-lock-unlocked-a")} ${pkgs.lib.getExe (unlocked "site-lock-unlocked-b")})
             if [ "$got" = 1 ]; then
               echo "PASS  the same pair without the builder loses an update (counter=$got)"

--- a/modules/browsers/firefoxpwa/site-lock-check.nix
+++ b/modules/browsers/firefoxpwa/site-lock-check.nix
@@ -72,7 +72,10 @@ _: {
             # Opts this check into the runtime build step in
             # .github/workflows/check.yml, which otherwise only forces drvPaths.
             passthru.runtimeCheck = true;
-            nativeBuildInputs = [ pkgs.coreutils ];
+            nativeBuildInputs = [
+              pkgs.coreutils
+              pkgs.util-linux
+            ];
           }
           ''
             set -o errexit -o nounset -o pipefail

--- a/modules/browsers/firefoxpwa/site-lock-check.nix
+++ b/modules/browsers/firefoxpwa/site-lock-check.nix
@@ -1,0 +1,111 @@
+/*
+  Check: site installers built by packages/firefoxpwa-site-installer exclude
+  one another.
+
+  firefoxpwa rewrites the whole of config.json through File::create with no
+  lock, so two site installers that overlap lose one another's sites. Unit
+  ordering cannot prevent it: Home Manager activates sd-switch before the
+  sops-nix step, so a switch starts one unit and then restarts another through
+  PartOf while the first is still installing, which is the direction an After=
+  on either unit does not constrain. The builder therefore takes the lock for
+  every installer it produces.
+
+  Proved on the builder rather than on the installers, because the property is
+  the builder's: naming any two of today's installers would have to be rewritten
+  the moment a third is added, and would say nothing about that third one. Two
+  installers built here through the builder must serialize; the same pair built
+  with writeShellApplication directly must not, which is what shows the
+  assertion can fail.
+*/
+_: {
+  perSystem =
+    { pkgs, ... }:
+    let
+      dataDir = "firefoxpwa-site-lock-check/data";
+
+      # Read, pause, write: the shape of what firefoxpwa does to config.json,
+      # so two runs that overlap here interleave the way they interleave there
+      # and the counter ends at 1 instead of 2.
+      body = ''
+        n=$(cat "$data_dir/counter")
+        sleep 1
+        printf '%s' "$((n + 1))" >"$data_dir/counter"
+      '';
+
+      locked =
+        name:
+        (pkgs.callPackage ../../../packages/firefoxpwa-site-installer { }) {
+          inherit name dataDir;
+          xdgDataHome = "firefoxpwa-site-lock-check/xdg";
+          text = body;
+        };
+
+      # The control. Same body, same directory, no builder, so the only
+      # difference between the two runs below is the lock.
+      unlocked =
+        name:
+        pkgs.writeShellApplication {
+          inherit name;
+          runtimeInputs = [ pkgs.coreutils ];
+          text = ''
+            data_dir=${dataDir}
+          ''
+          + body;
+        };
+    in
+    {
+      checks."browsers/firefoxpwa-site-lock" =
+        pkgs.runCommand "firefoxpwa-site-lock-check"
+          {
+            # Opts this check into the runtime build step in
+            # .github/workflows/check.yml, which otherwise only forces drvPaths.
+            passthru.runtimeCheck = true;
+            nativeBuildInputs = [ pkgs.coreutils ];
+          }
+          ''
+            set -o errexit -o nounset -o pipefail
+
+            data_dir=${dataDir}
+            failures=0
+
+            # Two distinct derivations, not one run twice: a lock the builder
+            # took per-installer rather than on the shared directory would pass
+            # a single-installer test and still let two installers overlap.
+            run_pair() {
+              rm -rf "$data_dir"
+              install -d -m 700 "$data_dir"
+              printf '0' >"$data_dir/counter"
+              "$1" &
+              local first=$!
+              "$2" &
+              local second=$!
+              wait "$first"
+              wait "$second"
+              cat "$data_dir/counter"
+            }
+
+            got=$(run_pair ${pkgs.lib.getExe (locked "site-lock-a")} ${pkgs.lib.getExe (locked "site-lock-b")})
+            if [ "$got" = 2 ]; then
+              echo "PASS  two installers from the builder serialize (counter=$got)"
+            else
+              echo "FAIL  two installers from the builder interleaved (counter=$got, expected 2)"
+              failures=$((failures + 1))
+            fi
+
+            got=$(run_pair ${pkgs.lib.getExe (unlocked "site-lock-unlocked-a")} ${pkgs.lib.getExe (unlocked "site-lock-unlocked-b")})
+            if [ "$got" = 1 ]; then
+              echo "PASS  the same pair without the builder loses an update (counter=$got)"
+            else
+              echo "FAIL  the unlocked control did not interleave (counter=$got, expected 1); this check cannot tell a working lock from a missing one" >&2
+              failures=$((failures + 1))
+            fi
+
+            echo
+            if [ "$failures" -ne 0 ]; then
+              echo "$failures assertion(s) failed"
+              exit 1
+            fi
+            echo "site installers built by the shared builder exclude one another" >"$out"
+          '';
+    };
+}

--- a/modules/browsers/firefoxpwa/site-lock-check.nix
+++ b/modules/browsers/firefoxpwa/site-lock-check.nix
@@ -117,7 +117,7 @@ _: {
             printf '0' >"$data_dir/counter"
             exec 8>"$data_dir/.config-lock"
             flock 8
-            ${pkgs.lib.getExe (locked "site-lock-a")} 2>"$PWD/wait.log" &
+            ${pkgs.lib.getExe (locked "site-lock-a")} 8>&- 2>"$PWD/wait.log" &
             queued=$!
             announced=0
             for _ in $(seq 100); do

--- a/modules/browsers/firefoxpwa/site-lock-check.nix
+++ b/modules/browsers/firefoxpwa/site-lock-check.nix
@@ -117,6 +117,7 @@ _: {
             printf '0' >"$data_dir/counter"
             exec 8>"$data_dir/.config-lock"
             flock 8
+            : >"$PWD/wait.log"
             ${pkgs.lib.getExe (locked "site-lock-a")} 8>&- 2>"$PWD/wait.log" &
             queued=$!
             announced=0

--- a/modules/browsers/firefoxpwa/site-lock-check.nix
+++ b/modules/browsers/firefoxpwa/site-lock-check.nix
@@ -23,12 +23,24 @@ _: {
     let
       dataDir = "firefoxpwa-site-lock-check/data";
 
-      # Read, pause, write: the shape of what firefoxpwa does to config.json,
-      # so two runs that overlap here interleave the way they interleave there
-      # and the counter ends at 1 instead of 2.
+      # Read, mark, wait for the peer, write: the shape of what firefoxpwa does
+      # to config.json, with the interleaving decided by whether the peer can
+      # enter rather than by which process the scheduler happens to run first. A
+      # fixed pause would make the unlocked control's result a race outcome, so
+      # a builder busy enough to delay the second exec past it would fail this
+      # check on a change that touched nothing here. Locked, the peer cannot
+      # enter and each run burns the bound; unlocked, both read before either
+      # writes and one update is lost, whatever the startup skew.
       body = ''
         n=$(cat "$data_dir/counter")
-        sleep 1
+        : >"$data_dir/entered.$$"
+        shopt -s nullglob
+        for _ in $(seq 100); do
+          entered=("$data_dir"/entered.*)
+          if [ "''${#entered[@]}" -ge 2 ]; then break; fi
+          sleep 0.1
+        done
+        shopt -u nullglob
         printf '%s' "$((n + 1))" >"$data_dir/counter"
       '';
 

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -56,7 +56,7 @@
             scan() {
               local status=0
               grep -rnE \
-                '^[[:space:]]*!?[[:space:]]*compgen\b|\$\(!?[[:space:]]*compgen\b|(if|elif|while|until|then|else|do|;|&&|\|\|?)[[:space:]]+!?[[:space:]]*compgen\b' \
+                '^[[:space:]]*!?[[:space:]]*compgen\b|\$\(!?[[:space:]]*compgen\b|(if|elif|while|until|then|else|do|;|&&|\|\|?|\{|\(|\))[[:space:]]+!?[[:space:]]*compgen\b' \
                 "$@" || status=$?
               # 1 is "matched nothing"; 2 and up mean grep could not read a path
               # it was given, and an empty result from that is indistinguishable
@@ -72,17 +72,19 @@
             planted="$PWD/planted"
             mkdir -p "$planted"
             # Assembled rather than written out, so this file is not a hit in its
-            # own scan and does not have to exclude itself from it. Both
-            # spellings, and counted: a fixture for one of them proves only the
-            # alternative it happens to take, which is how the negated form went
-            # unscanned while the self-test stayed green.
+            # own scan and does not have to exclude itself from it. Every
+            # command-position spelling is planted and counted: a fixture for
+            # one of them proves only the alternative it happens to take.
             printf 'if %s -A function; then :; fi\n' compgen >"$planted/plain.sh"
             printf 'if ! %s -A function; then :; fi\n' compgen >"$planted/negated.sh"
             printf 'elif %s -A function; then :; fi\n' compgen >"$planted/elif.sh"
             printf 'true | %s -A function\n' compgen >"$planted/pipe.sh"
+            printf 'case x in *) %s -A function ;; esac\n' compgen >"$planted/case.sh"
+            printf 'if { %s -A function; }; then :; fi\n' compgen >"$planted/group.sh"
+            printf '( %s -A function )\n' compgen >"$planted/subshell.sh"
             planted_hits=$(scan "$planted" | wc -l)
-            if [ "$planted_hits" -ne 4 ]; then
-              echo "build-time-shell: the scan reports $planted_hits of 4 planted usages, so the tree scan below would pass regardless" >&2
+            if [ "$planted_hits" -ne 7 ]; then
+              echo "build-time-shell: the scan reports $planted_hits of 7 planted usages, so the tree scan below would pass regardless" >&2
               exit 1
             fi
 

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -1,0 +1,72 @@
+/*
+  Check: build-time shell text avoids programmable-completion builtins.
+
+  The bash a runCommand builder runs is built without programmable completion,
+  so `compgen` is not a builtin there, it is an unresolved command. In a
+  condition context that difference is silent rather than fatal: an assertion
+  whose condition is a `compgen -G` call takes its else branch and reports a
+  pass on every run, which is how a leftover-temporary assertion in
+  modules/browsers/firefoxpwa/m365-check.nix checked nothing while looking
+  green. `declare -F`, `declare -p` and a `shopt -s nullglob` array are plain
+  builtins and cover the same ground.
+
+  Scoped to the trees whose shell text a Nix build executes. scripts/ runs under
+  the user's own bash, where the builtin exists.
+
+  Matched at command positions only, so the prose in this file and in the
+  comments that explain the rule are not themselves hits, and planted against a
+  fixture before the tree is scanned: a detector that cannot report a hit is the
+  same defect this guards against.
+*/
+{ lib, ... }:
+{
+  perSystem =
+    { pkgs, ... }:
+    let
+      sources = lib.fileset.toSource {
+        root = ../..;
+        fileset = lib.fileset.unions [
+          (lib.fileset.fileFilter (file: file.hasExt "nix") ../../modules)
+          (lib.fileset.fileFilter (file: file.hasExt "nix") ../../packages)
+          (lib.fileset.fileFilter (file: file.hasExt "sh") ../../tests)
+        ];
+      };
+    in
+    {
+      checks.build-time-shell =
+        pkgs.runCommand "build-time-shell-check"
+          {
+            # Opts this check into the runtime build step in
+            # .github/workflows/check.yml, which otherwise only forces drvPaths.
+            passthru.runtimeCheck = true;
+            nativeBuildInputs = [ pkgs.gnugrep ];
+          }
+          ''
+            set -o errexit -o nounset -o pipefail
+
+            scan() {
+              grep -rnE \
+                '^[[:space:]]*compgen\b|\$\(compgen\b|(if|while|until|then|else|do|;|&&|\|\|)[[:space:]]+compgen\b' \
+                "$@" || true
+            }
+
+            planted="$PWD/planted"
+            mkdir -p "$planted"
+            # Assembled rather than written out, so this file is not a hit in its
+            # own scan and does not have to exclude itself from it.
+            printf 'if %s -A function; then :; fi\n' compgen >"$planted/fixture.sh"
+            if [ -z "$(scan "$planted")" ]; then
+              echo "build-time-shell: the scan reports nothing for a planted usage, so the tree scan below would pass regardless" >&2
+              exit 1
+            fi
+
+            hits=$(scan ${sources}/modules ${sources}/packages ${sources}/tests)
+            if [ -n "$hits" ]; then
+              printf '%s\n' "$hits" >&2
+              echo "build-time-shell: compgen needs programmable completion, which the bash a runCommand builder runs is built without; use declare -F or a nullglob array" >&2
+              exit 1
+            fi
+            echo "no programmable-completion builtins in build-time shell text" >"$out"
+          '';
+    };
+}

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -56,7 +56,7 @@
             scan() {
               local status=0
               grep -rnE \
-                '^[[:space:]]*!?[[:space:]]*compgen\b|\$\(!?[[:space:]]*compgen\b|(if|while|until|then|else|do|;|&&|\|\|)[[:space:]]+!?[[:space:]]*compgen\b' \
+                '^[[:space:]]*!?[[:space:]]*compgen\b|\$\(!?[[:space:]]*compgen\b|(if|elif|while|until|then|else|do|;|&&|\|\|?)[[:space:]]+!?[[:space:]]*compgen\b' \
                 "$@" || status=$?
               # 1 is "matched nothing"; 2 and up mean grep could not read a path
               # it was given, and an empty result from that is indistinguishable

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -51,9 +51,19 @@
             # quoted in this comment, because the scan below reads this file
             # too and a quoted command position is a hit like any other.
             scan() {
+              local status=0
               grep -rnE \
                 '^[[:space:]]*!?[[:space:]]*compgen\b|\$\(!?[[:space:]]*compgen\b|(if|while|until|then|else|do|;|&&|\|\|)[[:space:]]+!?[[:space:]]*compgen\b' \
-                "$@" || true
+                "$@" || status=$?
+              # 1 is "matched nothing"; 2 and up mean grep could not read a path
+              # it was given, and an empty result from that is indistinguishable
+              # from a clean tree. Reachable without anything being broken:
+              # lib.fileset.toSource materializes a directory only when a file
+              # in it matches, so ${"\${sources}"}/tests exists only while tests/ still
+              # holds a .sh file. Returned rather than reported, so the callers
+              # abort: hits=$(scan ...) fails the assignment under errexit, and
+              # the planted count fails through pipefail.
+              [ "$status" -le 1 ] || return "$status"
             }
 
             planted="$PWD/planted"

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -56,7 +56,7 @@
             scan() {
               local status=0
               grep -rnE \
-                '^[[:space:]]*!?[[:space:]]*compgen\b|\$\(!?[[:space:]]*compgen\b|(if|elif|while|until|then|else|do|;|&&|\|\|?|\{|\(|\))[[:space:]]+!?[[:space:]]*compgen\b' \
+                '^[[:space:]]*!?[[:space:]]*compgen\b|[$<>]\(!?[[:space:]]*compgen\b|(if|elif|while|until|then|else|do|;|&&|\|\|?|\{|\(|\))[[:space:]]+!?[[:space:]]*compgen\b' \
                 "$@" || status=$?
               # 1 is "matched nothing"; 2 and up mean grep could not read a path
               # it was given, and an empty result from that is indistinguishable
@@ -73,8 +73,9 @@
             mkdir -p "$planted"
             # Assembled rather than written out, so this file is not a hit in its
             # own scan and does not have to exclude itself from it. Every
-            # command-position spelling is planted and counted: a fixture for
-            # one of them proves only the alternative it happens to take.
+            # command-position spelling, including process-substitution
+            # openings, is planted and counted: a fixture for one of them
+            # proves only the alternative it happens to take.
             printf 'if %s -A function; then :; fi\n' compgen >"$planted/plain.sh"
             printf 'if ! %s -A function; then :; fi\n' compgen >"$planted/negated.sh"
             printf 'elif %s -A function; then :; fi\n' compgen >"$planted/elif.sh"
@@ -82,9 +83,10 @@
             printf 'case x in *) %s -A function ;; esac\n' compgen >"$planted/case.sh"
             printf 'if { %s -A function; }; then :; fi\n' compgen >"$planted/group.sh"
             printf '( %s -A function )\n' compgen >"$planted/subshell.sh"
+            printf 'while read -r _; do :; done < <(%s -A function)\n' compgen >"$planted/procsub.sh"
             planted_hits=$(scan "$planted" | wc -l)
-            if [ "$planted_hits" -ne 7 ]; then
-              echo "build-time-shell: the scan reports $planted_hits of 7 planted usages, so the tree scan below would pass regardless" >&2
+            if [ "$planted_hits" -ne 8 ]; then
+              echo "build-time-shell: the scan reports $planted_hits of 8 planted usages, so the tree scan below would pass regardless" >&2
               exit 1
             fi
 

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -44,19 +44,30 @@
           ''
             set -o errexit -o nounset -o pipefail
 
+            # The optional ! keeps the anchoring at a command position while
+            # admitting the negated spelling of it, which fails open the same
+            # way and is the more natural way to write an assertion that wants
+            # to report a leftover. Spelled with the negation inline rather than
+            # quoted in this comment, because the scan below reads this file
+            # too and a quoted command position is a hit like any other.
             scan() {
               grep -rnE \
-                '^[[:space:]]*compgen\b|\$\(compgen\b|(if|while|until|then|else|do|;|&&|\|\|)[[:space:]]+compgen\b' \
+                '^[[:space:]]*!?[[:space:]]*compgen\b|\$\(!?[[:space:]]*compgen\b|(if|while|until|then|else|do|;|&&|\|\|)[[:space:]]+!?[[:space:]]*compgen\b' \
                 "$@" || true
             }
 
             planted="$PWD/planted"
             mkdir -p "$planted"
             # Assembled rather than written out, so this file is not a hit in its
-            # own scan and does not have to exclude itself from it.
-            printf 'if %s -A function; then :; fi\n' compgen >"$planted/fixture.sh"
-            if [ -z "$(scan "$planted")" ]; then
-              echo "build-time-shell: the scan reports nothing for a planted usage, so the tree scan below would pass regardless" >&2
+            # own scan and does not have to exclude itself from it. Both
+            # spellings, and counted: a fixture for one of them proves only the
+            # alternative it happens to take, which is how the negated form went
+            # unscanned while the self-test stayed green.
+            printf 'if %s -A function; then :; fi\n' compgen >"$planted/plain.sh"
+            printf 'if ! %s -A function; then :; fi\n' compgen >"$planted/negated.sh"
+            planted_hits=$(scan "$planted" | wc -l)
+            if [ "$planted_hits" -ne 2 ]; then
+              echo "build-time-shell: the scan reports $planted_hits of 2 planted usages, so the tree scan below would pass regardless" >&2
               exit 1
             fi
 

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -56,7 +56,7 @@
             scan() {
               local status=0
               grep -rnE \
-                '^[[:space:]]*!?[[:space:]]*compgen\b|[$<>]\(!?[[:space:]]*compgen\b|(if|elif|while|until|then|else|do|;|&&|\|\|?|\{|\(|\))[[:space:]]+!?[[:space:]]*compgen\b' \
+                '^[[:space:]]*!?[[:space:]]*compgen\b|[$<>]\(!?[[:space:]]*compgen\b|=`!?[[:space:]]*compgen\b|(if|elif|while|until|then|else|do|;|&&|\|\|?|\{|\(|\))[[:space:]]+!?[[:space:]]*compgen\b' \
                 "$@" || status=$?
               # 1 is "matched nothing"; 2 and up mean grep could not read a path
               # it was given, and an empty result from that is indistinguishable
@@ -73,9 +73,9 @@
             mkdir -p "$planted"
             # Assembled rather than written out, so this file is not a hit in its
             # own scan and does not have to exclude itself from it. Every
-            # command-position spelling, including process-substitution
-            # openings, is planted and counted: a fixture for one of them
-            # proves only the alternative it happens to take.
+            # command-position spelling, including process-substitution openings
+            # and assignment-capture forms, is planted and counted: a fixture
+            # for one of them proves only the alternative it happens to take.
             printf 'if %s -A function; then :; fi\n' compgen >"$planted/plain.sh"
             printf 'if ! %s -A function; then :; fi\n' compgen >"$planted/negated.sh"
             printf 'elif %s -A function; then :; fi\n' compgen >"$planted/elif.sh"
@@ -84,9 +84,10 @@
             printf 'if { %s -A function; }; then :; fi\n' compgen >"$planted/group.sh"
             printf '( %s -A function )\n' compgen >"$planted/subshell.sh"
             printf 'while read -r _; do :; done < <(%s -A function)\n' compgen >"$planted/procsub.sh"
+            printf 'x=`%s -A function`\n' compgen >"$planted/backtick.sh"
             planted_hits=$(scan "$planted" | wc -l)
-            if [ "$planted_hits" -ne 8 ]; then
-              echo "build-time-shell: the scan reports $planted_hits of 8 planted usages, so the tree scan below would pass regardless" >&2
+            if [ "$planted_hits" -ne 9 ]; then
+              echo "build-time-shell: the scan reports $planted_hits of 9 planted usages, so the tree scan below would pass regardless" >&2
               exit 1
             fi
 

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -56,7 +56,7 @@
             scan() {
               local status=0
               grep -rnE \
-                '^[[:space:]]*!?[[:space:]]*compgen\b|[$<>]\(!?[[:space:]]*compgen\b|=`!?[[:space:]]*compgen\b|(if|elif|while|until|then|else|do|;|&&|\|\|?|\{|\(|\))[[:space:]]+!?[[:space:]]*compgen\b' \
+                '^[[:space:]]*!?[[:space:]]*compgen\b|[$<>]\(!?[[:space:]]*compgen\b|["=(|;&]`!?[[:space:]]*compgen\b|(if|elif|while|until|then|else|do|;|&&|\|\|?|\{|\(|\))[[:space:]]+!?[[:space:]]*compgen\b' \
                 "$@" || status=$?
               # 1 is "matched nothing"; 2 and up mean grep could not read a path
               # it was given, and an empty result from that is indistinguishable
@@ -74,8 +74,9 @@
             # Assembled rather than written out, so this file is not a hit in its
             # own scan and does not have to exclude itself from it. Every
             # command-position spelling, including process-substitution openings
-            # and assignment-capture forms, is planted and counted: a fixture
-            # for one of them proves only the alternative it happens to take.
+            # and backtick substitutions after shell openings, is planted and
+            # counted: a fixture for one of them proves only the alternative it
+            # happens to take.
             printf 'if %s -A function; then :; fi\n' compgen >"$planted/plain.sh"
             printf 'if ! %s -A function; then :; fi\n' compgen >"$planted/negated.sh"
             printf 'elif %s -A function; then :; fi\n' compgen >"$planted/elif.sh"
@@ -85,9 +86,10 @@
             printf '( %s -A function )\n' compgen >"$planted/subshell.sh"
             printf 'while read -r _; do :; done < <(%s -A function)\n' compgen >"$planted/procsub.sh"
             printf 'x=`%s -A function`\n' compgen >"$planted/backtick.sh"
+            printf 'if [ -n "`%s -A function`" ]; then :; fi\n' compgen >"$planted/backtick-quoted.sh"
             planted_hits=$(scan "$planted" | wc -l)
-            if [ "$planted_hits" -ne 9 ]; then
-              echo "build-time-shell: the scan reports $planted_hits of 9 planted usages, so the tree scan below would pass regardless" >&2
+            if [ "$planted_hits" -ne 10 ]; then
+              echo "build-time-shell: the scan reports $planted_hits of 10 planted usages, so the tree scan below would pass regardless" >&2
               exit 1
             fi
 

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -78,9 +78,11 @@
             # unscanned while the self-test stayed green.
             printf 'if %s -A function; then :; fi\n' compgen >"$planted/plain.sh"
             printf 'if ! %s -A function; then :; fi\n' compgen >"$planted/negated.sh"
+            printf 'elif %s -A function; then :; fi\n' compgen >"$planted/elif.sh"
+            printf 'true | %s -A function\n' compgen >"$planted/pipe.sh"
             planted_hits=$(scan "$planted" | wc -l)
-            if [ "$planted_hits" -ne 2 ]; then
-              echo "build-time-shell: the scan reports $planted_hits of 2 planted usages, so the tree scan below would pass regardless" >&2
+            if [ "$planted_hits" -ne 4 ]; then
+              echo "build-time-shell: the scan reports $planted_hits of 4 planted usages, so the tree scan below would pass regardless" >&2
               exit 1
             fi
 

--- a/modules/meta/build-time-shell.nix
+++ b/modules/meta/build-time-shell.nix
@@ -39,7 +39,10 @@
             # Opts this check into the runtime build step in
             # .github/workflows/check.yml, which otherwise only forces drvPaths.
             passthru.runtimeCheck = true;
-            nativeBuildInputs = [ pkgs.gnugrep ];
+            nativeBuildInputs = [
+              pkgs.gnugrep
+              pkgs.coreutils
+            ];
           }
           ''
             set -o errexit -o nounset -o pipefail

--- a/modules/meta/hooks/statix.nix
+++ b/modules/meta/hooks/statix.nix
@@ -1,6 +1,20 @@
+/*
+  Hook: statix
+
+  Also exposed as a flake check over the whole tree. The pre-commit hook only
+  ever sees staged files, and nothing in .github/workflows/check.yml runs
+  statix, so a lint in a file nobody stages again was reachable on main
+  indefinitely. The check runs the hook's own binary rather than a second
+  invocation of its own, so CI and pre-commit cannot drift apart.
+*/
 _: {
   perSystem =
-    { pkgs, ... }:
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
     {
       packages.hook-statix = pkgs.writeShellApplication {
         name = "hook-statix";
@@ -26,5 +40,27 @@ _: {
             exit "$status"
           '';
       };
+
+      # Only the .nix files: statix reads nothing else, and narrowing the
+      # source keeps this off the rebuild path of every unrelated commit.
+      checks.statix-tree =
+        let
+          nixSources = lib.fileset.toSource {
+            root = ../../..;
+            fileset = lib.fileset.fileFilter (file: file.hasExt "nix") ../../..;
+          };
+        in
+        pkgs.runCommand "statix-tree-check"
+          {
+            # Opts this check into the runtime build step in
+            # .github/workflows/check.yml, which otherwise only forces drvPaths.
+            passthru.runtimeCheck = true;
+            nativeBuildInputs = [ config.packages.hook-statix ];
+          }
+          ''
+            cd ${nixSources}
+            hook-statix
+            echo "statix reported nothing across the tree" >"$out"
+          '';
     };
 }

--- a/modules/meta/hooks/statix.nix
+++ b/modules/meta/hooks/statix.nix
@@ -66,6 +66,22 @@ _: {
             nativeBuildInputs = [ config.packages.hook-statix ];
           }
           ''
+            set -o errexit -o nounset -o pipefail
+
+            # Planted before the tree is trusted, the way ../build-time-shell.nix
+            # plants its own fixture: nothing else calls hook-statix without
+            # arguments (../pre-commit.nix sets pass_filenames), so a clean $out
+            # here would otherwise be indistinguishable from a run that walked
+            # nothing.
+            planted="$PWD/planted"
+            mkdir -p "$planted"
+            # W02, an empty let-in.
+            printf 'let in 1\n' >"$planted/fixture.nix"
+            if (cd "$planted" && hook-statix); then
+              echo "statix-tree: hook-statix reported nothing on a planted lint, so the tree scan below would pass regardless" >&2
+              exit 1
+            fi
+
             cd ${nixSources}
             hook-statix
             echo "statix reported nothing across the tree" >"$out"

--- a/modules/meta/hooks/statix.nix
+++ b/modules/meta/hooks/statix.nix
@@ -47,7 +47,15 @@ _: {
         let
           nixSources = lib.fileset.toSource {
             root = ../../..;
-            fileset = lib.fileset.fileFilter (file: file.hasExt "nix") ../../..;
+            # docs/nixos-manual/ is an upstream mirror synced by
+            # scripts/update-nixos-manual.sh, excluded by ../pre-commit.nix and
+            # ../treefmt.nix for that reason. Scanning it here would fail CI on
+            # code this repo cannot fix without diverging from upstream, and
+            # would be the scope drift between hook and check this file exists
+            # to remove.
+            fileset = lib.fileset.difference (lib.fileset.fileFilter (
+              file: file.hasExt "nix"
+            ) ../../..) ../../../docs/nixos-manual;
           };
         in
         pkgs.runCommand "statix-tree-check"

--- a/modules/meta/hooks/statix.nix
+++ b/modules/meta/hooks/statix.nix
@@ -63,7 +63,10 @@ _: {
             # Opts this check into the runtime build step in
             # .github/workflows/check.yml, which otherwise only forces drvPaths.
             passthru.runtimeCheck = true;
-            nativeBuildInputs = [ config.packages.hook-statix ];
+            nativeBuildInputs = [
+              config.packages.hook-statix
+              pkgs.coreutils
+            ];
           }
           ''
             set -o errexit -o nounset -o pipefail

--- a/packages/firefoxpwa-dmail-install/default.nix
+++ b/packages/firefoxpwa-dmail-install/default.nix
@@ -305,10 +305,22 @@ mkSiteInstaller {
     # a missing record here to refuse on. Told apart from the documented
     # uninstall, which leaves the records behind but takes the site with it, by
     # the site still being there.
-    if [ -r "$ulid_file" ] \
-      && jq -e --arg u "$(<"$ulid_file")" '.sites[$u]' "$config_file" >/dev/null 2>&1; then
-      echo "firefoxpwa-dmail: '$app_name' is a new name for the site this unit installed as $(<"$ulid_file"); uninstall that site so this unit can reinstall it under the new name" >&2
-      exit 1
+    if [ -r "$ulid_file" ] && [ -f "$config_file" ]; then
+      # jq's failure separated from "no such site", the way site_ulid's caller
+      # above separates it from "no site": a read racing firefoxpwa connector's
+      # own rewrite exits non-zero, and treating that as "the recorded site is
+      # gone" falls into the install below with the dmail-* records fixed, so
+      # the second site takes them. The -f test keeps a config.json that is gone
+      # entirely installing, which is what site_ulid's own [ -f ] does with it.
+      if ! recorded=$(jq -r --arg u "$(<"$ulid_file")" \
+        'if ((.sites // {}) | has($u)) then "yes" else "" end' "$config_file" 2>/dev/null); then
+        echo "firefoxpwa-dmail: cannot read $config_file; not installing a second '$app_name'" >&2
+        exit 1
+      fi
+      if [ -n "$recorded" ]; then
+        echo "firefoxpwa-dmail: '$app_name' is a new name for the site this unit installed as $(<"$ulid_file"); uninstall that site so this unit can reinstall it under the new name" >&2
+        exit 1
+      fi
     fi
 
     # A data: manifest keeps the install self-contained: firefoxpwa does not

--- a/packages/firefoxpwa-dmail-install/default.nix
+++ b/packages/firefoxpwa-dmail-install/default.nix
@@ -296,6 +296,21 @@ mkSiteInstaller {
       exit 1
     fi
 
+    # A rename changes the launcher name while this installer's records keep
+    # their fixed dmail-* paths, so the lookup above misses the site it already
+    # installed and this branch would register a second one under the new name
+    # while overwriting the only records of the first, leaving the original app
+    # and its .desktop entry with nothing pointing at them. Unlike the m365
+    # installer, whose records are keyed by the entry's slug, there is not even
+    # a missing record here to refuse on. Told apart from the documented
+    # uninstall, which leaves the records behind but takes the site with it, by
+    # the site still being there.
+    if [ -r "$ulid_file" ] \
+      && jq -e --arg u "$(<"$ulid_file")" '.sites[$u]' "$config_file" >/dev/null 2>&1; then
+      echo "firefoxpwa-dmail: '$app_name' is a new name for the site this unit installed as $(<"$ulid_file"); uninstall that site so this unit can reinstall it under the new name" >&2
+      exit 1
+    fi
+
     # A data: manifest keeps the install self-contained: firefoxpwa does not
     # have to fetch or parse a manifest from the target site.
     #

--- a/packages/firefoxpwa-dmail-install/default.nix
+++ b/packages/firefoxpwa-dmail-install/default.nix
@@ -9,13 +9,19 @@
 
   Returns a function: the caller supplies the firefoxpwa package and the runtime
   path of the decrypted URL secret.
+
+  Built through ../firefoxpwa-site-installer, which supplies the prelude every
+  site installer needs and takes the lock that keeps two of them off
+  config.json at once. Only what is specific to this site lives here.
 */
 {
   lib,
-  writeShellApplication,
+  callPackage,
   jq,
-  coreutils,
 }:
+let
+  mkSiteInstaller = callPackage ../firefoxpwa-site-installer { };
+in
 {
   firefoxpwa,
   urlPath,
@@ -26,32 +32,16 @@
   # three real 5-second sleeps per run.
   retryDelay ? 5,
 }:
-writeShellApplication {
+mkSiteInstaller {
   name = "firefoxpwa-install-dmail";
+  inherit dataDir xdgDataHome;
   runtimeInputs = [
     firefoxpwa
     jq
-    coreutils
   ];
   text = ''
     url_file=${lib.escapeShellArg urlPath}
     app_name=${lib.escapeShellArg appName}
-    # Passed in rather than re-derived from XDG_DATA_HOME: the caller uses this
-    # same value for the sops secret path and the 0700 activation step, and a
-    # second rule here would put the marker and config.json outside the
-    # directory those protect whenever xdg.dataHome is not at its default.
-    data_dir=${lib.escapeShellArg dataDir}
-    # Exported, not just read: firefoxpwa resolves its own userdata tree from
-    # FFPWA_USERDATA and, separately, its system-integration directory (the
-    # .desktop entry and icon, through directories::BaseDirs) from
-    # XDG_DATA_HOME. Neither is read by this script, but both are read by the
-    # site install / site update calls it makes below, so pinning them from
-    # the values the caller already chose makes the binary and this script
-    # agree by construction, rather than depending on a systemd unit's
-    # Environment= staying in sync with this file from the outside.
-    export FFPWA_USERDATA="$data_dir"
-    export XDG_DATA_HOME=${lib.escapeShellArg xdgDataHome}
-    config_file="$data_dir/config.json"
     retry_delay=${lib.escapeShellArg (toString retryDelay)}
 
     # firefoxpwa deserializes start_url into the Rust url crate's Url

--- a/packages/firefoxpwa-dmail-install/default.nix
+++ b/packages/firefoxpwa-dmail-install/default.nix
@@ -95,6 +95,10 @@ mkSiteInstaller {
     # which pipefail then reports as failure.
     site_ulid() {
       [ -f "$config_file" ] || return 0
+      # File::create truncates before writing, so zero bytes is a mid-write
+      # config rather than an empty site list. jq otherwise exits 0 without
+      # producing a value, which callers would take as "no site".
+      [ -s "$config_file" ] || return 1
       jq -r --arg n "$app_name" \
         'first((.sites // {}) | to_entries[] | select(.value.config.name == $n) | .key) // empty' \
         "$config_file" 2>/dev/null
@@ -273,6 +277,10 @@ mkSiteInstaller {
         # fault, not proof of a foreign site.
         installed_manifest=""
         if [ -s "$pending_file" ]; then
+          if [ ! -s "$config_file" ]; then
+            echo "firefoxpwa-dmail: cannot read $config_file; not installing a second '$app_name'" >&2
+            exit 1
+          fi
           if ! installed_manifest=$(jq -r --arg u "$ulid" \
             '.sites[$u].config.manifest_url // empty' "$config_file" 2>/dev/null); then
             echo "firefoxpwa-dmail: cannot read $config_file; not installing a second '$app_name'" >&2
@@ -313,6 +321,10 @@ mkSiteInstaller {
     # uninstall, which leaves the records behind but takes the site with it, by
     # the site still being there.
     if [ -r "$ulid_file" ] && [ -f "$config_file" ]; then
+      if [ ! -s "$config_file" ]; then
+        echo "firefoxpwa-dmail: cannot read $config_file; not installing a second '$app_name'" >&2
+        exit 1
+      fi
       # jq's failure separated from "no such site", the way site_ulid's caller
       # above separates it from "no site": a read racing firefoxpwa connector's
       # own rewrite exits non-zero, and treating that as "the recorded site is

--- a/packages/firefoxpwa-dmail-install/default.nix
+++ b/packages/firefoxpwa-dmail-install/default.nix
@@ -269,10 +269,17 @@ mkSiteInstaller {
         # then yields empty output too) would otherwise compare "" = "" and
         # adopt regardless. Requiring non-empty here is enough on its own:
         # equality against a non-empty marker already implies the jq read
-        # produced that same non-empty value.
-        if [ -s "$pending_file" ] \
-          && [ "$(jq -r --arg u "$ulid" '.sites[$u].config.manifest_url // empty' \
-                "$config_file" 2>/dev/null)" = "$(<"$pending_file")" ]; then
+        # produced that same non-empty value. A jq read failure is a transient
+        # fault, not proof of a foreign site.
+        installed_manifest=""
+        if [ -s "$pending_file" ]; then
+          if ! installed_manifest=$(jq -r --arg u "$ulid" \
+            '.sites[$u].config.manifest_url // empty' "$config_file" 2>/dev/null); then
+            echo "firefoxpwa-dmail: cannot read $config_file; not installing a second '$app_name'" >&2
+            exit 1
+          fi
+        fi
+        if [ -s "$pending_file" ] && [ "$installed_manifest" = "$(<"$pending_file")" ]; then
           record_ulid
           rm -f "$pending_file"
         else

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -10,6 +10,10 @@
   Returns a function: the caller supplies the firefoxpwa package and the app
   table to install.
 
+  Built through ../firefoxpwa-site-installer, which supplies the prelude every
+  site installer needs and takes the lock that keeps two of them off
+  config.json at once. Only what is specific to this suite lives here.
+
   Same site bookkeeping as packages/firefoxpwa-dmail-install, minus the parts
   that only a secret needs: the start URLs are public and declared in the Nix
   store, so they are logged, and the records are ordinary 0600-by-directory
@@ -27,10 +31,12 @@
 */
 {
   lib,
-  writeShellApplication,
+  callPackage,
   jq,
-  coreutils,
 }:
+let
+  mkSiteInstaller = callPackage ../firefoxpwa-site-installer { };
+in
 {
   firefoxpwa,
   dataDir,
@@ -40,35 +46,15 @@
   # three real 5-second sleeps per entry.
   retryDelay ? 5,
 }:
-writeShellApplication {
+mkSiteInstaller {
   name = "firefoxpwa-install-m365";
+  inherit dataDir xdgDataHome;
   runtimeInputs = [
     firefoxpwa
     jq
-    coreutils
   ];
   text = ''
-    # Passed in rather than re-derived from XDG_DATA_HOME: the caller uses this
-    # same value for the 0700 activation step, and a second rule here would put
-    # the records and config.json outside the directory that protects them
-    # whenever xdg.dataHome is not at its default.
-    data_dir=${lib.escapeShellArg dataDir}
-    # Exported, not just read: firefoxpwa resolves its own userdata tree from
-    # FFPWA_USERDATA and, separately, its system-integration directory (the
-    # .desktop entry and icon, through directories::BaseDirs) from
-    # XDG_DATA_HOME. Neither is read by this script, but both are read by the
-    # site install / site update calls it makes, so pinning them from the
-    # values the caller already chose makes the binary and this script agree by
-    # construction rather than through a systemd unit's Environment=.
-    export FFPWA_USERDATA="$data_dir"
-    export XDG_DATA_HOME=${lib.escapeShellArg xdgDataHome}
-    config_file="$data_dir/config.json"
     retry_delay=${lib.escapeShellArg (toString retryDelay)}
-
-    # Created here, not only by ./home.nix's activation step: unlike the DMail
-    # unit, nothing decrypts a secret into this directory first, and the first
-    # record below is written before firefoxpwa (which would create it) has run.
-    install -d -m 700 "$data_dir"
 
     # firefoxpwa stores the managed site under .sites.<ulid> and the launcher
     # name set with --name lands at .config.name, so a site carrying an entry's

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -1,0 +1,306 @@
+/*
+  firefoxpwa: Microsoft 365 installer
+
+  Build logic for the oneshot installer that
+  modules/browsers/firefoxpwa/m365.nix runs as a user service. It lives here
+  rather than inline in the module so the same derivation can be built against
+  a stub firefoxpwa, which is what the regression check in
+  modules/browsers/firefoxpwa/m365-check.nix does.
+
+  Returns a function: the caller supplies the firefoxpwa package and the app
+  table to install.
+
+  Same site bookkeeping as packages/firefoxpwa-dmail-install, minus the parts
+  that only a secret needs: the start URLs are public and declared in the Nix
+  store, so they are logged, and the records are ordinary 0600-by-directory
+  files rather than umask-guarded ones. What this installer adds is the loop:
+  each entry is installed independently and a failure is counted rather than
+  raised, so one site that cannot be installed does not cost the others theirs.
+*/
+{
+  lib,
+  writeShellApplication,
+  jq,
+  coreutils,
+}:
+{
+  firefoxpwa,
+  dataDir,
+  xdgDataHome,
+  apps,
+  # 0 in the regression check, which needs the retry loop's control flow, not
+  # three real 5-second sleeps per entry.
+  retryDelay ? 5,
+}:
+writeShellApplication {
+  name = "firefoxpwa-install-m365";
+  runtimeInputs = [
+    firefoxpwa
+    jq
+    coreutils
+  ];
+  text = ''
+    # Passed in rather than re-derived from XDG_DATA_HOME: the caller uses this
+    # same value for the 0700 activation step, and a second rule here would put
+    # the records and config.json outside the directory that protects them
+    # whenever xdg.dataHome is not at its default.
+    data_dir=${lib.escapeShellArg dataDir}
+    # Exported, not just read: firefoxpwa resolves its own userdata tree from
+    # FFPWA_USERDATA and, separately, its system-integration directory (the
+    # .desktop entry and icon, through directories::BaseDirs) from
+    # XDG_DATA_HOME. Neither is read by this script, but both are read by the
+    # site install / site update calls it makes, so pinning them from the
+    # values the caller already chose makes the binary and this script agree by
+    # construction rather than through a systemd unit's Environment=.
+    export FFPWA_USERDATA="$data_dir"
+    export XDG_DATA_HOME=${lib.escapeShellArg xdgDataHome}
+    config_file="$data_dir/config.json"
+    retry_delay=${lib.escapeShellArg (toString retryDelay)}
+
+    # Created here, not only by ./home.nix's activation step: unlike the DMail
+    # unit, nothing decrypts a secret into this directory first, and the first
+    # record below is written before firefoxpwa (which would create it) has run.
+    install -d -m 700 "$data_dir"
+
+    # firefoxpwa stores the managed site under .sites.<ulid> and the launcher
+    # name set with --name lands at .config.name, so a site carrying an entry's
+    # name is that entry's install. Emits the ulid, or nothing. Taking the
+    # first match inside jq keeps the exit status jq's own: piping to `head -n1`
+    # lets head close the pipe first and SIGPIPE jq, which pipefail then
+    # reports as failure.
+    site_ulid() {
+      [ -f "$config_file" ] || return 0
+      jq -r --arg n "$1" \
+        'first((.sites // {}) | to_entries[] | select(.value.config.name == $n) | .key) // empty' \
+        "$config_file" 2>/dev/null
+    }
+
+    # RFC 3986 3.1: the scheme is case-insensitive, and the authority ends at
+    # the first /, ? or #. Userinfo is dropped (3.2.1 puts it before @, and it
+    # is not part of an origin). Default ports are omitted and scheme and host
+    # case is folded so equivalent origin spellings compare identically.
+    # Emits the origin, or nothing.
+    url_origin() {
+      [[ $1 =~ ^([A-Za-z][A-Za-z0-9+.-]*://)([^/?#]+) ]] || return 0
+      local scheme authority
+      scheme="''${BASH_REMATCH[1],,}"
+      authority="''${BASH_REMATCH[2]##*@}"
+      authority="''${authority,,}"
+      case "$scheme$authority" in
+        https://*:443) authority="''${authority%:443}" ;;
+        http://*:80) authority="''${authority%:80}" ;;
+      esac
+      printf '%s' "$scheme$authority"
+    }
+
+    # Written through a sibling and renamed: truncating in place would leave a
+    # partial record if the write is interrupted, and a truncated URL yields
+    # either a wrong origin or none, which the cross-origin guard below then
+    # reports as a mismatch on every run with no way back.
+    record() {
+      printf '%s' "$2" >"$1.next"
+      mv "$1.next" "$1"
+    }
+
+    install_app() {
+      local key=$1 name=$2 url=$3
+      local applied_file="$data_dir/m365-$key-applied-url"
+      local origin_file="$data_dir/m365-$key-applied-origin"
+      # Origin alone does not authenticate identity: a same-named site at the
+      # recorded origin is not necessarily the site this script installed.
+      local ulid_file="$data_dir/m365-$key-applied-ulid"
+      # Says an install by this script was in flight, so a kill between
+      # firefoxpwa registering the site and record below is repaired rather
+      # than refused. Cleared on every path that ends one.
+      local pending_file="$data_dir/m365-$key-installing"
+      local origin ulid guard_origin manifest manifest_url attempt
+
+      # Refused rather than installed: url_origin drops userinfo, so the scope
+      # derived from it cannot be a prefix of a start URL that keeps it, and
+      # site update cannot rewrite scope afterwards.
+      if [[ $url =~ ^[A-Za-z][A-Za-z0-9+.-]*://[^/?#]*@ ]]; then
+        echo "firefoxpwa-m365: the start URL for '$name' embeds credentials; declare it without them" >&2
+        return 1
+      fi
+
+      # Manifest scope is a prefix match and site update cannot rewrite it, so
+      # it must be the bare origin: anything longer pushes same-origin
+      # navigation and every later URL change into the external browser.
+      origin=$(url_origin "$url")
+      if [ -z "$origin" ]; then
+        echo "firefoxpwa-m365: cannot derive an origin from the start URL '$url' for '$name'" >&2
+        return 1
+      fi
+
+      # Separated from "no site": jq exits non-zero on an unreadable or
+      # partially written config.json (firefoxpwa writes it through
+      # File::create with no rename, and firefoxpwa connector can be mid-write
+      # when this unit runs), and treating that as absent would register a
+      # second site under the same name.
+      if ! ulid=$(site_ulid "$name"); then
+        echo "firefoxpwa-m365: cannot read $config_file; not installing a second '$name'" >&2
+        return 1
+      fi
+
+      if [ -n "$ulid" ]; then
+        # The pending record only licenses adopting a site whose identity is
+        # not yet recorded. Once ulid_file names this site it has no further
+        # job, and a record left behind by a kill between the two would
+        # otherwise never be cleared.
+        if [ -r "$ulid_file" ] && [ "$(<"$ulid_file")" = "$ulid" ]; then
+          rm -f "$pending_file"
+        fi
+
+        # Gated on ulid_file too, not just the URL: without it, a foreign
+        # same-named site the browser extension created after an uninstall
+        # would silently pass as a no-op whenever the declared URL has not
+        # changed, the steady state, while the launcher points at whatever that
+        # foreign site carries.
+        if [ -r "$ulid_file" ] && [ "$(<"$ulid_file")" = "$ulid" ] \
+          && [ -r "$applied_file" ] && [ "$(<"$applied_file")" = "$url" ]; then
+          return 0
+        fi
+
+        # origin_file first: it is written on every success and also when an
+        # install registers the site and then fails, so it is never staler than
+        # applied_file. No record at all is refused rather than skipped: the
+        # site's scope is then unknown, so it cannot be shown to still contain
+        # the declared URL.
+        guard_origin=""
+        if [ -r "$origin_file" ]; then
+          guard_origin=$(<"$origin_file")
+        elif [ -r "$applied_file" ]; then
+          guard_origin=$(url_origin "$(<"$applied_file")")
+        else
+          echo "firefoxpwa-m365: '$name' exists but nothing records the origin it was installed at; uninstall the site so this unit can reinstall it" >&2
+          return 1
+        fi
+
+        if [ ! -r "$ulid_file" ] || [ "$(<"$ulid_file")" != "$ulid" ]; then
+          # -s, not -r: the pending record is truncated in place rather than
+          # renamed into place, so a kill between open and printf leaves an
+          # empty, readable file, and an empty one paired with a config.json
+          # read racing firefoxpwa connector would otherwise compare "" = ""
+          # and adopt regardless. Its content is the manifest_url the attempt
+          # used, which only an install through this script's synthetic data:
+          # manifest could produce, so matching it authenticates the site
+          # whatever state ulid_file is in.
+          if [ -s "$pending_file" ] \
+            && [ "$(jq -r --arg u "$ulid" '.sites[$u].config.manifest_url // empty' \
+                  "$config_file" 2>/dev/null)" = "$(<"$pending_file")" ]; then
+            record "$ulid_file" "$ulid"
+            rm -f "$pending_file"
+          else
+            echo "firefoxpwa-m365: '$name' ($ulid) is not the site this unit installed; uninstall it so this unit can reinstall its own" >&2
+            return 1
+          fi
+        fi
+
+        # Compared against what this script recorded, never against
+        # .manifest.scope: firefoxpwa stores the scope through the url crate,
+        # which drops a default port, punycodes an IDN host and fills in an
+        # empty path, so a raw-against-normalized test refuses same-origin
+        # changes. Uninstalling is the only remedy offered on purpose: scope is
+        # fixed at install time, so the new start URL would sit outside it and
+        # every navigation would go to the external browser.
+        if [ "''${guard_origin,,}" != "''${origin,,}" ]; then
+          echo "firefoxpwa-m365: '$name' is installed at '$guard_origin' but is now declared at '$origin'; uninstall the site so this unit can reinstall it at the new origin" >&2
+          return 1
+        fi
+
+        echo "firefoxpwa-m365: refreshing start URL for '$name' ($ulid)"
+        if firefoxpwa site update "$ulid" --start-url "$url" --no-manifest-updates; then
+          record "$origin_file" "$origin"
+          record "$applied_file" "$url"
+          return 0
+        fi
+        echo "firefoxpwa-m365: failed to update start URL for '$name'" >&2
+        return 1
+      fi
+
+      # A data: manifest keeps the install self-contained: firefoxpwa does not
+      # have to fetch or parse a manifest from the target site, which for these
+      # apps sits behind a sign-in redirect. Site::url prefers config.start_url
+      # over the manifest's, so the app still opens the declared URL.
+      manifest=$(jq -nc --arg s "$origin" --arg n "$name" \
+        '{name: $n, scope: $s, start_url: $s, display: "standalone"}')
+      manifest_url="data:application/manifest+json;base64,$(printf '%s' "$manifest" | base64 -w0)"
+
+      # Recorded before the attempt: this branch is only reachable when no site
+      # exists, so the record cannot be stale relative to a live site, while
+      # recording afterwards would leave a registered site with no record at
+      # all when the script is killed mid-install, which the guard above then
+      # refuses on every run.
+      record "$origin_file" "$origin"
+
+      for attempt in 1 2 3; do
+        # Written before the call: firefoxpwa registers the site through
+        # storage.write partway through site install, so a kill during the call
+        # leaves a site this script installed with no ulid record.
+        printf '%s' "$manifest_url" >"$pending_file"
+        if firefoxpwa site install "$manifest_url" \
+          --document-url "$origin" \
+          --start-url "$url" \
+          --name "$name"; then
+          if ! ulid=$(site_ulid "$name"); then
+            echo "firefoxpwa-m365: cannot read $config_file after installing '$name'" >&2
+            return 1
+          fi
+          if [ -z "$ulid" ]; then
+            rm -f "$pending_file"
+            echo "firefoxpwa-m365: '$name' reported installed but is not in $config_file" >&2
+            return 1
+          fi
+          record "$ulid_file" "$ulid"
+          rm -f "$pending_file"
+          record "$applied_file" "$url"
+          echo "firefoxpwa-m365: installed '$name'"
+          return 0
+        fi
+        # A failed attempt can still register the site before erroring (for
+        # example on desktop integration), so retrying install here would
+        # create a second entry under the same name. applied_file is cleared
+        # too: a stale record left by an earlier install of this same URL would
+        # otherwise satisfy the no-op fast path on the next run and skip the
+        # site update this branch defers the repair to.
+        if ! ulid=$(site_ulid "$name"); then
+          echo "firefoxpwa-m365: cannot read $config_file; not retrying '$name'" >&2
+          return 1
+        fi
+        if [ -n "$ulid" ]; then
+          record "$ulid_file" "$ulid"
+          rm -f "$pending_file" "$applied_file"
+          echo "firefoxpwa-m365: '$name' was registered by a failed install; the next activation repairs it with site update" >&2
+          return 1
+        fi
+        rm -f "$pending_file"
+        [ "$attempt" -lt 3 ] || break
+        echo "firefoxpwa-m365: install attempt $attempt for '$name' failed; retrying" >&2
+        sleep "$retry_delay"
+      done
+
+      # Reached only through the break above, with $ulid last seen empty: no
+      # attempt registered a site, so none of the records can describe one that
+      # exists, and a stale one would let a future foreign site pass the
+      # identity check above.
+      rm -f "$origin_file" "$applied_file" "$ulid_file" "$pending_file"
+      echo "firefoxpwa-m365: installing '$name' failed after 3 attempts" >&2
+      return 1
+    }
+
+    failed=0
+    # Unrolled from the app table at build time rather than iterated from an
+    # embedded JSON document: the values reach the shell through
+    # escapeShellArg, so no field separator can be confused with content, and
+    # the store path shows exactly which sites a generation installs.
+    ${lib.concatMapStringsSep "\n" (
+      app:
+      "install_app ${lib.escapeShellArg app.key} ${lib.escapeShellArg app.name} ${lib.escapeShellArg app.url} || failed=$((failed + 1))"
+    ) apps}
+
+    if [ "$failed" -ne 0 ]; then
+      echo "firefoxpwa-m365: $failed of ${toString (builtins.length apps)} web apps could not be installed" >&2
+      exit 1
+    fi
+  '';
+}

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -14,8 +14,16 @@
   that only a secret needs: the start URLs are public and declared in the Nix
   store, so they are logged, and the records are ordinary 0600-by-directory
   files rather than umask-guarded ones. What this installer adds is the loop:
-  each entry is installed independently and a failure is counted rather than
+  each entry is installed independently and a refusal is counted rather than
   raised, so one site that cannot be installed does not cost the others theirs.
+
+  A refusal is counted; a fault is not. The refusals are the states this script
+  decides it must not act on (a foreign site under a managed name, a move
+  across origins, an install that never registered), and each one leaves the
+  entry describable and recoverable. A failed write to a record or to
+  config.json is neither, so it aborts the run under errexit instead: the
+  records are what authenticate a site on the next run, and continuing past a
+  half-written one is how an entry ends up permanently refused.
 */
 {
   lib,
@@ -102,6 +110,19 @@ writeShellApplication {
       mv "$1.next" "$1"
     }
 
+    failed=0
+    # Counted here rather than by the caller testing install_app's status: a
+    # bash function invoked as the left side of `||` runs its whole body with
+    # errexit ignored, and that suppression is inherited by every compound
+    # command inside it, so a failed record or config.json read would pass
+    # silently and the entry would be reported installed. install_app is called
+    # as a plain command instead, which keeps errexit in force for the writes,
+    # and the states it decides not to act on land here.
+    refuse() {
+      echo "firefoxpwa-m365: $1" >&2
+      failed=$((failed + 1))
+    }
+
     install_app() {
       local key=$1 name=$2 url=$3
       local applied_file="$data_dir/m365-$key-applied-url"
@@ -119,8 +140,8 @@ writeShellApplication {
       # derived from it cannot be a prefix of a start URL that keeps it, and
       # site update cannot rewrite scope afterwards.
       if [[ $url =~ ^[A-Za-z][A-Za-z0-9+.-]*://[^/?#]*@ ]]; then
-        echo "firefoxpwa-m365: the start URL for '$name' embeds credentials; declare it without them" >&2
-        return 1
+        refuse "the start URL for '$name' embeds credentials; declare it without them"
+        return
       fi
 
       # Manifest scope is a prefix match and site update cannot rewrite it, so
@@ -128,8 +149,8 @@ writeShellApplication {
       # navigation and every later URL change into the external browser.
       origin=$(url_origin "$url")
       if [ -z "$origin" ]; then
-        echo "firefoxpwa-m365: cannot derive an origin from the start URL '$url' for '$name'" >&2
-        return 1
+        refuse "cannot derive an origin from the start URL '$url' for '$name'"
+        return
       fi
 
       # Separated from "no site": jq exits non-zero on an unreadable or
@@ -138,8 +159,8 @@ writeShellApplication {
       # when this unit runs), and treating that as absent would register a
       # second site under the same name.
       if ! ulid=$(site_ulid "$name"); then
-        echo "firefoxpwa-m365: cannot read $config_file; not installing a second '$name'" >&2
-        return 1
+        refuse "cannot read $config_file; not installing a second '$name'"
+        return
       fi
 
       if [ -n "$ulid" ]; then
@@ -172,8 +193,8 @@ writeShellApplication {
         elif [ -r "$applied_file" ]; then
           guard_origin=$(url_origin "$(<"$applied_file")")
         else
-          echo "firefoxpwa-m365: '$name' exists but nothing records the origin it was installed at; uninstall the site so this unit can reinstall it" >&2
-          return 1
+          refuse "'$name' exists but nothing records the origin it was installed at; uninstall the site so this unit can reinstall it"
+          return
         fi
 
         if [ ! -r "$ulid_file" ] || [ "$(<"$ulid_file")" != "$ulid" ]; then
@@ -191,8 +212,8 @@ writeShellApplication {
             record "$ulid_file" "$ulid"
             rm -f "$pending_file"
           else
-            echo "firefoxpwa-m365: '$name' ($ulid) is not the site this unit installed; uninstall it so this unit can reinstall its own" >&2
-            return 1
+            refuse "'$name' ($ulid) is not the site this unit installed; uninstall it so this unit can reinstall its own"
+            return
           fi
         fi
 
@@ -204,8 +225,8 @@ writeShellApplication {
         # fixed at install time, so the new start URL would sit outside it and
         # every navigation would go to the external browser.
         if [ "''${guard_origin,,}" != "''${origin,,}" ]; then
-          echo "firefoxpwa-m365: '$name' is installed at '$guard_origin' but is now declared at '$origin'; uninstall the site so this unit can reinstall it at the new origin" >&2
-          return 1
+          refuse "'$name' is installed at '$guard_origin' but is now declared at '$origin'; uninstall the site so this unit can reinstall it at the new origin"
+          return
         fi
 
         echo "firefoxpwa-m365: refreshing start URL for '$name' ($ulid)"
@@ -214,8 +235,8 @@ writeShellApplication {
           record "$applied_file" "$url"
           return 0
         fi
-        echo "firefoxpwa-m365: failed to update start URL for '$name'" >&2
-        return 1
+        refuse "failed to update start URL for '$name'"
+        return
       fi
 
       # A data: manifest keeps the install self-contained: firefoxpwa does not
@@ -243,13 +264,13 @@ writeShellApplication {
           --start-url "$url" \
           --name "$name"; then
           if ! ulid=$(site_ulid "$name"); then
-            echo "firefoxpwa-m365: cannot read $config_file after installing '$name'" >&2
-            return 1
+            refuse "cannot read $config_file after installing '$name'"
+            return
           fi
           if [ -z "$ulid" ]; then
             rm -f "$pending_file"
-            echo "firefoxpwa-m365: '$name' reported installed but is not in $config_file" >&2
-            return 1
+            refuse "'$name' reported installed but is not in $config_file"
+            return
           fi
           record "$ulid_file" "$ulid"
           rm -f "$pending_file"
@@ -264,14 +285,14 @@ writeShellApplication {
         # otherwise satisfy the no-op fast path on the next run and skip the
         # site update this branch defers the repair to.
         if ! ulid=$(site_ulid "$name"); then
-          echo "firefoxpwa-m365: cannot read $config_file; not retrying '$name'" >&2
-          return 1
+          refuse "cannot read $config_file; not retrying '$name'"
+          return
         fi
         if [ -n "$ulid" ]; then
           record "$ulid_file" "$ulid"
           rm -f "$pending_file" "$applied_file"
-          echo "firefoxpwa-m365: '$name' was registered by a failed install; the next activation repairs it with site update" >&2
-          return 1
+          refuse "'$name' was registered by a failed install; the next run repairs it with site update"
+          return
         fi
         rm -f "$pending_file"
         [ "$attempt" -lt 3 ] || break
@@ -284,18 +305,16 @@ writeShellApplication {
       # exists, and a stale one would let a future foreign site pass the
       # identity check above.
       rm -f "$origin_file" "$applied_file" "$ulid_file" "$pending_file"
-      echo "firefoxpwa-m365: installing '$name' failed after 3 attempts" >&2
-      return 1
+      refuse "installing '$name' failed after 3 attempts"
     }
 
-    failed=0
     # Unrolled from the app table at build time rather than iterated from an
     # embedded JSON document: the values reach the shell through
     # escapeShellArg, so no field separator can be confused with content, and
     # the store path shows exactly which sites a generation installs.
     ${lib.concatMapStringsSep "\n" (
       app:
-      "install_app ${lib.escapeShellArg app.key} ${lib.escapeShellArg app.name} ${lib.escapeShellArg app.url} || failed=$((failed + 1))"
+      "install_app ${lib.escapeShellArg app.key} ${lib.escapeShellArg app.name} ${lib.escapeShellArg app.url}"
     ) apps}
 
     if [ "$failed" -ne 0 ]; then

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -66,6 +66,10 @@ mkSiteInstaller {
     # reports as failure.
     site_ulid() {
       [ -f "$config_file" ] || return 0
+      # File::create truncates before writing, so zero bytes is a mid-write
+      # config rather than an empty site list. jq otherwise exits 0 without
+      # producing a value, which callers would take as "no site".
+      [ -s "$config_file" ] || return 1
       jq -r --arg n "$1" \
         'first((.sites // {}) | to_entries[] | select(.value.config.name == $n) | .key) // empty' \
         "$config_file" 2>/dev/null
@@ -203,6 +207,10 @@ mkSiteInstaller {
           # rather than the permanent foreign-site refusal below.
           installed_manifest=""
           if [ -s "$pending_file" ]; then
+            if [ ! -s "$config_file" ]; then
+              retry_refusal "cannot read $config_file; not installing a second '$name'"
+              return
+            fi
             if ! installed_manifest=$(jq -r --arg u "$ulid" \
               '.sites[$u].config.manifest_url // empty' "$config_file" 2>/dev/null); then
               retry_refusal "cannot read $config_file; not installing a second '$name'"
@@ -249,6 +257,10 @@ mkSiteInstaller {
       # still being there.
       if [ -r "$ulid_file" ] && [ -f "$config_file" ]; then
         local recorded
+        if [ ! -s "$config_file" ]; then
+          retry_refusal "cannot read $config_file; not installing a second '$name'"
+          return
+        fi
         # jq's failure separated from "no such site", the way the lookup above
         # separates it from "no site": a read racing firefoxpwa connector's own
         # rewrite exits non-zero, and treating that as "the recorded site is

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -97,6 +97,7 @@ mkSiteInstaller {
     }
 
     failed=0
+    retryable=0
     # Counted here rather than by the caller testing install_app's status: a
     # bash function invoked as the left side of `||` runs its whole body with
     # errexit ignored, and that suppression is inherited by every compound
@@ -107,6 +108,11 @@ mkSiteInstaller {
     refuse() {
       echo "firefoxpwa-m365: $1" >&2
       failed=$((failed + 1))
+    }
+
+    retry_refusal() {
+      refuse "$1"
+      retryable=1
     }
 
     install_app() {
@@ -145,7 +151,7 @@ mkSiteInstaller {
       # when this unit runs), and treating that as absent would register a
       # second site under the same name.
       if ! ulid=$(site_ulid "$name"); then
-        refuse "cannot read $config_file; not installing a second '$name'"
+        retry_refusal "cannot read $config_file; not installing a second '$name'"
         return
       fi
 
@@ -221,7 +227,7 @@ mkSiteInstaller {
           record "$applied_file" "$url"
           return 0
         fi
-        refuse "failed to update start URL for '$name'"
+        retry_refusal "failed to update start URL for '$name'"
         return
       fi
 
@@ -242,7 +248,7 @@ mkSiteInstaller {
         # is what site_ulid's own [ -f ] does with it.
         if ! recorded=$(jq -r --arg u "$(<"$ulid_file")" \
           'if ((.sites // {}) | has($u)) then "yes" else "" end' "$config_file" 2>/dev/null); then
-          refuse "cannot read $config_file; not installing a second '$name'"
+          retry_refusal "cannot read $config_file; not installing a second '$name'"
           return
         fi
         if [ -n "$recorded" ]; then
@@ -276,12 +282,12 @@ mkSiteInstaller {
           --start-url "$url" \
           --name "$name"; then
           if ! ulid=$(site_ulid "$name"); then
-            refuse "cannot read $config_file after installing '$name'"
+            retry_refusal "cannot read $config_file after installing '$name'"
             return
           fi
           if [ -z "$ulid" ]; then
             rm -f "$pending_file"
-            refuse "'$name' reported installed but is not in $config_file"
+            retry_refusal "'$name' reported installed but is not in $config_file"
             return
           fi
           record "$ulid_file" "$ulid"
@@ -297,13 +303,13 @@ mkSiteInstaller {
         # otherwise satisfy the no-op fast path on the next run and skip the
         # site update this branch defers the repair to.
         if ! ulid=$(site_ulid "$name"); then
-          refuse "cannot read $config_file; not retrying '$name'"
+          retry_refusal "cannot read $config_file; not retrying '$name'"
           return
         fi
         if [ -n "$ulid" ]; then
           record "$ulid_file" "$ulid"
           rm -f "$pending_file" "$applied_file"
-          refuse "'$name' was registered by a failed install; the next run repairs it with site update"
+          retry_refusal "'$name' was registered by a failed install; the next run repairs it with site update"
           return
         fi
         rm -f "$pending_file"
@@ -317,7 +323,7 @@ mkSiteInstaller {
       # exists, and a stale one would let a future foreign site pass the
       # identity check above.
       rm -f "$origin_file" "$applied_file" "$ulid_file" "$pending_file"
-      refuse "installing '$name' failed after 3 attempts"
+      retry_refusal "installing '$name' failed after 3 attempts"
     }
 
     # Unrolled from the app table at build time rather than iterated from an
@@ -331,6 +337,13 @@ mkSiteInstaller {
 
     if [ "$failed" -ne 0 ]; then
       echo "firefoxpwa-m365: $failed of ${toString (builtins.length apps)} web apps could not be installed" >&2
+      # 78 is EX_CONFIG: a refusal needs user action and must remain visible in
+      # the journal, but it must not consume the service's restart burst before
+      # the user can fix the entry and switch again. Retryable faults keep the
+      # ordinary failure status so systemd reruns them with its bounded policy.
+      if [ "$retryable" -eq 0 ]; then
+        exit 78
+      fi
       exit 1
     fi
   '';

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -239,6 +239,19 @@ writeShellApplication {
         return
       fi
 
+      # A rename keeps the key and changes the launcher name, so the lookup
+      # above misses the site this key already installed and this branch would
+      # register a second one under the new name while overwriting the only
+      # record of the first, leaving the original PWA and its .desktop entry
+      # with nothing pointing at them. Told apart from the documented uninstall,
+      # which leaves the record behind but takes the site with it, by the site
+      # still being there.
+      if [ -r "$ulid_file" ] \
+        && jq -e --arg u "$(<"$ulid_file")" '.sites[$u]' "$config_file" >/dev/null 2>&1; then
+        refuse "'$name' is a new name for the site this unit installed as $(<"$ulid_file"); uninstall that site so this unit can reinstall it under the new name"
+        return
+      fi
+
       # A data: manifest keeps the install self-contained: firefoxpwa does not
       # have to fetch or parse a manifest from the target site, which for these
       # apps sits behind a sign-in redirect. Site::url prefers config.start_url

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -232,10 +232,23 @@ mkSiteInstaller {
       # with nothing pointing at them. Told apart from the documented uninstall,
       # which leaves the record behind but takes the site with it, by the site
       # still being there.
-      if [ -r "$ulid_file" ] \
-        && jq -e --arg u "$(<"$ulid_file")" '.sites[$u]' "$config_file" >/dev/null 2>&1; then
-        refuse "'$name' is a new name for the site this unit installed as $(<"$ulid_file"); uninstall that site so this unit can reinstall it under the new name"
-        return
+      if [ -r "$ulid_file" ] && [ -f "$config_file" ]; then
+        local recorded
+        # jq's failure separated from "no such site", the way the lookup above
+        # separates it from "no site": a read racing firefoxpwa connector's own
+        # rewrite exits non-zero, and treating that as "the recorded site is
+        # gone" drops into the fresh install below and duplicates it. The -f
+        # test above keeps a config.json that is gone entirely installing, which
+        # is what site_ulid's own [ -f ] does with it.
+        if ! recorded=$(jq -r --arg u "$(<"$ulid_file")" \
+          'if ((.sites // {}) | has($u)) then "yes" else "" end' "$config_file" 2>/dev/null); then
+          refuse "cannot read $config_file; not installing a second '$name'"
+          return
+        fi
+        if [ -n "$recorded" ]; then
+          refuse "'$name' is a new name for the site this unit installed as $(<"$ulid_file"); uninstall that site so this unit can reinstall it under the new name"
+          return
+        fi
       fi
 
       # A data: manifest keeps the install self-contained: firefoxpwa does not

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -132,7 +132,7 @@ mkSiteInstaller {
       # firefoxpwa registering the site and record below is repaired rather
       # than refused. Cleared on every path that ends one.
       local pending_file="$data_dir/m365-$key-installing"
-      local origin ulid guard_origin manifest manifest_url attempt
+      local origin ulid guard_origin manifest manifest_url attempt installed_manifest
 
       # Refused rather than installed: url_origin drops userinfo, so the scope
       # derived from it cannot be a prefix of a start URL that keeps it, and

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -199,10 +199,17 @@ mkSiteInstaller {
           # and adopt regardless. Its content is the manifest_url the attempt
           # used, which only an install through this script's synthetic data:
           # manifest could produce, so matching it authenticates the site
-          # whatever state ulid_file is in.
-          if [ -s "$pending_file" ] \
-            && [ "$(jq -r --arg u "$ulid" '.sites[$u].config.manifest_url // empty' \
-                  "$config_file" 2>/dev/null)" = "$(<"$pending_file")" ]; then
+          # whatever state ulid_file is in. A jq read failure is retryable,
+          # rather than the permanent foreign-site refusal below.
+          installed_manifest=""
+          if [ -s "$pending_file" ]; then
+            if ! installed_manifest=$(jq -r --arg u "$ulid" \
+              '.sites[$u].config.manifest_url // empty' "$config_file" 2>/dev/null); then
+              retry_refusal "cannot read $config_file; not installing a second '$name'"
+              return
+            fi
+          fi
+          if [ -s "$pending_file" ] && [ "$installed_manifest" = "$(<"$pending_file")" ]; then
             record "$ulid_file" "$ulid"
             rm -f "$pending_file"
           else

--- a/packages/firefoxpwa-m365-install/default.nix
+++ b/packages/firefoxpwa-m365-install/default.nix
@@ -36,6 +36,7 @@
 }:
 let
   mkSiteInstaller = callPackage ../firefoxpwa-site-installer { };
+  refusalExitStatus = 78;
 in
 {
   firefoxpwa,
@@ -49,6 +50,7 @@ in
 mkSiteInstaller {
   name = "firefoxpwa-install-m365";
   inherit dataDir xdgDataHome;
+  passthru = { inherit refusalExitStatus; };
   runtimeInputs = [
     firefoxpwa
     jq
@@ -337,12 +339,13 @@ mkSiteInstaller {
 
     if [ "$failed" -ne 0 ]; then
       echo "firefoxpwa-m365: $failed of ${toString (builtins.length apps)} web apps could not be installed" >&2
-      # 78 is EX_CONFIG: a refusal needs user action and must remain visible in
-      # the journal, but it must not consume the service's restart burst before
+      # EX_CONFIG is the refusal status: a refusal needs user action and must
+      # remain visible in the journal, but it must not trigger an automatic
+      # restart before
       # the user can fix the entry and switch again. Retryable faults keep the
       # ordinary failure status so systemd reruns them with its bounded policy.
       if [ "$retryable" -eq 0 ]; then
-        exit 78
+        exit ${toString refusalExitStatus}
       fi
       exit 1
     fi

--- a/packages/firefoxpwa-site-installer/default.nix
+++ b/packages/firefoxpwa-site-installer/default.nix
@@ -65,11 +65,21 @@ writeShellApplication {
     # first. 0700 is what modules/browsers/firefoxpwa/home.nix pins it to.
     install -d -m 700 "$data_dir"
 
-    # Held for the whole run rather than per call: the installs are short, the
-    # entries few, and a lock reacquired between them would let another
-    # installer land in the gap with a stale copy of config.json.
+    # Held for the whole run rather than per call: a lock reacquired between
+    # calls would let another installer land in the gap with a stale copy of
+    # config.json.
     exec 9>"$data_dir/.config-lock"
-    flock 9
+    # Announced before blocking. A run holding this can span several site
+    # installs and their retry sleeps, so a queued one can wait past the unit's
+    # TimeoutStartSec and be killed, and a bare blocking acquire leaves the
+    # journal showing only a timeout with nothing naming the lock or the
+    # installer holding it. The units that run these raise that timeout past
+    # what a legitimate wait costs; this is what makes the wait legible when
+    # something exceeds even that.
+    if ! flock -n 9; then
+      echo "${name}: waiting for another firefoxpwa site installer to release $data_dir/.config-lock" >&2
+      flock 9
+    fi
 
   ''
   + text;

--- a/packages/firefoxpwa-site-installer/default.nix
+++ b/packages/firefoxpwa-site-installer/default.nix
@@ -1,0 +1,76 @@
+/*
+  firefoxpwa: shared site-installer builder
+
+  Every installer that drives `firefoxpwa site install` / `site update` shares
+  one hazard: firefoxpwa rewrites the whole of config.json through File::create
+  with no lock, so two of them running at once lose one another's sites. Unit
+  ordering cannot prevent it. Home Manager activates sd-switch before the
+  sops-nix step, so a switch starts one unit and then restarts another through
+  PartOf while the first is still installing, which is the direction an After=
+  on either unit does not constrain.
+
+  The lock is therefore taken here rather than in each installer: an installer
+  that does not take it cannot exist, because this is how they are built.
+  Adding another site installer means calling this with its own text, and it
+  inherits the lock, the directory it locks in, and the two environment
+  variables firefoxpwa resolves its own paths from.
+
+  Callers supply only what is theirs: the site bookkeeping and the entries.
+  modules/browsers/firefoxpwa/site-lock-check.nix proves the mutual exclusion,
+  against a deliberately unlocked pair that fails the same assertion.
+*/
+{
+  lib,
+  writeShellApplication,
+  coreutils,
+  util-linux,
+}:
+{
+  name,
+  dataDir,
+  xdgDataHome,
+  runtimeInputs ? [ ],
+  text,
+}:
+writeShellApplication {
+  inherit name;
+  runtimeInputs = runtimeInputs ++ [
+    coreutils
+    util-linux
+  ];
+  text = ''
+    # Passed in rather than re-derived from XDG_DATA_HOME: callers use this same
+    # value for the 0700 activation step and, where a secret backs the site, for
+    # the sops secret path. A second rule here would put the records and
+    # config.json outside the directory that protects them whenever
+    # xdg.dataHome is not at its default.
+    data_dir=${lib.escapeShellArg dataDir}
+    # Part of the prelude every installer gets, so shellcheck sees it unused in
+    # any caller that only needs the directory. Kept here rather than restated
+    # per caller: it is the file the lock below exists to protect.
+    # shellcheck disable=SC2034
+    config_file="$data_dir/config.json"
+    # Exported, not just read: firefoxpwa resolves its own userdata tree from
+    # FFPWA_USERDATA and, separately, its system-integration directory (the
+    # .desktop entry and icon, through directories::BaseDirs) from
+    # XDG_DATA_HOME. Neither is read by the scripts themselves, but both are
+    # read by every site install / site update they make, so pinning them from
+    # the values the caller already chose makes the binary and the script agree
+    # by construction rather than through a systemd unit's Environment=.
+    export FFPWA_USERDATA="$data_dir"
+    export XDG_DATA_HOME=${lib.escapeShellArg xdgDataHome}
+
+    # Created here rather than left to an activation step: the lock below opens
+    # a file inside it, and not every caller has something that creates it
+    # first. 0700 is what modules/browsers/firefoxpwa/home.nix pins it to.
+    install -d -m 700 "$data_dir"
+
+    # Held for the whole run rather than per call: the installs are short, the
+    # entries few, and a lock reacquired between them would let another
+    # installer land in the gap with a stale copy of config.json.
+    exec 9>"$data_dir/.config-lock"
+    flock 9
+
+  ''
+  + text;
+}

--- a/packages/firefoxpwa-site-installer/default.nix
+++ b/packages/firefoxpwa-site-installer/default.nix
@@ -30,10 +30,12 @@
   dataDir,
   xdgDataHome,
   runtimeInputs ? [ ],
+  passthru ? { },
   text,
 }:
 writeShellApplication {
   inherit name;
+  inherit passthru;
   runtimeInputs = runtimeInputs ++ [
     coreutils
     util-linux

--- a/tests/prune-old-stashes/run.sh
+++ b/tests/prune-old-stashes/run.sh
@@ -1585,7 +1585,13 @@ test_cdpath_does_not_divert_the_dedup_key
 # which the bash a runCommand builder runs is built without, so the enumeration
 # this guard depends on would exist only because modules/meta/script-tests.nix
 # happens to put pkgs.bash on PATH. declare -F is a plain builtin.
-expected="$(declare -F | sed -n 's/^declare -f \(test_.*\)$/\1/p' | sort)"
+expected="$(
+  while read -r _ _ fn; do
+    if [[ ${fn} == test_* ]]; then
+      printf '%s\n' "${fn}"
+    fi
+  done < <(declare -F) | sort
+)"
 ran="$(printf '%s\n' "${tests_ran[@]}" | sort -u)"
 if [[ ${ran} != "${expected}" ]]; then
   printf 'run.sh: defined but never ran:\n%s\n' \

--- a/tests/prune-old-stashes/run.sh
+++ b/tests/prune-old-stashes/run.sh
@@ -1580,7 +1580,12 @@ test_cdpath_does_not_divert_the_dedup_key
 # the suite green while guarding nothing, which is the same failure as a test
 # that can no longer fail. Compared as sets, not counts: one function listed
 # twice and another omitted keeps the totals equal.
-expected="$(compgen -A function 'test_' | sort)"
+#
+# declare -F, not compgen -A function: compgen needs programmable completion,
+# which the bash a runCommand builder runs is built without, so the enumeration
+# this guard depends on would exist only because modules/meta/script-tests.nix
+# happens to put pkgs.bash on PATH. declare -F is a plain builtin.
+expected="$(declare -F | sed -n 's/^declare -f \(test_.*\)$/\1/p' | sort)"
 ran="$(printf '%s\n' "${tests_ran[@]}" | sort -u)"
 if [[ ${ran} != "${expected}" ]]; then
   printf 'run.sh: defined but never ran:\n%s\n' \


### PR DESCRIPTION
## Summary

The initial implementation, validation fixes, and review remediations are described below.

### 1. `feat(browsers)`: Microsoft 365 web apps through firefoxpwa

firefoxpwa keeps its site list in a profile database under `$XDG_DATA_HOME/firefoxpwa`, so a suite clicked together in
the browser extension survives neither a reinstall nor a move to another host.

- `packages/firefoxpwa-site-installer`: the shared builder every firefoxpwa site installer is made with. It supplies
  the prelude they all need (`data_dir`, `config_file`, `FFPWA_USERDATA`, `XDG_DATA_HOME`, the 0700 directory) and takes
  the lock that keeps two of them off `config.json` at once, which firefoxpwa rewrites whole through `File::create`
  with no lock of its own. Both existing installers lose their duplicated preludes to it, and an installer that skips
  the lock cannot exist, since that is how they are built.
- `packages/firefoxpwa-m365-install`: oneshot installer built from the DMail installer's site bookkeeping (the ulid,
  origin and applied-URL records kept next to `config.json`, plus the pending record covering the kill window inside
  `firefoxpwa site install`), with a per-entry loop on top. An entry the installer decides it must not act on is
  counted and reported at the end rather than aborting the run, so one refusal does not cost the remaining entries
  their install. A failed write is not a refusal: it aborts under `errexit`, because the records are what
  authenticate a site on the next run.
- `modules/browsers/firefoxpwa/m365.nix`: `firefoxpwa-m365` user service, layered onto the existing
  `browsers.firefoxpwa` Home Manager key. No secret to wait for, so it is ordered against nothing: its `ExecStart` path
  changes with the app table and `systemd.user.startServices = "sd-switch"` restarts it on the switch that changes it.
That is the only switch it runs on, so transient installer faults retry themselves (`Restart=on-failure`,
`RestartSec=1080`, bounded by `StartLimitIntervalSec=10800` and `StartLimitBurst=5`) instead of sitting `failed`
until the next login. Permanent user-action refusals return `EX_CONFIG` 78, which the unit treats as successful and
non-restarting. Their starts still count toward that five-start window, which leaves room for corrective switches
while pacing fast retries across the same window. Ordered
  `After` the DMail unit, since firefoxpwa rewrites the whole of `config.json` with no lock and the two would
  otherwise start together at login. The lock is what actually keeps them apart; the ordering keeps the common case
  from reaching it.
- `modules/browsers/firefoxpwa/apps.nix`: `programs.firefoxpwa.m365.{enable,apps}` at NixOS scope, next to the existing
  `dmail.enable`, with assertions against duplicate keys and names.
- `modules/browsers/firefoxpwa/_m365-apps.nix`: the default catalog (Microsoft 365, Word, Excel, PowerPoint, Outlook,
  OneNote, OneDrive).

Start URLs are the bare `cloud.microsoft` origins: the manifest scope is fixed at install time and
`firefoxpwa site update` cannot rewrite it, so scope has to be the origin, and the landing paths Microsoft redirects to
(`/en-us/`, `/mail/`, `/tasks/`) are locale or tenant dependent. Checked on 2026-08-04 and left out on purpose:
`teams.cloud.microsoft` answers Gecko with `/v2/unsupported-browser`, `visio.cloud.microsoft` redirects to
`m365.cloud.microsoft` and would leave its own scope on first load, and `clipchamp.cloud.microsoft` does not resolve.

`programs.firefoxpwa.m365.enable` defaults to false and no host sets it yet.

### 2. `fix(checks)`: stop trusting compgen in build-time shell text

The leftover-temporary assertion first written for the m365 check reported a pass on every run while checking nothing:
the bash a `runCommand` builder runs is built without programmable completion, so `compgen -G` resolved to no command,
and a condition context turns that into a false rather than an error. Probed both interpreters to confirm the split:
`type -t compgen` in a plain `runCommand` reports MISSING, a bash from `nativeBuildInputs` reports HAVE.

- `tests/prune-old-stashes/run.sh` used the same builtin for its defined-but-never-ran guard, the one thing stopping a
  test function from being added and silently never called. It passes today only because
  `modules/meta/script-tests.nix` puts `pkgs.bash` (resolved to bash-interactive) on PATH. Now `declare -F`.
- `m365-check.nix` proves the detector before trusting it: a planted `.next` file has to be reported first.
- `checks.build-time-shell` scans `modules/`, `packages/` and `tests/` for the builtin at a command position, plain or
  negated, and plants both spellings the scan must hit before scanning the tree, so the guard cannot go quiet the way
  the assertion did. `scripts/` is out of scope: it runs under the user's own bash.

### 3. `feat(meta)`: run statix across the whole tree as a flake check

statix reached only staged files. `modules/meta/pre-commit.nix` invokes `hook-statix` with filenames and nothing in
`.github/workflows/check.yml` runs statix at all, so a lint in a file nobody edits again was reachable on main
indefinitely. The repeated `options` assignment fixed in `apps.nix` on this branch was caught only because that file
happened to be staged. `checks.statix-tree` runs `hook-statix` with no arguments (its own whole-tree branch), so CI and
pre-commit share one binary and one set of lints. `passthru.runtimeCheck` opts it into the workflow's runtime build
step, which discovers checks by that marker, so no workflow edit is needed. Source narrowed to `.nix` files through
`lib.fileset`, minus `docs/nixos-manual/`, the upstream mirror both the hook and treefmt already exclude. A lint is
planted and has to be reported before the tree is scanned, since nothing else calls `hook-statix` without arguments.
The tree is clean under it today.

### 4. Review round

- `fix(browsers)`: `install_app` ran as the left side of `|| failed=$((failed + 1))`, and bash ignores `-e` for the
  whole body of a function invoked that way, including every compound command inside it. A `record` that failed on a
  full or read-only filesystem was silent, the pending record was then removed, the entry was reported installed, and
  every later run refused it as foreign with no recovery short of `firefoxpwa site uninstall`. The per-entry status is
  now collected by a `refuse` helper, so `install_app` is called as a plain command and `errexit` covers the record
  writes, the pending write, the manifest `jq` and the `base64`.
- `fix(browsers)`: the installer returns non-zero for a site that registered and then failed, expecting the next run to
  repair it, but nothing produced that run: sd-switch restarts a unit only when its own text changed, and
  `RemainAfterExit` keeps the failed unit there until the next login. `dmail.nix` gets its rerun from
  `PartOf = sops-nix.service`; this unit now gets it from a bounded `Restart=on-failure` for retryable faults.
  Permanent refusals use `EX_CONFIG` 78, and the five-start window accounts for the refusal and corrective switches
  while the retry delay paces fast faults across that window. The
  `programs.firefoxpwa.m365.enable` text that claimed failure "on every switch and login" is corrected with it.
- `feat(browsers)`: `apps.*.url` was a bare `str`, so `m365.cloud.microsoft` or `htps://...` built fine and surfaced
  only as a runtime refusal in a user unit's journal. Now `strMatching "https?://[^[:space:]]+"`.
Round two, on the commits above:

- `fix(checks)`: the command-position alternation required `compgen` to follow the keyword or operator immediately, so
  `if ! compgen -G ...` matched none of its branches and passed the tree scan. Each alternative now admits an optional
  `!`, and the self-test plants both spellings and requires two hits, since a fixture for one of them proves only the
  branch it happens to take.
- `test(browsers)`: nothing applied the `key` option's `strMatching` to the shipped catalog, because an option's type
  is checked when its value is forced and no host forces this one. Asserted next to the duplicate-key and https
  assertions already there for that reason.
- `test(browsers)`: the stub could fail `site install` two ways but never `site update`, leaving untested that a failed
  update does not advance `applied_file` and so is retried rather than swallowed by the no-op fast path.

Round three:

- `fix(checks)`: the scan helper ended in `|| true`, which collapsed grep's three-valued status. 1 is "matched
  nothing", but 2 and up mean grep could not read a path it was given, and both produced an empty result and a
  reported pass, the same fail-open shape the check exists to catch. The status is now returned when it exceeds 1, so
  both callers abort.

Round four:

- `fix(meta)`: `checks.statix-tree` scanned `docs/nixos-manual/`, the vendored upstream mirror that both the pre-commit
  hook and treefmt exclude, so the check was strictly wider than the hook it shares a binary with and the next
  `update-nixos-manual.sh` sync could fail CI on code this repo cannot fix.
- `test(meta)`: nothing else calls `hook-statix` without arguments, so a clean `$out` was indistinguishable from a run
  that walked nothing. An empty let-in is planted and has to be reported first.

Round five:

- `fix(browsers)`: nothing ordered `firefoxpwa-m365.service` against `firefoxpwa-dmail.service`. Both are
  `WantedBy = [ "default.target" ]` and both drive `firefoxpwa site install`, which rewrites `config.json` unlocked, so
  on a host with both toggles on they race at login and the later writer drops the other's site. `tpnix` already sets
  `dmail.enable`, so this was one `m365.enable` away from being live.
- `fix(browsers)`: editing an entry's `name` while keeping its `key` landed in the fresh-install branch, registering a
  second site and overwriting the only record of the first, leaving the original app and its launcher orphaned in
  silence. Refused now, told apart from the documented uninstall by the recorded ulid still being present in
  `config.json`. The stub's ulid allocation was derived from the site count, so it reused the id of a deleted site;
  a counter now, since a real ulid is unique for the life of the profile.

Round six:

- `fix(browsers)`: the ordering added in round five does not close the race. `After=` is enforced across transactions,
  not only within one, but Home Manager activates `reloadSystemd` before the sops-nix step, so a switch starts the m365
  unit and only then restarts the dmail unit through `PartOf`, the direction an `After=` on the m365 unit does not
  constrain. The lock in the shared builder is the fix, and it is in the builder rather than in the two installers
  because more site installers are coming and a lock only some of them take is not a lock.
- `test(browsers)`: `deepSeq` forced the `After=` value but asserted nothing about it, and systemd ignores an ordering
  dependency naming a unit that does not exist, so a typo would have been silent at switch and at login.

Round seven:

- `fix(browsers)`: the lock acquire blocked unbounded and silent, so a queued installer could wait past the user
  manager's default `TimeoutStartSec` of 90s and be killed with nothing in the journal naming the lock. It now
  announces the wait before blocking, and both units raise `TimeoutStartSec` to 900, since being killed for waiting is
  not a fault and the default is shorter than a legitimate wait.
- `test(browsers)`: `site-lock-check.nix` proves the builder serializes and deliberately names no installer, which left
  nothing proving today's two go through it. Each installer's own check now greps its built text for the shared lock
  path, so a rewrite back to a direct `writeShellApplication` fails.

Round eight:

- `docs(browsers)`: `key` reads as a naming detail but every record path is `m365-<key>-*`, so editing it while keeping
  `name` moves the records to a slug that has none and the entry hits the refusal that tells the user to run
  `firefoxpwa site uninstall`, destroying a working PWA profile. Documented, and pinned by a check.
- `fix(checks)`: the site-lock control's result was a race outcome decided by a fixed pause, so a busy builder could
  fail it on a change that touched nothing. The two runs now rendezvous, which makes the outcome depend on whether the
  peer can enter rather than on which process starts first.

Round nine:

- `fix(browsers)`: the duplicate-name assertion only saw the m365 list, but the launcher name is the idempotency key in
  a `config.json` every site installer shares, so an m365 entry named `DMail` collided with the DMail site and hit a
  refusal whose only remedy destroys that site's PWA profile. `programs.firefoxpwa.siteNames` is now an internal
  registry each enabled site contributes to, with one assertion over the union, so a site added later joins by
  contributing rather than by someone widening a comparison. New `checks.browsers/firefoxpwa-apps-eval` forces the
  option module, which no host does.
- `docs(browsers)`: the m365 module header still said the unit "is ordered against nothing" after the `After=` went in
  below it.

Round ten:

- `fix(browsers)`: promoting the DMail launcher name to an option in round nine made an edit reachable that the DMail
  installer had no guard for, and it is worse than the m365 case it mirrors: those records are keyed by the entry's
  slug, so a name edit lands on a missing-record refusal, while these paths are fixed and the installer silently
  registers a second site and overwrites the only records of the first. Same guard ported over, plus the option text
  and a check case.

Round eleven, both on assertions that could not fail:

- `test(browsers)`: the m365 stub read `manifest.scope` from `--document-url` rather than from the `data:` manifest the
  installer built, and every entry declared a start URL equal to its own origin, which normalizes identically either
  way. Building the manifest with `scope: $url` kept the check green while the real firefoxpwa would install a scope
  that excludes nothing. The stub decodes the manifest now, and a new entry installs below its own origin, which is
  what discriminates.
- `test(browsers)`: the dmail rename assertions were invariant under a stub that writes every install to one hardcoded
  ulid, so removing the guard overwrote the site rather than adding one and only the exit status went red. The site's
  own name is now the observable.

Rounds twelve to fifteen, in the same vein:

- `fix(browsers)`: the rename guards read `jq -e` failure as "the recorded site is gone", so an unreadable
  `config.json` fell into the fresh-install branch and duplicated the site. Both scripts separate those two statuses
  everywhere else they read that file.
- `test(browsers)`: the dmail reinstall cases matched `"installed"`, which is also a substring of "already installed
  with current URL", so they pinned neither the branch nor the name.
- `test(browsers)`: both m365 rerun cases passed an empty message fragment, so deleting the installer's no-op fast path
  left every assertion green. Silence is the observable now.
- `feat(browsers)`: the `url` type admitted userinfo, so a start URL embedding credentials built fine and surfaced only
  as the installer's runtime refusal. These are static strings, unlike the DMail secret, so it is rejected at eval.

- Rejected, with the reasoning recorded in both check files: the reviewed claim that
  `case "$out" in *"$want_text"*) [ "$rc" = "$want_rc" ] && ok=0 ;; esac` aborts the builder under `errexit` when the
  fragment matches but the status does not. It does not, for the same reason the installer defect above existed: bash
  ignores `-e` for the left side of an `&&` list and the enclosing compound inherits that state.

Round twenty:

- `fix(meta)`: the build-time shell detector matched command substitution but missed process substitution,
  allowing `compgen` immediately after a process-substitution opening to pass the tree scan. The shared
  command-opening branch now covers both process-substitution directions, and the planted self-test requires
  all eight command-position fixtures.

Round twenty-one:

- `fix(meta)`: the detector also missed legacy backtick command substitution, so an assignment capture could
  pass the tree scan. An assignment-capture anchor and a ninth planted fixture now cover this form without
  matching the scanned prose that documents `compgen`.

Round twenty-two:

- `fix(meta)`: the assignment-anchored backtick branch missed the quoted conditional assertion shape. The
  backtick branch now covers the realistic shell openings for this form, and a tenth planted fixture proves
  the widened alternative.

## Test plan

- `nix fmt`
- `nix flake check path:. --accept-flake-config --no-build --offline` (exit 0)
- `nix build path:.#checks.x86_64-linux."browsers/firefoxpwa-m365"`: drives the real installer against a stub firefoxpwa
  through a fresh install, an idempotent rerun, a same-origin move applied with `site update`, a cross-origin move
  refused, a start URL carrying credentials refused before any site lookup, a same-named site the unit did not install
  refused rather than adopted, an entry that never registers not stopping the others, an install that registers and then
  fails repaired on the next run rather than duplicated, a record write that fails stopping the run with the pending
  record intact and recovering on the next run, an entry renamed onto its own live site refused while the same stale
  record after an uninstall still reinstalls, the shipped catalog installed end to end, the leftover-temporary
  detector planted before it is trusted, and a failed `site update` counted as a refusal without advancing the
  applied-URL record, and an entry installed below its own origin still scoped to the origin. 64 assertions. Restoring the `|| failed=$((failed + 1))` call site turns the
  three new ones red.
- `nix build path:.#checks.x86_64-linux."browsers/firefoxpwa-dmail"`
- `nix build path:.#checks.x86_64-linux."browsers/firefoxpwa-site-lock"`: two installers from the shared builder
  serialize on a read-rendezvous-write counter (ends at 2); the same pair built with `writeShellApplication` directly
  loses an update (ends at 1), which is what shows the assertion can fail. Confirmed against a deliberate 3-second
  startup skew
- `nix eval path:.#checks.x86_64-linux."browsers/firefoxpwa-apps-eval".drvPath`: the launcher-name collision, the
  shipped catalog alongside DMail passing, a name claimed only while its site is enabled, and duplicate keys. Dropping
  the DMail registration turns the first red
- `nix eval path:.#checks.x86_64-linux."browsers/firefoxpwa-module-eval".drvPath`: extended with the m365 unit, the
  empty-app-list warning and the disabled cases, since the module's `mkIf` blocks are unforced while no host enables the
  toggle. Forces the whole m365 unit, so the restart policy is evaluated too.
- `systemd-analyze verify --user` on the rendered `firefoxpwa-m365.service`, ordering included: exit 0, and exit 1 with
  `Restart=always` in its place, which is what makes the acceptance meaningful.
- `nix build path:.#checks.x86_64-linux.build-time-shell`: passes on the clean tree, and its ten planted
  command-position fixtures include process substitution, backtick assignment capture, and a quoted
  conditional backtick form. It fails with the expected message when a `tests/_scratch/probe.sh` using the
  builtin is planted. Fails with exit code 2 and the path named when an unmaterialized directory is added to
  the scan arguments.
- `nix build path:.#checks.x86_64-linux.statix-tree`: the materialized source has no `docs/nixos-manual`, and the
  check fails both with a `let in { }` planted under `modules/` and with the zero-argument branch stubbed to `exit 0`
- `nix build path:.#checks.x86_64-linux.script-tests-prune-old-stashes` (47 passed)
- `nix develop path:. --fallback -c pre-commit run --files <changed files>` (deadnix, nix-parse, shellcheck, statix,
  treefmt, typos)