### PR TITLE
feat(rclone): source Proton Drive credentials from 1Password, and latch a bisync safety abort

### DIFF
--- a/modules/apps/rclone.nix
+++ b/modules/apps/rclone.nix
@@ -110,6 +110,10 @@ let
               ];
               message = "programs.rclone.extended.protonDrive.authSource = \"onePassword\" requires four non-empty op:// references: usernameRef, passwordRef, otpRef, and mailboxPasswordRef.";
             }
+            {
+              assertion = config.programs._1password.enable;
+              message = "programs.rclone.extended.protonDrive.authSource = \"onePassword\" resolves its op:// references during Home Manager activation, which needs the setgid ${config.security.wrapperDir}/op wrapper declared by programs._1password: the 1Password desktop app authorizes CLI integration by the caller's onepassword-cli group, and no user is a member of it directly. Enable programs.\"1password-cli\".extended or set authSource = \"sops\".";
+            }
           ];
         })
 

--- a/modules/apps/rclone.nix
+++ b/modules/apps/rclone.nix
@@ -62,33 +62,41 @@ let
             description = "Credential source for the Proton Drive rclone remote.";
           };
 
+          # No defaults here: this module is shared by every host, and a
+          # non-empty default would make every host with protonDrive.enable
+          # and the default authSource shell out to `op read` against one
+          # specific person's vault. The owning host/user sets these (see
+          # modules/hosts/common/rclone-protondrive-1password.nix), matching
+          # the secretsRoot-gated pattern the sops authSource branch above
+          # already uses for the same reason.
           onePassword = {
             usernameRef = lib.mkOption {
               type = lib.types.str;
-              default = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/username";
+              default = "";
               description = "1Password secret reference for the Proton username.";
             };
 
             passwordRef = lib.mkOption {
               type = lib.types.str;
-              default = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/password";
+              default = "";
               description = "1Password secret reference for the Proton login password.";
             };
 
             otpRef = lib.mkOption {
               type = lib.types.str;
-              default = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/one-time password";
+              default = "";
               description = ''
-                1Password secret reference for the OTP field. The reference must
-                return the otpauth:// URI, without the ?attribute=otp query, so
-                the stable seed can be extracted and rclone can generate codes.
+                1Password secret reference for the OTP field, or "" if the
+                account has no 2FA enabled. The reference must return the
+                otpauth:// URI, without the ?attribute=otp query, so the
+                stable seed can be extracted and rclone can generate codes.
               '';
             };
 
             mailboxPasswordRef = lib.mkOption {
               type = lib.types.str;
-              default = "op://Personal/zgofe2wyj3j27vetjth7qr4hs4/password";
-              description = "1Password secret reference for the Proton mailbox password.";
+              default = "";
+              description = "1Password secret reference for the Proton mailbox password, or \"\" on a single-password account.";
             };
           };
         };

--- a/modules/apps/rclone.nix
+++ b/modules/apps/rclone.nix
@@ -125,7 +125,7 @@ let
                   cfg.protonDrive.onePassword.otpRef
                   cfg.protonDrive.onePassword.mailboxPasswordRef
                 ];
-              message = "programs.rclone.extended.protonDrive.authSource = \"onePassword\" requires non-empty op:// references for usernameRef and passwordRef. otpRef and mailboxPasswordRef are per-account optional (2FA / two-password accounts only): leave empty to opt out, or set an op:// reference.";
+              message = "programs.rclone.extended.protonDrive.authSource = \"onePassword\" requires non-empty op:// references for usernameRef and passwordRef. otpRef and mailboxPasswordRef are per-account optional (2FA / two-password accounts only): leave empty to opt out, or set an op:// reference. Hosts in the hosts-common aggregate inherit all four from modules/hosts/common/rclone-protondrive-1password.nix; a host outside that aggregate sets them itself.";
             }
             {
               assertion = config.programs._1password.enable;

--- a/modules/apps/rclone.nix
+++ b/modules/apps/rclone.nix
@@ -88,8 +88,10 @@ let
               description = ''
                 1Password secret reference for the OTP field, or "" if the
                 account has no 2FA enabled. The reference must return the
-                otpauth:// URI, without the ?attribute=otp query, so the
-                stable seed can be extracted and rclone can generate codes.
+                stable seed, either as an otpauth:// URI carrying a secret=
+                parameter or as the bare base32 seed, so rclone can generate
+                codes. Omit the ?attribute=otp query: it renders the current
+                six-digit code, which is rejected.
               '';
             };
 

--- a/modules/apps/rclone.nix
+++ b/modules/apps/rclone.nix
@@ -45,11 +45,72 @@ let
         };
 
         package = lib.mkPackageOption pkgs "rclone" { };
+
+        protonDrive = {
+          enable = lib.mkOption {
+            type = lib.types.bool;
+            default = false;
+            description = "Whether to enable the Proton Drive rclone integration.";
+          };
+
+          authSource = lib.mkOption {
+            type = lib.types.enum [
+              "sops"
+              "onePassword"
+            ];
+            default = "onePassword";
+            description = "Credential source for the Proton Drive rclone remote.";
+          };
+
+          onePassword = {
+            usernameRef = lib.mkOption {
+              type = lib.types.str;
+              default = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/username";
+              description = "1Password secret reference for the Proton username.";
+            };
+
+            passwordRef = lib.mkOption {
+              type = lib.types.str;
+              default = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/password";
+              description = "1Password secret reference for the Proton login password.";
+            };
+
+            otpRef = lib.mkOption {
+              type = lib.types.str;
+              default = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/one-time password";
+              description = ''
+                1Password secret reference for the OTP field. The reference must
+                return the otpauth:// URI, without the ?attribute=otp query, so
+                the stable seed can be extracted and rclone can generate codes.
+              '';
+            };
+
+            mailboxPasswordRef = lib.mkOption {
+              type = lib.types.str;
+              default = "op://Personal/zgofe2wyj3j27vetjth7qr4hs4/password";
+              description = "1Password secret reference for the Proton mailbox password.";
+            };
+          };
+        };
       };
 
       config = lib.mkMerge [
         (lib.mkIf cfg.enable {
           environment.systemPackages = [ cfg.package ];
+        })
+
+        (lib.mkIf (cfg.enable && cfg.protonDrive.enable && cfg.protonDrive.authSource == "onePassword") {
+          assertions = [
+            {
+              assertion = lib.all (ref: lib.hasPrefix "op://" ref) [
+                cfg.protonDrive.onePassword.usernameRef
+                cfg.protonDrive.onePassword.passwordRef
+                cfg.protonDrive.onePassword.otpRef
+                cfg.protonDrive.onePassword.mailboxPasswordRef
+              ];
+              message = "programs.rclone.extended.protonDrive.authSource = \"onePassword\" requires four non-empty op:// references: usernameRef, passwordRef, otpRef, and mailboxPasswordRef.";
+            }
+          ];
         })
 
         (lib.mkIf (cfg.enable && gdriveSecretExists && repoSecretsEnabled) {
@@ -74,24 +135,42 @@ let
           ];
         })
 
-        (lib.mkIf (cfg.enable && protondriveSecretExists && repoSecretsEnabled) {
-          sops.secrets."rclone/protondrive-env" = {
-            sopsFile = protondriveSecretFile;
-            format = "dotenv";
-            path = protondriveSecretPath;
-            inherit owner;
-            mode = "0400";
-          };
-        })
+        (lib.mkIf
+          (
+            cfg.enable
+            && cfg.protonDrive.enable
+            && cfg.protonDrive.authSource == "sops"
+            && protondriveSecretExists
+            && repoSecretsEnabled
+          )
+          {
+            sops.secrets."rclone/protondrive-env" = {
+              sopsFile = protondriveSecretFile;
+              format = "dotenv";
+              path = protondriveSecretPath;
+              inherit owner;
+              mode = "0400";
+            };
+          }
+        )
 
-        # Proton Drive is opt-in: a missing secret is the common case (most hosts
-        # do not use it), so no warning fires on absence. Only surface the
-        # actionable case where the secret exists but repo secrets are off.
-        (lib.mkIf (cfg.enable && protondriveSecretExists && (!repoSecretsEnabled)) {
-          warnings = [
-            "programs.rclone.extended.enable is true and ${toString protondriveSecretFile} exists, but security.repoSecrets.enable is false on this host; skipping protondrive secret materialization. Manage rclone protondrive config manually or enable repo secrets after SOPS decryption is configured."
-          ];
-        })
+        # Proton Drive is separately gated by protonDrive.enable. A missing SOPS
+        # secret is valid while the 1Password source is selected, so only
+        # surface the actionable case where SOPS is explicitly selected.
+        (lib.mkIf
+          (
+            cfg.enable
+            && cfg.protonDrive.enable
+            && cfg.protonDrive.authSource == "sops"
+            && protondriveSecretExists
+            && (!repoSecretsEnabled)
+          )
+          {
+            warnings = [
+              "programs.rclone.extended.protonDrive.enable is true and ${toString protondriveSecretFile} exists, but security.repoSecrets.enable is false on this host; skipping protondrive secret materialization. Manage rclone protondrive config manually or enable repo secrets after SOPS decryption is configured."
+            ];
+          }
+        )
       ];
     };
 in

--- a/modules/apps/rclone.nix
+++ b/modules/apps/rclone.nix
@@ -98,7 +98,13 @@ let
             mailboxPasswordRef = lib.mkOption {
               type = lib.types.str;
               default = "";
-              description = "1Password secret reference for the Proton mailbox password, or \"\" on a single-password account.";
+              description = ''
+                1Password secret reference for the Proton mailbox password, or
+                "" on a single-password account. A set reference must resolve to
+                a non-empty value: pointing it at a blank field renders a remote
+                that authenticates and then cannot decrypt, so activation fails
+                instead.
+              '';
             };
           };
         };

--- a/modules/apps/rclone.nix
+++ b/modules/apps/rclone.nix
@@ -102,13 +102,14 @@ let
         (lib.mkIf (cfg.enable && cfg.protonDrive.enable && cfg.protonDrive.authSource == "onePassword") {
           assertions = [
             {
-              assertion = lib.all (ref: lib.hasPrefix "op://" ref) [
-                cfg.protonDrive.onePassword.usernameRef
-                cfg.protonDrive.onePassword.passwordRef
-                cfg.protonDrive.onePassword.otpRef
-                cfg.protonDrive.onePassword.mailboxPasswordRef
-              ];
-              message = "programs.rclone.extended.protonDrive.authSource = \"onePassword\" requires four non-empty op:// references: usernameRef, passwordRef, otpRef, and mailboxPasswordRef.";
+              assertion =
+                lib.hasPrefix "op://" cfg.protonDrive.onePassword.usernameRef
+                && lib.hasPrefix "op://" cfg.protonDrive.onePassword.passwordRef
+                && lib.all (ref: ref == "" || lib.hasPrefix "op://" ref) [
+                  cfg.protonDrive.onePassword.otpRef
+                  cfg.protonDrive.onePassword.mailboxPasswordRef
+                ];
+              message = "programs.rclone.extended.protonDrive.authSource = \"onePassword\" requires non-empty op:// references for usernameRef and passwordRef. otpRef and mailboxPasswordRef are per-account optional (2FA / two-password accounts only): leave empty to opt out, or set an op:// reference.";
             }
             {
               assertion = config.programs._1password.enable;

--- a/modules/hm-apps/proton-drive-check-fixtures/rclone_protondrive.env
+++ b/modules/hm-apps/proton-drive-check-fixtures/rclone_protondrive.env
@@ -1,0 +1,6 @@
+# Fixture for modules/hm-apps/proton-drive-check.nix.
+#
+# Not a real secret and never decrypted or read: the module only calls
+# builtins.pathExists (secretsRoot + "/rclone_protondrive.env"). Its only job is
+# to exist, so protondriveReady takes the same branch in that check as it does
+# on a host with the secrets submodule present.

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -41,6 +41,10 @@
           localPath = "${root}/home/ProtonDrive";
 
           rcloneStub = pkgs.writeShellScriptBin "rclone" ''
+            if [ -n "''${RCLONE_LOG_FILE:-}''${RCLONE_LOG_FORMAT:-}''${RCLONE_LOG_LEVEL:-}''${RCLONE_SYSLOG:-}''${RCLONE_USE_JSON_LOG:-}" ]; then
+              echo "rclone stub: a log-routing RCLONE_ variable reached rclone" >&2
+              exit 99
+            fi
             printf '%s\n' "$*" >> "$RCLONE_STUB_CALLS"
             if [ -n "''${RCLONE_STUB_STDERR:-}" ]; then
               printf '%s\n' "$RCLONE_STUB_STDERR" >&2
@@ -227,6 +231,8 @@
                 # a full listing of both sides every interval, forever.
                 rc=0
                 RCLONE_STUB_EXIT=2 \
+                RCLONE_LOG_FILE=/dev/null RCLONE_SYSLOG=true RCLONE_USE_JSON_LOG=true \
+                RCLONE_LOG_LEVEL=NOTICE RCLONE_LOG_FORMAT=nolevel \
                 RCLONE_STUB_STDERR='ERROR : Safety abort: too many deletes (>25%, 8 of 8) on Path1 "/x". Run with --force if desired.' \
                   "$sync" || rc=$?
                 [ "$rc" -ne 0 ] || fail "a bisync safety abort must fail the run"

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -201,6 +201,7 @@
                   echo "hm-apps/proton-drive-sync: $check_root already exists; this check needs the sandbox's private /tmp" >&2
                   exit 1
                 fi
+                trap 'rm -rf -- "$check_root"' EXIT
 
                 export HOME=${lib.escapeShellArg "${root}/home"}
                 mkdir -p "$local_path"

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -112,6 +112,21 @@
           installsScript =
             hmConfig: lib.any (drv: (drv.name or "") == "proton-drive-sync") hmConfig.config.home.packages;
 
+          # The runner asserts each of these is on a normal bisync command line.
+          # They are asserted there only because rejectedFlags refuses an
+          # extraArg that would replace them, so the two lists must agree: four
+          # review rounds found a flag present in one and missing from the
+          # other. Split on "=" because the runner pins values too.
+          ownedFlagTokens = [
+            "--config"
+            "--conflict-resolve=newer"
+            "--max-delete=25"
+            "--protondrive-enable-caching=false"
+            "--resilient"
+            "--workdir"
+          ];
+          ownedFlagNames = map (token: lib.head (lib.splitString "=" token)) ownedFlagTokens;
+
           hm = mkHm {
             protonDrive = {
               enable = true;
@@ -383,8 +398,7 @@
                 # every other case here green. This is the first run that
                 # reaches rclone by the normal bisync path.
                 last_call=$(tail -n1 "$PROTON_DRIVE_STUB_CALLS")
-                for flag in --max-delete=25 --resilient --conflict-resolve=newer \
-                  --protondrive-enable-caching=false --config --workdir; do
+                for flag in ${lib.escapeShellArgs ownedFlagTokens}; do
                   case "$last_call" in
                     *"$flag"*) ;;
                     *) fail "a normal bisync run must pass $flag" ;;
@@ -513,6 +527,11 @@
         assert lib.assertMsg (
           !(builtins.tryEval workdirHm.config.home.packages).success
         ) "hm-apps/proton-drive-sync: --workdir in extraArgs must fail an assertion";
+        # Asserting a flag is passed is only meaningful while extraArgs cannot
+        # replace it, so every flag the runner pins must also be refused.
+        assert lib.assertMsg
+          (lib.subtractLists hm.config.services.protonDriveSync.rejectedExtraArgs ownedFlagNames == [ ])
+          "hm-apps/proton-drive-sync: flags asserted on the command line but absent from rejectedExtraArgs: ${lib.concatStringsSep " " (lib.subtractLists hm.config.services.protonDriveSync.rejectedExtraArgs ownedFlagNames)}";
         # The unit inherits the user manager's environment, and the script reads
         # these three before any other logic, so the timer must run the
         # configured values rather than whatever the session happens to export.

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -120,12 +120,24 @@
           ownedFlagTokens = [
             "--config"
             "--conflict-resolve=newer"
+            "--create-empty-src-dirs"
             "--max-delete=25"
             "--protondrive-enable-caching=false"
             "--resilient"
             "--workdir"
           ];
           ownedFlagNames = map (token: lib.head (lib.splitString "=" token)) ownedFlagTokens;
+
+          # Flags the script passes and deliberately leaves overridable:
+          # throughput knobs, and the depth of the down-direction emptiness
+          # probe, which extraArgs never reaches. Anything the script passes
+          # that is neither here nor refused is a value the module chose and
+          # extraArgs can silently replace.
+          tunableFlags = [
+            "--checkers"
+            "--max-depth"
+            "--transfers"
+          ];
 
           hm = mkHm {
             protonDrive = {
@@ -479,6 +491,21 @@
                   *) ;;
                 esac
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--force-resync must release the latch"
+
+                # Every flag any invocation above actually passed must be one
+                # extraArgs cannot replace, or one deliberately left tunable.
+                # Reading the recorded argv rather than a hand-kept list is what
+                # makes this cover a flag missing from both: that is how
+                # --create-empty-src-dirs sat outside them while four rounds
+                # patched the flags beside it.
+                rejected=${lib.escapeShellArg (lib.concatStringsSep " " hm.config.services.protonDriveSync.rejectedExtraArgs)}
+                tunable=${lib.escapeShellArg (lib.concatStringsSep " " tunableFlags)}
+                while read -r flag; do
+                  case " $rejected $tunable " in
+                    *" $flag "*) ;;
+                    *) fail "the script passes $flag, which extraArgs can replace and neither list covers" ;;
+                  esac
+                done < <(grep -oh -- '--[a-z][a-z0-9-]*' "$PROTON_DRIVE_STUB_CALLS" | sort -u)
 
                 touch "$out"
               '';

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -377,7 +377,7 @@
                 # reaches rclone by the normal bisync path.
                 last_call=$(tail -n1 "$PROTON_DRIVE_STUB_CALLS")
                 for flag in --max-delete=25 --resilient --conflict-resolve=newer \
-                  --protondrive-enable-caching=false --config; do
+                  --protondrive-enable-caching=false --config --workdir; do
                   case "$last_call" in
                     *"$flag"*) ;;
                     *) fail "a normal bisync run must pass $flag" ;;
@@ -442,11 +442,22 @@
                   *) fail "--resync after a fatal one-way abort must retain the deletion cap" ;;
                 esac
 
+                # That --resync succeeded, so sync_one_way cleared $aborted. The
+                # cap-free assertion below would then be satisfied by the
+                # "[ ! -e $aborted ]" disjunct rather than by force, leaving
+                # --force-resync's documented purpose unpinned. Re-latch first,
+                # so only [ "$force" -eq 1 ] can drop the cap.
+                rc=0
+                PROTON_DRIVE_DIRECTION=up PROTON_DRIVE_STUB_EXIT=7 "$sync" || rc=$?
+                [ "$rc" -eq 7 ] || fail "re-latching the up tuple must propagate rclone's exit 7"
+                [ "$(marker_count 'aborted-*')" -eq 1 ] || fail "re-latching the up tuple must latch"
+
                 PROTON_DRIVE_DIRECTION=up PROTON_DRIVE_STUB_EXIT=0 "$sync" --force-resync
                 case "$(tail -n1 "$PROTON_DRIVE_STUB_CALLS")" in
                   *--max-delete*) fail "--force-resync must bypass the deletion cap" ;;
                   *) ;;
                 esac
+                [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--force-resync must release the latch"
 
                 touch "$out"
               '';

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -45,6 +45,10 @@
               echo "rclone stub: a log-routing RCLONE_ variable reached rclone" >&2
               exit 99
             fi
+            if [ -n "''${RCLONE_FORCE:-}''${RCLONE_RESYNC:-}" ]; then
+              echo "rclone stub: a safety-disabling RCLONE_ variable reached rclone" >&2
+              exit 98
+            fi
             printf '%s\n' "$*" >> "$RCLONE_STUB_CALLS"
             if [ -n "''${RCLONE_STUB_STDERR:-}" ]; then
               printf '%s\n' "$RCLONE_STUB_STDERR" >&2
@@ -233,6 +237,7 @@
                 RCLONE_STUB_EXIT=2 \
                 RCLONE_LOG_FILE=/dev/null RCLONE_SYSLOG=true RCLONE_USE_JSON_LOG=true \
                 RCLONE_LOG_LEVEL=NOTICE RCLONE_LOG_FORMAT=nolevel \
+                RCLONE_FORCE=true RCLONE_RESYNC=true \
                 RCLONE_STUB_STDERR='ERROR : Safety abort: too many deletes (>25%, 8 of 8) on Path1 "/x". Run with --force if desired.' \
                   "$sync" || rc=$?
                 [ "$rc" -ne 0 ] || fail "a bisync safety abort must fail the run"

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -1,0 +1,165 @@
+/*
+  Check: proton-drive-sync builds, and a bisync safety abort latches the tuple
+  (modules/hm-apps/proton-drive.nix).
+
+  home.packages carries the script only when protondriveReady is true, which
+  needs secrets/rclone_protondrive.env. No tracked host ships that file and CI
+  has no secrets submodule at all, so writeShellApplication's shellcheck pass
+  has never run on the script and none of its abort handling has ever executed.
+
+  Builds a standalone Home Manager configuration the way
+  modules/browsers/firefoxpwa/module-check.nix does, with osConfig stubbed to
+  make the remote ready and secretsRoot pointed at an in-repo fixture, then
+  replaces programs.rclone.package with a stub replaying a scripted exit code
+  and stderr so the script's control flow, not rclone, is under test.
+
+  Runs under the build sandbox's private /tmp because the state root and local
+  path are pinned at eval time; the pre-existing-state guard below turns an
+  unsandboxed build into a failure instead of a stale-state pass.
+*/
+{
+  lib,
+  inputs,
+  config,
+  ...
+}:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks."hm-apps/proton-drive-sync" =
+        let
+          root = "/tmp/proton-drive-sync-check";
+          stateDir = "${root}/state/proton-drive-sync";
+          localPath = "${root}/home/ProtonDrive";
+
+          rcloneStub = pkgs.writeShellScriptBin "rclone" ''
+            printf '%s\n' "$*" >> "$RCLONE_STUB_CALLS"
+            if [ -n "''${RCLONE_STUB_STDERR:-}" ]; then
+              printf '%s\n' "$RCLONE_STUB_STDERR" >&2
+            fi
+            exit "''${RCLONE_STUB_EXIT:-0}"
+          '';
+
+          hm = inputs.home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
+            modules = [
+              config.flake.homeManagerModules.apps.proton-drive
+              {
+                home = {
+                  username = "hm-smoke";
+                  homeDirectory = "${root}/home";
+                  stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
+                  enableNixpkgsReleaseCheck = false;
+                };
+                programs.home-manager.enable = true;
+                programs.rclone.package = rcloneStub;
+                xdg.stateHome = "${root}/state";
+                xdg.configHome = "${root}/config";
+                services.protonDriveSync.enable = true;
+              }
+            ];
+            extraSpecialArgs = {
+              osConfig = {
+                programs.rclone.extended.enable = true;
+                security.repoSecrets.enable = true;
+                sops.secrets."rclone/protondrive-env".path = "${root}/protondrive-env";
+              };
+              secretsRoot = ./proton-drive-check-fixtures;
+            };
+          };
+
+          syncScript = lib.findFirst (
+            drv: (drv.name or "") == "proton-drive-sync"
+          ) null hm.config.home.packages;
+
+          # The units are declared but never installed here, so force the
+          # attributes a real switch would render.
+          units = {
+            execStart = hm.config.systemd.user.services.proton-drive-sync.Service.ExecStart;
+            timer = hm.config.systemd.user.timers.proton-drive-sync.Timer;
+          };
+
+          drive =
+            pkgs.runCommand "proton-drive-sync-check"
+              {
+                passthru.runtimeCheck = true;
+                nativeBuildInputs = [
+                  pkgs.coreutils
+                  pkgs.findutils
+                  pkgs.gnugrep
+                ];
+              }
+              ''
+                set -o errexit -o nounset -o pipefail
+
+                state=${lib.escapeShellArg stateDir}
+                local_path=${lib.escapeShellArg localPath}
+                sync=${lib.getExe syncScript}
+
+                if [ -e "$state" ]; then
+                  echo "hm-apps/proton-drive-sync: $state already exists; this check needs the sandbox's private /tmp" >&2
+                  exit 1
+                fi
+
+                export HOME=${lib.escapeShellArg "${root}/home"}
+                mkdir -p "$local_path"
+                : > "$local_path/seed"
+                RCLONE_STUB_CALLS="$TMPDIR/rclone-calls"
+                export RCLONE_STUB_CALLS
+                : > "$RCLONE_STUB_CALLS"
+
+                fail() {
+                  echo "hm-apps/proton-drive-sync: $1" >&2
+                  exit 1
+                }
+                marker_count() { find "$state" -maxdepth 1 -name "$1" | wc -l; }
+                call_count() { wc -l < "$RCLONE_STUB_CALLS"; }
+
+                RCLONE_STUB_EXIT=0 "$sync" --resync
+                [ "$(marker_count 'initialized-*')" -eq 1 ] || fail "--resync must write the baseline marker"
+                [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--resync must not latch"
+
+                # rclone's bisync safety checks set abort without critical, so
+                # they leave the listings valid and exit non-zero having changed
+                # nothing. Without the latch the timer recomputes this abort from
+                # a full listing of both sides every interval, forever.
+                rc=0
+                RCLONE_STUB_EXIT=2 \
+                RCLONE_STUB_STDERR='ERROR : Safety abort: too many deletes (>25%, 8 of 8) on Path1 "/x". Run with --force if desired.' \
+                  "$sync" || rc=$?
+                [ "$rc" -ne 0 ] || fail "a bisync safety abort must fail the run"
+                [ "$(marker_count 'aborted-*')" -eq 1 ] || fail "a bisync safety abort must latch the tuple"
+                [ "$(marker_count 'initialized-*')" -eq 1 ] || fail "a bisync safety abort must keep the baseline marker"
+
+                before=$(call_count)
+                rc=0
+                RCLONE_STUB_EXIT=0 "$sync" || rc=$?
+                [ "$rc" -eq 1 ] || fail "a latched tuple must exit 1"
+                [ "$(call_count)" -eq "$before" ] || fail "a latched tuple must not reach rclone"
+
+                RCLONE_STUB_EXIT=0 "$sync" --force
+                [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--force must release the latch"
+                grep -q -- '--force' "$RCLONE_STUB_CALLS" || fail "--force must reach rclone"
+
+                # A transient backend failure must keep retrying on the timer;
+                # latching it would strand the sync until a human runs --force.
+                rc=0
+                RCLONE_STUB_EXIT=5 \
+                RCLONE_STUB_STDERR='ERROR : Attempt 1/3 failed: connection reset by peer' \
+                  "$sync" || rc=$?
+                [ "$rc" -ne 0 ] || fail "a transient rclone failure must fail the run"
+                [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "a transient rclone failure must not latch"
+
+                touch "$out"
+              '';
+        in
+        assert lib.assertMsg (
+          syncScript != null
+        ) "hm-apps/proton-drive-sync: the stubbed configuration must install proton-drive-sync";
+        assert lib.assertMsg (lib.all (entry: entry.assertion)
+          hm.config.assertions
+        ) "hm-apps/proton-drive-sync: the stubbed configuration must satisfy its own assertions";
+        builtins.deepSeq units drive;
+    };
+}

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -222,6 +222,17 @@
             };
           };
 
+          # rclone withholds destination deletes from a run that hit errors;
+          # this is the flag that turns that off, and --max-delete cannot
+          # express it because the deletes are within the cap.
+          ignoreErrorsHm = mkHm {
+            extraArgs = [ "--ignore-errors" ];
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
           # The command line is the sole authority for a backend option
           # (fs/configmap.go ConfigMap puts set flag values at PriorityNormal
           # and the config file at PriorityConfig), so this beats the stanza's
@@ -338,6 +349,21 @@
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--force must release the latch"
                 grep -q -- '--force' "$PROTON_DRIVE_STUB_CALLS" || fail "--force must reach rclone"
 
+                # rejectedFlags refuses these in extraArgs on the premise that
+                # the module passes its own value and an extraArg would replace
+                # it. Deleting one from the invocation leaves that guard
+                # forbidding an override of a flag that is no longer there, and
+                # every other case here green. This is the first run that
+                # reaches rclone by the normal bisync path.
+                last_call=$(tail -n1 "$PROTON_DRIVE_STUB_CALLS")
+                for flag in --max-delete=25 --resilient --conflict-resolve=newer \
+                  --protondrive-enable-caching=false --config; do
+                  case "$last_call" in
+                    *"$flag"*) ;;
+                    *) fail "a normal bisync run must pass $flag" ;;
+                  esac
+                done
+
                 # A transient backend failure must keep retrying on the timer;
                 # latching it would strand the sync until a human runs --force.
                 rc=0
@@ -369,6 +395,38 @@
                 PROTON_DRIVE_STUB_EXIT=0 "$sync" --resync
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--resync must release the latch"
                 [ "$(marker_count 'initialized-*')" -eq 1 ] || fail "--resync must keep the baseline marker"
+
+                # Every case above runs the default bisync direction, so
+                # sync_one_way, which is where the one-way branches clear the
+                # baseline and latch on rclone's exit 7, had never executed.
+                # The direction is part of the tuple key, so these markers are
+                # the up tuple's own and the bisync ones stay put.
+                PROTON_DRIVE_DIRECTION=up PROTON_DRIVE_STUB_EXIT=0 "$sync" --resync
+                [ "$(marker_count 'initialized-*')" -eq 2 ] ||
+                  fail "up --resync must write its own baseline marker"
+
+                rc=0
+                PROTON_DRIVE_DIRECTION=up PROTON_DRIVE_STUB_EXIT=7 "$sync" || rc=$?
+                [ "$rc" -eq 7 ] || fail "a fatal one-way abort must propagate rclone's exit 7"
+                [ "$(marker_count 'initialized-*')" -eq 1 ] ||
+                  fail "a fatal one-way abort must clear its own baseline marker"
+                [ "$(marker_count 'aborted-*')" -eq 1 ] || fail "a fatal one-way abort must latch the tuple"
+
+                # The latch withholds the cap-free --resync that would otherwise
+                # follow a fatal abort; only --force-resync bypasses it.
+                rc=0
+                PROTON_DRIVE_DIRECTION=up PROTON_DRIVE_STUB_EXIT=0 "$sync" --resync || rc=$?
+                [ "$rc" -eq 0 ] || fail "up --resync after a fatal abort must succeed (exit $rc)"
+                case "$(tail -n1 "$PROTON_DRIVE_STUB_CALLS")" in
+                  *--max-delete=25*) ;;
+                  *) fail "--resync after a fatal one-way abort must retain the deletion cap" ;;
+                esac
+
+                PROTON_DRIVE_DIRECTION=up PROTON_DRIVE_STUB_EXIT=0 "$sync" --force-resync
+                case "$(tail -n1 "$PROTON_DRIVE_STUB_CALLS")" in
+                  *--max-delete*) fail "--force-resync must bypass the deletion cap" ;;
+                  *) ;;
+                esac
 
                 touch "$out"
               '';
@@ -408,6 +466,9 @@
         assert lib.assertMsg (
           !(builtins.tryEval enableCachingHm.config.home.packages).success
         ) "hm-apps/proton-drive-sync: --protondrive-enable-caching in extraArgs must fail an assertion";
+        assert lib.assertMsg (
+          !(builtins.tryEval ignoreErrorsHm.config.home.packages).success
+        ) "hm-apps/proton-drive-sync: --ignore-errors in extraArgs must fail an assertion";
         assert lib.assertMsg (installsScript tuningHm)
           "hm-apps/proton-drive-sync: long-form tuning arguments must still be accepted";
         builtins.deepSeq units drive;

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -118,6 +118,22 @@
             };
           };
 
+          # otp_secret_key and mailbox_password are per-account optional (2FA
+          # / two-password accounts only); an empty ref must still be ready.
+          onePasswordNoOtpHm = mkHm {
+            secretsRoot = "${./proton-drive-check-fixtures}/missing";
+            protonDrive = {
+              enable = true;
+              authSource = "onePassword";
+              onePassword = {
+                usernameRef = opRef "username";
+                passwordRef = opRef "password";
+                otpRef = "";
+                mailboxPasswordRef = "";
+              };
+            };
+          };
+
           disabledHm = mkHm {
             protonDrive = {
               enable = false;
@@ -260,6 +276,8 @@
         ) "hm-apps/proton-drive-sync: the sops source must install proton-drive-sync";
         assert lib.assertMsg (installsScript onePasswordHm)
           "hm-apps/proton-drive-sync: op:// references must install proton-drive-sync with no secret present";
+        assert lib.assertMsg (installsScript onePasswordNoOtpHm)
+          "hm-apps/proton-drive-sync: an empty otpRef/mailboxPasswordRef must still be ready (per-account optional fields)";
         assert lib.assertMsg (
           !installsScript disabledHm
         ) "hm-apps/proton-drive-sync: protonDrive.enable = false must withhold proton-drive-sync";

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -492,6 +492,24 @@
                 esac
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--force-resync must release the latch"
 
+                # down mirrors remote -> local and deletes local-only files, so
+                # the emptiness probe is what stops a listing that came back
+                # empty from wiping the local tree. It was the one direction
+                # with no coverage, and the only one whose deletions are local.
+                # --force-resync skips both the first-run gate and the probe;
+                # the fire after it hits the probe against a remote the stub
+                # reports as empty, which is the refusal.
+                PROTON_DRIVE_DIRECTION=down PROTON_DRIVE_STUB_EXIT=0 "$sync" --force-resync
+                [ "$(marker_count 'initialized-*')" -eq 3 ] ||
+                  fail "down --force-resync must write its own baseline marker"
+
+                rc=0
+                PROTON_DRIVE_DIRECTION=down PROTON_DRIVE_STUB_EXIT=0 "$sync" || rc=$?
+                [ "$rc" -eq 1 ] ||
+                  fail "an empty remote listing must refuse to mirror onto the local tree"
+                [ "$(marker_count 'initialized-*')" -eq 3 ] ||
+                  fail "a refused down run must leave every baseline marker in place"
+
                 # Every flag any invocation above actually passed must be one
                 # extraArgs cannot replace, or one deliberately left tunable.
                 # Reading the recorded argv rather than a hand-kept list is what

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -191,6 +191,49 @@
             };
           };
 
+          # extraArgs is appended last, so --dry-run wins over nothing the
+          # script passes and makes --resync record a baseline with only `-dry`
+          # listings behind it: the same unlatchable repeat RCLONE_DRY_RUN
+          # produced before the namespace sweep, by the stronger surface.
+          dryRunHm = mkHm {
+            extraArgs = [ "--dry-run" ];
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
+          # --max-delete replaces the cap rather than tightening it, verified
+          # against rclone: `--max-delete=25 --max-delete=0` takes the 0.
+          maxDeleteHm = mkHm {
+            extraArgs = [ "--max-delete=0" ];
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
+          # -nv is --dry-run plus --verbose, which no per-flag match catches.
+          clusteredShortHm = mkHm {
+            extraArgs = [ "-nv" ];
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
+          # The tuning knobs the option exists for must survive all of it.
+          tuningHm = mkHm {
+            extraArgs = [
+              "--bwlimit=2M"
+              "--transfers=2"
+            ];
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
           syncScript = lib.findFirst (
             drv: (drv.name or "") == "proton-drive-sync"
           ) null hm.config.home.packages;
@@ -341,6 +384,17 @@
         assert lib.assertMsg (
           !(builtins.tryEval logSystemdHm.config.home.packages).success
         ) "hm-apps/proton-drive-sync: --log-systemd in extraArgs must fail an assertion";
+        assert lib.assertMsg (
+          !(builtins.tryEval dryRunHm.config.home.packages).success
+        ) "hm-apps/proton-drive-sync: --dry-run in extraArgs must fail an assertion";
+        assert lib.assertMsg (
+          !(builtins.tryEval maxDeleteHm.config.home.packages).success
+        ) "hm-apps/proton-drive-sync: --max-delete in extraArgs must fail an assertion";
+        assert lib.assertMsg (
+          !(builtins.tryEval clusteredShortHm.config.home.packages).success
+        ) "hm-apps/proton-drive-sync: a clustered short option in extraArgs must fail an assertion";
+        assert lib.assertMsg (installsScript tuningHm)
+          "hm-apps/proton-drive-sync: long-form tuning arguments must still be accepted";
         builtins.deepSeq units drive;
     };
 }

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -222,6 +222,18 @@
             };
           };
 
+          # The command line is the sole authority for a backend option
+          # (fs/configmap.go ConfigMap puts set flag values at PriorityNormal
+          # and the config file at PriorityConfig), so this beats the stanza's
+          # enable_caching = false as well as the flag in common.
+          enableCachingHm = mkHm {
+            extraArgs = [ "--protondrive-enable-caching=true" ];
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
           # The tuning knobs the option exists for must survive all of it.
           tuningHm = mkHm {
             extraArgs = [
@@ -393,6 +405,9 @@
         assert lib.assertMsg (
           !(builtins.tryEval clusteredShortHm.config.home.packages).success
         ) "hm-apps/proton-drive-sync: a clustered short option in extraArgs must fail an assertion";
+        assert lib.assertMsg (
+          !(builtins.tryEval enableCachingHm.config.home.packages).success
+        ) "hm-apps/proton-drive-sync: --protondrive-enable-caching in extraArgs must fail an assertion";
         assert lib.assertMsg (installsScript tuningHm)
           "hm-apps/proton-drive-sync: long-form tuning arguments must still be accepted";
         builtins.deepSeq units drive;

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -265,11 +265,18 @@
             };
           };
 
-          # The tuning knobs the option exists for must survive all of it.
+          # The tuning knobs the option exists for must survive all of it. An
+          # rclone exclude rule is a value beginning with a dash, so a
+          # short-option test written as "not a dash" rejects half of a filter
+          # pair and accepts the other half.
           tuningHm = mkHm {
             extraArgs = [
               "--bwlimit=2M"
               "--transfers=2"
+              "--filter"
+              "- *.partial"
+              "--filter"
+              "+ *.txt"
             ];
             protonDrive = {
               enable = true;

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -199,6 +199,23 @@
                 [ "$rc" -ne 0 ] || fail "a transient rclone failure must fail the run"
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "a transient rclone failure must not latch"
 
+                # An INFO line echoes the transferred path, so the abort text can
+                # reach the log without either safety check having fired.
+                rc=0
+                RCLONE_STUB_EXIT=5 \
+                RCLONE_STUB_STDERR='2026/01/01 00:00:00 INFO  : notes/Safety abort: too many deletes.md: Copied (new)' \
+                  "$sync" || rc=$?
+                [ "$rc" -ne 0 ] || fail "the stubbed failure must fail the run"
+                [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "a transferred path naming the abort must not latch"
+
+                # The second safety check rclone releases with --force.
+                rc=0
+                RCLONE_STUB_EXIT=2 \
+                RCLONE_STUB_STDERR='2026/01/01 00:00:00 ERROR : Safety abort: all files were changed on Path1 "/x". Run with --force if desired.' \
+                  "$sync" || rc=$?
+                [ "$rc" -ne 0 ] || fail "an all-files-changed abort must fail the run"
+                [ "$(marker_count 'aborted-*')" -eq 1 ] || fail "an all-files-changed abort must latch the tuple"
+
                 touch "$out"
               '';
         in

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -20,8 +20,9 @@
   alone.
 
   Runs under the build sandbox's private /tmp because the state root and local
-  path are pinned at eval time; the pre-existing-state guard below turns an
-  unsandboxed build into a failure instead of a stale-state pass.
+  path are pinned at eval time; the check creates that whole root itself and
+  fails when it already exists, so an unsandboxed build cannot pass on stale
+  state or write through a planted symlink.
 */
 {
   lib,
@@ -170,12 +171,18 @@
               ''
                 set -o errexit -o nounset -o pipefail
 
+                check_root=${lib.escapeShellArg root}
                 state=${lib.escapeShellArg stateDir}
                 local_path=${lib.escapeShellArg localPath}
                 sync=${lib.getExe syncScript}
 
-                if [ -e "$state" ]; then
-                  echo "hm-apps/proton-drive-sync: $state already exists; this check needs the sandbox's private /tmp" >&2
+                # Every path below is a fixed /tmp path, so without the sandbox's
+                # private /tmp another user could plant the root and have the
+                # mkdir and seed-file writes below follow its symlinks. mkdir
+                # fails on an existing directory or symlink, which also catches
+                # leftover state from an earlier unsandboxed run.
+                if ! mkdir -m 700 -- "$check_root" 2>/dev/null; then
+                  echo "hm-apps/proton-drive-sync: $check_root already exists; this check needs the sandbox's private /tmp" >&2
                   exit 1
                 fi
 

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -52,6 +52,7 @@
             {
               protonDrive,
               secretsRoot ? ./proton-drive-check-fixtures,
+              extraArgs ? [ ],
             }:
             inputs.home-manager.lib.homeManagerConfiguration {
               inherit pkgs;
@@ -68,7 +69,10 @@
                   programs.rclone.package = rcloneStub;
                   xdg.stateHome = "${root}/state";
                   xdg.configHome = "${root}/config";
-                  services.protonDriveSync.enable = protonDrive.enable;
+                  services.protonDriveSync = {
+                    inherit (protonDrive) enable;
+                    inherit extraArgs;
+                  };
                 }
               ];
               extraSpecialArgs = {
@@ -113,6 +117,16 @@
           disabledHm = mkHm {
             protonDrive = {
               enable = false;
+              authSource = "sops";
+            };
+          };
+
+          # Routing rclone's log away from stderr would leave the abort below
+          # unlatched, so the module must refuse the argument at eval.
+          logRoutedHm = mkHm {
+            extraArgs = [ "--log-file=/tmp/rclone.log" ];
+            protonDrive = {
+              enable = true;
               authSource = "sops";
             };
           };
@@ -230,6 +244,11 @@
         assert lib.assertMsg (lib.all (entry: entry.assertion)
           hm.config.assertions
         ) "hm-apps/proton-drive-sync: the stubbed configuration must satisfy its own assertions";
+        # home-manager throws on the whole configuration when an assertion
+        # fails, so a rejected extraArg reads as an eval failure here.
+        assert lib.assertMsg (
+          !(builtins.tryEval logRoutedHm.config.home.packages).success
+        ) "hm-apps/proton-drive-sync: --log-file in extraArgs must fail an assertion";
         builtins.deepSeq units drive;
     };
 }

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -14,9 +14,10 @@
   and stderr so the script's control flow, not rclone, is under test.
 
   Both credential sources gate the same script, so the op:// source is asserted
-  to install it without any secret present and protonDrive.enable = false to
-  withhold it, keeping protondriveReady's three inputs (rclone, protonDrive,
-  authSource) covered by eval alone.
+  to install it without any secret present, while protonDrive.enable = false and
+  rclone.extended.enable = false are each asserted to withhold it. That covers
+  protondriveReady's three inputs (rclone, protonDrive, authSource) by eval
+  alone.
 
   Runs under the build sandbox's private /tmp because the state root and local
   path are pinned at eval time; the pre-existing-state guard below turns an
@@ -53,6 +54,8 @@
               protonDrive,
               secretsRoot ? ./proton-drive-check-fixtures,
               extraArgs ? [ ],
+              rcloneEnabled ? true,
+              serviceEnable ? protonDrive.enable,
             }:
             inputs.home-manager.lib.homeManagerConfiguration {
               inherit pkgs;
@@ -70,7 +73,7 @@
                   xdg.stateHome = "${root}/state";
                   xdg.configHome = "${root}/config";
                   services.protonDriveSync = {
-                    inherit (protonDrive) enable;
+                    enable = serviceEnable;
                     inherit extraArgs;
                   };
                 }
@@ -78,7 +81,7 @@
               extraSpecialArgs = {
                 osConfig = {
                   programs.rclone.extended = {
-                    enable = true;
+                    enable = rcloneEnabled;
                     inherit protonDrive;
                   };
                   security.repoSecrets.enable = true;
@@ -117,6 +120,18 @@
           disabledHm = mkHm {
             protonDrive = {
               enable = false;
+              authSource = "sops";
+            };
+          };
+
+          # The system-side rclone module renders the [protondrive] remote this
+          # script syncs against, so a ready credential source is not enough.
+          # The timer stays off here because its own assertion would fire first.
+          rcloneDisabledHm = mkHm {
+            rcloneEnabled = false;
+            serviceEnable = false;
+            protonDrive = {
+              enable = true;
               authSource = "sops";
             };
           };
@@ -241,6 +256,8 @@
         assert lib.assertMsg (
           !installsScript disabledHm
         ) "hm-apps/proton-drive-sync: protonDrive.enable = false must withhold proton-drive-sync";
+        assert lib.assertMsg (!installsScript rcloneDisabledHm)
+          "hm-apps/proton-drive-sync: programs.rclone.extended.enable = false must withhold proton-drive-sync";
         assert lib.assertMsg (lib.all (entry: entry.assertion)
           hm.config.assertions
         ) "hm-apps/proton-drive-sync: the stubbed configuration must satisfy its own assertions";

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -19,6 +19,12 @@
   protondriveReady's three inputs (rclone, protonDrive, authSource) by eval
   alone.
 
+  The stub also measures the RCLONE_ namespace sweep, which is the only runtime
+  guard on the latch: it exits 99 when any RCLONE_ variable survives into
+  rclone's environment, and the safety-abort case sets ten of them. Its own
+  knobs are PROTON_DRIVE_STUB_* precisely so the sweep cannot silence the stub
+  that measures it.
+
   Runs under the build sandbox's private /tmp because the state root and local
   path are pinned at eval time; the check creates that whole root itself and
   fails when it already exists, so an unsandboxed build cannot pass on stale
@@ -40,20 +46,23 @@
           stateDir = "${root}/state/proton-drive-sync";
           localPath = "${root}/home/ProtonDrive";
 
+          # The stub's own knobs sit outside the RCLONE_ namespace the script
+          # sweeps, so the sweep cannot defang the stub that measures it.
           rcloneStub = pkgs.writeShellScriptBin "rclone" ''
-            if [ -n "''${RCLONE_LOG_FILE:-}''${RCLONE_LOG_FORMAT:-}''${RCLONE_LOG_LEVEL:-}''${RCLONE_SYSLOG:-}''${RCLONE_USE_JSON_LOG:-}" ]; then
-              echo "rclone stub: a log-routing RCLONE_ variable reached rclone" >&2
+            leaked=("''${!RCLONE_@}")
+            if [ "''${#leaked[@]}" -gt 0 ]; then
+              echo "rclone stub: RCLONE_ variables reached rclone: ''${leaked[*]}" >&2
               exit 99
             fi
-            if [ -n "''${RCLONE_FORCE:-}''${RCLONE_RESYNC:-}" ]; then
-              echo "rclone stub: a safety-disabling RCLONE_ variable reached rclone" >&2
+            if [ -z "''${PROTON_DRIVE_STUB_CALLS:-}" ]; then
+              echo "rclone stub: PROTON_DRIVE_STUB_CALLS is unset; the call log would be silently dropped" >&2
               exit 98
             fi
-            printf '%s\n' "$*" >> "$RCLONE_STUB_CALLS"
-            if [ -n "''${RCLONE_STUB_STDERR:-}" ]; then
-              printf '%s\n' "$RCLONE_STUB_STDERR" >&2
+            printf '%s\n' "$*" >> "$PROTON_DRIVE_STUB_CALLS"
+            if [ -n "''${PROTON_DRIVE_STUB_STDERR:-}" ]; then
+              printf '%s\n' "$PROTON_DRIVE_STUB_STDERR" >&2
             fi
-            exit "''${RCLONE_STUB_EXIT:-0}"
+            exit "''${PROTON_DRIVE_STUB_EXIT:-0}"
           '';
 
           opRef = field: "op://check/protondrive/${field}";
@@ -171,6 +180,17 @@
             };
           };
 
+          # --log-systemd takes no value, so it is the shape the assertion's
+          # "${flag}=" prefix test cannot catch, and it both moves the record to
+          # the journal and clears the level prefix the abort pattern requires.
+          logSystemdHm = mkHm {
+            extraArgs = [ "--log-systemd" ];
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
           syncScript = lib.findFirst (
             drv: (drv.name or "") == "proton-drive-sync"
           ) null hm.config.home.packages;
@@ -214,18 +234,18 @@
                 export HOME=${lib.escapeShellArg "${root}/home"}
                 mkdir -p "$local_path"
                 : > "$local_path/seed"
-                RCLONE_STUB_CALLS="$TMPDIR/rclone-calls"
-                export RCLONE_STUB_CALLS
-                : > "$RCLONE_STUB_CALLS"
+                PROTON_DRIVE_STUB_CALLS="$TMPDIR/rclone-calls"
+                export PROTON_DRIVE_STUB_CALLS
+                : > "$PROTON_DRIVE_STUB_CALLS"
 
                 fail() {
                   echo "hm-apps/proton-drive-sync: $1" >&2
                   exit 1
                 }
                 marker_count() { find "$state" -maxdepth 1 -name "$1" | wc -l; }
-                call_count() { wc -l < "$RCLONE_STUB_CALLS"; }
+                call_count() { wc -l < "$PROTON_DRIVE_STUB_CALLS"; }
 
-                RCLONE_STUB_EXIT=0 "$sync" --resync
+                PROTON_DRIVE_STUB_EXIT=0 "$sync" --resync
                 [ "$(marker_count 'initialized-*')" -eq 1 ] || fail "--resync must write the baseline marker"
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--resync must not latch"
 
@@ -233,12 +253,21 @@
                 # they leave the listings valid and exit non-zero having changed
                 # nothing. Without the latch the timer recomputes this abort from
                 # a full listing of both sides every interval, forever.
+                #
+                # The RCLONE_ variables here are the payload for the script's
+                # namespace sweep, and the stub exits 99 on any survivor. They
+                # deliberately reach past the log-routing and safety-disabling
+                # names two earlier rounds enumerated: RCLONE_DRY_RUN,
+                # RCLONE_RESYNC_MODE and RCLONE_CONFLICT_LOSER are equally
+                # destructive and were never on any list, which is why the guard
+                # is a namespace and not a list.
                 rc=0
-                RCLONE_STUB_EXIT=2 \
+                PROTON_DRIVE_STUB_EXIT=2 \
                 RCLONE_LOG_FILE=/dev/null RCLONE_SYSLOG=true RCLONE_USE_JSON_LOG=true \
-                RCLONE_LOG_LEVEL=NOTICE RCLONE_LOG_FORMAT=nolevel \
+                RCLONE_LOG_LEVEL=NOTICE RCLONE_LOG_FORMAT=nolevel RCLONE_LOG_SYSTEMD=true \
                 RCLONE_FORCE=true RCLONE_RESYNC=true \
-                RCLONE_STUB_STDERR='ERROR : Safety abort: too many deletes (>25%, 8 of 8) on Path1 "/x". Run with --force if desired.' \
+                RCLONE_DRY_RUN=true RCLONE_RESYNC_MODE=path2 RCLONE_CONFLICT_LOSER=delete \
+                PROTON_DRIVE_STUB_STDERR='ERROR : Safety abort: too many deletes (>25%, 8 of 8) on Path1 "/x". Run with --force if desired.' \
                   "$sync" || rc=$?
                 [ "$rc" -ne 0 ] || fail "a bisync safety abort must fail the run"
                 [ "$(marker_count 'aborted-*')" -eq 1 ] || fail "a bisync safety abort must latch the tuple"
@@ -246,19 +275,19 @@
 
                 before=$(call_count)
                 rc=0
-                RCLONE_STUB_EXIT=0 "$sync" || rc=$?
+                PROTON_DRIVE_STUB_EXIT=0 "$sync" || rc=$?
                 [ "$rc" -eq 1 ] || fail "a latched tuple must exit 1"
                 [ "$(call_count)" -eq "$before" ] || fail "a latched tuple must not reach rclone"
 
-                RCLONE_STUB_EXIT=0 "$sync" --force
+                PROTON_DRIVE_STUB_EXIT=0 "$sync" --force
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--force must release the latch"
-                grep -q -- '--force' "$RCLONE_STUB_CALLS" || fail "--force must reach rclone"
+                grep -q -- '--force' "$PROTON_DRIVE_STUB_CALLS" || fail "--force must reach rclone"
 
                 # A transient backend failure must keep retrying on the timer;
                 # latching it would strand the sync until a human runs --force.
                 rc=0
-                RCLONE_STUB_EXIT=5 \
-                RCLONE_STUB_STDERR='ERROR : Attempt 1/3 failed: connection reset by peer' \
+                PROTON_DRIVE_STUB_EXIT=5 \
+                PROTON_DRIVE_STUB_STDERR='ERROR : Attempt 1/3 failed: connection reset by peer' \
                   "$sync" || rc=$?
                 [ "$rc" -ne 0 ] || fail "a transient rclone failure must fail the run"
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "a transient rclone failure must not latch"
@@ -266,23 +295,23 @@
                 # An INFO line echoes the transferred path, so the abort text can
                 # reach the log without either safety check having fired.
                 rc=0
-                RCLONE_STUB_EXIT=5 \
-                RCLONE_STUB_STDERR='2026/01/01 00:00:00 INFO  : notes/Safety abort: too many deletes.md: Copied (new)' \
+                PROTON_DRIVE_STUB_EXIT=5 \
+                PROTON_DRIVE_STUB_STDERR='2026/01/01 00:00:00 INFO  : notes/Safety abort: too many deletes.md: Copied (new)' \
                   "$sync" || rc=$?
                 [ "$rc" -ne 0 ] || fail "the stubbed failure must fail the run"
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "a transferred path naming the abort must not latch"
 
                 # The second safety check rclone releases with --force.
                 rc=0
-                RCLONE_STUB_EXIT=2 \
-                RCLONE_STUB_STDERR='2026/01/01 00:00:00 ERROR : Safety abort: all files were changed on Path1 "/x". Run with --force if desired.' \
+                PROTON_DRIVE_STUB_EXIT=2 \
+                PROTON_DRIVE_STUB_STDERR='2026/01/01 00:00:00 ERROR : Safety abort: all files were changed on Path1 "/x". Run with --force if desired.' \
                   "$sync" || rc=$?
                 [ "$rc" -ne 0 ] || fail "an all-files-changed abort must fail the run"
                 [ "$(marker_count 'aborted-*')" -eq 1 ] || fail "an all-files-changed abort must latch the tuple"
 
                 # The other release the refusal message advertises, on a
                 # different branch than --force.
-                RCLONE_STUB_EXIT=0 "$sync" --resync
+                PROTON_DRIVE_STUB_EXIT=0 "$sync" --resync
                 [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--resync must release the latch"
                 [ "$(marker_count 'initialized-*')" -eq 1 ] || fail "--resync must keep the baseline marker"
 
@@ -309,6 +338,9 @@
         assert lib.assertMsg (
           !(builtins.tryEval logRoutedHm.config.home.packages).success
         ) "hm-apps/proton-drive-sync: --log-file in extraArgs must fail an assertion";
+        assert lib.assertMsg (
+          !(builtins.tryEval logSystemdHm.config.home.packages).success
+        ) "hm-apps/proton-drive-sync: --log-systemd in extraArgs must fail an assertion";
         builtins.deepSeq units drive;
     };
 }

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -268,6 +268,12 @@
                 [ "$rc" -ne 0 ] || fail "an all-files-changed abort must fail the run"
                 [ "$(marker_count 'aborted-*')" -eq 1 ] || fail "an all-files-changed abort must latch the tuple"
 
+                # The other release the refusal message advertises, on a
+                # different branch than --force.
+                RCLONE_STUB_EXIT=0 "$sync" --resync
+                [ "$(marker_count 'aborted-*')" -eq 0 ] || fail "--resync must release the latch"
+                [ "$(marker_count 'initialized-*')" -eq 1 ] || fail "--resync must keep the baseline marker"
+
                 touch "$out"
               '';
         in

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -2,16 +2,21 @@
   Check: proton-drive-sync builds, and a bisync safety abort latches the tuple
   (modules/hm-apps/proton-drive.nix).
 
-  home.packages carries the script only when protondriveReady is true, which
-  needs secrets/rclone_protondrive.env. No tracked host ships that file and CI
-  has no secrets submodule at all, so writeShellApplication's shellcheck pass
-  has never run on the script and none of its abort handling has ever executed.
+  home.packages carries the script only when protondriveReady is true. CI has no
+  secrets submodule and no 1Password session, and no `nix flake check` step
+  builds a host toplevel, so writeShellApplication's shellcheck pass had never
+  run on the script and none of its abort handling had ever executed.
 
   Builds a standalone Home Manager configuration the way
   modules/browsers/firefoxpwa/module-check.nix does, with osConfig stubbed to
   make the remote ready and secretsRoot pointed at an in-repo fixture, then
   replaces programs.rclone.package with a stub replaying a scripted exit code
   and stderr so the script's control flow, not rclone, is under test.
+
+  Both credential sources gate the same script, so the op:// source is asserted
+  to install it without any secret present and protonDrive.enable = false to
+  withhold it, keeping protondriveReady's three inputs (rclone, protonDrive,
+  authSource) covered by eval alone.
 
   Runs under the build sandbox's private /tmp because the state root and local
   path are pinned at eval time; the pre-existing-state guard below turns an
@@ -41,31 +46,74 @@
             exit "''${RCLONE_STUB_EXIT:-0}"
           '';
 
-          hm = inputs.home-manager.lib.homeManagerConfiguration {
-            inherit pkgs;
-            modules = [
-              config.flake.homeManagerModules.apps.proton-drive
-              {
-                home = {
-                  username = "hm-smoke";
-                  homeDirectory = "${root}/home";
-                  stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
-                  enableNixpkgsReleaseCheck = false;
+          opRef = field: "op://check/protondrive/${field}";
+
+          mkHm =
+            {
+              protonDrive,
+              secretsRoot ? ./proton-drive-check-fixtures,
+            }:
+            inputs.home-manager.lib.homeManagerConfiguration {
+              inherit pkgs;
+              modules = [
+                config.flake.homeManagerModules.apps.proton-drive
+                {
+                  home = {
+                    username = "hm-smoke";
+                    homeDirectory = "${root}/home";
+                    stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
+                    enableNixpkgsReleaseCheck = false;
+                  };
+                  programs.home-manager.enable = true;
+                  programs.rclone.package = rcloneStub;
+                  xdg.stateHome = "${root}/state";
+                  xdg.configHome = "${root}/config";
+                  services.protonDriveSync.enable = protonDrive.enable;
+                }
+              ];
+              extraSpecialArgs = {
+                osConfig = {
+                  programs.rclone.extended = {
+                    enable = true;
+                    inherit protonDrive;
+                  };
+                  security.repoSecrets.enable = true;
+                  sops.secrets."rclone/protondrive-env".path = "${root}/protondrive-env";
                 };
-                programs.home-manager.enable = true;
-                programs.rclone.package = rcloneStub;
-                xdg.stateHome = "${root}/state";
-                xdg.configHome = "${root}/config";
-                services.protonDriveSync.enable = true;
-              }
-            ];
-            extraSpecialArgs = {
-              osConfig = {
-                programs.rclone.extended.enable = true;
-                security.repoSecrets.enable = true;
-                sops.secrets."rclone/protondrive-env".path = "${root}/protondrive-env";
+                inherit secretsRoot;
               };
-              secretsRoot = ./proton-drive-check-fixtures;
+            };
+
+          installsScript =
+            hmConfig: lib.any (drv: (drv.name or "") == "proton-drive-sync") hmConfig.config.home.packages;
+
+          hm = mkHm {
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
+          # The op:// source authenticates through the activation script at run
+          # time, so no secret exists at eval and secretsRoot must not matter.
+          onePasswordHm = mkHm {
+            secretsRoot = "${./proton-drive-check-fixtures}/missing";
+            protonDrive = {
+              enable = true;
+              authSource = "onePassword";
+              onePassword = {
+                usernameRef = opRef "username";
+                passwordRef = opRef "password";
+                otpRef = opRef "one-time password";
+                mailboxPasswordRef = opRef "mailbox";
+              };
+            };
+          };
+
+          disabledHm = mkHm {
+            protonDrive = {
+              enable = false;
+              authSource = "sops";
             };
           };
 
@@ -156,7 +204,12 @@
         in
         assert lib.assertMsg (
           syncScript != null
-        ) "hm-apps/proton-drive-sync: the stubbed configuration must install proton-drive-sync";
+        ) "hm-apps/proton-drive-sync: the sops source must install proton-drive-sync";
+        assert lib.assertMsg (installsScript onePasswordHm)
+          "hm-apps/proton-drive-sync: op:// references must install proton-drive-sync with no secret present";
+        assert lib.assertMsg (
+          !installsScript disabledHm
+        ) "hm-apps/proton-drive-sync: protonDrive.enable = false must withhold proton-drive-sync";
         assert lib.assertMsg (lib.all (entry: entry.assertion)
           hm.config.assertions
         ) "hm-apps/proton-drive-sync: the stubbed configuration must satisfy its own assertions";

--- a/modules/hm-apps/proton-drive-check.nix
+++ b/modules/hm-apps/proton-drive-check.nix
@@ -222,6 +222,26 @@
             };
           };
 
+          # The tuple key is direction/local/remote, so neither of these appears
+          # in it: --config re-points the account the baseline stands for, and
+          # --workdir moves the listings without moving the marker that claims
+          # they exist.
+          configHm = mkHm {
+            extraArgs = [ "--config=/tmp/other.conf" ];
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
+          workdirHm = mkHm {
+            extraArgs = [ "--workdir=/tmp/bisync" ];
+            protonDrive = {
+              enable = true;
+              authSource = "sops";
+            };
+          };
+
           # rclone withholds destination deletes from a run that hit errors;
           # this is the flag that turns that off, and --max-delete cannot
           # express it because the deletes are within the cap.
@@ -469,6 +489,19 @@
         assert lib.assertMsg (
           !(builtins.tryEval ignoreErrorsHm.config.home.packages).success
         ) "hm-apps/proton-drive-sync: --ignore-errors in extraArgs must fail an assertion";
+        assert lib.assertMsg (
+          !(builtins.tryEval configHm.config.home.packages).success
+        ) "hm-apps/proton-drive-sync: --config in extraArgs must fail an assertion";
+        assert lib.assertMsg (
+          !(builtins.tryEval workdirHm.config.home.packages).success
+        ) "hm-apps/proton-drive-sync: --workdir in extraArgs must fail an assertion";
+        # The unit inherits the user manager's environment, and the script reads
+        # these three before any other logic, so the timer must run the
+        # configured values rather than whatever the session happens to export.
+        assert lib.assertMsg (
+          (hm.config.systemd.user.services.proton-drive-sync.Service.UnsetEnvironment or "")
+          == "PROTON_DRIVE_LOCAL PROTON_DRIVE_REMOTE PROTON_DRIVE_DIRECTION"
+        ) "hm-apps/proton-drive-sync: the unit must drop the PROTON_DRIVE_* per-invocation overrides";
         assert lib.assertMsg (installsScript tuningHm)
           "hm-apps/proton-drive-sync: long-form tuning arguments must still be accepted";
         builtins.deepSeq units drive;

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -161,25 +161,49 @@ _: {
       cfg = config.services.protonDriveSync;
       rclonePackage = lib.attrByPath [ "programs" "rclone" "package" ] pkgs.rclone config;
 
-      # run_bisync reads the run's own stderr to detect a safety abort, so an
-      # extraArg that moves or reshapes that record disables the latch without
-      # any other symptom: --log-file and --syslog write elsewhere
-      # (rclone fs/log/log.go), a --log-level under ERROR drops it,
+      # extraArgs is appended last on every invocation and rclone's parser takes
+      # the last occurrence of a flag, so an extraArg silently replaces the same
+      # flag this module passes (verified against rclone 1.74.4:
+      # `--max-delete=25 --max-delete=0` refuses the deletes). Two classes are
+      # refused, both because the override is invisible in the sync's own output.
+      #
+      # Log routing, because run_bisync reads the run's own stderr to detect a
+      # safety abort: --log-file and --syslog write elsewhere
+      # (rclone fs/log/log.go), a --log-level under ERROR drops the record,
       # --log-format nolevel and --use-json-log strip the level prefix, and
       # --log-systemd does both (fs/log/systemd_unix.go startSystemdLog sets a
       # journald output and logFormatNoLevel). Auto-detection of a journal
       # stream is not a hole: run_bisync pipes rclone into tee, and
       # journal.StderrIsJournalStream stats fd 2, which is that pipe.
-      logRoutingFlags = [
+      #
+      # Safety and mode, because each defeats a flag this module passes to hold
+      # deletions back or to keep the baseline honest: --force skips both bisync
+      # safety checks outright (cmd/bisync/operations.go guards each with
+      # `if !opt.Force`), --max-delete replaces the cap, --conflict-loser=delete
+      # drops the losing copy of every conflict, --dry-run leaves --resync
+      # writing only `-dry` listings while the branch still records a baseline,
+      # and --resync / --resync-mode turn a scheduled fire into a superset merge.
+      rejectedFlags = [
+        "--conflict-loser"
+        "--dry-run"
+        "--force"
         "--log-file"
         "--log-format"
         "--log-level"
         "--log-systemd"
+        "--max-delete"
+        "--resync"
+        "--resync-mode"
         "--syslog"
         "--use-json-log"
       ];
-      logRoutingArgs = lib.filter (
-        arg: lib.any (flag: arg == flag || lib.hasPrefix "${flag}=" arg) logRoutingFlags
+      # Short options cluster, so they cannot be matched flag by flag: `-nv` is
+      # --dry-run plus --verbose, and bisync gives --resync the shorthand `-1`.
+      # Every rejected flag has a long form, so require it rather than parse
+      # clusters here.
+      isShortOption = arg: builtins.match "-[^-].*" arg != null;
+      rejectedArgs = lib.filter (
+        arg: isShortOption arg || lib.any (flag: arg == flag || lib.hasPrefix "${flag}=" arg) rejectedFlags
       ) cfg.extraArgs;
 
       syncScript = pkgs.writeShellApplication {
@@ -448,13 +472,25 @@ _: {
           example = [ "--bwlimit=2M" ];
           description = ''
             Extra arguments appended to every rclone sync and bisync
-            invocation, not to the down-direction emptiness probe. Arguments
-            that redirect or reshape rclone's log output (`--log-file`,
-            `--log-format`, `--log-level`, `--log-systemd`, `--syslog`,
-            `--use-json-log`) are rejected: safety-abort detection reads the
-            run's own stderr. The equivalent `RCLONE_<FLAG>` environment
-            variables cannot be rejected at eval, so the script clears the whole
-            `RCLONE_` namespace before invoking rclone.
+            invocation, not to the down-direction emptiness probe. Because they
+            are appended last, they override the flags proton-drive-sync passes
+            itself, so two classes are rejected at evaluation.
+
+            Arguments that redirect or reshape rclone's log output
+            (`--log-file`, `--log-format`, `--log-level`, `--log-systemd`,
+            `--syslog`, `--use-json-log`): safety-abort detection reads the
+            run's own stderr.
+
+            Arguments that override a safety flag or the sync mode
+            (`--conflict-loser`, `--dry-run`, `--force`, `--max-delete`,
+            `--resync`, `--resync-mode`): each defeats the deletion cap, the
+            bisync safety checks, or the baseline the tuple marker records.
+
+            Short options are rejected wholesale because they cluster (`-nv` is
+            `--dry-run` plus `--verbose`); use the long form. The equivalent
+            `RCLONE_<FLAG>` environment variables cannot be rejected at
+            evaluation, so the script clears the whole `RCLONE_` namespace
+            before invoking rclone.
           '';
         };
       };
@@ -466,8 +502,8 @@ _: {
         (lib.mkIf protondriveReady {
           assertions = [
             {
-              assertion = logRoutingArgs == [ ];
-              message = "services.protonDriveSync.extraArgs must not redirect or reshape rclone's log output, but carries ${lib.concatStringsSep " " logRoutingArgs}. proton-drive-sync detects rclone's bisync safety abort by matching its ERROR record on the run's stderr; these flags send that record to a file, syslog or the journal, drop it below the ERROR threshold, or strip the level prefix, leaving the abort unlatched and the timer repeating the same aborted run every ${cfg.interval}.";
+              assertion = rejectedArgs == [ ];
+              message = "services.protonDriveSync.extraArgs is appended last on every rclone invocation, so it overrides the flags proton-drive-sync passes itself, but carries ${lib.concatStringsSep " " rejectedArgs}. Refused: ${lib.concatStringsSep " " rejectedFlags}, and every short option, because they cluster (-nv is --dry-run) and each rejected flag has a long form. The log-routing ones send rclone's ERROR record to a file, syslog or the journal, drop it below the ERROR threshold, or strip the level prefix, leaving the bisync safety abort unlatched and the timer repeating the same aborted run every ${cfg.interval}. The rest defeat the deletion cap, the safety checks, or the baseline the tuple marker records.";
             }
           ];
 

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -208,9 +208,19 @@ _: {
       # /tmp (a tmpfs cleared on boot on this fleet) survives one reboot as a
       # baseline with nothing behind it: the unlatchable repeat --dry-run is
       # rejected for, reached with no intent to disable anything.
+      #
+      # --conflict-resolve and --resilient close the same set: the first is the
+      # other half of the decision --conflict-loser governs, and --resilient is
+      # a bool, so --resilient=false reinstates bisync's -err listing rename on
+      # a retryable critical error (cmd/bisync/operations.go skips it only under
+      # `b.retryable && b.opt.Resilient && !b.opt.Resync`), turning the
+      # offline-at-boot retry the unit relies on into that same repeat. Every
+      # flag the script puts on the command line is here, which is the invariant
+      # the check asserts against rejectedExtraArgs below.
       rejectedFlags = [
         "--config"
         "--conflict-loser"
+        "--conflict-resolve"
         "--dry-run"
         "--force"
         "--ignore-errors"
@@ -220,6 +230,7 @@ _: {
         "--log-systemd"
         "--max-delete"
         "--protondrive-enable-caching"
+        "--resilient"
         "--resync"
         "--resync-mode"
         "--syslog"
@@ -451,6 +462,19 @@ _: {
     in
     {
       options.services.protonDriveSync = {
+        # Four rounds of review found a flag the script passes that extraArgs
+        # could still replace, each time because the two lists were maintained
+        # by hand. Exposing this lets the check assert that every flag it
+        # verifies on the command line is also refused here, so the pair cannot
+        # drift again without a check failure.
+        rejectedExtraArgs = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          internal = true;
+          readOnly = true;
+          default = rejectedFlags;
+          description = "Arguments refused in extraArgs, for the module's own check.";
+        };
+
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
@@ -514,12 +538,13 @@ _: {
 
             Arguments that override a safety flag, the sync mode, or the state
             the tuple key does not cover (`--config`, `--conflict-loser`,
-            `--dry-run`, `--force`, `--ignore-errors`, `--max-delete`,
-            `--protondrive-enable-caching`, `--resync`, `--resync-mode`,
-            `--workdir`): each defeats the deletion cap, the withholding of
-            deletes from an errored run, the bisync safety checks, the
-            caching-off the Beta backend requires, or the correspondence between
-            the tuple marker and the account and listings it stands for.
+            `--conflict-resolve`, `--dry-run`, `--force`, `--ignore-errors`,
+            `--max-delete`, `--protondrive-enable-caching`, `--resilient`,
+            `--resync`, `--resync-mode`, `--workdir`): each defeats the deletion
+            cap, the withholding of deletes from an errored run, the bisync
+            safety checks, the conflict winner, the retry the unit relies on,
+            the caching-off the Beta backend requires, or the correspondence
+            between the tuple marker and the account and listings it stands for.
 
             Short options are rejected wholesale because they cluster (`-nv` is
             `--dry-run` plus `--verbose`); use the long form. The equivalent

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -144,6 +144,22 @@ _: {
       cfg = config.services.protonDriveSync;
       rclonePackage = lib.attrByPath [ "programs" "rclone" "package" ] pkgs.rclone config;
 
+      # run_bisync reads the run's own stderr to detect a safety abort, so an
+      # extraArg that moves or reshapes that record disables the latch without
+      # any other symptom: --log-file and --syslog write elsewhere
+      # (rclone fs/log/log.go), a --log-level under ERROR drops it, and
+      # --log-format nolevel and --use-json-log strip the level prefix.
+      logRoutingFlags = [
+        "--log-file"
+        "--log-format"
+        "--log-level"
+        "--syslog"
+        "--use-json-log"
+      ];
+      logRoutingArgs = lib.filter (
+        arg: lib.any (flag: arg == flag || lib.hasPrefix "${flag}=" arg) logRoutingFlags
+      ) cfg.extraArgs;
+
       syncScript = pkgs.writeShellApplication {
         name = "proton-drive-sync";
         runtimeInputs = [
@@ -386,7 +402,13 @@ _: {
           type = lib.types.listOf lib.types.str;
           default = [ ];
           example = [ "--bwlimit=2M" ];
-          description = "Extra arguments appended to every rclone sync and bisync invocation, not to the down-direction emptiness probe.";
+          description = ''
+            Extra arguments appended to every rclone sync and bisync
+            invocation, not to the down-direction emptiness probe. Arguments
+            that redirect or reshape rclone's log output (`--log-file`,
+            `--log-format`, `--log-level`, `--syslog`, `--use-json-log`) are
+            rejected: safety-abort detection reads the run's own stderr.
+          '';
         };
       };
 
@@ -395,6 +417,13 @@ _: {
         # (proton-drive-sync --resync), so it must exist while the timer is
         # still off; only the units are gated on cfg.enable.
         (lib.mkIf protondriveReady {
+          assertions = [
+            {
+              assertion = logRoutingArgs == [ ];
+              message = "services.protonDriveSync.extraArgs must not redirect or reshape rclone's log output, but carries ${lib.concatStringsSep " " logRoutingArgs}. proton-drive-sync detects rclone's bisync safety abort by matching its ERROR record on the run's stderr; these flags send that record to a file or syslog, drop it below the ERROR threshold, or strip the level prefix, leaving the abort unlatched and the timer repeating the same aborted run every ${cfg.interval}.";
+            }
+          ];
+
           home.packages = [ syncScript ];
         })
 

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -32,11 +32,15 @@
        authorizes that call by its onepassword-cli group. usernameRef and
        passwordRef are mandatory; otpRef and mailboxPasswordRef may be left ""
        (only if 2FA is enabled / only on two-password accounts, same as the
-       SOPS fields above). The OTP reference must return the stable seed,
-       either as an otpauth:// URI carrying `secret=` or as the bare base32
-       seed 1Password stores when the operator pastes one; the module extracts
-       and obscures it. Omit `?attribute=otp`: it renders the changing
-       six-digit code, which the module rejects rather than storing.
+       SOPS fields above). Leaving a ref empty is how an account opts out, so a
+       ref that is set must resolve to a non-empty value; a blank field fails
+       activation rather than rendering a remote that cannot work. The OTP
+       reference must return the stable seed, either as an otpauth:// URI
+       carrying `secret=` or as the bare base32 seed 1Password stores when the
+       operator pastes one; the module extracts and obscures it, and requires
+       at least the 16 base32 characters of an 80-bit seed. Omit
+       `?attribute=otp` in either shape: it renders the changing six-digit
+       code, which the module rejects rather than storing.
        Proton passkeys remain browser-only because the rclone backend logs in
        through the Proton API with username, password, mailbox password, and 2FA.
 

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -19,8 +19,15 @@
 
   Authentication prerequisites (one-time, cannot be automated):
     1. Log into Proton Drive in a browser once so account encryption keys exist.
-    2. Enable `programs.rclone.extended.protonDrive.enable`; the rclone module
-       defaults to the shared 1Password-backed credential references.
+    2. Enable `programs.rclone.extended.enable` and
+       `programs.rclone.extended.protonDrive.enable`. Hosts in the hosts-common
+       aggregate inherit those, `programs."1password-cli".extended`, and the
+       four vault references at that aggregate's mkOverride 1100 baseline
+       (modules/hosts/common/apps-enable.nix and
+       modules/hosts/common/rclone-protondrive-1password.nix), which a per-host
+       file overrides at 1000. Any other host supplies them itself: all four
+       `onePassword.*Ref` options default to "", and usernameRef and passwordRef
+       must be set.
     3. To use the SOPS fallback, set `authSource = "sops"` and obscure and store:
          PROTONDRIVE_USERNAME=you@proton.me
          PROTONDRIVE_PASSWORD=<obscured>
@@ -457,7 +464,7 @@ _: {
           assertions = [
             {
               assertion = protondriveReady;
-              message = "services.protonDriveSync.enable requires the protondrive rclone remote to be ready: enable programs.rclone.extended and programs.rclone.extended.protonDrive, then configure either the SOPS secret secrets/rclone_protondrive.env or four programs.rclone.extended.protonDrive.onePassword op:// references.";
+              message = "services.protonDriveSync.enable requires the protondrive rclone remote to be ready: enable programs.rclone.extended and programs.rclone.extended.protonDrive, then configure either the SOPS secret secrets/rclone_protondrive.env or the programs.rclone.extended.protonDrive.onePassword usernameRef and passwordRef op:// references (otpRef and mailboxPasswordRef are per-account optional).";
             }
           ];
 

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -250,6 +250,15 @@ _: {
           # bypassable from the unit's inherited environment. Clear the
           # log-routing ones run_bisync depends on to detect the abort.
           unset RCLONE_LOG_FILE RCLONE_LOG_FORMAT RCLONE_LOG_LEVEL RCLONE_SYSLOG RCLONE_USE_JSON_LOG
+          # bisync's own --force and --resync register the same way
+          # (cmd/bisync/cmd.go flags.BoolVarP), and neither is on the command
+          # line for a normal run, so the environment supplies their default
+          # unopposed. --force skips both safety checks outright
+          # (cmd/bisync/operations.go guards each with `if !opt.Force`), leaving
+          # the deletions to propagate with no abort for the latch to catch, and
+          # --resync makes every fire a superset merge. Every other flag this
+          # script depends on is passed explicitly, so the command line wins.
+          unset RCLONE_FORCE RCLONE_RESYNC
 
           extra=(${lib.escapeShellArgs cfg.extraArgs})
           common=(--config ${lib.escapeShellArg "${config.xdg.configHome}/rclone/rclone.conf"} --protondrive-enable-caching=false --transfers=4 --checkers=8 --log-level INFO)

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -40,10 +40,14 @@
     that abort, --resync retains the cap and --force-resync is required to
     bypass it; --force-resync also permits an empty source. Normal bisync runs
     pass the same value as rclone's 25-percent deletion check; bisync --resync
-    establishes the initial baseline without that check, and --force explicitly
-    bypasses the normal bisync safety abort after confirming a nonempty local
-    source. Bisync listings live under this module's state directory beside the
-    tuple marker.
+    establishes the initial baseline without that check. A tripped bisync safety
+    check leaves both sides untouched and carries no --resync lockout, so the run
+    latches the same tuple instead of recomputing the abort from a full listing
+    every interval; --force releases the latch and propagates the deletions after
+    confirming a nonempty local source, and --resync releases it by rebuilding
+    the baseline as a superset of both sides. Bisync listings live under this
+    module's state directory beside the tuple marker, rooted at xdg.stateHome so
+    the timer and an interactive shell resolve the same path.
 
     Per-invocation overrides:
       PROTON_DRIVE_LOCAL=/path proton-drive-sync
@@ -55,7 +59,7 @@
     proton-drive-sync            # run the configured sync immediately
     proton-drive-sync --resync   # establish (or rebuild) a nonempty baseline
     proton-drive-sync --force-resync # override the abort cap or permit an empty source
-    proton-drive-sync --force    # retry a bisync safety abort after confirming the local source
+    proton-drive-sync --force    # release a latched bisync safety abort after confirming the local source
 
   Multi-host caveat:
     services.protonDriveSync.enable is off by default and should be enabled on
@@ -97,6 +101,7 @@ _: {
           rclonePackage
           pkgs.coreutils
           pkgs.findutils
+          pkgs.gnugrep
         ];
         text = ''
           # The defaults are single-quoted shell literals so metacharacters
@@ -107,7 +112,10 @@ _: {
           remote=''${PROTON_DRIVE_REMOTE:-${lib.escapeShellArg cfg.remote}}
           # shellcheck disable=SC2016
           direction=''${PROTON_DRIVE_DIRECTION:-${lib.escapeShellArg cfg.direction}}
-          state_dir=''${XDG_STATE_HOME:-$HOME/.local/state}/proton-drive-sync
+          # Pinned at eval time like the rclone config below: the systemd user
+          # manager and an interactive shell must never disagree about where
+          # the baseline marker lives, or the timer looks in the wrong root.
+          state_dir=${lib.escapeShellArg "${config.xdg.stateHome}/proton-drive-sync"}
           state_key=$(printf '%s\0%s\0%s' "$direction" "$local_path" "$remote" | sha256sum | cut -c1-16)
           marker="$state_dir/initialized-$state_key"
           aborted="$state_dir/aborted-$state_key"
@@ -184,6 +192,25 @@ _: {
             return "$rc"
           }
 
+          run_bisync() {
+            local rc=0
+            local log
+            log=$(mktemp -t proton-drive-sync-bisync.XXXXXX)
+            rclone bisync "$@" 2>&1 | tee -- "$log" >&2 || rc=$?
+            # rclone's bisync safety checks (excess deletes, all files changed)
+            # set abort without critical, so no listing is invalidated and no
+            # --resync lockout follows: the next timer fire would recompute the
+            # same abort from a full uncached listing of both sides, forever.
+            # Latch instead. "Safety abort" marks exactly the two checks whose
+            # documented release is --force (cmd/bisync/{deltas,operations}.go).
+            if [ "$rc" -ne 0 ] && grep -qF 'Safety abort' -- "$log"; then
+              touch "$aborted"
+              echo "proton-drive-sync: rclone's bisync safety check aborted the run without changing either side; latched the timer off. Confirm '$local_path' is mounted and its deletions are intended, then re-run 'proton-drive-sync --force'." >&2
+            fi
+            rm -f -- "$log"
+            return "$rc"
+          }
+
           case "$direction" in
             up)
               # rclone sync mirrors local -> remote and deletes remote-only
@@ -230,13 +257,21 @@ _: {
                 echo "proton-drive-sync: building bisync baseline (--resync; local side wins conflicts)" >&2
                 rclone bisync "$local_path" "$remote" --resync --workdir "$state_dir/bisync" --create-empty-src-dirs --resilient "''${bisync_force[@]}" "''${common[@]}" "''${extra[@]}"
                 touch "$marker"
+                rm -f -- "$aborted"
               elif [ ! -e "$marker" ]; then
                 echo "proton-drive-sync: no bisync baseline; run 'proton-drive-sync --resync' once after confirming '$local_path' holds the desired seed contents." >&2
+                exit 1
+              elif [ -e "$aborted" ] && [ "''${#bisync_force[@]}" -eq 0 ]; then
+                # Clearing the marker would be the wrong stop: --resync merges
+                # both sides into a superset, resurrecting the very deletions
+                # that tripped the check instead of propagating them.
+                echo "proton-drive-sync: the previous bisync hit rclone's safety check and changed nothing; refusing to repeat it every interval. Confirm '$local_path' is mounted and its deletions are intended, then re-run with --force to propagate them (or --resync to rebuild the baseline as a superset of both sides)." >&2
                 exit 1
               else
                 # rclone sync treats --max-delete as an absolute file count,
                 # while bisync treats the same value as a percentage.
-                rclone bisync "$local_path" "$remote" --workdir "$state_dir/bisync" --create-empty-src-dirs --resilient --conflict-resolve=newer --max-delete=25 "''${bisync_force[@]}" "''${common[@]}" "''${extra[@]}"
+                run_bisync "$local_path" "$remote" --workdir "$state_dir/bisync" --create-empty-src-dirs --resilient --conflict-resolve=newer --max-delete=25 "''${bisync_force[@]}" "''${common[@]}" "''${extra[@]}"
+                rm -f -- "$aborted"
               fi
               ;;
             *)

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -26,9 +26,13 @@
          PROTONDRIVE_PASSWORD=<obscured>
          PROTONDRIVE_OTP_SECRET_KEY=<obscured>      # only if 2FA is enabled
          PROTONDRIVE_MAILBOX_PASSWORD=<obscured>    # only on two-password accounts
-    4. For the 1Password source, the OTP reference must return the stable
-       otpauth:// URI without `?attribute=otp`; the module extracts and obscures
-       its seed. It does not store or request the changing six-digit code.
+    4. For the 1Password source, the desktop app must be running and unlocked
+       with CLI integration turned on: activation resolves the references
+       through the setgid `op` wrapper from `programs._1password`, and the app
+       authorizes that call by its onepassword-cli group. The OTP reference must
+       return the stable otpauth:// URI without `?attribute=otp`; the module
+       extracts and obscures its seed. It does not store or request the changing
+       six-digit code.
        Proton passkeys remain browser-only because the rclone backend logs in
        through the Proton API with username, password, mailbox password, and 2FA.
 

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -238,6 +238,13 @@ _: {
           fi
           mkdir -p "$state_dir" "$local_path"
 
+          # rclone honours an RCLONE_<FLAG> environment variable for every
+          # flag (fs/config/flags: installFlag reads it before command-line
+          # parsing), so the eval-time extraArgs assertion above is
+          # bypassable from the unit's inherited environment. Clear the
+          # log-routing ones run_bisync depends on to detect the abort.
+          unset RCLONE_LOG_FILE RCLONE_LOG_FORMAT RCLONE_LOG_LEVEL RCLONE_SYSLOG RCLONE_USE_JSON_LOG
+
           extra=(${lib.escapeShellArgs cfg.extraArgs})
           common=(--config ${lib.escapeShellArg "${config.xdg.configHome}/rclone/rclone.conf"} --protondrive-enable-caching=false --transfers=4 --checkers=8 --log-level INFO)
           # The cap protects unattended timer runs. --resync lifts it for a

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -183,6 +183,14 @@ _: {
       # drops the losing copy of every conflict, --dry-run leaves --resync
       # writing only `-dry` listings while the branch still records a baseline,
       # and --resync / --resync-mode turn a scheduled fire into a superset merge.
+      #
+      # --protondrive-enable-caching belongs to the same class, and the command
+      # line is its sole authority rather than a reinforcement: fs/configmap.go
+      # ConfigMap registers set flag values at PriorityNormal and the config
+      # file at PriorityConfig, so an extraArg beats both the flag in common and
+      # the enable_caching = false the rclone module writes into the stanza.
+      # Caching stays off because Proton's change-event system is unimplemented,
+      # so a stale metadata cache feeds bisync's delta computation directly.
       rejectedFlags = [
         "--conflict-loser"
         "--dry-run"
@@ -192,6 +200,7 @@ _: {
         "--log-level"
         "--log-systemd"
         "--max-delete"
+        "--protondrive-enable-caching"
         "--resync"
         "--resync-mode"
         "--syslog"
@@ -483,8 +492,9 @@ _: {
 
             Arguments that override a safety flag or the sync mode
             (`--conflict-loser`, `--dry-run`, `--force`, `--max-delete`,
-            `--resync`, `--resync-mode`): each defeats the deletion cap, the
-            bisync safety checks, or the baseline the tuple marker records.
+            `--protondrive-enable-caching`, `--resync`, `--resync-mode`): each
+            defeats the deletion cap, the bisync safety checks, the baseline the
+            tuple marker records, or the caching-off the Beta backend requires.
 
             Short options are rejected wholesale because they cluster (`-nv` is
             `--dry-run` plus `--verbose`); use the long form. The equivalent

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -7,8 +7,9 @@
     * Drives an automatic, periodic Proton Drive sync from a systemd user timer
       plus an on-demand `proton-drive-sync` command for forcing a sync now.
     * The `[protondrive]` rclone remote itself is rendered by the rclone home
-      module (modules/hm-apps/rclone.nix) from the SOPS secret
-      secrets/rclone_protondrive.env; this module only orchestrates syncing.
+      module (modules/hm-apps/rclone.nix) from either the SOPS secret
+      secrets/rclone_protondrive.env or configured 1Password references; this
+      module only orchestrates syncing.
 
   Status caveat:
     The protondrive backend is reverse-engineered (third-party Proton-API-Bridge)
@@ -16,15 +17,20 @@
     of important data. enable_caching is forced off on the remote because Proton's
     change-event system is unimplemented.
 
-  Activation prerequisites (one-time, cannot be automated, see CLAUDE.md flow):
+  Authentication prerequisites (one-time, cannot be automated):
     1. Log into Proton Drive in a browser once so account encryption keys exist.
-    2. `rclone obscure '<login-password>'` (and the same for the TOTP secret and,
-       on two-password accounts, the mailbox password).
-    3. `sops secrets/rclone_protondrive.env` and store:
+    2. Enable `programs.rclone.extended.protonDrive.enable`; the rclone module
+       defaults to the shared 1Password-backed credential references.
+    3. To use the SOPS fallback, set `authSource = "sops"` and obscure and store:
          PROTONDRIVE_USERNAME=you@proton.me
          PROTONDRIVE_PASSWORD=<obscured>
          PROTONDRIVE_OTP_SECRET_KEY=<obscured>      # only if 2FA is enabled
          PROTONDRIVE_MAILBOX_PASSWORD=<obscured>    # only on two-password accounts
+    4. For the 1Password source, the OTP reference must return the stable
+       otpauth:// URI without `?attribute=otp`; the module extracts and obscures
+       its seed. It does not store or request the changing six-digit code.
+       Proton passkeys remain browser-only because the rclone backend logs in
+       through the Proton API with username, password, mailbox password, and 2FA.
 
   Bootstrap and on-demand use:
     The proton-drive-sync CLI is installed whenever the protondrive remote is
@@ -89,8 +95,47 @@ _: {
         "rclone/protondrive-env"
         "path"
       ] null osConfig;
+      protondriveAuth =
+        lib.attrByPath
+          [
+            "programs"
+            "rclone"
+            "extended"
+            "protonDrive"
+          ]
+          {
+            enable = false;
+            authSource = "sops";
+            onePassword = {
+              usernameRef = "";
+              passwordRef = "";
+              otpRef = "";
+              mailboxPasswordRef = "";
+            };
+          }
+          osConfig;
+      protondriveOnePassword = protondriveAuth.onePassword or { };
+      protondriveOnePasswordReady =
+        protondriveAuth.enable
+        && protondriveAuth.authSource == "onePassword"
+        && lib.all (ref: lib.hasPrefix "op://" ref) [
+          (protondriveOnePassword.usernameRef or "")
+          (protondriveOnePassword.passwordRef or "")
+          (protondriveOnePassword.otpRef or "")
+          (protondriveOnePassword.mailboxPasswordRef or "")
+        ];
       protondriveReady =
-        rcloneEnabled && protondriveSecretExists && repoSecretsEnabled && protondriveEnvPath != null;
+        rcloneEnabled
+        && (
+          protondriveOnePasswordReady
+          || (
+            protondriveAuth.enable
+            && protondriveAuth.authSource == "sops"
+            && protondriveSecretExists
+            && repoSecretsEnabled
+            && protondriveEnvPath != null
+          )
+        );
 
       cfg = config.services.protonDriveSync;
       rclonePackage = lib.attrByPath [ "programs" "rclone" "package" ] pkgs.rclone config;
@@ -350,7 +395,7 @@ _: {
           assertions = [
             {
               assertion = protondriveReady;
-              message = "services.protonDriveSync.enable requires the protondrive rclone remote to be ready: programs.rclone.extended.enable and security.repoSecrets.enable must be true, and secrets/rclone_protondrive.env must exist so sops.secrets.\"rclone/protondrive-env\" has a path.";
+              message = "services.protonDriveSync.enable requires the protondrive rclone remote to be ready: enable programs.rclone.extended and programs.rclone.extended.protonDrive, then configure either the SOPS secret secrets/rclone_protondrive.env or four programs.rclone.extended.protonDrive.onePassword op:// references.";
             }
           ];
 

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -164,12 +164,17 @@ _: {
       # run_bisync reads the run's own stderr to detect a safety abort, so an
       # extraArg that moves or reshapes that record disables the latch without
       # any other symptom: --log-file and --syslog write elsewhere
-      # (rclone fs/log/log.go), a --log-level under ERROR drops it, and
-      # --log-format nolevel and --use-json-log strip the level prefix.
+      # (rclone fs/log/log.go), a --log-level under ERROR drops it,
+      # --log-format nolevel and --use-json-log strip the level prefix, and
+      # --log-systemd does both (fs/log/systemd_unix.go startSystemdLog sets a
+      # journald output and logFormatNoLevel). Auto-detection of a journal
+      # stream is not a hole: run_bisync pipes rclone into tee, and
+      # journal.StderrIsJournalStream stats fd 2, which is that pipe.
       logRoutingFlags = [
         "--log-file"
         "--log-format"
         "--log-level"
+        "--log-systemd"
         "--syslog"
         "--use-json-log"
       ];
@@ -251,21 +256,27 @@ _: {
           fi
           mkdir -p "$state_dir" "$local_path"
 
-          # rclone honours an RCLONE_<FLAG> environment variable for every
-          # flag (fs/config/flags: installFlag reads it before command-line
-          # parsing), so the eval-time extraArgs assertion above is
-          # bypassable from the unit's inherited environment. Clear the
-          # log-routing ones run_bisync depends on to detect the abort.
-          unset RCLONE_LOG_FILE RCLONE_LOG_FORMAT RCLONE_LOG_LEVEL RCLONE_SYSLOG RCLONE_USE_JSON_LOG
-          # bisync's own --force and --resync register the same way
-          # (cmd/bisync/cmd.go flags.BoolVarP), and neither is on the command
-          # line for a normal run, so the environment supplies their default
-          # unopposed. --force skips both safety checks outright
-          # (cmd/bisync/operations.go guards each with `if !opt.Force`), leaving
-          # the deletions to propagate with no abort for the latch to catch, and
-          # --resync makes every fire a superset merge. Every other flag this
-          # script depends on is passed explicitly, so the command line wins.
-          unset RCLONE_FORCE RCLONE_RESYNC
+          # rclone reads RCLONE_<FLAG> for every registered flag before
+          # command-line parsing (fs/config/flags.go installFlag via
+          # fs.OptionToEnv), and the systemd user unit inherits the manager's
+          # environment, which the eval-time extraArgs assertion cannot see.
+          # Enumerating the dangerous names came up short twice: past the
+          # log-routing ones that move the record run_bisync greps for,
+          # RCLONE_FORCE skips both safety checks outright
+          # (cmd/bisync/operations.go guards each with `if !opt.Force`),
+          # RCLONE_RESYNC and RCLONE_RESYNC_MODE turn a normal fire into a
+          # superset merge (the latter also inverting the conflict winner the
+          # resync branch announces), RCLONE_DRY_RUN diverts the resync listings
+          # to `-dry` paths while that branch still writes $marker, leaving
+          # every later fire on a critical error the abort pattern never
+          # matches, and RCLONE_CONFLICT_LOSER=delete drops the losing copy of
+          # every conflict. Every flag this script depends on is passed
+          # explicitly and the command line wins, so clear the whole namespace.
+          # Prefix expansion, not compgen: nixpkgs' runtimeShell is built
+          # without progcomp, where compgen exits 127 and sweeps nothing.
+          for rclone_env_name in "''${!RCLONE_@}"; do
+            unset "$rclone_env_name"
+          done
 
           extra=(${lib.escapeShellArgs cfg.extraArgs})
           common=(--config ${lib.escapeShellArg "${config.xdg.configHome}/rclone/rclone.conf"} --protondrive-enable-caching=false --transfers=4 --checkers=8 --log-level INFO)
@@ -439,8 +450,11 @@ _: {
             Extra arguments appended to every rclone sync and bisync
             invocation, not to the down-direction emptiness probe. Arguments
             that redirect or reshape rclone's log output (`--log-file`,
-            `--log-format`, `--log-level`, `--syslog`, `--use-json-log`) are
-            rejected: safety-abort detection reads the run's own stderr.
+            `--log-format`, `--log-level`, `--log-systemd`, `--syslog`,
+            `--use-json-log`) are rejected: safety-abort detection reads the
+            run's own stderr. The equivalent `RCLONE_<FLAG>` environment
+            variables cannot be rejected at eval, so the script clears the whole
+            `RCLONE_` namespace before invoking rclone.
           '';
         };
       };
@@ -453,7 +467,7 @@ _: {
           assertions = [
             {
               assertion = logRoutingArgs == [ ];
-              message = "services.protonDriveSync.extraArgs must not redirect or reshape rclone's log output, but carries ${lib.concatStringsSep " " logRoutingArgs}. proton-drive-sync detects rclone's bisync safety abort by matching its ERROR record on the run's stderr; these flags send that record to a file or syslog, drop it below the ERROR threshold, or strip the level prefix, leaving the abort unlatched and the timer repeating the same aborted run every ${cfg.interval}.";
+              message = "services.protonDriveSync.extraArgs must not redirect or reshape rclone's log output, but carries ${lib.concatStringsSep " " logRoutingArgs}. proton-drive-sync detects rclone's bisync safety abort by matching its ERROR record on the run's stderr; these flags send that record to a file, syslog or the journal, drop it below the ERROR threshold, or strip the level prefix, leaving the abort unlatched and the timer repeating the same aborted run every ${cfg.interval}.";
             }
           ];
 

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -196,7 +196,17 @@ _: {
       # the enable_caching = false the rclone module writes into the stanza.
       # Caching stays off because Proton's change-event system is unimplemented,
       # so a stale metadata cache feeds bisync's delta computation directly.
+      # --config and --workdir are the same class by a longer route, through the
+      # tuple key rather than a deletion: the key is direction/local/remote, so
+      # neither appears in it. A replacement --config that also defines
+      # protondrive: reuses this account's baseline and latch against another
+      # account's tree, and --workdir moves the bisync listings without moving
+      # the $marker under state_dir that claims they exist, so pointing it at
+      # /tmp (a tmpfs cleared on boot on this fleet) survives one reboot as a
+      # baseline with nothing behind it: the unlatchable repeat --dry-run is
+      # rejected for, reached with no intent to disable anything.
       rejectedFlags = [
+        "--config"
         "--conflict-loser"
         "--dry-run"
         "--force"
@@ -211,6 +221,7 @@ _: {
         "--resync-mode"
         "--syslog"
         "--use-json-log"
+        "--workdir"
       ];
       # Short options cluster, so they cannot be matched flag by flag: `-nv` is
       # --dry-run plus --verbose, and bisync gives --resync the shorthand `-1`.
@@ -496,13 +507,14 @@ _: {
             `--syslog`, `--use-json-log`): safety-abort detection reads the
             run's own stderr.
 
-            Arguments that override a safety flag or the sync mode
-            (`--conflict-loser`, `--dry-run`, `--force`, `--ignore-errors`,
-            `--max-delete`, `--protondrive-enable-caching`, `--resync`,
-            `--resync-mode`): each defeats the deletion cap, the withholding of
-            deletes from an errored run, the bisync safety checks, the baseline
-            the tuple marker records, or the caching-off the Beta backend
-            requires.
+            Arguments that override a safety flag, the sync mode, or the state
+            the tuple key does not cover (`--config`, `--conflict-loser`,
+            `--dry-run`, `--force`, `--ignore-errors`, `--max-delete`,
+            `--protondrive-enable-caching`, `--resync`, `--resync-mode`,
+            `--workdir`): each defeats the deletion cap, the withholding of
+            deletes from an errored run, the bisync safety checks, the
+            caching-off the Beta backend requires, or the correspondence between
+            the tuple marker and the account and listings it stands for.
 
             Short options are rejected wholesale because they cluster (`-nv` is
             `--dry-run` plus `--verbose`); use the long form. The equivalent
@@ -545,6 +557,16 @@ _: {
               Type = "oneshot";
               TimeoutStartSec = "2h";
               ExecStart = lib.getExe syncScript;
+              # local_path, remote and direction come from PROTON_DRIVE_* before
+              # any other logic, and this unit inherits the user manager's
+              # environment, which no eval-time guard sees: the same surface the
+              # RCLONE_ sweep closes, for the values that decide what is synced
+              # rather than how. A stray PROTON_DRIVE_DIRECTION=up turns every
+              # scheduled bisync into a one-way mirror keyed on a tuple of its
+              # own, so neither the configured tuple's baseline gate nor its
+              # abort latch applies to it. Dropped for the unit only, so the
+              # documented interactive override still works.
+              UnsetEnvironment = "PROTON_DRIVE_LOCAL PROTON_DRIVE_REMOTE PROTON_DRIVE_DIRECTION";
             };
           };
 

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -29,10 +29,12 @@
     4. For the 1Password source, the desktop app must be running and unlocked
        with CLI integration turned on: activation resolves the references
        through the setgid `op` wrapper from `programs._1password`, and the app
-       authorizes that call by its onepassword-cli group. The OTP reference must
-       return the stable otpauth:// URI without `?attribute=otp`; the module
-       extracts and obscures its seed. It does not store or request the changing
-       six-digit code.
+       authorizes that call by its onepassword-cli group. usernameRef and
+       passwordRef are mandatory; otpRef and mailboxPasswordRef may be left ""
+       (only if 2FA is enabled / only on two-password accounts, same as the
+       SOPS fields above). The OTP reference must return the stable otpauth://
+       URI without `?attribute=otp`; the module extracts and obscures its
+       seed. It does not store or request the changing six-digit code.
        Proton passkeys remain browser-only because the rclone backend logs in
        through the Proton API with username, password, mailbox password, and 2FA.
 
@@ -119,15 +121,17 @@ _: {
           }
           osConfig;
       protondriveOnePassword = protondriveAuth.onePassword or { };
+      # otp_secret_key and mailbox_password are per-account optional (2FA /
+      # two-password accounts only), so an empty ref opts out instead of
+      # failing readiness; a non-empty ref still must be an op:// reference.
+      protondriveOptionalRefValid = ref: ref == "" || lib.hasPrefix "op://" ref;
       protondriveOnePasswordReady =
         protondriveAuth.enable
         && protondriveAuth.authSource == "onePassword"
-        && lib.all (ref: lib.hasPrefix "op://" ref) [
-          (protondriveOnePassword.usernameRef or "")
-          (protondriveOnePassword.passwordRef or "")
-          (protondriveOnePassword.otpRef or "")
-          (protondriveOnePassword.mailboxPasswordRef or "")
-        ];
+        && lib.hasPrefix "op://" (protondriveOnePassword.usernameRef or "")
+        && lib.hasPrefix "op://" (protondriveOnePassword.passwordRef or "")
+        && protondriveOptionalRefValid (protondriveOnePassword.otpRef or "")
+        && protondriveOptionalRefValid (protondriveOnePassword.mailboxPasswordRef or "");
       protondriveReady =
         rcloneEnabled
         && (

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -79,7 +79,10 @@
       PROTON_DRIVE_REMOTE=protondrive:Folder proton-drive-sync
       PROTON_DRIVE_DIRECTION=up proton-drive-sync
     These values are part of the baseline tuple, so changing one requires
-    another explicit --resync.
+    another explicit --resync. The timer unit clears all three
+    (UnsetEnvironment=), so they affect interactive runs only: a scheduled fire
+    always syncs the configured direction, path and remote, whatever the user
+    manager's environment holds.
 
     proton-drive-sync            # run the configured sync immediately
     proton-drive-sync --resync   # establish (or rebuild) a nonempty baseline
@@ -226,8 +229,10 @@ _: {
       # Short options cluster, so they cannot be matched flag by flag: `-nv` is
       # --dry-run plus --verbose, and bisync gives --resync the shorthand `-1`.
       # Every rejected flag has a long form, so require it rather than parse
-      # clusters here.
-      isShortOption = arg: builtins.match "-[^-].*" arg != null;
+      # clusters here. The first character must be an option character, not just
+      # a non-dash: an rclone exclude rule is written `- *.partial`, which is a
+      # value rather than a flag and has no long form to demand.
+      isShortOption = arg: builtins.match "-[A-Za-z0-9].*" arg != null;
       rejectedArgs = lib.filter (
         arg: isShortOption arg || lib.any (flag: arg == flag || lib.hasPrefix "${flag}=" arg) rejectedFlags
       ) cfg.extraArgs;

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -32,9 +32,11 @@
        authorizes that call by its onepassword-cli group. usernameRef and
        passwordRef are mandatory; otpRef and mailboxPasswordRef may be left ""
        (only if 2FA is enabled / only on two-password accounts, same as the
-       SOPS fields above). The OTP reference must return the stable otpauth://
-       URI without `?attribute=otp`; the module extracts and obscures its
-       seed. It does not store or request the changing six-digit code.
+       SOPS fields above). The OTP reference must return the stable seed,
+       either as an otpauth:// URI carrying `secret=` or as the bare base32
+       seed 1Password stores when the operator pastes one; the module extracts
+       and obscures it. Omit `?attribute=otp`: it renders the changing
+       six-digit code, which the module rejects rather than storing.
        Proton passkeys remain browser-only because the rclone backend logs in
        through the Proton API with username, password, mailbox password, and 2FA.
 

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -183,6 +183,11 @@ _: {
       # drops the losing copy of every conflict, --dry-run leaves --resync
       # writing only `-dry` listings while the branch still records a baseline,
       # and --resync / --resync-mode turn a scheduled fire into a superset merge.
+      # --ignore-errors lifts the one guard --max-delete cannot express: rclone
+      # withholds destination deletes from a run that hit errors
+      # (fs/sync/sync.go returns fs.ErrorNotDeleting under
+      # `if accounting.Stats(ctx).Errored() && !s.ci.IgnoreErrors`), so against a
+      # Beta backend a partial listing failure would delete rather than abort.
       #
       # --protondrive-enable-caching belongs to the same class, and the command
       # line is its sole authority rather than a reinforcement: fs/configmap.go
@@ -195,6 +200,7 @@ _: {
         "--conflict-loser"
         "--dry-run"
         "--force"
+        "--ignore-errors"
         "--log-file"
         "--log-format"
         "--log-level"
@@ -491,10 +497,12 @@ _: {
             run's own stderr.
 
             Arguments that override a safety flag or the sync mode
-            (`--conflict-loser`, `--dry-run`, `--force`, `--max-delete`,
-            `--protondrive-enable-caching`, `--resync`, `--resync-mode`): each
-            defeats the deletion cap, the bisync safety checks, the baseline the
-            tuple marker records, or the caching-off the Beta backend requires.
+            (`--conflict-loser`, `--dry-run`, `--force`, `--ignore-errors`,
+            `--max-delete`, `--protondrive-enable-caching`, `--resync`,
+            `--resync-mode`): each defeats the deletion cap, the withholding of
+            deletes from an errored run, the bisync safety checks, the baseline
+            the tuple marker records, or the caching-off the Beta backend
+            requires.
 
             Short options are rejected wholesale because they cluster (`-nv` is
             `--dry-run` plus `--verbose`); use the long form. The equivalent

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -250,9 +250,12 @@ _: {
             # set abort without critical, so no listing is invalidated and no
             # --resync lockout follows: the next timer fire would recompute the
             # same abort from a full uncached listing of both sides, forever.
-            # Latch instead. "Safety abort" marks exactly the two checks whose
-            # documented release is --force (cmd/bisync/{deltas,operations}.go).
-            if [ "$rc" -ne 0 ] && grep -qF 'Safety abort' -- "$log"; then
+            # Latch instead. The pattern is rclone's own ERROR record for
+            # exactly the two checks whose documented release is --force
+            # (cmd/bisync/{deltas,operations}.go); matching the bare phrase
+            # would also latch on a transferred path that happens to contain it.
+            if [ "$rc" -ne 0 ] &&
+              grep -qE 'ERROR +: Safety abort: (too many deletes|all files were changed)' -- "$log"; then
               touch "$aborted"
               echo "proton-drive-sync: rclone's bisync safety check aborted the run without changing either side; latched the timer off. Confirm '$local_path' is mounted and its deletions are intended, then re-run 'proton-drive-sync --force'." >&2
             fi

--- a/modules/hm-apps/proton-drive.nix
+++ b/modules/hm-apps/proton-drive.nix
@@ -214,13 +214,22 @@ _: {
       # a bool, so --resilient=false reinstates bisync's -err listing rename on
       # a retryable critical error (cmd/bisync/operations.go skips it only under
       # `b.retryable && b.opt.Resilient && !b.opt.Resync`), turning the
-      # offline-at-boot retry the unit relies on into that same repeat. Every
-      # flag the script puts on the command line is here, which is the invariant
-      # the check asserts against rejectedExtraArgs below.
+      # offline-at-boot retry the unit relies on into that same repeat.
+      # --create-empty-src-dirs decides whether an empty source directory is
+      # mirrored at all, and it is on all four invocations, so flipping it
+      # changes what the bisync listings describe from one fire to the next.
+      #
+      # The invariant is that every flag the script passes is either here or
+      # deliberately tunable (--transfers, --checkers, and --max-depth on the
+      # down probe, which extra never reaches). The check reads the stub's
+      # recorded argv and fails on any flag covered by neither, because stating
+      # this in a comment is how --create-empty-src-dirs stayed outside both
+      # lists while four rounds patched the ones next to it.
       rejectedFlags = [
         "--config"
         "--conflict-loser"
         "--conflict-resolve"
+        "--create-empty-src-dirs"
         "--dry-run"
         "--force"
         "--ignore-errors"
@@ -538,13 +547,16 @@ _: {
 
             Arguments that override a safety flag, the sync mode, or the state
             the tuple key does not cover (`--config`, `--conflict-loser`,
-            `--conflict-resolve`, `--dry-run`, `--force`, `--ignore-errors`,
-            `--max-delete`, `--protondrive-enable-caching`, `--resilient`,
-            `--resync`, `--resync-mode`, `--workdir`): each defeats the deletion
-            cap, the withholding of deletes from an errored run, the bisync
-            safety checks, the conflict winner, the retry the unit relies on,
-            the caching-off the Beta backend requires, or the correspondence
-            between the tuple marker and the account and listings it stands for.
+            `--conflict-resolve`, `--create-empty-src-dirs`, `--dry-run`,
+            `--force`, `--ignore-errors`, `--max-delete`,
+            `--protondrive-enable-caching`, `--resilient`, `--resync`,
+            `--resync-mode`, `--workdir`): each defeats the deletion cap, the
+            withholding of deletes from an errored run, the bisync safety
+            checks, the conflict winner, the retry the unit relies on, the
+            caching-off the Beta backend requires, the mirroring of empty
+            directories, or the correspondence between the tuple marker and the
+            account and listings it stands for. `--transfers`, `--checkers` and
+            everything else stay tunable.
 
             Short options are rejected wholesale because they cluster (`-nv` is
             `--dry-run` plus `--verbose`); use the long form. The equivalent

--- a/modules/hm-apps/rclone-protondrive-otp-check.nix
+++ b/modules/hm-apps/rclone-protondrive-otp-check.nix
@@ -200,6 +200,17 @@
               run_activation_keeping_config
             }
 
+            # Home Manager's run echoes instead of executing under --dry-run,
+            # so anything the entry writes outside run survives a dry run.
+            run_dry_activation() {
+              rc=0
+              (
+                run() { echo "DRY: $*"; }
+                . "$check_root/activation.sh"
+              ) > "$check_root/stdout" 2> "$check_root/stderr" || rc=$?
+              printf '%s' "$rc"
+            }
+
             run_mailbox_activation() {
               rm -rf -- "$check_root/config"
               rc=0
@@ -322,6 +333,25 @@
             [ "$rc" -ne 0 ] || fail "a blank mailbox reference must fail activation"
             ! grep -q '^\[protondrive\]$' "$rendered" ||
               fail "a blank mailbox reference must not render a stanza"
+
+            # A dry run must not advance the fingerprint while leaving the
+            # config it describes untouched: the next real activation would read
+            # that as an unchanged credential set and graft the pre-rotation
+            # session keys onto the post-rotation stanza.
+            fingerprint="$check_root/config/rclone/protondrive-credentials.fingerprint"
+            rc=$(OP_STUB_OTP="$seed" run_activation)
+            [ "$rc" -eq 0 ] || fail "seeding the dry-run path must succeed (exit $rc)"
+            before=$(cat "$fingerprint")
+            config_before=$(cat "$rendered")
+
+            rc=$(OP_STUB_OTP="$seed" OP_STUB_PASSWORD=rotated run_dry_activation)
+            [ "$rc" -eq 0 ] || fail "a dry run must not fail activation (exit $rc)"
+            [ "$(cat "$fingerprint")" = "$before" ] ||
+              fail "a dry run must not advance the credential fingerprint"
+            [ "$(cat "$rendered")" = "$config_before" ] ||
+              fail "a dry run must not rewrite the rendered config"
+            [ -z "$(find "$check_root/config/rclone" -name 'protondrive-credentials.fingerprint.*' -print -quit)" ] ||
+              fail "a dry run must not leave a staged fingerprint behind"
 
             touch "$out"
           '';

--- a/modules/hm-apps/rclone-protondrive-otp-check.nix
+++ b/modules/hm-apps/rclone-protondrive-otp-check.nix
@@ -17,8 +17,17 @@
   stub replays a scripted field value, and the rclone obscure stub is
   deterministic where the real one draws a random IV per call.
 
+  Both credential sources are driven, not just the op:// one the check is named
+  for. The entry assembles its credential fingerprint per source, from plaintext
+  op read values on one side and the already-obscured secret values on the
+  other, and only the digest, comparison and session-key graft below them are
+  shared. With the sops assembly unexecuted, a defect confined to it grafted
+  pre-rotation client_uid/client_access_token onto a post-rotation stanza with
+  every op:// assertion still green.
+
   The activation entry is a raw DAG string, so unlike the sync script it never
-  passes through writeShellApplication's shellcheck; the check lints it here.
+  passes through writeShellApplication's shellcheck; the check lints all three
+  rendered entries here.
 
   Runs under the build sandbox's private /tmp because xdg.configHome is pinned at
   eval time; the check creates that whole root itself and fails when it already
@@ -73,8 +82,19 @@
             printf 'obscured:%s' "$(cat)"
           '';
 
+          # protondriveSopsReady gates on an eval-time pathExists against
+          # secretsRoot, while the file the sops arm sources at run time is the
+          # osConfig secret path below, which the runner writes and rewrites.
+          # The two are independent, so the fixture arms the branch without any
+          # decryptable secret existing.
+          sopsEnv = "${root}/protondrive-env";
+
           mkHm =
-            { mailboxPasswordRef }:
+            {
+              mailboxPasswordRef,
+              authSource ? "onePassword",
+              secretsRoot ? "${./proton-drive-check-fixtures}/missing",
+            }:
             inputs.home-manager.lib.homeManagerConfiguration {
               inherit pkgs;
               modules = [
@@ -98,18 +118,23 @@
               extraSpecialArgs = {
                 # No secret exists at eval under the op:// source, and a present
                 # one would additionally arm the gdrive and sops branches.
-                secretsRoot = "${./proton-drive-check-fixtures}/missing";
+                inherit secretsRoot;
                 osConfig = {
                   security.repoSecrets.enable = true;
                   # Selects "${security.wrapperDir}/op" as the op executable,
                   # which is the only seam the script offers for that binary.
                   programs._1password.enable = true;
                   security.wrapperDir = "${opStub}/bin";
+                  # Inert under the op:// source: protondriveSopsReady tests
+                  # authSource and the secretsRoot fixture before this path
+                  # reaches the rendered script, so the op:// activation text is
+                  # byte-identical with and without it.
+                  sops.secrets."rclone/protondrive-env".path = sopsEnv;
                   programs.rclone.extended = {
                     enable = true;
                     protonDrive = {
                       enable = true;
-                      authSource = "onePassword";
+                      inherit authSource;
                       onePassword = {
                         usernameRef = "op://check/protondrive/username";
                         passwordRef = "op://check/protondrive/password";
@@ -131,6 +156,19 @@
             (mkHm { mailboxPasswordRef = "op://check/protondrive/mailbox"; })
             .config.home.activation.configureRcloneConfig.data;
 
+          # The credential fingerprint that decides whether the backend's
+          # session keys survive an activation is assembled per credential
+          # source: the op:// arm digests the plaintext op read values, this one
+          # the already-obscured values the secret carries. Only the shared
+          # digest, comparison and graft below them were under test, so a defect
+          # confined to this assembly left every existing assertion green.
+          sopsActivation =
+            (mkHm {
+              mailboxPasswordRef = "";
+              authSource = "sops";
+              secretsRoot = ./proton-drive-check-fixtures;
+            }).config.home.activation.configureRcloneConfig.data;
+
           # RFC 4226 R6 puts the shared secret at 128 bits; this is the 160-bit
           # base32 shape Proton issues.
           seed = "MFRGGZDFMZTWQ2LKNNWG23TPOBYXE43U";
@@ -149,6 +187,7 @@
             check_root=${lib.escapeShellArg root}
             rendered=${lib.escapeShellArg "${root}/config/rclone/rclone.conf"}
             seed=${lib.escapeShellArg seed}
+            sops_env=${lib.escapeShellArg sopsEnv}
 
             # Every path here is fixed at eval time, so without the sandbox's
             # private /tmp another user could plant the root and have the
@@ -172,12 +211,17 @@
             ${mailboxActivation}
             MAILBOX_ACTIVATION_EOF
 
+            cat > "$check_root/activation-sops.sh" <<'SOPS_ACTIVATION_EOF'
+            ${sopsActivation}
+            SOPS_ACTIVATION_EOF
+
             # writeShellApplication lints the sync script, but an activation
             # entry is a raw string that nothing lints, which is how this branch
             # grew to its current size unchecked. SC1090 is excluded because
             # both env files it names are resolved at run time by design.
             shellcheck --shell=bash --severity=warning --exclude=SC1090 \
-              "$check_root/activation.sh" "$check_root/activation-mailbox.sh"
+              "$check_root/activation.sh" "$check_root/activation-mailbox.sh" \
+              "$check_root/activation-sops.sh"
 
             fail() {
               echo "hm-apps/rclone-protondrive-otp: $1" >&2
@@ -219,6 +263,30 @@
                 . "$check_root/activation-mailbox.sh"
               ) > "$check_root/stdout" 2> "$check_root/stderr" || rc=$?
               printf '%s' "$rc"
+            }
+
+            run_sops_activation_keeping_config() {
+              rc=0
+              (
+                run() { "$@"; }
+                . "$check_root/activation-sops.sh"
+              ) > "$check_root/stdout" 2> "$check_root/stderr" || rc=$?
+              printf '%s' "$rc"
+            }
+
+            run_sops_activation() {
+              rm -rf -- "$check_root/config"
+              run_sops_activation_keeping_config
+            }
+
+            # sops stores these already obscured, which is why this arm never
+            # calls rclone and why its fingerprint material is the ciphertext
+            # rather than the plaintext the op:// arm digests.
+            write_sops_env() {
+              printf 'PROTONDRIVE_USERNAME=%s\n' user@proton.me > "$sops_env"
+              printf 'PROTONDRIVE_PASSWORD=%s\n' "$1" >> "$sops_env"
+              printf 'PROTONDRIVE_OTP_SECRET_KEY=%s\n' stored-otp >> "$sops_env"
+              printf 'PROTONDRIVE_MAILBOX_PASSWORD=%s\n' stored-mailbox >> "$sops_env"
             }
 
             # A seed pasted verbatim into the 1Password field, which is what op
@@ -331,7 +399,11 @@
 
             rc=$(OP_STUB_OTP="$seed" OP_STUB_MAILBOX="" run_mailbox_activation)
             [ "$rc" -ne 0 ] || fail "a blank mailbox reference must fail activation"
-            ! grep -q '^\[protondrive\]$' "$rendered" ||
+            # The exit 1 precedes the run mv, so the config is absent rather
+            # than stanza-free; grep on a missing path would satisfy this by
+            # exiting 2, which is not the same assertion.
+            [ ! -e "$rendered" ] ||
+              ! grep -q '^\[protondrive\]$' "$rendered" ||
               fail "a blank mailbox reference must not render a stanza"
 
             # A dry run must not advance the fingerprint while leaving the
@@ -352,6 +424,57 @@
               fail "a dry run must not rewrite the rendered config"
             [ -z "$(find "$check_root/config/rclone" -name 'protondrive-credentials.fingerprint.*' -print -quit)" ] ||
               fail "a dry run must not leave a staged fingerprint behind"
+
+            # The sops arm reaches the same fingerprint comparison through its
+            # own credential-material assembly, which nothing executed: a defect
+            # confined to it grafts pre-rotation session keys onto a
+            # post-rotation stanza with every assertion above still green.
+            write_sops_env already-obscured-1
+            rc=$(run_sops_activation)
+            [ "$rc" -eq 0 ] || fail "a materialized sops secret must not fail activation (exit $rc)"
+            # Verbatim, not "obscured:...": the secret already holds the
+            # obscured form, so this arm must not re-obscure it.
+            grep -qxF 'password = already-obscured-1' "$rendered" ||
+              fail "the sops source must render the secret's obscured password verbatim"
+            grep -qxF 'otp_secret_key = stored-otp' "$rendered" ||
+              fail "the sops source must render otp_secret_key"
+            grep -qxF 'mailbox_password = stored-mailbox' "$rendered" ||
+              fail "the sops source must render mailbox_password"
+
+            printf 'client_uid = uid-1\nclient_access_token = tok-1\n' >> "$rendered"
+            rc=$(run_sops_activation_keeping_config)
+            [ "$rc" -eq 0 ] || fail "an unchanged sops secret must not fail activation (exit $rc)"
+            grep -qxF 'client_uid = uid-1' "$rendered" ||
+              fail "an unchanged sops secret must preserve the session keys"
+            grep -qxF 'client_access_token = tok-1' "$rendered" ||
+              fail "an unchanged sops secret must preserve every session key"
+
+            write_sops_env already-obscured-2
+            rc=$(run_sops_activation_keeping_config)
+            [ "$rc" -eq 0 ] || fail "a rotated sops password must not fail activation (exit $rc)"
+            ! grep -q '^client_uid = ' "$rendered" ||
+              fail "a rotated sops password must drop the session keys"
+
+            # sops-nix materializes the secret after the switch, so an absent
+            # one is the first-activation case, not a configuration error.
+            # Removed rather than chmod 000, because the builder can be uid 0.
+            printf 'client_uid = uid-2\n' >> "$rendered"
+            rm -f -- "$sops_env"
+            rc=$(run_sops_activation_keeping_config)
+            [ "$rc" -eq 0 ] || fail "an unmaterialized sops secret must not fail activation (exit $rc)"
+            grep -q 'env file is missing or unreadable' "$check_root/stderr" ||
+              fail "an unmaterialized sops secret must warn"
+            grep -qxF 'client_uid = uid-2' "$rendered" ||
+              fail "an unmaterialized sops secret must carry the previous stanza forward"
+
+            # A secret that materialized without the login pair is a
+            # configuration error, and takes the same exit 1 the op:// arm does.
+            printf 'PROTONDRIVE_USERNAME=%s\n' user@proton.me > "$sops_env"
+            rc=$(run_sops_activation)
+            [ "$rc" -ne 0 ] || fail "a sops secret with no PROTONDRIVE_PASSWORD must fail activation"
+            [ ! -e "$rendered" ] ||
+              ! grep -q '^\[protondrive\]$' "$rendered" ||
+              fail "a rejected sops secret must not render a [protondrive] stanza"
 
             touch "$out"
           '';

--- a/modules/hm-apps/rclone-protondrive-otp-check.nix
+++ b/modules/hm-apps/rclone-protondrive-otp-check.nix
@@ -73,54 +73,63 @@
             printf 'obscured:%s' "$(cat)"
           '';
 
-          hm = inputs.home-manager.lib.homeManagerConfiguration {
-            inherit pkgs;
-            modules = [
-              # The module declares a sops template for the r2 endpoint
-              # unconditionally, so its options must exist even though
-              # home.r2Secrets.enable is off here.
-              inputs.sops-nix.homeManagerModules.sops
-              config.flake.homeManagerModules.apps.rclone
-              {
-                home = {
-                  username = "hm-smoke";
-                  homeDirectory = "${root}/home";
-                  stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
-                  enableNixpkgsReleaseCheck = false;
-                };
-                programs.home-manager.enable = true;
-                programs.rclone.package = rcloneStub;
-                xdg.configHome = "${root}/config";
-              }
-            ];
-            extraSpecialArgs = {
-              # No secret exists at eval under the op:// source, and a present
-              # one would additionally arm the gdrive and sops branches.
-              secretsRoot = "${./proton-drive-check-fixtures}/missing";
-              osConfig = {
-                security.repoSecrets.enable = true;
-                # Selects "${security.wrapperDir}/op" as the op executable, which
-                # is the only seam the activation script offers for that binary.
-                programs._1password.enable = true;
-                security.wrapperDir = "${opStub}/bin";
-                programs.rclone.extended = {
-                  enable = true;
-                  protonDrive = {
+          mkHm =
+            { mailboxPasswordRef }:
+            inputs.home-manager.lib.homeManagerConfiguration {
+              inherit pkgs;
+              modules = [
+                # The module declares a sops template for the r2 endpoint
+                # unconditionally, so its options must exist even though
+                # home.r2Secrets.enable is off here.
+                inputs.sops-nix.homeManagerModules.sops
+                config.flake.homeManagerModules.apps.rclone
+                {
+                  home = {
+                    username = "hm-smoke";
+                    homeDirectory = "${root}/home";
+                    stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
+                    enableNixpkgsReleaseCheck = false;
+                  };
+                  programs.home-manager.enable = true;
+                  programs.rclone.package = rcloneStub;
+                  xdg.configHome = "${root}/config";
+                }
+              ];
+              extraSpecialArgs = {
+                # No secret exists at eval under the op:// source, and a present
+                # one would additionally arm the gdrive and sops branches.
+                secretsRoot = "${./proton-drive-check-fixtures}/missing";
+                osConfig = {
+                  security.repoSecrets.enable = true;
+                  # Selects "${security.wrapperDir}/op" as the op executable,
+                  # which is the only seam the script offers for that binary.
+                  programs._1password.enable = true;
+                  security.wrapperDir = "${opStub}/bin";
+                  programs.rclone.extended = {
                     enable = true;
-                    authSource = "onePassword";
-                    onePassword = {
-                      usernameRef = "op://check/protondrive/username";
-                      passwordRef = "op://check/protondrive/password";
-                      otpRef = "op://check/protondrive/one-time password";
-                      mailboxPasswordRef = "";
+                    protonDrive = {
+                      enable = true;
+                      authSource = "onePassword";
+                      onePassword = {
+                        usernameRef = "op://check/protondrive/username";
+                        passwordRef = "op://check/protondrive/password";
+                        otpRef = "op://check/protondrive/one-time password";
+                        inherit mailboxPasswordRef;
+                      };
                     };
                   };
                 };
               };
             };
-          };
 
-          activation = hm.config.home.activation.configureRcloneConfig.data;
+          activation = (mkHm { mailboxPasswordRef = ""; }).config.home.activation.configureRcloneConfig.data;
+
+          # A two-password account. Kept separate because the ref is what
+          # decides between opting out and reading a field that must not be
+          # blank, and that is exactly the distinction under test.
+          mailboxActivation =
+            (mkHm { mailboxPasswordRef = "op://check/protondrive/mailbox"; })
+            .config.home.activation.configureRcloneConfig.data;
 
           # RFC 4226 R6 puts the shared secret at 128 bits; this is the 160-bit
           # base32 shape Proton issues.
@@ -159,12 +168,16 @@
             ${activation}
             ACTIVATION_EOF
 
+            cat > "$check_root/activation-mailbox.sh" <<'MAILBOX_ACTIVATION_EOF'
+            ${mailboxActivation}
+            MAILBOX_ACTIVATION_EOF
+
             # writeShellApplication lints the sync script, but an activation
             # entry is a raw string that nothing lints, which is how this branch
             # grew to its current size unchecked. SC1090 is excluded because
             # both env files it names are resolved at run time by design.
             shellcheck --shell=bash --severity=warning --exclude=SC1090 \
-              "$check_root/activation.sh"
+              "$check_root/activation.sh" "$check_root/activation-mailbox.sh"
 
             fail() {
               echo "hm-apps/rclone-protondrive-otp: $1" >&2
@@ -185,6 +198,16 @@
             run_activation() {
               rm -rf -- "$check_root/config"
               run_activation_keeping_config
+            }
+
+            run_mailbox_activation() {
+              rm -rf -- "$check_root/config"
+              rc=0
+              (
+                run() { "$@"; }
+                . "$check_root/activation-mailbox.sh"
+              ) > "$check_root/stdout" 2> "$check_root/stderr" || rc=$?
+              printf '%s' "$rc"
             }
 
             # A seed pasted verbatim into the 1Password field, which is what op
@@ -215,7 +238,7 @@
             for code in 234567 123456 23456723; do
               rc=$(OP_STUB_OTP="$code" run_activation)
               [ "$rc" -ne 0 ] || fail "the rendered six-digit code $code must fail activation"
-              grep -q 'stable TOTP seed' "$check_root/stderr" ||
+              grep -q 'OTP reference did not yield' "$check_root/stderr" ||
                 fail "the rendered code $code must be rejected by the OTP diagnostic"
             done
 
@@ -249,7 +272,7 @@
               fail "an unavailable 1Password must warn"
             # The seed was never read, so reporting it as malformed would turn a
             # transient lock into a failed switch.
-            ! grep -q 'stable TOTP seed' "$check_root/stderr" ||
+            ! grep -q 'OTP reference did not yield' "$check_root/stderr" ||
               fail "an unavailable 1Password must not report an OTP validation failure"
 
             rc=$(OP_STUB_FAIL=1 run_activation)
@@ -278,6 +301,27 @@
             [ "$rc" -eq 0 ] || fail "a rotated password must not fail activation (exit $rc)"
             ! grep -q '^client_uid = ' "$rendered" ||
               fail "a rotated password must drop the session keys"
+
+            # ?attribute=otp renders the code into the URI's own secret=, so
+            # validating only the bare arm would let the same six digits through
+            # by the other shape.
+            rc=$(OP_STUB_OTP="otpauth://totp/Proton:me?secret=234567&issuer=Proton" run_activation)
+            [ "$rc" -ne 0 ] || fail "an otpauth:// URI carrying a rendered code must fail activation"
+            rc=$(OP_STUB_OTP="otpauth://totp/Proton:me?secret=MFRG%3D&issuer=Proton" run_activation)
+            [ "$rc" -ne 0 ] || fail "an otpauth:// URI whose secret= is not decodable base32 must fail activation"
+
+            # A configured mailboxPasswordRef that reads back blank would
+            # otherwise render a stanza that authenticates and then cannot
+            # decrypt. Opting out is an empty ref, which never reaches op read.
+            rc=$(OP_STUB_OTP="$seed" OP_STUB_MAILBOX=mailbox-secret run_mailbox_activation)
+            [ "$rc" -eq 0 ] || fail "a populated mailbox reference must not fail activation (exit $rc)"
+            grep -qxF 'mailbox_password = obscured:mailbox-secret' "$rendered" ||
+              fail "a populated mailbox reference must render mailbox_password"
+
+            rc=$(OP_STUB_OTP="$seed" OP_STUB_MAILBOX="" run_mailbox_activation)
+            [ "$rc" -ne 0 ] || fail "a blank mailbox reference must fail activation"
+            ! grep -q '^\[protondrive\]$' "$rendered" ||
+              fail "a blank mailbox reference must not render a stanza"
 
             touch "$out"
           '';

--- a/modules/hm-apps/rclone-protondrive-otp-check.nix
+++ b/modules/hm-apps/rclone-protondrive-otp-check.nix
@@ -1,0 +1,285 @@
+/*
+  Check: the 1Password OTP reference resolves to a TOTP seed, or fails loudly
+  (modules/hm-apps/rclone.nix, activation entry configureRcloneConfig).
+
+  That parsing decides between three outcomes on every activation of every
+  shareCommon host, because modules/hosts/common/rclone-protondrive-1password.nix
+  ships otpRef for all of them: render otp_secret_key, exit 1 and abort the whole
+  Home Manager activation, or render a [protondrive] stanza with no otp_secret_key
+  at all. Only the third is silent, and it is the one that produces a remote which
+  cannot authenticate. Nothing executed the branch before this check: the sibling
+  proton-drive-sync check covers the sync script, not the activation script.
+
+  The activation text is parameterized entirely through shell variables assigned
+  at its top, so it runs here unmodified. security.wrapperDir selects the op
+  binary and programs.rclone.package selects the rclone binary, so pointing both
+  at stubs puts the parsing under test rather than 1Password or rclone. The op
+  stub replays a scripted field value, and the rclone obscure stub is
+  deterministic where the real one draws a random IV per call.
+
+  The activation entry is a raw DAG string, so unlike the sync script it never
+  passes through writeShellApplication's shellcheck; the check lints it here.
+
+  Runs under the build sandbox's private /tmp because xdg.configHome is pinned at
+  eval time; the check creates that whole root itself and fails when it already
+  exists, so an unsandboxed build cannot pass on stale state or write through a
+  planted symlink.
+*/
+{
+  lib,
+  inputs,
+  config,
+  ...
+}:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks."hm-apps/rclone-protondrive-otp" =
+        let
+          root = "/tmp/rclone-protondrive-otp-check";
+
+          opStub = pkgs.writeShellScriptBin "op" ''
+            if [ "''${1:-}" != read ]; then
+              echo "op stub: expected 'read', got: $*" >&2
+              exit 1
+            fi
+            # A locked desktop app, and equally the exit 124 of the timeout the
+            # script wraps each read in.
+            if [ -n "''${OP_STUB_FAIL-}" ]; then
+              echo "op stub: vault is locked" >&2
+              exit 1
+            fi
+            ref="''${3:-}"
+            case "''${ref##*/}" in
+              username) printf '%s' "''${OP_STUB_USERNAME-user@proton.me}" ;;
+              password) printf '%s' "''${OP_STUB_PASSWORD-proton-password}" ;;
+              "one-time password") printf '%s' "''${OP_STUB_OTP-}" ;;
+              mailbox) printf '%s' "''${OP_STUB_MAILBOX-}" ;;
+              *)
+                echo "op stub: unknown reference: $ref" >&2
+                exit 1
+                ;;
+            esac
+          '';
+
+          # The real obscure draws a fresh random IV per call, so its output
+          # cannot be asserted on; this one is reversible by inspection.
+          rcloneStub = pkgs.writeShellScriptBin "rclone" ''
+            if [ "''${1:-}" != obscure ]; then
+              echo "rclone stub: expected 'obscure', got: $*" >&2
+              exit 1
+            fi
+            printf 'obscured:%s' "$(cat)"
+          '';
+
+          hm = inputs.home-manager.lib.homeManagerConfiguration {
+            inherit pkgs;
+            modules = [
+              # The module declares a sops template for the r2 endpoint
+              # unconditionally, so its options must exist even though
+              # home.r2Secrets.enable is off here.
+              inputs.sops-nix.homeManagerModules.sops
+              config.flake.homeManagerModules.apps.rclone
+              {
+                home = {
+                  username = "hm-smoke";
+                  homeDirectory = "${root}/home";
+                  stateVersion = (lib.importJSON "${inputs.home-manager}/release.json").release;
+                  enableNixpkgsReleaseCheck = false;
+                };
+                programs.home-manager.enable = true;
+                programs.rclone.package = rcloneStub;
+                xdg.configHome = "${root}/config";
+              }
+            ];
+            extraSpecialArgs = {
+              # No secret exists at eval under the op:// source, and a present
+              # one would additionally arm the gdrive and sops branches.
+              secretsRoot = "${./proton-drive-check-fixtures}/missing";
+              osConfig = {
+                security.repoSecrets.enable = true;
+                # Selects "${security.wrapperDir}/op" as the op executable, which
+                # is the only seam the activation script offers for that binary.
+                programs._1password.enable = true;
+                security.wrapperDir = "${opStub}/bin";
+                programs.rclone.extended = {
+                  enable = true;
+                  protonDrive = {
+                    enable = true;
+                    authSource = "onePassword";
+                    onePassword = {
+                      usernameRef = "op://check/protondrive/username";
+                      passwordRef = "op://check/protondrive/password";
+                      otpRef = "op://check/protondrive/one-time password";
+                      mailboxPasswordRef = "";
+                    };
+                  };
+                };
+              };
+            };
+          };
+
+          activation = hm.config.home.activation.configureRcloneConfig.data;
+
+          # RFC 4226 R6 puts the shared secret at 128 bits; this is the 160-bit
+          # base32 shape Proton issues.
+          seed = "MFRGGZDFMZTWQ2LKNNWG23TPOBYXE43U";
+        in
+        pkgs.runCommand "rclone-protondrive-otp-check"
+          {
+            passthru.runtimeCheck = true;
+            nativeBuildInputs = [
+              pkgs.coreutils
+              pkgs.shellcheck
+            ];
+          }
+          ''
+            set -o errexit -o nounset -o pipefail
+
+            check_root=${lib.escapeShellArg root}
+            rendered=${lib.escapeShellArg "${root}/config/rclone/rclone.conf"}
+            seed=${lib.escapeShellArg seed}
+
+            # Every path here is fixed at eval time, so without the sandbox's
+            # private /tmp another user could plant the root and have the
+            # activation script's mkdir and writes follow its symlinks. mkdir
+            # fails on an existing directory or symlink, which also catches
+            # leftover state from an earlier unsandboxed run.
+            if ! mkdir -m 700 -- "$check_root" 2>/dev/null; then
+              echo "hm-apps/rclone-protondrive-otp: $check_root already exists; this check needs the sandbox's private /tmp" >&2
+              exit 1
+            fi
+            trap 'rm -rf -- "$check_root"' EXIT
+
+            export HOME="$check_root/home"
+            mkdir -p "$HOME"
+
+            cat > "$check_root/activation.sh" <<'ACTIVATION_EOF'
+            ${activation}
+            ACTIVATION_EOF
+
+            # writeShellApplication lints the sync script, but an activation
+            # entry is a raw string that nothing lints, which is how this branch
+            # grew to its current size unchecked. SC1090 is excluded because
+            # both env files it names are resolved at run time by design.
+            shellcheck --shell=bash --severity=warning --exclude=SC1090 \
+              "$check_root/activation.sh"
+
+            fail() {
+              echo "hm-apps/rclone-protondrive-otp: $1" >&2
+              exit 1
+            }
+
+            # Home Manager defines run for its activation scripts; nothing here
+            # exercises its dry-run behaviour, so pass the command through.
+            run_activation_keeping_config() {
+              rc=0
+              (
+                run() { "$@"; }
+                . "$check_root/activation.sh"
+              ) > "$check_root/stdout" 2> "$check_root/stderr" || rc=$?
+              printf '%s' "$rc"
+            }
+
+            run_activation() {
+              rm -rf -- "$check_root/config"
+              run_activation_keeping_config
+            }
+
+            # A seed pasted verbatim into the 1Password field, which is what op
+            # read returns when the operator did not store an otpauth:// URI.
+            rc=$(OP_STUB_OTP="$seed" run_activation)
+            [ "$rc" -eq 0 ] || fail "a bare base32 seed must not fail activation (exit $rc)"
+            grep -qxF "otp_secret_key = obscured:$seed" "$rendered" ||
+              fail "a bare base32 seed must render otp_secret_key"
+
+            # 1Password renders the field as this URI when the operator stored a
+            # full otpauth:// value; the seed must come back identical.
+            rc=$(OP_STUB_OTP="otpauth://totp/Proton:me?secret=$seed&issuer=Proton" run_activation)
+            [ "$rc" -eq 0 ] || fail "an otpauth:// URI must not fail activation (exit $rc)"
+            grep -qxF "otp_secret_key = obscured:$seed" "$rendered" ||
+              fail "an otpauth:// URI must render the same otp_secret_key as its bare seed"
+
+            # 1Password groups the printed seed for legibility; op read returns
+            # the spacing verbatim.
+            rc=$(OP_STUB_OTP="MFRG GZDF MZTW Q2LK NNWG 23TP OBYX E43U" run_activation)
+            [ "$rc" -eq 0 ] || fail "a space-grouped seed must not fail activation (exit $rc)"
+            grep -qxF "otp_secret_key = obscured:$seed" "$rendered" ||
+              fail "a space-grouped seed must render the same otp_secret_key"
+
+            # ?attribute=otp renders the current code instead of the seed.
+            # Digits 2-7 are base32, so a code can satisfy a bare character-class
+            # test on length alone; obscuring one yields a remote that cannot
+            # authenticate and never says why.
+            for code in 234567 123456 23456723; do
+              rc=$(OP_STUB_OTP="$code" run_activation)
+              [ "$rc" -ne 0 ] || fail "the rendered six-digit code $code must fail activation"
+              grep -q 'stable TOTP seed' "$check_root/stderr" ||
+                fail "the rendered code $code must be rejected by the OTP diagnostic"
+            done
+
+            # A literal secret= outside the query string once matched the case
+            # guard while failing the extraction, which left the seed empty,
+            # kept the state at ready, and rendered a stanza with no
+            # otp_secret_key rather than failing.
+            rc=$(OP_STUB_OTP="otpauth://totp/xsecret=y" run_activation)
+            [ "$rc" -ne 0 ] || fail "an otpauth:// URI whose secret= is not a query parameter must fail activation"
+            [ ! -e "$rendered" ] ||
+              ! grep -q '^\[protondrive\]$' "$rendered" ||
+              fail "a rejected OTP value must not render a [protondrive] stanza"
+
+            rc=$(OP_STUB_OTP="otpauth://totp/Proton:me?issuer=Proton" run_activation)
+            [ "$rc" -ne 0 ] || fail "an otpauth:// URI with no secret= must fail activation"
+
+            rc=$(OP_STUB_OTP="" run_activation)
+            [ "$rc" -ne 0 ] || fail "an empty OTP value must fail activation while otpRef is set"
+
+            # The lookup-failure branch gates whether the OTP parsing runs at
+            # all, so it decides whether a locked vault reads as a transient
+            # skip or as the configuration error that exits 1. Seed a good
+            # config first, then lock the vault without clearing it.
+            rc=$(OP_STUB_OTP="$seed" run_activation)
+            [ "$rc" -eq 0 ] || fail "seeding the preserve path must succeed (exit $rc)"
+            rc=$(OP_STUB_FAIL=1 run_activation_keeping_config)
+            [ "$rc" -eq 0 ] || fail "an unavailable 1Password must not fail activation (exit $rc)"
+            grep -qxF "otp_secret_key = obscured:$seed" "$rendered" ||
+              fail "an unavailable 1Password must carry the previous stanza forward"
+            grep -q 'credentials are unavailable' "$check_root/stderr" ||
+              fail "an unavailable 1Password must warn"
+            # The seed was never read, so reporting it as malformed would turn a
+            # transient lock into a failed switch.
+            ! grep -q 'stable TOTP seed' "$check_root/stderr" ||
+              fail "an unavailable 1Password must not report an OTP validation failure"
+
+            rc=$(OP_STUB_FAIL=1 run_activation)
+            [ "$rc" -eq 0 ] ||
+              fail "an unavailable 1Password with nothing to preserve must not fail activation (exit $rc)"
+            ! grep -q '^\[protondrive\]$' "$rendered" ||
+              fail "an unavailable 1Password with nothing to preserve must not render a stanza"
+
+            # The backend writes these into the stanza after a login, and Proton
+            # rate-limits repeated logins, so they must survive an activation
+            # that changed nothing. obscure draws a random IV per call, which is
+            # why the rendered ciphertext cannot be the comparison and a
+            # fingerprint of the 1Password values stands in for it.
+            rc=$(OP_STUB_OTP="$seed" run_activation)
+            [ "$rc" -eq 0 ] || fail "seeding the session-preservation path must succeed (exit $rc)"
+            printf 'client_uid = uid-1\nclient_access_token = tok-1\n' >> "$rendered"
+
+            rc=$(OP_STUB_OTP="$seed" run_activation_keeping_config)
+            [ "$rc" -eq 0 ] || fail "an unchanged credential set must not fail activation (exit $rc)"
+            grep -qxF 'client_uid = uid-1' "$rendered" ||
+              fail "an unchanged credential set must preserve the session keys"
+            grep -qxF 'client_access_token = tok-1' "$rendered" ||
+              fail "an unchanged credential set must preserve every session key"
+
+            rc=$(OP_STUB_OTP="$seed" OP_STUB_PASSWORD=rotated run_activation_keeping_config)
+            [ "$rc" -eq 0 ] || fail "a rotated password must not fail activation (exit $rc)"
+            ! grep -q '^client_uid = ' "$rendered" ||
+              fail "a rotated password must drop the session keys"
+
+            touch "$out"
+          '';
+    };
+}

--- a/modules/hm-apps/rclone-protondrive-otp-check.nix
+++ b/modules/hm-apps/rclone-protondrive-otp-check.nix
@@ -53,6 +53,11 @@
               echo "op stub: expected 'read', got: $*" >&2
               exit 1
             fi
+            # Counted so the check can assert that a failing read short-circuits
+            # the remaining three rather than waiting out four timeouts.
+            if [ -n "''${OP_STUB_CALLS-}" ]; then
+              printf '%s\n' "$*" >> "$OP_STUB_CALLS"
+            fi
             # A locked desktop app, and equally the exit 124 of the timeout the
             # script wraps each read in.
             if [ -n "''${OP_STUB_FAIL-}" ]; then
@@ -343,8 +348,14 @@
             # config first, then lock the vault without clearing it.
             rc=$(OP_STUB_OTP="$seed" run_activation)
             [ "$rc" -eq 0 ] || fail "seeding the preserve path must succeed (exit $rc)"
-            rc=$(OP_STUB_FAIL=1 run_activation_keeping_config)
+            # A locked vault answers no read, so the first expiry settles the
+            # outcome. Unguarded, the other three re-raise the same prompt and
+            # wait out another timeout each, adding 90 seconds to every switch.
+            : > "$check_root/op-calls"
+            rc=$(OP_STUB_CALLS="$check_root/op-calls" OP_STUB_FAIL=1 run_activation_keeping_config)
             [ "$rc" -eq 0 ] || fail "an unavailable 1Password must not fail activation (exit $rc)"
+            [ "$(wc -l < "$check_root/op-calls")" -eq 1 ] ||
+              fail "a failing op read must short-circuit the remaining reads"
             grep -qxF "otp_secret_key = obscured:$seed" "$rendered" ||
               fail "an unavailable 1Password must carry the previous stanza forward"
             grep -q 'credentials are unavailable' "$check_root/stderr" ||

--- a/modules/hm-apps/rclone-protondrive-otp-check.nix
+++ b/modules/hm-apps/rclone-protondrive-otp-check.nix
@@ -98,6 +98,7 @@
             {
               mailboxPasswordRef,
               authSource ? "onePassword",
+              otpRef ? "op://check/protondrive/one-time password",
               secretsRoot ? "${./proton-drive-check-fixtures}/missing",
             }:
             inputs.home-manager.lib.homeManagerConfiguration {
@@ -143,7 +144,7 @@
                       onePassword = {
                         usernameRef = "op://check/protondrive/username";
                         passwordRef = "op://check/protondrive/password";
-                        otpRef = "op://check/protondrive/one-time password";
+                        inherit otpRef;
                         inherit mailboxPasswordRef;
                       };
                     };
@@ -160,6 +161,17 @@
           mailboxActivation =
             (mkHm { mailboxPasswordRef = "op://check/protondrive/mailbox"; })
             .config.home.activation.configureRcloneConfig.data;
+
+          # An account without 2FA. The empty ref is three decisions in the
+          # entry, all skips: no op read, no case/base32 validation, no obscure,
+          # so the stanza must render well-formed with no otp_secret_key. Only
+          # the readiness half was covered, by eval in proton-drive-check.nix,
+          # and the OTP arm has taken three rounds of fixes without this.
+          noOtpActivation =
+            (mkHm {
+              mailboxPasswordRef = "";
+              otpRef = "";
+            }).config.home.activation.configureRcloneConfig.data;
 
           # The credential fingerprint that decides whether the backend's
           # session keys survive an activation is assembled per credential
@@ -220,13 +232,17 @@
             ${sopsActivation}
             SOPS_ACTIVATION_EOF
 
+            cat > "$check_root/activation-no-otp.sh" <<'NO_OTP_ACTIVATION_EOF'
+            ${noOtpActivation}
+            NO_OTP_ACTIVATION_EOF
+
             # writeShellApplication lints the sync script, but an activation
             # entry is a raw string that nothing lints, which is how this branch
             # grew to its current size unchecked. SC1090 is excluded because
             # both env files it names are resolved at run time by design.
             shellcheck --shell=bash --severity=warning --exclude=SC1090 \
               "$check_root/activation.sh" "$check_root/activation-mailbox.sh" \
-              "$check_root/activation-sops.sh"
+              "$check_root/activation-sops.sh" "$check_root/activation-no-otp.sh"
 
             fail() {
               echo "hm-apps/rclone-protondrive-otp: $1" >&2
@@ -256,6 +272,16 @@
               (
                 run() { echo "DRY: $*"; }
                 . "$check_root/activation.sh"
+              ) > "$check_root/stdout" 2> "$check_root/stderr" || rc=$?
+              printf '%s' "$rc"
+            }
+
+            run_no_otp_activation() {
+              rm -rf -- "$check_root/config"
+              rc=0
+              (
+                run() { "$@"; }
+                . "$check_root/activation-no-otp.sh"
               ) > "$check_root/stdout" 2> "$check_root/stderr" || rc=$?
               printf '%s' "$rc"
             }
@@ -399,6 +425,21 @@
             [ "$rc" -ne 0 ] || fail "an otpauth:// URI carrying a rendered code must fail activation"
             rc=$(OP_STUB_OTP="otpauth://totp/Proton:me?secret=MFRG%3D&issuer=Proton" run_activation)
             [ "$rc" -ne 0 ] || fail "an otpauth:// URI whose secret= is not decodable base32 must fail activation"
+
+            # An account with no 2FA. The empty ref skips the read, the
+            # validation and the obscure, so the stanza must come out
+            # well-formed with no otp_secret_key rather than failing the way a
+            # configured ref reading back empty does.
+            rc=$(OP_STUB_OTP="should-not-be-read" run_no_otp_activation)
+            [ "$rc" -eq 0 ] || fail "an empty otpRef must not fail activation (exit $rc)"
+            grep -q '^\[protondrive\]$' "$rendered" ||
+              fail "an empty otpRef must still render a [protondrive] stanza"
+            ! grep -q '^otp_secret_key' "$rendered" ||
+              fail "an empty otpRef must render no otp_secret_key"
+            grep -qxF 'password = obscured:proton-password' "$rendered" ||
+              fail "an empty otpRef must still render the password"
+            ! grep -q 'OTP reference did not yield' "$check_root/stderr" ||
+              fail "an empty otpRef must not report an OTP validation failure"
 
             # A configured mailboxPasswordRef that reads back blank would
             # otherwise render a stanza that authenticates and then cannot

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -80,11 +80,12 @@ _: {
       # effective onepassword-cli group, which only the setgid wrapper from
       # programs._1password carries; the plain package binary runs without it
       # and every op read fails. modules/apps/rclone.nix asserts the wrapper
-      # exists whenever the op:// source is selected.
-      onePasswordEnabled = lib.attrByPath [ "programs" "_1password" "enable" ] false osConfig;
+      # exists whenever the op:// source is selected, so falling back to the
+      # package would only substitute one failing binary for another while
+      # making the unfree CLI a store reference of the activation script, which
+      # is emitted for every host with programs.rclone.extended.enable.
       onePasswordWrapperDir = lib.attrByPath [ "security" "wrapperDir" ] "/run/wrappers/bin" osConfig;
-      onePasswordExecutable =
-        if onePasswordEnabled then "${onePasswordWrapperDir}/op" else lib.getExe' pkgs._1password-cli "op";
+      onePasswordExecutable = "${onePasswordWrapperDir}/op";
       # Ownership guard inputs. The r2-flake Home Manager module declares
       # programs.r2-cloud only when a host policy imports it, so probe with
       # attrByPath instead of reading undeclared options.

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -120,6 +120,7 @@ _: {
             home.activation.configureRcloneConfig = lib.hm.dag.entryAfter [ "reloadSystemd" ] ''
               renderedConfig=${lib.escapeShellArg renderedRcloneConfig}
               renderedDir="$(dirname "$renderedConfig")"
+              protondriveFingerprintFile="$renderedDir/protondrive-credentials.fingerprint"
               endpointFile=${
                 lib.escapeShellArg (
                   if r2EndpointAvailable then config.sops.templates."rclone/r2-endpoint".path else ""
@@ -194,6 +195,7 @@ _: {
 
               if [ "$protondriveEnabled" = true ]; then
                 protondriveCredentialsState=unavailable
+                protondriveCredentialMaterial=""
                 unset PROTONDRIVE_USERNAME PROTONDRIVE_PASSWORD PROTONDRIVE_OTP_SECRET_KEY PROTONDRIVE_MAILBOX_PASSWORD
 
                 if [ "$protondriveAuthSource" = onePassword ]; then
@@ -229,6 +231,10 @@ _: {
                       PROTONDRIVE_PASSWORD="$(printf '%s\n' "$protondrivePasswordRaw" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
                       PROTONDRIVE_OTP_SECRET_KEY="$(printf '%s\n' "$protondriveOtpSeed" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
                       PROTONDRIVE_MAILBOX_PASSWORD="$(printf '%s\n' "$protondriveMailboxPasswordRaw" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
+                      # rclone obscure draws a fresh random IV per call, so the
+                      # ciphertexts above differ on every activation. Fingerprint
+                      # the stable 1Password values instead.
+                      protondriveCredentialMaterial="$(printf '%s\n%s\n%s\n%s' "$protondriveUsernameRaw" "$protondrivePasswordRaw" "$protondriveOtpSeed" "$protondriveMailboxPasswordRaw")"
                       if [ "$protondriveCredentialsState" != invalid ]; then
                         protondriveCredentialsState=ready
                       fi
@@ -250,6 +256,8 @@ _: {
                       echo "rclone protondrive env file is missing PROTONDRIVE_USERNAME or PROTONDRIVE_PASSWORD: $protondriveEnvPath" >&2
                       protondriveCredentialsState=invalid
                     else
+                      # Already obscured in the secret, so these are stable.
+                      protondriveCredentialMaterial="$(printf '%s\n%s\n%s\n%s' "$PROTONDRIVE_USERNAME" "$PROTONDRIVE_PASSWORD" "''${PROTONDRIVE_OTP_SECRET_KEY:-}" "''${PROTONDRIVE_MAILBOX_PASSWORD:-}")"
                       protondriveCredentialsState=ready
                     fi
                   fi
@@ -260,21 +268,16 @@ _: {
                 elif [ "$protondriveCredentialsState" = ready ]; then
                   # The protondrive backend persists reusable login credentials
                   # in the remote stanza after authentication. Preserve only
-                  # those backend-owned keys when every login credential is unchanged.
+                  # those backend-owned keys when every login credential is
+                  # unchanged; dropping them forces a fresh Proton login, and
+                  # Proton rate-limits repeated logins.
                   prevProtonSession=""
-                  prevProtonCreds=""
-                  currentProtonCreds="$(printf '%s\n%s' "$PROTONDRIVE_USERNAME" "$PROTONDRIVE_PASSWORD")"
-                  if [ -n "''${PROTONDRIVE_OTP_SECRET_KEY:-}" ]; then
-                    currentProtonCreds="$(printf '%s\n%s' "$currentProtonCreds" "$PROTONDRIVE_OTP_SECRET_KEY")"
-                  fi
-                  if [ -n "''${PROTONDRIVE_MAILBOX_PASSWORD:-}" ]; then
-                    currentProtonCreds="$(printf '%s\n%s' "$currentProtonCreds" "$PROTONDRIVE_MAILBOX_PASSWORD")"
-                  fi
-                  if [ -r "$renderedConfig" ]; then
-                    prevProtonCreds="$(sed -n '/^\[protondrive\]$/,/^\[/{ s/^username *= *//p; s/^password *= *//p; s/^otp_secret_key *= *//p; s/^mailbox_password *= *//p; }' "$renderedConfig")"
-                    if [ "$prevProtonCreds" = "$currentProtonCreds" ]; then
-                      prevProtonSession="$(sed -n '/^\[protondrive\]$/,/^\[/{ /^client_uid *=/p; /^client_access_token *=/p; /^client_refresh_token *=/p; /^client_salted_key_pass *=/p; }' "$renderedConfig")"
-                    fi
+                  protondriveFingerprint="$(printf '%s' "$protondriveCredentialMaterial" | sha256sum | cut -d' ' -f1)"
+                  if
+                    [ -r "$protondriveFingerprintFile" ] && [ -r "$renderedConfig" ] &&
+                      [ "$(cat "$protondriveFingerprintFile")" = "$protondriveFingerprint" ]
+                  then
+                    prevProtonSession="$(sed -n '/^\[protondrive\]$/,/^\[/{ /^client_uid *=/p; /^client_access_token *=/p; /^client_refresh_token *=/p; /^client_salted_key_pass *=/p; }' "$renderedConfig")"
                   fi
 
                   # password/otp_secret_key/mailbox_password are rclone-obscured;
@@ -310,11 +313,18 @@ _: {
 
                 unset PROTONDRIVE_USERNAME PROTONDRIVE_PASSWORD PROTONDRIVE_OTP_SECRET_KEY PROTONDRIVE_MAILBOX_PASSWORD
                 unset protondriveUsernameRaw protondrivePasswordRaw protondriveOtpUri protondriveOtpSeed protondriveMailboxPasswordRaw
-                unset prevProtonSession prevProtonCreds currentProtonCreds
+                unset prevProtonSession protondriveCredentialMaterial
               fi
 
               chmod 600 "$tmpConfig"
               run mv "$tmpConfig" "$renderedConfig"
+
+              if [ -n "''${protondriveFingerprint:-}" ]; then
+                # A digest of the credentials, not the credentials: the config
+                # beside it already carries their reversible obscured form.
+                printf '%s\n' "$protondriveFingerprint" > "$protondriveFingerprintFile"
+                chmod 600 "$protondriveFingerprintFile"
+              fi
             '';
           }
 

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -10,6 +10,7 @@ _: {
       config,
       osConfig,
       lib,
+      pkgs,
       secretsRoot,
       ...
     }:
@@ -30,12 +31,51 @@ _: {
         "rclone/protondrive-env"
         "path"
       ] null osConfig;
-      protondriveReady = protondriveSecretExists && repoSecretsEnabled && protondriveEnvPath != null;
+      protondriveAuth =
+        lib.attrByPath
+          [
+            "programs"
+            "rclone"
+            "extended"
+            "protonDrive"
+          ]
+          {
+            enable = false;
+            authSource = "sops";
+            onePassword = {
+              usernameRef = "";
+              passwordRef = "";
+              otpRef = "";
+              mailboxPasswordRef = "";
+            };
+          }
+          osConfig;
+      protondriveOnePassword = protondriveAuth.onePassword or { };
+      protondriveOnePasswordRefs = [
+        (protondriveOnePassword.usernameRef or "")
+        (protondriveOnePassword.passwordRef or "")
+        (protondriveOnePassword.otpRef or "")
+        (protondriveOnePassword.mailboxPasswordRef or "")
+      ];
+      protondriveOnePasswordReady =
+        protondriveAuth.enable
+        && protondriveAuth.authSource == "onePassword"
+        && lib.all (ref: lib.hasPrefix "op://" ref) protondriveOnePasswordRefs;
+      protondriveSopsReady =
+        protondriveAuth.enable
+        && protondriveAuth.authSource == "sops"
+        && protondriveSecretExists
+        && repoSecretsEnabled
+        && protondriveEnvPath != null;
+      protondriveReady = protondriveSopsReady || protondriveOnePasswordReady;
       r2SecretFile = secretsRoot + "/r2.yaml";
       r2SecretExists = builtins.pathExists r2SecretFile;
       r2SecretsEnabled = lib.attrByPath [ "home" "r2Secrets" "enable" ] false config;
       r2EndpointAvailable = r2SecretsEnabled && r2SecretExists;
       renderedRcloneConfig = "${config.xdg.configHome}/rclone/rclone.conf";
+      rclonePackage = lib.attrByPath [ "programs" "rclone" "package" ] pkgs.rclone config;
+      rcloneExecutable = lib.getExe' rclonePackage "rclone";
+      onePasswordExecutable = lib.getExe' pkgs._1password-cli "op";
       # Ownership guard inputs. The r2-flake Home Manager module declares
       # programs.r2-cloud only when a host policy imports it, so probe with
       # attrByPath instead of reading undeclared options.
@@ -80,7 +120,16 @@ _: {
               gdriveEnabled=${lib.boolToString gdriveReady}
               gdriveEnvPath=${lib.escapeShellArg (if gdriveReady then gdriveEnvPath else "")}
               protondriveEnabled=${lib.boolToString protondriveReady}
-              protondriveEnvPath=${lib.escapeShellArg (if protondriveReady then protondriveEnvPath else "")}
+              protondriveEnvPath=${lib.escapeShellArg (if protondriveSopsReady then protondriveEnvPath else "")}
+              protondriveAuthSource=${lib.escapeShellArg protondriveAuth.authSource}
+              protondriveUsernameRef=${lib.escapeShellArg (protondriveOnePassword.usernameRef or "")}
+              protondrivePasswordRef=${lib.escapeShellArg (protondriveOnePassword.passwordRef or "")}
+              protondriveOtpRef=${lib.escapeShellArg (protondriveOnePassword.otpRef or "")}
+              protondriveMailboxPasswordRef=${
+                lib.escapeShellArg (protondriveOnePassword.mailboxPasswordRef or "")
+              }
+              opExecutable=${lib.escapeShellArg onePasswordExecutable}
+              rcloneExecutable=${lib.escapeShellArg rcloneExecutable}
 
               run mkdir -p "$renderedDir"
               chmod 700 "$renderedDir"
@@ -136,36 +185,74 @@ _: {
               fi
 
               if [ "$protondriveEnabled" = true ]; then
-                # Mirror the gdrive guard: the sops secret may be unmaterialized
-                # on a first activation, so skip with a warning instead of letting
-                # `. "$protondriveEnvPath"` abort the whole home-manager activation
-                # under set -eu.
-                if [ ! -r "$protondriveEnvPath" ]; then
-                  echo "rclone protondrive env file is missing or unreadable at $protondriveEnvPath; skipping protondrive remote refresh for this activation" >&2
-                  # Carry the previously rendered [protondrive] stanza forward so a
-                  # transiently unreadable secret does not drop a working remote.
-                  if [ -r "$renderedConfig" ]; then
-                    prevProton="$(sed -n '/^\[protondrive\]$/,/^\[/{ /^\[protondrive\]$/p; /^\[/!p; }' "$renderedConfig")"
-                    if [ -n "$prevProton" ]; then
-                      printf '\n%s\n' "$prevProton" >> "$tmpConfig"
-                      echo "rclone protondrive remote preserved from the previous rendered config" >&2
+                protondriveCredentialsState=unavailable
+                unset PROTONDRIVE_USERNAME PROTONDRIVE_PASSWORD PROTONDRIVE_OTP_SECRET_KEY PROTONDRIVE_MAILBOX_PASSWORD
+
+                if [ "$protondriveAuthSource" = onePassword ]; then
+                  protondriveLookupFailed=0
+                  protondriveUsernameRaw=""
+                  protondrivePasswordRaw=""
+                  protondriveOtpUri=""
+                  protondriveOtpSeed=""
+                  protondriveMailboxPasswordRaw=""
+                  protondriveUsernameRaw="$("$opExecutable" read --no-newline "$protondriveUsernameRef")" || protondriveLookupFailed=1
+                  protondrivePasswordRaw="$("$opExecutable" read --no-newline "$protondrivePasswordRef")" || protondriveLookupFailed=1
+                  protondriveOtpUri="$("$opExecutable" read --no-newline "$protondriveOtpRef")" || protondriveLookupFailed=1
+                  protondriveMailboxPasswordRaw="$("$opExecutable" read --no-newline "$protondriveMailboxPasswordRef")" || protondriveLookupFailed=1
+
+                  if [ "$protondriveLookupFailed" -eq 0 ]; then
+                    case "$protondriveOtpUri" in
+                      otpauth://*secret=*)
+                        protondriveOtpSeed="$(printf '%s\n' "$protondriveOtpUri" | sed -n 's/.*[?&]secret=\([^&]*\).*/\1/p')"
+                        ;;
+                      *)
+                        echo "rclone protondrive 1Password OTP reference did not return an otpauth:// URI containing a secret" >&2
+                        protondriveCredentialsState=invalid
+                        ;;
+                    esac
+
+                    if [ -z "$protondriveUsernameRaw" ] || [ -z "$protondrivePasswordRaw" ] || [ -z "$protondriveOtpSeed" ] || [ -z "$protondriveMailboxPasswordRaw" ]; then
+                      echo "rclone protondrive 1Password references returned an empty required value" >&2
+                      protondriveCredentialsState=invalid
+                    fi
+
+                    if [ "$protondriveCredentialsState" != invalid ]; then
+                      PROTONDRIVE_USERNAME="$protondriveUsernameRaw"
+                      PROTONDRIVE_PASSWORD="$(printf '%s\n' "$protondrivePasswordRaw" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
+                      PROTONDRIVE_OTP_SECRET_KEY="$(printf '%s\n' "$protondriveOtpSeed" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
+                      PROTONDRIVE_MAILBOX_PASSWORD="$(printf '%s\n' "$protondriveMailboxPasswordRaw" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
+                      if [ "$protondriveCredentialsState" != invalid ]; then
+                        protondriveCredentialsState=ready
+                      fi
                     fi
                   fi
-                else
-                  unset PROTONDRIVE_USERNAME PROTONDRIVE_PASSWORD PROTONDRIVE_OTP_SECRET_KEY PROTONDRIVE_MAILBOX_PASSWORD
-                  . "$protondriveEnvPath"
 
-                  # A readable but malformed secret is an explicit configuration
-                  # error. Do not preserve stale credentials for invalid input.
-                  if [ -z "''${PROTONDRIVE_USERNAME:-}" ] || [ -z "''${PROTONDRIVE_PASSWORD:-}" ]; then
-                    echo "rclone protondrive env file is missing PROTONDRIVE_USERNAME or PROTONDRIVE_PASSWORD: $protondriveEnvPath" >&2
-                    exit 1
+                  if [ "$protondriveLookupFailed" -ne 0 ]; then
+                    echo "rclone protondrive 1Password credentials are unavailable; skipping protondrive remote refresh for this activation" >&2
                   fi
+                else
+                  # The SOPS secret may be unmaterialized on a first activation,
+                  # so preserve a working remote instead of aborting activation.
+                  if [ ! -r "$protondriveEnvPath" ]; then
+                    echo "rclone protondrive env file is missing or unreadable at $protondriveEnvPath; skipping protondrive remote refresh for this activation" >&2
+                  else
+                    . "$protondriveEnvPath"
 
+                    if [ -z "''${PROTONDRIVE_USERNAME:-}" ] || [ -z "''${PROTONDRIVE_PASSWORD:-}" ]; then
+                      echo "rclone protondrive env file is missing PROTONDRIVE_USERNAME or PROTONDRIVE_PASSWORD: $protondriveEnvPath" >&2
+                      protondriveCredentialsState=invalid
+                    else
+                      protondriveCredentialsState=ready
+                    fi
+                  fi
+                fi
+
+                if [ "$protondriveCredentialsState" = invalid ]; then
+                  exit 1
+                elif [ "$protondriveCredentialsState" = ready ]; then
                   # The protondrive backend persists reusable login credentials
                   # in the remote stanza after authentication. Preserve only
-                  # those backend-owned keys when every SOPS-sourced credential
-                  # that feeds login is unchanged.
+                  # those backend-owned keys when every login credential is unchanged.
                   prevProtonSession=""
                   prevProtonCreds=""
                   currentProtonCreds="$(printf '%s\n%s' "$PROTONDRIVE_USERNAME" "$PROTONDRIVE_PASSWORD")"
@@ -182,11 +269,9 @@ _: {
                     fi
                   fi
 
-                  # password/otp_secret_key/mailbox_password must already be rclone-obscured
-                  # in the secret (run `rclone obscure <value>`); the backend reveals them.
-                  # enable_caching is forced off: required for `rclone mount` (Proton's
-                  # change-event system is unimplemented, so a metadata cache goes stale)
-                  # and harmless for bisync.
+                  # password/otp_secret_key/mailbox_password are rclone-obscured;
+                  # the backend reveals them. enable_caching is forced off because
+                  # Proton's change-event system is unimplemented.
                   {
                     printf '\n[protondrive]\n'
                     printf 'type = protondrive\n'
@@ -203,8 +288,20 @@ _: {
                     fi
                     printf 'enable_caching = false\n'
                   } >> "$tmpConfig"
+                else
+                  # Carry the previous stanza forward when 1Password is locked or
+                  # a SOPS secret is unavailable during a transient activation.
+                  if [ -r "$renderedConfig" ]; then
+                    prevProton="$(sed -n '/^\[protondrive\]$/,/^\[/{ /^\[protondrive\]$/p; /^\[/!p; }' "$renderedConfig")"
+                    if [ -n "$prevProton" ]; then
+                      printf '\n%s\n' "$prevProton" >> "$tmpConfig"
+                      echo "rclone protondrive remote preserved from the previous rendered config" >&2
+                    fi
+                  fi
                 fi
+
                 unset PROTONDRIVE_USERNAME PROTONDRIVE_PASSWORD PROTONDRIVE_OTP_SECRET_KEY PROTONDRIVE_MAILBOX_PASSWORD
+                unset protondriveUsernameRaw protondrivePasswordRaw protondriveOtpUri protondriveOtpSeed protondriveMailboxPasswordRaw
                 unset prevProtonSession prevProtonCreds currentProtonCreds
               fi
 

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -75,7 +75,15 @@ _: {
       renderedRcloneConfig = "${config.xdg.configHome}/rclone/rclone.conf";
       rclonePackage = lib.attrByPath [ "programs" "rclone" "package" ] pkgs.rclone config;
       rcloneExecutable = lib.getExe' rclonePackage "rclone";
-      onePasswordExecutable = lib.getExe' pkgs._1password-cli "op";
+      # The 1Password desktop app authorizes CLI integration by the caller's
+      # effective onepassword-cli group, which only the setgid wrapper from
+      # programs._1password carries; the plain package binary runs without it
+      # and every op read fails. modules/apps/rclone.nix asserts the wrapper
+      # exists whenever the op:// source is selected.
+      onePasswordEnabled = lib.attrByPath [ "programs" "_1password" "enable" ] false osConfig;
+      onePasswordWrapperDir = lib.attrByPath [ "security" "wrapperDir" ] "/run/wrappers/bin" osConfig;
+      onePasswordExecutable =
+        if onePasswordEnabled then "${onePasswordWrapperDir}/op" else lib.getExe' pkgs._1password-cli "op";
       # Ownership guard inputs. The r2-flake Home Manager module declares
       # programs.r2-cloud only when a host policy imports it, so probe with
       # attrByPath instead of reading undeclared options.

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -61,9 +61,9 @@ _: {
         protondriveAuth.enable
         && protondriveAuth.authSource == "onePassword"
         && lib.all (ref: lib.hasPrefix "op://" ref) protondriveOnePasswordRefs;
+      protondriveSopsSelected = protondriveAuth.enable && protondriveAuth.authSource == "sops";
       protondriveSopsReady =
-        protondriveAuth.enable
-        && protondriveAuth.authSource == "sops"
+        protondriveSopsSelected
         && protondriveSecretExists
         && repoSecretsEnabled
         && protondriveEnvPath != null;
@@ -337,17 +337,28 @@ _: {
             ];
           })
 
-          (lib.mkIf (protondriveSecretExists && (!repoSecretsEnabled)) {
+          # Only the SOPS source needs the secret; under the 1Password source the
+          # system side declares no rclone/protondrive-env path, so an ungated
+          # warning fires while the remote renders fine.
+          (lib.mkIf (protondriveSopsSelected && protondriveSecretExists && (!repoSecretsEnabled)) {
             warnings = [
-              "programs.rclone.extended.enable is true and ${toString protondriveSecretFile} exists, but security.repoSecrets.enable is false on this host; skipping protondrive remote setup. Manage ~/.config/rclone/rclone.conf manually or enable repo secrets after SOPS decryption is configured."
+              "programs.rclone.extended.protonDrive.authSource is \"sops\" and ${toString protondriveSecretFile} exists, but security.repoSecrets.enable is false on this host; skipping protondrive remote setup. Manage ~/.config/rclone/rclone.conf manually or enable repo secrets after SOPS decryption is configured."
             ];
           })
 
-          (lib.mkIf (protondriveSecretExists && repoSecretsEnabled && protondriveEnvPath == null) {
-            warnings = [
-              "programs.rclone.extended.enable is true and ${toString protondriveSecretFile} exists, but no system-side rclone/protondrive-env secret path was declared in osConfig; skipping protondrive remote setup."
-            ];
-          })
+          (lib.mkIf
+            (
+              protondriveSopsSelected
+              && protondriveSecretExists
+              && repoSecretsEnabled
+              && protondriveEnvPath == null
+            )
+            {
+              warnings = [
+                "programs.rclone.extended.protonDrive.authSource is \"sops\" and ${toString protondriveSecretFile} exists, but no system-side rclone/protondrive-env secret path was declared in osConfig; skipping protondrive remote setup."
+              ];
+            }
+          )
         ]
       );
     };

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -51,16 +51,17 @@ _: {
           }
           osConfig;
       protondriveOnePassword = protondriveAuth.onePassword or { };
-      protondriveOnePasswordRefs = [
-        (protondriveOnePassword.usernameRef or "")
-        (protondriveOnePassword.passwordRef or "")
-        (protondriveOnePassword.otpRef or "")
-        (protondriveOnePassword.mailboxPasswordRef or "")
-      ];
+      # otp_secret_key and mailbox_password are per-account optional (2FA /
+      # two-password accounts only), so an empty ref opts out instead of
+      # failing readiness; a non-empty ref still must be an op:// reference.
+      protondriveOptionalRefValid = ref: ref == "" || lib.hasPrefix "op://" ref;
       protondriveOnePasswordReady =
         protondriveAuth.enable
         && protondriveAuth.authSource == "onePassword"
-        && lib.all (ref: lib.hasPrefix "op://" ref) protondriveOnePasswordRefs;
+        && lib.hasPrefix "op://" (protondriveOnePassword.usernameRef or "")
+        && lib.hasPrefix "op://" (protondriveOnePassword.passwordRef or "")
+        && protondriveOptionalRefValid (protondriveOnePassword.otpRef or "")
+        && protondriveOptionalRefValid (protondriveOnePassword.mailboxPasswordRef or "");
       protondriveSopsSelected = protondriveAuth.enable && protondriveAuth.authSource == "sops";
       protondriveSopsReady =
         protondriveSopsSelected
@@ -205,32 +206,49 @@ _: {
                   protondriveOtpUri=""
                   protondriveOtpSeed=""
                   protondriveMailboxPasswordRaw=""
-                  protondriveUsernameRaw="$("$opExecutable" read --no-newline "$protondriveUsernameRef")" || protondriveLookupFailed=1
-                  protondrivePasswordRaw="$("$opExecutable" read --no-newline "$protondrivePasswordRef")" || protondriveLookupFailed=1
-                  protondriveOtpUri="$("$opExecutable" read --no-newline "$protondriveOtpRef")" || protondriveLookupFailed=1
-                  protondriveMailboxPasswordRaw="$("$opExecutable" read --no-newline "$protondriveMailboxPasswordRef")" || protondriveLookupFailed=1
+                  # A locked desktop app raises an unlock/biometric prompt and
+                  # blocks op read until it is answered; time out instead of
+                  # stalling activation, and let the existing failure path
+                  # below take the warn-and-preserve branch.
+                  protondriveUsernameRaw="$(timeout 30 "$opExecutable" read --no-newline "$protondriveUsernameRef")" || protondriveLookupFailed=1
+                  protondrivePasswordRaw="$(timeout 30 "$opExecutable" read --no-newline "$protondrivePasswordRef")" || protondriveLookupFailed=1
+                  # otp_secret_key and mailbox_password are per-account optional
+                  # (2FA / two-password accounts only), so an empty configured
+                  # ref opts out instead of being read.
+                  if [ -n "$protondriveOtpRef" ]; then
+                    protondriveOtpUri="$(timeout 30 "$opExecutable" read --no-newline "$protondriveOtpRef")" || protondriveLookupFailed=1
+                  fi
+                  if [ -n "$protondriveMailboxPasswordRef" ]; then
+                    protondriveMailboxPasswordRaw="$(timeout 30 "$opExecutable" read --no-newline "$protondriveMailboxPasswordRef")" || protondriveLookupFailed=1
+                  fi
 
                   if [ "$protondriveLookupFailed" -eq 0 ]; then
-                    case "$protondriveOtpUri" in
-                      otpauth://*secret=*)
-                        protondriveOtpSeed="$(printf '%s\n' "$protondriveOtpUri" | sed -n 's/.*[?&]secret=\([^&]*\).*/\1/p')"
-                        ;;
-                      *)
-                        echo "rclone protondrive 1Password OTP reference did not return an otpauth:// URI containing a secret" >&2
-                        protondriveCredentialsState=invalid
-                        ;;
-                    esac
+                    if [ -n "$protondriveOtpRef" ]; then
+                      case "$protondriveOtpUri" in
+                        otpauth://*secret=*)
+                          protondriveOtpSeed="$(printf '%s\n' "$protondriveOtpUri" | sed -n 's/.*[?&]secret=\([^&]*\).*/\1/p')"
+                          ;;
+                        *)
+                          echo "rclone protondrive 1Password OTP reference did not return an otpauth:// URI containing a secret" >&2
+                          protondriveCredentialsState=invalid
+                          ;;
+                      esac
+                    fi
 
-                    if [ -z "$protondriveUsernameRaw" ] || [ -z "$protondrivePasswordRaw" ] || [ -z "$protondriveOtpSeed" ] || [ -z "$protondriveMailboxPasswordRaw" ]; then
-                      echo "rclone protondrive 1Password references returned an empty required value" >&2
+                    if [ -z "$protondriveUsernameRaw" ] || [ -z "$protondrivePasswordRaw" ]; then
+                      echo "rclone protondrive 1Password references returned an empty username or password" >&2
                       protondriveCredentialsState=invalid
                     fi
 
                     if [ "$protondriveCredentialsState" != invalid ]; then
                       PROTONDRIVE_USERNAME="$protondriveUsernameRaw"
                       PROTONDRIVE_PASSWORD="$(printf '%s\n' "$protondrivePasswordRaw" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
-                      PROTONDRIVE_OTP_SECRET_KEY="$(printf '%s\n' "$protondriveOtpSeed" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
-                      PROTONDRIVE_MAILBOX_PASSWORD="$(printf '%s\n' "$protondriveMailboxPasswordRaw" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
+                      if [ -n "$protondriveOtpSeed" ]; then
+                        PROTONDRIVE_OTP_SECRET_KEY="$(printf '%s\n' "$protondriveOtpSeed" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
+                      fi
+                      if [ -n "$protondriveMailboxPasswordRaw" ]; then
+                        PROTONDRIVE_MAILBOX_PASSWORD="$(printf '%s\n' "$protondriveMailboxPasswordRaw" | "$rcloneExecutable" obscure -)" || protondriveCredentialsState=invalid
+                      fi
                       # rclone obscure draws a fresh random IV per call, so the
                       # ciphertexts above differ on every activation. Fingerprint
                       # the stable 1Password values instead.

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -231,22 +231,37 @@ _: {
                         *)
                           # 1Password stores the one-time password field
                           # verbatim, which is commonly the bare base32 seed
-                          # rather than an otpauth:// URI. Digits 2-7 are base32,
-                          # so a rendered code passes a bare character test; the
-                          # length floor is what separates the two (RFC 4226 R6
-                          # puts the shared secret at 128 bits, and no TOTP seed
-                          # is under the 16 characters of an 80-bit one).
-                          protondriveOtpSeed="$(printf '%s' "$protondriveOtpUri" | tr -d ' ' | sed -n '/^[A-Za-z2-7]\{16,\}=*$/p')"
+                          # rather than an otpauth:// URI.
+                          protondriveOtpSeed="$protondriveOtpUri"
                           ;;
                       esac
+                      # Validate whichever arm produced it: an otpauth:// URI
+                      # built with ?attribute=otp carries a rendered code in
+                      # secret= just as a bare field can hold one. Digits 2-7 are
+                      # base32, so a code passes a bare character test and the
+                      # length floor is what separates the two (RFC 4226 R6 puts
+                      # the shared secret at 128 bits, and no TOTP seed is under
+                      # the 16 characters of an 80-bit one).
+                      protondriveOtpSeed="$(printf '%s' "$protondriveOtpSeed" | tr -d ' ' | sed -n '/^[A-Za-z2-7]\{16,\}=*$/p')"
                       if [ -z "$protondriveOtpSeed" ]; then
-                        echo "rclone protondrive 1Password OTP reference returned neither an otpauth:// URI with a secret= parameter nor a bare base32 seed; it must hold the stable TOTP seed, not the rendered six-digit code" >&2
+                        echo "rclone protondrive 1Password OTP reference did not yield a base32 TOTP seed of at least 16 characters, from either an otpauth:// secret= parameter or a bare field value; it must hold the stable seed, not the rendered six-digit code" >&2
                         protondriveCredentialsState=invalid
                       fi
                     fi
 
                     if [ -z "$protondriveUsernameRaw" ] || [ -z "$protondrivePasswordRaw" ]; then
                       echo "rclone protondrive 1Password references returned an empty username or password" >&2
+                      protondriveCredentialsState=invalid
+                    fi
+
+                    # A configured ref that reads back empty is a configuration
+                    # error, not an opt-out: opting out is an empty ref, which
+                    # never reaches op read. Rendering the stanza without
+                    # mailbox_password instead would authenticate and then fail
+                    # to decrypt, which is the silent outcome the OTP arm above
+                    # already treats as fatal.
+                    if [ -n "$protondriveMailboxPasswordRef" ] && [ -z "$protondriveMailboxPasswordRaw" ]; then
+                      echo "rclone protondrive 1Password mailbox-password reference returned an empty value; clear mailboxPasswordRef to opt out of a two-password account instead of pointing it at a blank field" >&2
                       protondriveCredentialsState=invalid
                     fi
 

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -225,14 +225,24 @@ _: {
                   if [ "$protondriveLookupFailed" -eq 0 ]; then
                     if [ -n "$protondriveOtpRef" ]; then
                       case "$protondriveOtpUri" in
-                        otpauth://*secret=*)
+                        otpauth://*)
                           protondriveOtpSeed="$(printf '%s\n' "$protondriveOtpUri" | sed -n 's/.*[?&]secret=\([^&]*\).*/\1/p')"
                           ;;
                         *)
-                          echo "rclone protondrive 1Password OTP reference did not return an otpauth:// URI containing a secret" >&2
-                          protondriveCredentialsState=invalid
+                          # 1Password stores the one-time password field
+                          # verbatim, which is commonly the bare base32 seed
+                          # rather than an otpauth:// URI. Digits 2-7 are base32,
+                          # so a rendered code passes a bare character test; the
+                          # length floor is what separates the two (RFC 4226 R6
+                          # puts the shared secret at 128 bits, and no TOTP seed
+                          # is under the 16 characters of an 80-bit one).
+                          protondriveOtpSeed="$(printf '%s' "$protondriveOtpUri" | tr -d ' ' | sed -n '/^[A-Za-z2-7]\{16,\}=*$/p')"
                           ;;
                       esac
+                      if [ -z "$protondriveOtpSeed" ]; then
+                        echo "rclone protondrive 1Password OTP reference returned neither an otpauth:// URI with a secret= parameter nor a bare base32 seed; it must hold the stable TOTP seed, not the rendered six-digit code" >&2
+                        protondriveCredentialsState=invalid
+                      fi
                     fi
 
                     if [ -z "$protondriveUsernameRaw" ] || [ -z "$protondrivePasswordRaw" ]; then

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -365,8 +365,16 @@ _: {
               if [ -n "''${protondriveFingerprint:-}" ]; then
                 # A digest of the credentials, not the credentials: the config
                 # beside it already carries their reversible obscured form.
-                printf '%s\n' "$protondriveFingerprint" > "$protondriveFingerprintFile"
-                chmod 600 "$protondriveFingerprintFile"
+                # Moved through run like the config above: a dry run that wrote
+                # this while leaving the config alone would leave the digest
+                # describing credentials the stanza beside it never received, and
+                # the next real activation would read that as "unchanged" and
+                # graft the pre-rotation session keys onto the new stanza.
+                tmpFingerprint="$(mktemp "$renderedDir/protondrive-credentials.fingerprint.XXXXXX")"
+                trap 'rm -f "$tmpConfig" "$tmpFingerprint"' EXIT
+                printf '%s\n' "$protondriveFingerprint" > "$tmpFingerprint"
+                chmod 600 "$tmpFingerprint"
+                run mv "$tmpFingerprint" "$protondriveFingerprintFile"
               fi
             '';
           }

--- a/modules/hm-apps/rclone.nix
+++ b/modules/hm-apps/rclone.nix
@@ -211,15 +211,24 @@ _: {
                   # blocks op read until it is answered; time out instead of
                   # stalling activation, and let the existing failure path
                   # below take the warn-and-preserve branch.
+                  #
+                  # Each read is gated on the running total because the first
+                  # expiry already proves the vault will not answer: unguarded,
+                  # the remaining three re-raise the same prompt and wait it out
+                  # again, so a locked vault cost 4 x 30s of every switch on
+                  # every host carrying the op:// source, which is the delay the
+                  # timeout was added to bound.
                   protondriveUsernameRaw="$(timeout 30 "$opExecutable" read --no-newline "$protondriveUsernameRef")" || protondriveLookupFailed=1
-                  protondrivePasswordRaw="$(timeout 30 "$opExecutable" read --no-newline "$protondrivePasswordRef")" || protondriveLookupFailed=1
+                  if [ "$protondriveLookupFailed" -eq 0 ]; then
+                    protondrivePasswordRaw="$(timeout 30 "$opExecutable" read --no-newline "$protondrivePasswordRef")" || protondriveLookupFailed=1
+                  fi
                   # otp_secret_key and mailbox_password are per-account optional
                   # (2FA / two-password accounts only), so an empty configured
                   # ref opts out instead of being read.
-                  if [ -n "$protondriveOtpRef" ]; then
+                  if [ "$protondriveLookupFailed" -eq 0 ] && [ -n "$protondriveOtpRef" ]; then
                     protondriveOtpUri="$(timeout 30 "$opExecutable" read --no-newline "$protondriveOtpRef")" || protondriveLookupFailed=1
                   fi
-                  if [ -n "$protondriveMailboxPasswordRef" ]; then
+                  if [ "$protondriveLookupFailed" -eq 0 ] && [ -n "$protondriveMailboxPasswordRef" ]; then
                     protondriveMailboxPasswordRaw="$(timeout 30 "$opExecutable" read --no-newline "$protondriveMailboxPasswordRef")" || protondriveLookupFailed=1
                   fi
 

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -368,6 +368,7 @@ let
       raindrop.extended.enable = lib.mkOverride 1100 true;
       rar.extended.enable = lib.mkOverride 1100 true;
       rclone.extended.enable = lib.mkOverride 1100 true;
+      rclone.extended.protonDrive.enable = lib.mkOverride 1100 true;
       readpdf.extended.enable = lib.mkOverride 1100 true;
       remmina.extended.enable = lib.mkOverride 1100 true;
       restringer.extended.enable = lib.mkOverride 1100 false; # Produces incorrect results, use webcrack

--- a/modules/hosts/common/rclone-protondrive-1password.nix
+++ b/modules/hosts/common/rclone-protondrive-1password.nix
@@ -1,0 +1,14 @@
+_:
+let
+  body = {
+    programs.rclone.extended.protonDrive.onePassword = {
+      usernameRef = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/username";
+      passwordRef = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/password";
+      otpRef = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/one-time password";
+      mailboxPasswordRef = "op://Personal/zgofe2wyj3j27vetjth7qr4hs4/password";
+    };
+  };
+in
+{
+  flake.nixosModules.hosts-common.imports = [ body ];
+}

--- a/modules/hosts/common/rclone-protondrive-1password.nix
+++ b/modules/hosts/common/rclone-protondrive-1password.nix
@@ -1,13 +1,20 @@
 _:
 let
-  body = {
-    programs.rclone.extended.protonDrive.onePassword = {
-      usernameRef = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/username";
-      passwordRef = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/password";
-      otpRef = "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/one-time password";
-      mailboxPasswordRef = "op://Personal/zgofe2wyj3j27vetjth7qr4hs4/password";
+  # mkOverride 1100 matches the hosts-common baseline priority used by
+  # apps-enable.nix, so a per-host file can point these at another vault at
+  # 1000 the way modules/tpnix/apps-enable.nix does. At default priority a
+  # per-host definition would either lose (1000) or conflict (100), leaving
+  # mkForce as the only escape hatch.
+  body =
+    { lib, ... }:
+    {
+      programs.rclone.extended.protonDrive.onePassword = {
+        usernameRef = lib.mkOverride 1100 "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/username";
+        passwordRef = lib.mkOverride 1100 "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/password";
+        otpRef = lib.mkOverride 1100 "op://Personal/wi7bkkt6pkphzioobyl2ddpkka/one-time password";
+        mailboxPasswordRef = lib.mkOverride 1100 "op://Personal/zgofe2wyj3j27vetjth7qr4hs4/password";
+      };
     };
-  };
 in
 {
   flake.nixosModules.hosts-common.imports = [ body ];


### PR DESCRIPTION
Follow-up to #314. A 1Password credential source for the Proton Drive remote, two review findings against the sync
script, and six rounds of review follow-up against the commits above.

## Summary

### 1. `feat(rclone)`: 1Password credential source

`programs.rclone.extended.protonDrive` is a new option tree that gates the whole Proton Drive integration and
selects the credential source:

- `authSource = "onePassword"` (the default) reads four `op://` references at activation. The activation script
  runs `rclone obscure` on the values itself, so nothing pre-obscured is stored anywhere and rotation is a
  1Password edit rather than a `sops` round trip.
- `authSource = "sops"` keeps the `secrets/rclone_protondrive.env` path from #314 unchanged.

The OTP reference must return the stable seed, not the rendered six-digit code: rclone's protondrive backend needs
the seed to generate a code per login, and a captured code is dead within 30 seconds. Either shape 1Password stores
is accepted, the `otpauth://` URI or the bare base32 seed, and a lookup returning anything else fails activation as
a configuration error instead of rendering a remote that cannot authenticate.

`protonDrive.enable` gating means a host that never uses Proton Drive stops evaluating the `sops.secrets`
declaration and the missing-secret warning. Credential unavailability stays non-fatal in both sources: a locked
1Password or an unmaterialized SOPS secret carries the previously rendered `[protondrive]` stanza forward with a
warning rather than dropping a working remote, while a readable but malformed credential still exits 1.

`modules/hosts/common/apps-enable.nix` turns `protonDrive` on for shared hosts at `mkOverride 1100`.
`services.protonDriveSync.enable` stays off everywhere, so this renders the remote without starting a timer.

**Operational note:** `op read` runs during Home Manager activation, so a `nixos-rebuild switch` with a locked
1Password falls back to the preserved stanza and logs a warning. It does not fail the switch, but the remote is not
refreshed until the next activation with an unlocked vault.

### 2. `fix(proton-drive)`: bisync abort latch

Traced through `/data/git/rclone-rclone`: `cmd/bisync/operations.go:348-353` (excess deletes) and `:357-368` (all
files changed) set `b.abort = true` and return **without** setting `b.critical`. Because `b.critical` stays false,
`operations.go:198-213` never renames the listings to `-err`, so no `--resync` lockout follows and `--resilient` is
not even reached. The run changes nothing on either side and exits non-zero (`errors.New` falls through
`resolveExitCode` to `exitcode.UncategorizedError`).

The one-way branches latch on exit 7 through `sync_one_way`; the default `bisync` direction called rclone bare. So
when the 25-percent deletion check tripped, from an unmounted `localPath` that `mkdir -p` recreated empty, a bulk
delete, or a top-level rename, `$marker` stayed, the unit failed, and the timer refired every 30m (48 times a day),
each fire a full uncached recursive listing of both sides against the Beta protondrive backend, until a human read
the journal.

Clearing `$marker` is the wrong stop: `--resync` merges both sides into a superset and would resurrect the
deletions that tripped the check instead of propagating them. `run_bisync` now latches `$aborted` when a failed run
printed `Safety abort`, the string emitted by exactly the two checks whose documented release is `--force`, and
`--force` (already gated on a mounted, nonempty local source) or `--resync` releases it. Matching that string
rather than the exit code is deliberate: bisync also returns exit 2 for transient backend errors wrapped as
critical+retryable, and latching those would strand the sync until a human intervened, defeating the
offline-at-boot retry the unit comment relies on.

### 3. `fix(proton-drive)`: state root pinned at eval time

The reported mechanism does not hold. Home Manager's xdg module sets **both** `home.sessionVariables` and
`systemd.user.sessionVariables` (`modules/misc/xdg/default.nix:177-178`), and the latter renders
`~/.config/environment.d/10-home-manager.conf`, which the per-user systemd manager does read, so the timer and
login shells see the same `XDG_STATE_HOME`. With `xdg.enable = false` (this repo, verified by eval) nothing exports
it and both fall back to `$HOME/.local/state`, which equals `config.xdg.stateHome` here.

The remedy still applies for other reasons: a shell not managed by Home Manager never sources
`hm-session-vars.sh`, `environment.d` is stale until `daemon-reload`, and an explicit `xdg.stateHome` under
`xdg.enable = false` is ignored by the script entirely. Pinning removes all of it and makes the state root
consistent with the rclone config path already pinned two lines below. The evaluated value is unchanged on both
hosts, so there is no migration.

### 4. The sync script was never built

`home.packages` carries `proton-drive-sync` only when `protondriveReady` is true. CI has no secrets submodule and
no 1Password session, and no `nix flake check` step builds a host toplevel, so `writeShellApplication`'s shellcheck
pass had never run on the script and none of its abort handling had ever executed.

`modules/hm-apps/proton-drive-check.nix` closes that gap the way `modules/browsers/firefoxpwa/module-check.nix`
does: a stubbed Home Manager configuration with `programs.rclone.package` replaced by a stub replaying a scripted
exit code and stderr, driving the baseline, abort, latch, refusal, `--force` release, and transient-failure paths.
It also covers all three `protondriveReady` inputs by eval (`op://` references install the script with no secret
present; `protonDrive.enable = false` withholds it). It sets `passthru.runtimeCheck`, which `check.yml`'s runtime
suite step already picks up without a workflow edit.

### 5. Review follow-up

Seven review findings against the two commits above, each validated against the code and rclone's source before
implementing.

**1Password wrapper (the blocker).** The activation script called `${pkgs._1password-cli}/bin/op` directly, so it
ran with the user's own groups. The desktop app authorizes CLI integration by the caller's effective
`onepassword-cli` group (nixpkgs `ids.gids.onepassword-cli = 31002`, carried only by the setgid
`security.wrappers."op"` that `programs._1password` installs), and no user is a member of it directly. All four
reads failed, the credential state stayed `unavailable`, and a fresh activation could never render
`[protondrive]`. The module now invokes `${security.wrapperDir}/op`, and the NixOS module asserts that wrapper
exists whenever `authSource = "onePassword"`.

**Session dropped on every activation.** `obscure.Obscure` draws its AES-CTR IV from `crypto/rand`
(`fs/config/obscure/obscure.go`), so the rendered ciphertexts never repeat and the comparison against the previous
`rclone.conf` never matched under the op:// source. `client_uid` and the three client tokens were dropped every
activation, forcing a full Proton login (which Proton rate-limits) on the next sync. Comparison now runs over a
sha256 fingerprint of the stable credential material, held at
`~/.config/rclone/protondrive-credentials.fingerprint` at mode 0600: a digest, not the credentials, which the
rendered config beside it already carries in reversible obscured form.

**Log routing defeated the latch.** `--log-file` and `--syslog` set the log handler's writer away from stderr
(`fs/log/log.go:255`), so `services.protonDriveSync.extraArgs` could silently disable abort detection. Those,
plus `--log-level`, `--log-format` (which takes `nolevel`) and `--use-json-log`, now fail an assertion. `--quiet`
stays allowed: it clamps the level to `ERROR` (`fs/config/configflags/configflags.go:88`), which keeps the record.

**Unanchored abort match.** `grep -F 'Safety abort'` also matched the INFO lines that echo each transferred path,
so a directory holding a file named after the message plus any nonzero exit created the latch with neither safety
check having fired. The pattern now requires rclone's own `ERROR` record for the two checks that produce it
(`cmd/bisync/deltas.go:557`, `cmd/bisync/operations.go:358`).

**Warning gating.** The Home Manager protondrive warnings still keyed only off `protondriveSecretExists`,
`repoSecretsEnabled`, and `protondriveEnvPath`, so a host keeping `secrets/rclone_protondrive.env` while running
the 1Password default would warn "skipping protondrive remote setup" against a working remote. Latent today, since
`secrets/` holds only the `.example`, but the migration path this branch introduces walks straight into it. Both
blocks now carry the same `protonDrive.enable` and `authSource == "sops"` conjunct as their NixOS twins.

**Check coverage.** The check header claimed `protondriveReady`'s three inputs were covered by eval alone, but
`mkHm` hardcoded `programs.rclone.extended.enable = true`, so dropping the `rcloneEnabled` conjunct would have
passed silently. Added that case, the `--log-file` rejection, the all-files-changed abort variant, and the
path-echo negative case.

**Check root guard.** The guard only rejected `/tmp/proton-drive-sync-check/state/proton-drive-sync`, so an
unsandboxed build inherited a bare `/tmp/proton-drive-sync-check` (leftover, or planted by another local user) and
then followed symlinks under it through `mkdir -p "$local_path"` and `: > "$local_path/seed"`. The check now
creates the whole root itself with `mkdir -m 700`, which fails on an existing directory or symlink.

### 6. Review follow-up (round 2)

Six more findings, against the state left by round 1, each verified against the code, the check, or rclone's
source (`/data/git/rclone-rclone`) before implementing.

**otp/mailbox refs were mandatory.** `modules/hm-apps/rclone.nix` required all four 1Password values non-empty,
but `otp_secret_key` and `mailbox_password` are per-account optional (`modules/hm-apps/proton-drive.nix`
documents "only if 2FA is enabled" / "only on two-password accounts" for the same SOPS fields), and the SOPS
branch itself only ever required username and password. An account without 2FA, or on single-password mode, hit
`protondriveCredentialsState=invalid` and `exit 1`, aborting the entire Home Manager activation, with no way to
opt out since `modules/apps/rclone.nix` asserted all four refs as `op://`. `otpRef`/`mailboxPasswordRef` now
default to `""` and may stay empty; the script skips their `op read` and `obscure` when empty, and the assertion
only requires `usernameRef`/`passwordRef`.

**`--resync` release of the bisync latch, untested.** `proton-drive-check.nix` drove the latch through `--force`
only; the `--resync` release (the `bisync` direction's `resync` branch in `proton-drive.nix`) that the refusal
message and the module docstring both advertise as the alternative recovery had never executed. Added a case:
re-latch, then `--resync`, then assert the `aborted-*` marker is gone and `initialized-*` is still present.

**`extraArgs` log-routing guard was bypassable via environment.** The eval-time assertion on
`services.protonDriveSync.extraArgs` only inspects the Nix-level list, but rclone also reads an `RCLONE_<FLAG>`
environment variable for every flag (`fs/config/flags.go`'s `installFlag`, which every globally registered option
group including the logging one goes through), and the systemd user unit inherits that environment unfiltered.
`RCLONE_LOG_FILE`, `RCLONE_LOG_FORMAT`, `RCLONE_LOG_LEVEL`, `RCLONE_SYSLOG`, and `RCLONE_USE_JSON_LOG` now get
`unset` in the script before it invokes rclone, closing the runtime path the eval-time guard cannot see.

**`op read` had no timeout.** A locked 1Password desktop app raises an unlock/biometric prompt and blocks `op
read` until answered, stalling `home-manager switch` instead of taking the documented warn-and-preserve path.
Each of the four reads now runs under `timeout 30`; the existing `|| protondriveLookupFailed=1` fallback already
routes a timeout (exit 124) to that path.

**Check root never cleaned up.** `proton-drive-check.nix` created `/tmp/proton-drive-sync-check` and never removed
it, so on an unsandboxed builder every rebuild after the first failed the existence guard added in round 1. Added
`trap 'rm -rf -- "$check_root"' EXIT` right after the `mkdir`.

**Personal vault UUIDs as shared-module defaults.** `modules/apps/rclone.nix` defaulted all four
`onePassword.*Ref` options to literal `op://Personal/<uuid>/...` references from one specific vault, and
`modules/hosts/common/apps-enable.nix` turns `protonDrive.enable` on for every host under `shareCommon`. A
repo-wide sweep for secret-reference-shaped option defaults turned up nothing else like it: every sibling
secret-bearing module (`modules/home/context7-secrets.nix`, `r2-secrets.nix`, `virustotal-secrets.nix`,
`modules/security/r2-cloud-secrets.nix`, `secrets.nix`, and this same file's own `sops` branch) keeps the option
surface generic and supplies the real value from an owning file, gated on presence. The four refs now default to
`""`; the real values live in the new `modules/hosts/common/rclone-protondrive-1password.nix`, contributing to the
`hosts-common` aggregate the same way `apps-enable.nix` does, and at the same `mkOverride 1100` priority (see
round 6). Both existing hosts resolve to the identical values as before (verified by eval); a host that does not
import that file, or a future host under a different owner, gets empty refs, fails
`protondriveOnePasswordReady`, and never shells out to `op`.

### 7. Review follow-up (round 3)

Two findings against the state left by round 2, both verified against the code before implementing, plus the
coverage gap they exposed.

**The OTP reference rejected the value 1Password most often holds.** `op read` returns a one-time-password field
verbatim, so an operator who pasted the bare base32 seed rather than a full `otpauth://` URI fell to the `*)` arm,
got `protondriveCredentialsState=invalid`, and hit the `exit 1` that aborts the entire Home Manager activation.
`modules/hosts/common/rclone-protondrive-1password.nix` ships `otpRef` for every `shareCommon` host, so that was
fleet-wide with no opt-out short of `otpRef = ""`, which silently drops 2FA. The two arms also disagreed: the
`case` guard matched a literal `secret=` anywhere while the `sed` required `[?&]secret=`, so
`otpauth://totp/xsecret=y` left the seed empty, skipped the `obscure` under the `[ -n ]` guard, kept the state at
`ready`, and rendered a `[protondrive]` stanza with **no** `otp_secret_key` at all. Extraction now runs first and
the extracted seed is validated once, so both defects close together.

The bare arm requires 16 or more base32 characters rather than accepting any base32 string. Digits 2-7 are
themselves base32, so roughly 5 percent of rendered six-digit codes satisfy a bare character-class test; the
diagnostic claims to reject exactly that value, and without a length floor the claim was false. RFC 4226 R6 puts
the shared secret at 128 bits, so no real TOTP seed falls under the 16 characters of an 80-bit one.

**The `RCLONE_<FLAG>` `unset` had no coverage.** Round 2 added the `unset` as the only runtime guard on the latch,
but nothing in `proton-drive-check.nix` set those variables, so deleting the line left every case green. The rclone
stub now exits 99 when any of the five survived, and the safety-abort invocation sets all five; that run depends on
the abort record reaching stderr, so a stub that refuses to run never emits it and never latches.

**The activation script had no runtime coverage at all.** Everything above lives in `configureRcloneConfig`, which
no check drove, which is why rounds 1 and 2 each left items verifiable only by hand.
`modules/hm-apps/rclone-protondrive-otp-check.nix` drives it directly: the entry is parameterized entirely through
shell variables at its top, `security.wrapperDir` selects the `op` binary and `programs.rclone.package` selects the
`rclone` binary, so stubbing both puts the script itself under test. That closes the OTP parsing, the
warn-and-preserve path behind a failing `op read`, and the credential fingerprint in both directions. The entry is
a raw DAG string that never reaches `writeShellApplication`'s shellcheck pass, so the check lints it too, excluding
only SC1090 for the two env files it sources at run time by design.

### 8. Review follow-up (round 4)

Two findings against round 3, both reproduced before implementing. They are the same defect in two places: a
configured `op://` reference that resolves to an unusable value rendered a `[protondrive]` stanza which cannot
work, with no diagnostic. Opting out of either reference is already expressed by leaving it empty, which never
reaches `op read`, so a configured reference reading back unusable is a configuration error.

**The base32 floor guarded only the bare arm.** `otpauth://totp/Proton:me?secret=234567` still rendered
`otp_secret_key` from a code, since `?attribute=otp` puts the rendered value into the URI's own `secret=`, and
a percent-encoded or truncated `secret=` still rendered a seed rclone cannot decode. The round-3 comment and
diagnostic both described a validation half the inputs never reached. Extraction already ran first, so the
filter moves after the `case` and one rule now covers both shapes; the diagnostic names the length requirement
rather than the input shape, since shape is no longer what it turns on.

**A blank `mailboxPasswordRef` read was silent.** `op read` on a field that exists but is blank exits 0 and
prints nothing, so the `[ -n ... ]` guard skipped the `obscure`, the state reached `ready`, and the stanza
rendered with no `mailbox_password`. On a two-password account that remote authenticates and then cannot
decrypt. It now fails the way the OTP arm does, with a message naming the empty ref as the way to opt out.
`modules/hosts/common/rclone-protondrive-1password.nix` points that ref at a separate populated item rather
than a blank field, so the live configuration is unaffected.

Both paths are covered. The mailbox case needs a second Home Manager configuration, because the reference
itself is what distinguishes opting out from reading a field that must not be blank, so the check drives and
lints both rendered activation scripts.

### 9. Review follow-up (round 5)

Two findings, both verified against rclone's source and Home Manager's activation semantics before
implementing. Each is a guard that was correct where it was written and stopped one step short.

**`RCLONE_FORCE` and `RCLONE_RESYNC` bypassed the safety checks entirely.** Round 2 cleared the log-routing
variables, which defeat abort *detection*. bisync's own `--force` and `--resync` register through the same
path, confirmed in the source: `cmd/bisync/cmd.go` passes both to `flags.BoolVarP`, whose `installFlag` reads
`fs.OptionToEnv(name)` from the environment before command-line parsing, and `fs.OptionToEnv` is
`"RCLONE_" + upper(name)`. Neither appears on the command line for a normal run, so the unit's inherited
environment supplied the default unopposed.

`RCLONE_FORCE=true` is the worse of the two. `cmd/bisync/operations.go` guards both safety checks with
`if !opt.Force`, so neither runs, no abort is emitted, and the deletions the 25-percent guard exists to hold
back propagate to Proton unattended. Defeating the checks is strictly worse than defeating their detection.
`RCLONE_RESYNC=true` turns every timer fire into a superset merge, the outcome the latch refusal message tells
operators to avoid. Every other flag the script depends on (`--workdir`, `--max-delete`, `--resilient`,
`--conflict-resolve`, `--create-empty-src-dirs`, `--config`) is passed explicitly on each path, so the command
line already wins for those; these two were the whole remaining exposure.

**The credential fingerprint write was not gated by `run`.** The config write beside it is. Under a dry run
`run` echoes instead of executing, so the digest landed on disk describing credentials the rendered config was
never updated to hold. After a password rotation the next real activation read that as an unchanged credential
set, took the preserve branch, and grafted `client_uid` and the three client tokens from the pre-rotation
stanza onto the post-rotation one, which is the inverse of what the fingerprint exists to do. It was also the
only state the entry left behind on a dry run, since `tmpConfig` is removed by the trap. Now staged through
`mktemp` and `run mv` like the config, with the trap extended to cover the staged file.

### 10. Review follow-up (round 6)

Two findings, both enhancements, both verified by eval before implementing.

**The shared vault refs were at the wrong priority.** They landed in the `hosts-common` aggregate at default
priority 100, inverting the scheme the rest of that aggregate uses: `apps-enable.nix` sets its baseline at
`mkOverride 1100` so a per-host file can override at 1000, which `modules/tpnix/apps-enable.nix` documents. At
100 a per-host definition either lost (at 1000) or failed evaluation with "conflicting definition values" (at
100), so the per-host escape hatch this file was introduced in round 2 to provide was reachable only through
`mkForce`, on every `shareCommon` host. Now at 1100. Both hosts resolve the same four values as before, and
`extendModules` with `usernameRef` at `mkOverride 1000` resolves to the per-host value.

**`_1password-cli` was a store reference of every rclone activation script.** `opExecutable` is interpolated
into `configureRcloneConfig` unconditionally, so the `else` arm put the unfree `1password-cli-2.34.1` into the
activation package for every host with `programs.rclone.extended.enable`, including sops-source hosts and
hosts with `protonDrive.enable = false` that never run an `op read`. Evaluating that entry for such a host
aborts on the unfree license before the reference is even reached, which is how the finding was confirmed. The
arm was unreachable anyway: `modules/apps/rclone.nix` asserts `programs._1password.enable` whenever the op://
source is selected, and the comment above it already recorded that the plain package binary fails every
`op read` for want of the setgid `onepassword-cli` group, so the fallback only substituted one failing binary
for another. Pinned to the wrapper path, which is a plain string and costs nothing when unused.

### 11. Review follow-up (round 7)

Three findings. One diagnosis accepted with its implementation rejected, one documentation defect with a
consequence the comment did not name, and one coverage gap.

**The `RCLONE_` enumeration was short a third time.** Rounds 2 and 5 unset seven names against a namespace
`installFlag` populates for every registered flag (`fs/config/flags.go`, via `fs.OptionToEnv`). Reproduced against
rclone 1.74.4: `RCLONE_DRY_RUN=true` diverts `--resync`'s listings to `-dry` paths
(`cmd/bisync/operations.go` `runLocked`) while the resync branch still writes `$marker`, so every later fire exits 7
on "cannot find prior Path1 or Path2 listings", which the `Safety abort` pattern does not match; nothing latches and
the run repeats every interval, the exact failure `run_bisync` was added to stop. `RCLONE_RESYNC_MODE=path2`
inverts the conflict winner the resync branch announces, and `setResyncDefaults` sets `Resync` whenever
`ResyncMode != PreferNone`, so it also turns a normal fire into a resync. `RCLONE_CONFLICT_LOSER=delete` drops the
losing copy of every conflict. The script now clears the whole namespace; every flag it depends on is passed
explicitly and the command line wins over the environment.

The review suggested `while read -r n; do unset "$n"; done < <(compgen -e RCLONE_ || true)`. That was rejected and
substituted: `writeShellApplication` builds against `pkgs.runtimeShell`, which carries no progcomp, so `compgen`
exits 127 and the `|| true` swallows it. Built and run, the suggestion replaces seven working `unset`s with a
silent no-op that still passes shellcheck. Prefix parameter expansion (`"${!RCLONE_@}"`) is a builtin with no PATH
or process-substitution dependency and was verified in that shell. The stub's own knobs move to
`PROTON_DRIVE_STUB_*` so the sweep cannot silence the stub that measures it, and its two enumerated guards become
one namespace guard that names the survivors.

**`--log-systemd` was missing from `logRoutingFlags`.** Found while verifying the above.
`fs/log/systemd_unix.go` `startSystemdLog` sets a journald output *and* `logFormatNoLevel`, so it both moves the
`ERROR` record off stderr and strips the level prefix the pattern requires: it defeats the latch by both mechanisms
the assertion exists to catch. It takes no value, so the assertion's `${flag}=` test never had a chance at it.
Journal auto-detection is not a third hole: `run_bisync` pipes rclone into `tee`, and
`journal.StderrIsJournalStream` stats fd 2, which is that pipe.

**The sops credential arm of the activation entry had never run.** The entry assembles its credential fingerprint
per source, from plaintext `op read` values on one side and the already-obscured secret values on the other; only
the digest, the comparison and the session-key graft below them are shared. `mkHm` in
`rclone-protondrive-otp-check.nix` hardcoded `authSource = "onePassword"`, so a defect confined to the sops
assembly grafted pre-rotation `client_uid`/`client_access_token` onto a post-rotation stanza with every existing
assertion green. A third `mkHm` closes it: `protondriveSopsReady` tests `builtins.pathExists` against
`secretsRoot` at eval, while the file the arm sources at run time is the `osConfig` secret path, so the existing
fixture plus a secret path inside `$check_root` arms the branch with nothing decryptable present. The arm needs no
binary past coreutils, since it consumes obscured values rather than calling `rclone obscure`, which a verbatim
`password = already-obscured-1` assertion pins. The sops-specific unreadable-secret guard and its warning get their
first execution too, and shellcheck now lints the third rendered entry.

The prerequisite step in `modules/hm-apps/proton-drive.nix` still said the rclone module defaults to the shared
1Password references, which round 2 made false. It now names `programs.rclone.extended.enable`, the aggregate's
`mkOverride 1100` baseline for both the enables and the refs, and the per-host 1000 override. The
`modules/apps/rclone.nix` assertion that an outside-aggregate host actually hits now names
`rclone-protondrive-1password.nix` as the source, and the `services.protonDriveSync.enable` assertion no longer
claims four references are required: readiness needs only `usernameRef` and `passwordRef`.

### 12. Review follow-up (round 8)

Two findings against round 7, both reproduced against rclone 1.74.4 before implementing.

**`extraArgs` is the stronger surface the sweep left open.** Round 7 closed the `RCLONE_<FLAG>` path for
`--dry-run`, `--force`, `--resync`, `--resync-mode` and `--conflict-loser`, but `extraArgs` still carried all five,
and it is appended last on every invocation while rclone's parser takes the last occurrence of a flag. Verified:
`rclone sync --max-delete=25 --max-delete=0` refuses the deletes, so an extraArg replaces the module's value rather
than adding to it. `--dry-run` reproduces the same unlatchable repeat the sweep was added to stop, by the other
route. `logRoutingFlags` becomes `rejectedFlags` and gains the six safety and mode flags.

Short options are refused wholesale rather than matched one at a time, which the review's list did not cover: they
cluster, so `-nv` is `--dry-run` plus `--verbose` and no per-flag test sees it (confirmed: `rclone copy -nv`
transfers nothing), and bisync gives `--resync` the shorthand `-1`. Every rejected flag has a long form, and the
option's documented use (`--bwlimit=2M`) is unaffected, which a positive check case now pins.

One flag was considered and left accepted: `--workdir` relocates the bisync listings but stays self-consistent
across runs, so it does not strand the baseline the way `--dry-run` does.

`--protondrive-enable-caching` was also left accepted here, on the reasoning that the command line only reinforces
the `enable_caching = false` in the stanza. Round 9 corrects that; see below.

**A locked 1Password cost four timeouts, not one.** The four `op read` calls ran unconditionally under
`timeout 30`, and a locked desktop app answers none of them, so each re-raised the same unlock prompt and waited
out its own timeout: 120 seconds to reach the warn-and-preserve branch instead of 30, on every switch of every host
carrying the op:// source, against exactly the case the round-2 timeout was added to bound. Each read after the
first is now gated on `protondriveLookupFailed`, and the op stub counts its invocations so the existing
`OP_STUB_FAIL` case asserts one read rather than four.

### 13. Review follow-up (round 9)

One finding, against a decision round 8 recorded rather than against code.

**The round-8 reasoning for leaving `--protondrive-enable-caching` accepted was wrong.** `fs/configmap.go`
`ConfigMap` registers explicitly set flag values at `PriorityNormal` and the config file at `PriorityConfig`, and
`Getn` returns the first match in priority order, so a command-line flag beats the stanza. The command line is
therefore the sole authority for that backend option, not a reinforcement of it, and `extraArgs` is appended after
the `--protondrive-enable-caching=false` in `common`, so an extraArg overrode both.

Caching is off because Proton's change-event system is unimplemented, which the module states in three places, and
a stale metadata cache feeds bisync's delta computation. That is the same class of override round 8 closed for the
deletion cap and the safety checks, so the flag is now rejected and `rejectedFlags` carries thirteen. The round-7
`RCLONE_` sweep already covered `RCLONE_PROTONDRIVE_ENABLE_CACHING`; only this surface was open.

`--workdir` remains accepted, for the reason round 8 gave. Round 11 reverses that; see below.

### 14. Review follow-up (round 10)

Three findings, all additive.

**`--ignore-errors` belongs in the safety class.** `fs/sync/sync.go` withholds destination deletes from a run that
accumulated errors, returning `fs.ErrorNotDeleting` under
`if accounting.Stats(ctx).Errored() && !s.ci.IgnoreErrors`. That is the guard `--max-delete` cannot express, since
the deletes are within the cap; against the Beta protondrive backend a partial listing failure would delete rather
than abort, on all 48 fires a day the default interval makes. `rejectedFlags` now carries fourteen.

**Nothing asserted the premise `rejectedFlags` rests on.** Rounds 8 to 10 refuse these overrides because the module
passes its own value on every invocation, yet deleting `--max-delete=25` from the bisync call, or
`--protondrive-enable-caching=false` from `common`, left every case green while the eval guard kept forbidding the
override of a flag that was no longer there. The `--force` release already records its full argv through the stub,
so it now asserts the five flags the list defends.

**`sync_one_way` had never executed.** Every case ran the default `bisync` direction, so the one-way branches that
clear the baseline and latch on rclone's exit 7 were untouched, which is the gap the check header says it closes.
Direction is part of the tuple key, so the `up` cases assert their own markers alongside the bisync ones: exit 7
propagates, clears the up baseline and latches the up tuple, then `--resync` retains the cap after that abort while
`--force-resync` drops it.

### 15. Review follow-up (round 11)

Three findings, one of which reverses a decision rounds 8 and 9 both recorded.

**The unit inherited the `PROTON_DRIVE_*` overrides.** The script reads `PROTON_DRIVE_LOCAL`,
`PROTON_DRIVE_REMOTE` and `PROTON_DRIVE_DIRECTION` before the `RCLONE_` sweep and before any safety logic, and the
systemd user unit inherits the manager's environment: the same surface the sweep closes, left open for the values
that decide *what* is synced rather than how. `PROTON_DRIVE_DIRECTION=up` from `environment.d` or
`systemctl --user set-environment` turns every fire of a bisync host into `rclone sync local remote`, and since
direction is part of the tuple key, that run carries its own `$marker` and `$aborted`, so neither the configured
tuple's first-run gate nor its latch applies to it. `UnsetEnvironment` drops all three for the unit only, leaving
the documented interactive form working. `systemd-analyze verify` accepts the directive, and Home Manager
serializes the `Service` attrset through `lib.generators.toINI`.

**`--config` was defended but not rejected.** The round-10 check asserts it as one of the flags `rejectedFlags`
protects while it was not in the list. The tuple key is direction/local/remote, so a replacement config that also
defines `protondrive:` reuses this account's baseline and latch against another account's tree.

**`--workdir` is now rejected, reversing rounds 8 and 9.** The recorded reason was that it relocates the bisync
listings but stays self-consistent across runs. That holds only while the relocated directory outlives a reboot,
which the module cannot check. `$marker` is written under `state_dir`, pinned to `xdg.stateHome`, while the
listings follow `--workdir`, so an extraArg moves one and not the other. Both hosts set `boot.tmp.useTmpfs` and
`boot.tmp.cleanOnBoot`, so `--workdir=/tmp/bisync` survives exactly one reboot as a baseline with no listings
behind it, and every later fire dies on "cannot find prior Path1 or Path2 listings", which the abort pattern does
not match. That is the unlatchable repeat `--dry-run` is rejected for, reached with no intent to disable anything.
`rejectedFlags` carries sixteen.

### 16. Review follow-up (round 12)

Two findings, both against assertions rounds 10 and 11 added.

**The `--force-resync` case did not test what its message claimed.** The `--resync` before it succeeded, so
`sync_one_way` cleared `$aborted`, and the cap was then dropped by the `[ ! -e "$aborted" ]` disjunct rather than
by `[ "$force" -eq 1 ]`. Removing the force disjunct left the assertion green, so the purpose the module header and
the exit-7 diagnostic both advertise for `--force-resync` was unpinned. The tuple is re-latched with a second
exit 7 first, so only force can drop the cap, and the release of the latch is asserted after it.

**`--workdir` was rejected without asserting it is passed.** Round 11 added it to `rejectedFlags` on the premise
the round-10 loop exists to assert, and did not add it to that loop. Deleting
`--workdir "$state_dir/bisync"` from both bisync invocations left every case green while the eval guard kept
refusing an override of a flag no longer passed.

### 17. Review follow-up (round 13)

Two findings, both against round 8 and round 11 respectively, both false positives of my own guards rather than
module defects.

**The short-option test rejected flag values.** `-[^-].*` matches any argument starting with a dash and one
non-dash character, which includes values. An rclone exclude rule is written exactly that way, so
`extraArgs = [ "--filter" "- *.partial" ]` failed with a message telling the operator to use "the long form",
which a value does not have, while the `+ *.txt` half of the same filter pair was accepted. Restricting the first
character to an option character keeps every cluster the guard exists for, since rclone's short options are letters
and bisync gives `--resync` the shorthand `-1`. The positive check case now carries both halves of a filter pair.

**Round 11 changed a documented interface without updating its documentation.** The header's per-invocation
override block still presented `PROTON_DRIVE_LOCAL`, `PROTON_DRIVE_REMOTE` and `PROTON_DRIVE_DIRECTION` as applying
everywhere, which `UnsetEnvironment` made false for the timer, so an operator exporting one from `environment.d` to
re-point what the timer syncs would have got no effect and no diagnostic. The block now states the scope.

### 18. Review follow-up (round 14)

Two findings, plus the structural fix the pattern behind them called for.

**`--conflict-resolve` and `--resilient` were defended but not rejected.** Both are asserted by the round-10 loop
as flags `rejectedFlags` protects while being absent from it, the same gap `--config` had in round 11 and
`--workdir` in round 12. `--conflict-resolve` is passed once on the normal bisync path, so
`extraArgs = [ "--conflict-resolve=path2" ]` replaces `newer` and hands the remote every conflict on all 48
unattended fires a day; `--conflict-loser` was already rejected for the other half of that same decision.
`--resilient` is a bool, so `--resilient=false` reinstates bisync's `-err` listing rename on a retryable critical
error, which `cmd/bisync/operations.go` skips only under `b.retryable && b.opt.Resilient && !b.opt.Resync`. That
turns the offline-at-boot retry the unit comment relies on into the unlatchable repeat `--dry-run` and `--workdir`
are rejected for, reached from the flag whose entire purpose is to prevent it.

**The lists are now bound together.** Four rounds finding the same gap is a hand-maintained pair of lists, not four
oversights. The module exposes `rejectedFlags` through an internal read-only option, the check derives its
command-line loop from a single list of owned tokens, and it asserts every one of those is refused. Asserting a
flag is passed means nothing while `extraArgs` can replace it, so the two can no longer drift without a check
failure that names the flag.

### 19. Review follow-up (round 15)

One finding, and the hole it exposed in round 14's fix.

**`--create-empty-src-dirs` was in neither list.** It is passed on all four invocations, so `extraArgs` could
replace it. Round 14's binding did not catch it: that asserts the owned tokens are refused, which says nothing
about a flag missing from *both* lists, so the comment claiming every flag the script passes is rejected was
enforced nowhere.

The reported mechanism does not hold as stated, and the flag is rejected on different grounds. Tested against
rclone 1.74.4 on the local backend: `--create-empty-src-dirs=false` does not prune the destination, and a
destination-only empty directory is removed either way, so `up` does not strip the directory structure from Proton.
What the flag actually decides is whether an empty *source* directory is mirrored at all, which changes what the
bisync listings describe from one fire to the next. That is the same class as the rest of the list, a value the
module chose that `extraArgs` replaces invisibly.

**The invariant is now checked rather than asserted.** The check reads the flags out of the stub's recorded argv
and fails on any that is neither refused nor listed tunable (`--transfers`, `--checkers`, and `--max-depth` on the
down probe that `extra` never reaches). Removing `--create-empty-src-dirs` from both lists reproduces exactly this
defect, which is the property round 14's version lacked.

### 20. Review follow-up (round 16)

Two coverage gaps, both in directions and arms the checks claimed to cover.

**`down` had no coverage, and it is the direction whose deletions are local.** Its guard is the emptiness probe: an
`rclone lsf` returning nothing refuses to mirror an empty remote onto `localPath`. Round 10 added `up` for
`sync_one_way`, leaving the probe, the down first-run gate and the `--force-resync` bypass of the probe
unexecuted, so the header's claim to cover the destructive-recovery logic held for two directions of three. No stub
change was needed: `--force-resync` skips the probe, and the fire after it hits the probe against the stub's empty
stdout. That run also puts `--max-depth` on the recorded argv for the first time, which the round-15 invariant loop
already covers through `tunableFlags`.

**The no-2FA activation arm never ran.** The activation check hardcoded `otpRef` non-empty in every configuration,
so the account-without-2FA case was untested. That arm is three skips in `rclone.nix`: the `op read`, the
`case` and base32 validation, and the `obscure`, so the stanza must render well-formed with no `otp_secret_key`.
Only the readiness half was covered, by eval through `onePasswordNoOtpHm`. That is the same asymmetry that gave
`mailboxPasswordRef` its own configuration, and the reason the OTP arm needed fixes in rounds 3 and 4. `mkHm` now
takes `otpRef`, and a fourth rendered entry is driven and linted.

## Test plan

```
nix fmt
nix flake check --accept-flake-config --no-build --offline path:.
nix eval path:.#nixosConfigurations.{tpnix,system76}.config.system.build.toplevel.drvPath
nix build path:.#checks.x86_64-linux."hm-apps/proton-drive-sync"
nix build path:.#checks.x86_64-linux."hm-apps/rclone-protondrive-otp"
nix eval path:.#nixosConfigurations.{tpnix,system76}.config.programs.rclone.extended.protonDrive.onePassword
nix develop path:. -c pre-commit run --all-files --hook-stage manual
```

All green. Both host toplevels evaluate with `protonDrive.enable` on, and resolve the same
`onePassword.*Ref` values as before the round-2 relocation (`nix eval
path:.#nixosConfigurations.{tpnix,system76}.config.programs.rclone.extended.protonDrive`).

`shellcheck --severity=warning` on the rendered `configureRcloneConfig` activation script, re-run after round 2,
still reports only the same two pre-existing SC1090 non-constant-source warnings (one of which predates this
branch); the `timeout`, `unset`, and optional-ref conditionals added in round 2 introduce none.

The new check was confirmed non-vacuous by reverting each sync-script fix in isolation and rebuilding:

- latch removed: `hm-apps/proton-drive-sync: a bisync safety abort must latch the tuple`
- `state_dir` pin reverted: `hm-apps/proton-drive-sync: --resync must write the baseline marker`
  (`find: '/tmp/proton-drive-sync-check/state/proton-drive-sync': No such file or directory`)

Not exercised: no host switch, and no live `op read` against a real vault. `services.protonDriveSync.enable` is off
everywhere, so the timer path stays inert until an operator opts a host in.

Each follow-up fix was confirmed non-vacuous by reverting it in isolation and rebuilding the check:

- bare `Safety abort` grep restored: `a transferred path naming the abort must not latch`
- `--log-file` dropped from the rejected set: `--log-file in extraArgs must fail an assertion`
- `rcloneEnabled` dropped from `protondriveReady`:
  `programs.rclone.extended.enable = false must withhold proton-drive-sync`
- root guard, `--rebuild --option sandbox false` against a pre-created `/tmp/proton-drive-sync-check`:
  `already exists; this check needs the sandbox's private /tmp`
- (round 2) `--resync`'s `rm -f -- "$aborted"` reverted: `--resync must release the latch`
- (round 2) the EXIT trap removed, two consecutive `--rebuild --option sandbox false` runs:
  first run passes, second fails `already exists; this check needs the sandbox's private /tmp`; restoring the
  trap makes both runs pass
- (round 3) the pre-fix reject of a bare seed restored: `a bare base32 seed must not fail activation`
- (round 3) the 16-character floor dropped: `the rendered six-digit code 234567 must fail activation`
- (round 3) the `otpauth://*secret=*` case guard restored without the shared empty-seed guard:
  `an otpauth:// URI whose secret= is not a query parameter must fail activation`
- (round 3) the carry-forward branch disabled: `an unavailable 1Password must carry the previous stanza forward`
- (round 3) the fingerprint comparison disabled: `an unchanged credential set must preserve the session keys`
- (round 3) the fingerprint made insensitive to the password: `a rotated password must drop the session keys`
- (round 4) the base32 filter moved back inside the bare arm:
  `an otpauth:// URI carrying a rendered code must fail activation`
- (round 4) the mailbox guard removed: `a blank mailbox reference must fail activation`
- (round 7, superseding the round-3 and round-5 probes of the same line) the namespace sweep removed:
  `a bisync safety abort must latch the tuple`, after the stub reports
  `RCLONE_ variables reached rclone: RCLONE_CONFLICT_LOSER RCLONE_DRY_RUN RCLONE_FORCE RCLONE_LOG_FILE
  RCLONE_LOG_FORMAT RCLONE_LOG_LEVEL RCLONE_LOG_SYSTEMD RCLONE_RESYNC RCLONE_RESYNC_MODE RCLONE_SYSLOG
  RCLONE_USE_JSON_LOG`
- (round 7) `--log-systemd` dropped from `logRoutingFlags`:
  `--log-systemd in extraArgs must fail an assertion`
- (round 7) `PROTONDRIVE_PASSWORD` dropped from the sops fingerprint material: every pre-existing assertion stays
  green and only `a rotated sops password must drop the session keys` fails
- (round 8) `--dry-run` dropped from `rejectedFlags` together with the short-option predicate:
  `--dry-run in extraArgs must fail an assertion`
- (round 8) the password read un-guarded: `a failing op read must short-circuit the remaining reads`
- (round 9) `--protondrive-enable-caching` dropped from `rejectedFlags`:
  `--protondrive-enable-caching in extraArgs must fail an assertion`
- (round 10) `--ignore-errors` dropped from `rejectedFlags`:
  `--ignore-errors in extraArgs must fail an assertion`
- (round 10) `--max-delete=25` dropped from the bisync invocation:
  `a normal bisync run must pass --max-delete=25`
- (round 10) `rm -f -- "$marker"` dropped from `sync_one_way`:
  `a fatal one-way abort must clear its own baseline marker`
- (round 11) `--config` dropped from `rejectedFlags`: `--config in extraArgs must fail an assertion`
- (round 11) `--workdir` dropped from `rejectedFlags`: `--workdir in extraArgs must fail an assertion`
- (round 11) `UnsetEnvironment` dropped from the unit:
  `the unit must drop the PROTON_DRIVE_* per-invocation overrides`
- (round 12) `[ "$force" -eq 1 ] ||` dropped from the cap condition:
  `--force-resync must bypass the deletion cap`, which stayed green before this round
- (round 12) `--workdir "$state_dir/bisync"` dropped from both bisync invocations:
  `a normal bisync run must pass --workdir`
- (round 13) `-[^-].*` restored as the short-option test: the positive tuning case fails on `- *.partial`
- (round 13) the short-option test dropped entirely:
  `a clustered short option in extraArgs must fail an assertion`
- (round 14) `--conflict-resolve` or `--resilient` dropped from `rejectedFlags`:
  `flags asserted on the command line but absent from rejectedExtraArgs`, naming the flag
- (round 15) `--create-empty-src-dirs` dropped from both lists:
  `the script passes --create-empty-src-dirs, which extraArgs can replace and neither list covers`
- (round 16) the down emptiness probe made to see a nonempty listing:
  `an empty remote listing must refuse to mirror onto the local tree`
- (round 16) the empty-`otpRef` skip removed: `an empty otpRef must not fail activation (exit 1)`
- (round 5) the direct fingerprint write restored: `a dry run must not advance the credential fingerprint`

The credential fingerprint is covered by `hm-apps/rclone-protondrive-otp`, which replaces the round-1 hand
replay: the session keys survive an unchanged credential set and are dropped after a password rotation, asserted in
both directions and, since round 7, in both credential sources.

The 1Password wrapper fix is verified by evaluation only (`opExecutable=/run/wrappers/bin/op` in the rendered
activation block, and `config.assertions` clean on both hosts). No live `op read` against the desktop app was run.

Round 3 closes most of what round 2 listed as uncovered. The `RCLONE_<FLAG>` `unset` is now covered by
`hm-apps/proton-drive-sync`, and the activation-script branches by `hm-apps/rclone-protondrive-otp`, including the
failing-`op read` path that a `timeout` expiry reaches by the same `|| protondriveLookupFailed=1` fallback (the
stub exits non-zero directly rather than making the check wait out the 30-second timeout, so the `timeout` prefix
itself is still unexercised; its failure mode is a hang, which is self-announcing). The optional-ref *readiness*
computation stays covered by eval (`onePasswordNoOtpHm` in `proton-drive-check.nix` asserts an empty
`otpRef`/`mailboxPasswordRef` still installs the script).









