### PR TITLE
feat(claude-code): route subagents off Haiku 4.5 and catalog the config surface

### DIFF
--- a/modules/agents/claude-code/_activation.nix
+++ b/modules/agents/claude-code/_activation.nix
@@ -20,10 +20,10 @@
   config,
   claudeSettingsFile,
   claudeJsonConfigFile,
+  claudeEnv,
+  claudeDefaults,
 }:
 let
-  claudeEnv = import ./_env.nix;
-  claudeDefaults = import ./_default-settings.nix;
   retiredEnvJq = lib.optionalString (claudeEnv.retired != [ ]) (
     " | " + lib.concatMapStringsSep " | " (name: "del(.env[${builtins.toJSON name}])") claudeEnv.retired
   );

--- a/modules/agents/claude-code/_activation.nix
+++ b/modules/agents/claude-code/_activation.nix
@@ -22,6 +22,17 @@
   claudeJsonConfigFile,
 }:
 let
+  claudeEnv = import ./_env.nix;
+  claudeDefaults = import ./_default-settings.nix;
+  retiredEnvJq = lib.optionalString (claudeEnv.retired != [ ]) (
+    " | " + lib.concatMapStringsSep " | " (name: "del(.env[${builtins.toJSON name}])") claudeEnv.retired
+  );
+  retiredJsonJq = lib.optionalString (claudeDefaults.retired.claudeJson != [ ]) (
+    " | "
+    + lib.concatMapStringsSep " | " (
+      name: "del(.[${builtins.toJSON name}])"
+    ) claudeDefaults.retired.claudeJson
+  );
   bunInstallEnabled = lib.attrByPath [
     "programs"
     "claude-code"
@@ -56,8 +67,7 @@ in
       | ($existing * $nix)
       | .deniedMcpServers = ((($existing.deniedMcpServers // []) + ($nix.deniedMcpServers // [])) | unique)
       | .enabledPlugins = (($existing.enabledPlugins // {}) + ($nix.enabledPlugins // {}))
-      | .env = (($existing.env // {}) + ($nix.env // {}))
-      | .env |= del(.DISABLE_NON_ESSENTIAL_MODEL_CALLS)' \
+      | .env = (($existing.env // {}) + ($nix.env // {}))${retiredEnvJq}' \
       "$existing_settings" > "$CLAUDE_SETTINGS_TMP"; then
       echo "ERROR: jq failed to merge Claude Code settings" >&2
       exit 1
@@ -84,7 +94,7 @@ in
       | $nixConfig[0] as $nix
       | ($existing * $nix)
       | .mcpServers = (($existing.mcpServers // {}) + ($nix.mcpServers // {}))
-      | del(.autocheckpointingEnabled)' \
+      ${retiredJsonJq}' \
       "$CLAUDE_CONFIG" > "$CLAUDE_CONFIG_TMP"; then
       echo "ERROR: jq failed to merge config" >&2
       exit 1

--- a/modules/agents/claude-code/_activation.nix
+++ b/modules/agents/claude-code/_activation.nix
@@ -3,8 +3,8 @@
 
   Produces:
     - claudeCodeSetup: idempotent jq merge into ~/.claude/settings.json and
-      ~/.claude.json, preserving user keys while wholly replacing Nix-managed
-      mcpServers entries.
+      ~/.claude.json, preserving user keys while deleting source-declared
+      retired keys and wholly replacing Nix-managed mcpServers entries.
     - installClaudeCodeViaBun: optional, only when
       programs.claude-code.extended.installMethods.bun.enable is true.
 
@@ -24,6 +24,12 @@
   claudeDefaults,
 }:
 let
+  retiredSettingsJq = lib.optionalString (claudeDefaults.retired.settings != [ ]) (
+    " | "
+    + lib.concatMapStringsSep " | " (
+      name: "del(.[${builtins.toJSON name}])"
+    ) claudeDefaults.retired.settings
+  );
   retiredEnvJq = lib.optionalString (claudeEnv.retired != [ ]) (
     " | " + lib.concatMapStringsSep " | " (name: "del(.env[${builtins.toJSON name}])") claudeEnv.retired
   );
@@ -67,7 +73,7 @@ in
       | ($existing * $nix)
       | .deniedMcpServers = ((($existing.deniedMcpServers // []) + ($nix.deniedMcpServers // [])) | unique)
       | .enabledPlugins = (($existing.enabledPlugins // {}) + ($nix.enabledPlugins // {}))
-      | .env = (($existing.env // {}) + ($nix.env // {}))${retiredEnvJq}' \
+      | .env = (($existing.env // {}) + ($nix.env // {}))${retiredEnvJq}${retiredSettingsJq}' \
       "$existing_settings" > "$CLAUDE_SETTINGS_TMP"; then
       echo "ERROR: jq failed to merge Claude Code settings" >&2
       exit 1

--- a/modules/agents/claude-code/_activation.nix
+++ b/modules/agents/claude-code/_activation.nix
@@ -4,7 +4,8 @@
   Produces:
     - claudeCodeSetup: idempotent jq merge into ~/.claude/settings.json and
       ~/.claude.json, preserving user keys while deleting source-declared
-      retired keys and wholly replacing Nix-managed mcpServers entries.
+      retired keys, invalid legacy environment values, and wholly replacing
+      Nix-managed mcpServers entries.
     - installClaudeCodeViaBun: optional, only when
       programs.claude-code.extended.installMethods.bun.enable is true.
 
@@ -32,6 +33,15 @@ let
   );
   retiredEnvJq = lib.optionalString (claudeEnv.retired != [ ]) (
     " | " + lib.concatMapStringsSep " | " (name: "del(.env[${builtins.toJSON name}])") claudeEnv.retired
+  );
+  legacyEnvValuesJq = lib.optionalString (claudeEnv.legacyEnvValues != { }) (
+    " | "
+    + lib.concatStringsSep " | " (
+      lib.mapAttrsToList (
+        name: value:
+        "if .env[${builtins.toJSON name}] == ${builtins.toJSON value} then del(.env[${builtins.toJSON name}]) else . end"
+      ) claudeEnv.legacyEnvValues
+    )
   );
   retiredJsonJq = lib.optionalString (claudeDefaults.retired.claudeJson != [ ]) (
     " | "
@@ -73,7 +83,7 @@ in
       | ($existing * $nix)
       | .deniedMcpServers = ((($existing.deniedMcpServers // []) + ($nix.deniedMcpServers // [])) | unique)
       | .enabledPlugins = (($existing.enabledPlugins // {}) + ($nix.enabledPlugins // {}))
-      | .env = (($existing.env // {}) + ($nix.env // {}))${retiredEnvJq}${retiredSettingsJq}' \
+      | .env = (($existing.env // {}) + ($nix.env // {}))${legacyEnvValuesJq}${retiredEnvJq}${retiredSettingsJq}' \
       "$existing_settings" > "$CLAUDE_SETTINGS_TMP"; then
       echo "ERROR: jq failed to merge Claude Code settings" >&2
       exit 1

--- a/modules/agents/claude-code/_activation.nix
+++ b/modules/agents/claude-code/_activation.nix
@@ -56,7 +56,8 @@ in
       | ($existing * $nix)
       | .deniedMcpServers = ((($existing.deniedMcpServers // []) + ($nix.deniedMcpServers // [])) | unique)
       | .enabledPlugins = (($existing.enabledPlugins // {}) + ($nix.enabledPlugins // {}))
-      | .env = (($existing.env // {}) + ($nix.env // {}))' \
+      | .env = (($existing.env // {}) + ($nix.env // {}))
+      | .env |= del(.DISABLE_NON_ESSENTIAL_MODEL_CALLS)' \
       "$existing_settings" > "$CLAUDE_SETTINGS_TMP"; then
       echo "ERROR: jq failed to merge Claude Code settings" >&2
       exit 1
@@ -82,7 +83,8 @@ in
       '. as $existing
       | $nixConfig[0] as $nix
       | ($existing * $nix)
-      | .mcpServers = (($existing.mcpServers // {}) + ($nix.mcpServers // {}))' \
+      | .mcpServers = (($existing.mcpServers // {}) + ($nix.mcpServers // {}))
+      | del(.autocheckpointingEnabled)' \
       "$CLAUDE_CONFIG" > "$CLAUDE_CONFIG_TMP"; then
       echo "ERROR: jq failed to merge config" >&2
       exit 1

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -166,40 +166,12 @@ let
   # `bash -c` in bashAsk are different rules, and both are live.
   deadAllow = builtins.filter (cmd: builtins.elem cmd bashAsk) bashAllow;
 
-  # Keys retired from existing ~/.claude.json files.
+  # Keys retired from existing ~/.claude/settings.json and ~/.claude.json files.
   retired = {
+    settings = [ ];
     claudeJson = [ "autocheckpointingEnabled" ];
   };
 
-  # UI preferences for ~/.claude.json (merged with existing config in _settings.nix)
-  claudeJsonConfigBase = {
-    hasTrustDialogAccepted = true;
-    hasCompletedProjectOnboarding = true;
-    bypassPermissionsModeAccepted = true;
-    autoCompactEnabled = true; # Auto-compact
-    autoConnectIde = false; # Auto-connect to IDE
-    autoUpdates = false; # Auto-updates
-    claudeInChromeDefaultEnabled = true; # Chrome enabled by default
-    defaultToAgentsView = true; # Open agents view by default
-    diffTool = "diff"; # Diff tool
-    editorMode = "vim"; # Editor mode
-    externalEditorContext = true; # Show last response in external editor
-    preferredNotifChannel = "iterm2_with_bell"; # Notifications
-    theme = "dark"; # Theme
-    verbose = true; # Verbose output
-  };
-  retiredJsonButLive = builtins.filter (
-    name: builtins.hasAttr name claudeJsonConfigBase
-  ) retired.claudeJson;
-in
-assert
-  deadAllow == [ ]
-  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " deadAllow} are in both bashAllow and bashAsk; ask wins, so drop them from bashAllow rather than leaving the two lists disagreeing";
-assert
-  retiredJsonButLive == [ ]
-  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " retiredJsonButLive} are both retired and live; remove the name from retired or claudeJsonConfigBase";
-{
-  inherit claudeJsonConfigBase retired;
   claudeSettingsBase = {
     cleanupPeriodDays = 30;
     # Disables + bash knobs from the shared source
@@ -227,6 +199,42 @@ assert
     terminalProgressBarEnabled = true; # Terminal progress bar
     useAutoModeDuringPlan = false; # Use auto mode during plan
   };
+
+  # UI preferences for ~/.claude.json (merged with existing config in _settings.nix)
+  claudeJsonConfigBase = {
+    hasTrustDialogAccepted = true;
+    hasCompletedProjectOnboarding = true;
+    bypassPermissionsModeAccepted = true;
+    autoCompactEnabled = true; # Auto-compact
+    autoConnectIde = false; # Auto-connect to IDE
+    autoUpdates = false; # Auto-updates
+    claudeInChromeDefaultEnabled = true; # Chrome enabled by default
+    defaultToAgentsView = true; # Open agents view by default
+    diffTool = "diff"; # Diff tool
+    editorMode = "vim"; # Editor mode
+    externalEditorContext = true; # Show last response in external editor
+    preferredNotifChannel = "iterm2_with_bell"; # Notifications
+    theme = "dark"; # Theme
+    verbose = true; # Verbose output
+  };
+  retiredJsonButLive = builtins.filter (
+    name: builtins.hasAttr name claudeJsonConfigBase
+  ) retired.claudeJson;
+  retiredSettingsButLive = builtins.filter (
+    name: builtins.hasAttr name claudeSettingsBase
+  ) retired.settings;
+in
+assert
+  deadAllow == [ ]
+  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " deadAllow} are in both bashAllow and bashAsk; ask wins, so drop them from bashAllow rather than leaving the two lists disagreeing";
+assert
+  retiredJsonButLive == [ ]
+  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " retiredJsonButLive} are both retired and live; remove the name from retired or claudeJsonConfigBase";
+assert
+  retiredSettingsButLive == [ ]
+  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " retiredSettingsButLive} are both retired and live; remove the name from retired or claudeSettingsBase";
+{
+  inherit claudeJsonConfigBase claudeSettingsBase retired;
 
   # === Undocumented settings.json keys (2.1.222 binary schema) ==============
   # Present in the binary's settings schema but absent from the published settings

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -512,7 +512,7 @@ assert
   #   "formatter@anthropic-tools": true }. Also supports extended format with
   #   version constraints. Settings precedence is user < project < local < flag
   #   < policy, so to disable a plugin that project settings enable, set it to
-  #   false in .claude/settings.local.json \u2014 setting false in
+  #   false in .claude/settings.local.json - setting false in
   #   ~/.claude/settings.json is overridden by the project.
   #   enabledPlugins = { };                             # [record]
   #
@@ -541,7 +541,7 @@ assert
   #   with fast mode off.
   #   fastModePerSessionOptIn = true;                   # [boolean]
   #
-  #   Probability (0\u20131) that the session quality survey appears when
+  #   Probability (0-1) that the session quality survey appears when
   #   eligible. 0.05 is a reasonable starting point.
   #   feedbackSurveyRate = 0;                           # [number]
   #
@@ -820,7 +820,7 @@ assert
   #   Advisory size guideline for the dynamic workflows Claude writes: "small"
   #   aims for fewer than 5 agents, "medium" (the default) fewer than 15,
   #   "large" fewer than 50, and "unrestricted" sends no guideline. A value here
-  #   \u2014 including from managed settings \u2014 takes precedence over the
+  #   - including from managed settings - takes precedence over the
   #   "Dynamic workflow size" choice in /config, and that /config row is hidden
   #   while a settings file provides the key. This is a guideline, not an
   #   enforced limit.
@@ -831,9 +831,9 @@ assert
   #   default. Common examples: "node_modules", ".cache", ".bin"
   #   worktree = { };                                   # [object]
   #
-  #   When set to true in either admin-only Windows source \u2014 the HKLM
+  #   When set to true in either admin-only Windows source - the HKLM
   #   SOFTWARE/Policies/ClaudeCode registry key or C:/Program
-  #   Files/ClaudeCode/managed-settings.json \u2014 WSL reads managed settings
+  #   Files/ClaudeCode/managed-settings.json - WSL reads managed settings
   #   from the full Windows policy chain (HKLM, C:/Program Files/ClaudeCode via
   #   DrvFs, HKCU) in addition to /etc/claude-code. Windows sources take
   #   priority. The flag is also required in HKCU itself for HKCU policy to

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -3,8 +3,9 @@
 
   Source of truth for default ~/.claude/settings.json keys, ~/.claude.json
   UI preferences, and ~/.claude/keybindings.json. Values that depend on runtime
-  evaluation (enabledPlugins, mcpServers) are injected by _settings.nix; this
-  attrset only carries the static portion shared across hosts.
+  evaluation (enabledPlugins, deniedMcpServers, mcpServers) are injected by
+  _settings.nix; this attrset only carries the static portion shared across
+  hosts.
 
   Permission rule semantics (code.claude.com/docs/en/permissions):
     * Rules evaluate deny -> ask -> allow; first match wins, so an ask/deny
@@ -172,6 +173,15 @@ let
     claudeJson = [ "autocheckpointingEnabled" ];
   };
 
+  # Runtime-owned keys are merged over these static bases by _settings.nix.
+  # Keep these lists aligned with that producer so retirement cannot delete a
+  # key that the same activation pass just injected.
+  injectedSettings = [
+    "enabledPlugins"
+    "deniedMcpServers"
+  ];
+  injectedClaudeJson = [ "mcpServers" ];
+
   claudeSettingsBase = {
     cleanupPeriodDays = 30;
     # Disables + bash knobs from the shared source
@@ -218,10 +228,10 @@ let
     verbose = true; # Verbose output
   };
   retiredJsonButLive = builtins.filter (
-    name: builtins.hasAttr name claudeJsonConfigBase
+    name: builtins.hasAttr name claudeJsonConfigBase || builtins.elem name injectedClaudeJson
   ) retired.claudeJson;
   retiredSettingsButLive = builtins.filter (
-    name: builtins.hasAttr name claudeSettingsBase
+    name: builtins.hasAttr name claudeSettingsBase || builtins.elem name injectedSettings
   ) retired.settings;
 in
 assert
@@ -229,10 +239,10 @@ assert
   || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " deadAllow} are in both bashAllow and bashAsk; ask wins, so drop them from bashAllow rather than leaving the two lists disagreeing";
 assert
   retiredJsonButLive == [ ]
-  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " retiredJsonButLive} are both retired and live; remove the name from retired or claudeJsonConfigBase";
+  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " retiredJsonButLive} are both retired and live; remove the name from retired, claudeJsonConfigBase, or the _settings.nix injected keys";
 assert
   retiredSettingsButLive == [ ]
-  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " retiredSettingsButLive} are both retired and live; remove the name from retired or claudeSettingsBase";
+  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " retiredSettingsButLive} are both retired and live; remove the name from retired, claudeSettingsBase, or the _settings.nix injected keys";
 {
   inherit claudeJsonConfigBase claudeSettingsBase retired;
 
@@ -476,7 +486,7 @@ assert
   #   server is on the denylist, it will be blocked across all scopes including
   #   enterprise. Denylist takes precedence over allowlist - if a server is on
   #   both lists, it is denied.
-  #   deniedMcpServers = [ ];                           # [array]
+  #   deniedMcpServers = [ ];                           # [array]    SET BY _settings.nix (programs.claude-code.extended.deniedMcpServers)
   #
   #   Disable agent view (`claude agents`, `--bg`, /background, the on-demand
   #   daemon). Typically set in managed settings. Equivalent to
@@ -554,7 +564,7 @@ assert
   #   < policy, so to disable a plugin that project settings enable, set it to
   #   false in .claude/settings.local.json - setting false in
   #   ~/.claude/settings.json is overridden by the project.
-  #   enabledPlugins = { };                             # [record]
+  #   enabledPlugins = { };                             # [record]   SET BY _settings.nix (programs.claude-code.extended.extraPlugins / lspPlugins)
   #
   #   When true and availableModels is a non-empty array, the Default model
   #   selection is also constrained: if the default model for the user tier is

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -362,7 +362,7 @@ assert
   #   attribution = { };                                # [object]
   #
   #   Automatically compact conversation when context fills
-  #   autoCompactEnabled = true;                        # [boolean]
+  #   autoCompactEnabled = true;                        # [boolean] ACTIVE in claudeJsonConfigBase
   #
   #   Auto-compact window size
   #   autoCompactWindow = 0;                            # [number]
@@ -494,7 +494,7 @@ assert
   #   disabledMcpjsonServers = [ ];                     # [array]
   #
   #   Key binding mode for the prompt input
-  #   editorMode = "";                                  # [enum]
+  #   editorMode = "";                                  # [enum]    ACTIVE in claudeJsonConfigBase
   #
   #   When false, the :emoji: shortcode typeahead (the suggestion popup and the
   #   :name: inline replacement) is disabled. When absent or true, it is
@@ -663,7 +663,7 @@ assert
   #   prUrlTemplate = "";                               # [string]
   #
   #   Preferred OS notification channel
-  #   preferredNotifChannel = "";                       # [enum]
+  #   preferredNotifChannel = "";                       # [enum]    ACTIVE in claudeJsonConfigBase
   #
   #   Reduce or disable animations for accessibility (spinner shimmer, flash
   #   effects, etc.)
@@ -779,7 +779,7 @@ assert
   #   teammateMode = "";                                # [enum]
   #
   #   Color theme for the UI
-  #   theme = "";                                       # [union]
+  #   theme = "";                                       # [union]   ACTIVE in claudeJsonConfigBase
   #
   #   Terminal UI renderer. "fullscreen" uses the flicker-free alt-screen
   #   renderer with virtualized scrollback (equivalent to
@@ -795,7 +795,7 @@ assert
   #   ultracode = true;                                 # [boolean]
   #
   #   Show full tool output instead of truncated summaries
-  #   verbose = true;                                   # [boolean]
+  #   verbose = true;                                   # [boolean] ACTIVE in claudeJsonConfigBase
   #
   #   Default transcript view mode on startup
   #   viewMode = "default";                             # [default | verbose | focus]

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -165,11 +165,41 @@ let
   # opposite of the one that does. Exact strings only: `bash` in bashAllow and
   # `bash -c` in bashAsk are different rules, and both are live.
   deadAllow = builtins.filter (cmd: builtins.elem cmd bashAsk) bashAllow;
+
+  # Keys retired from existing ~/.claude.json files.
+  retired = {
+    claudeJson = [ "autocheckpointingEnabled" ];
+  };
+
+  # UI preferences for ~/.claude.json (merged with existing config in _settings.nix)
+  claudeJsonConfigBase = {
+    hasTrustDialogAccepted = true;
+    hasCompletedProjectOnboarding = true;
+    bypassPermissionsModeAccepted = true;
+    autoCompactEnabled = true; # Auto-compact
+    autoConnectIde = false; # Auto-connect to IDE
+    autoUpdates = false; # Auto-updates
+    claudeInChromeDefaultEnabled = true; # Chrome enabled by default
+    defaultToAgentsView = true; # Open agents view by default
+    diffTool = "diff"; # Diff tool
+    editorMode = "vim"; # Editor mode
+    externalEditorContext = true; # Show last response in external editor
+    preferredNotifChannel = "iterm2_with_bell"; # Notifications
+    theme = "dark"; # Theme
+    verbose = true; # Verbose output
+  };
+  retiredJsonButLive = builtins.filter (
+    name: builtins.hasAttr name claudeJsonConfigBase
+  ) retired.claudeJson;
 in
 assert
   deadAllow == [ ]
   || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " deadAllow} are in both bashAllow and bashAsk; ask wins, so drop them from bashAllow rather than leaving the two lists disagreeing";
+assert
+  retiredJsonButLive == [ ]
+  || throw "modules/agents/claude-code/_default-settings.nix: ${builtins.concatStringsSep ", " retiredJsonButLive} are both retired and live; remove the name from retired or claudeJsonConfigBase";
 {
+  inherit claudeJsonConfigBase retired;
   claudeSettingsBase = {
     cleanupPeriodDays = 30;
     # Disables + bash knobs from the shared source
@@ -843,29 +873,6 @@ assert
   #   On native Windows the flag has no effect.
   #   wslInheritsWindowsSettings = true;                # [boolean]
   #
-
-  # Keys retired from existing ~/.claude.json files.
-  retired = {
-    claudeJson = [ "autocheckpointingEnabled" ];
-  };
-
-  # UI preferences for ~/.claude.json (merged with existing config in _settings.nix)
-  claudeJsonConfigBase = {
-    hasTrustDialogAccepted = true;
-    hasCompletedProjectOnboarding = true;
-    bypassPermissionsModeAccepted = true;
-    autoCompactEnabled = true; # Auto-compact
-    autoConnectIde = false; # Auto-connect to IDE
-    autoUpdates = false; # Auto-updates
-    claudeInChromeDefaultEnabled = true; # Chrome enabled by default
-    defaultToAgentsView = true; # Open agents view by default
-    diffTool = "diff"; # Diff tool
-    editorMode = "vim"; # Editor mode
-    externalEditorContext = true; # Show last response in external editor
-    preferredNotifChannel = "iterm2_with_bell"; # Notifications
-    theme = "dark"; # Theme
-    verbose = true; # Verbose output
-  };
 
   # ~/.claude/keybindings.json. Claude only reads this file, so Home Manager can
   # own it outright instead of jq-merging like settings.json.

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -276,8 +276,8 @@ assert
   #   'countdown' uses the live remaining context-window tokens, 'padded-
   #   countdown' counts down from totalTokensReminderBudget (re-anchoring to the
   #   full budget on each regular user prompt when
-  #   totalTokensReminderAfterUserTurn "+"is on \u2014 task-budget semantics).
-  #   Defaults to off. Env var "+"CLAUDE_CODE_TOTAL_TOKENS_REMINDER overrides.
+  #   totalTokensReminderAfterUserTurn is on - task-budget semantics).
+  #   Defaults to off. Env var CLAUDE_CODE_TOTAL_TOKENS_REMINDER overrides.
   #   totalTokensReminder = "off";  # off | infinite | fixed | countdown | padded-countdown
   #
   #   @internal When true, emit the totalTokensReminder block after each regular
@@ -330,8 +330,8 @@ assert
   #   local, and CLI argument permission rules are ignored.
   #   allowManagedPermissionRulesOnly = true;           # [boolean]
   #
-  #   Managed-org allowlist of channel plugins. When set, "+"replaces the
-  #   default Anthropic allowlist \u2014 admins decide which "+"plugins may push
+  #   Managed-org allowlist of channel plugins. When set, replaces the
+  #   default Anthropic allowlist - admins decide which plugins may push
   #   inbound messages. Undefined falls back to the default. Requires
   #   channelsEnabled: true.
   #   allowedChannelPlugins = [ ];                      # [array]
@@ -353,8 +353,8 @@ assert
   #   apiKeyHelper = "";                                # [string]
   #
   #   Idle time before Claude's questions auto-continue with any answers
-  #   "+"selected so far. Defaults to never \u2014 auto-continue only runs
-  #   "+"when explicitly set to 60s/5m/10m.
+  #   selected so far. Defaults to never - auto-continue only runs
+  #   when explicitly set to 60s/5m/10m.
   #   askUserQuestionTimeout = "60s";                   # [60s | 5m | 10m | never]
   #
   #   Attribution text for git commits, including any trailers. Empty string
@@ -460,8 +460,8 @@ assert
   #   disableBundledSkills = true;                      # [boolean]
   #
   #   When true in any settings source, claude.ai MCP cloud connectors are not
-  #   auto-fetched or connected. "+"Only gates auto-fetched connectors \u2014 a
-  #   claudeai-proxy server passed explicitly "+"(e.g. via --mcp-config or the
+  #   auto-fetched or connected. Only gates auto-fetched connectors - a
+  #   claudeai-proxy server passed explicitly (e.g. via --mcp-config or the
   #   SDK mcpServers option) still follows the normal MCP config trust flow.
   #   Any-source-true wins: a project can opt out, but a project-level false
   #   cannot override a user-level true.
@@ -757,8 +757,8 @@ assert
   #   Enterprise strict list of allowed marketplace sources. When set in managed
   #   settings, ONLY these exact sources can be added as marketplaces. The check
   #   happens BEFORE downloading, so blocked sources never touch the filesystem.
-  #   "+"Note: this is a policy gate only \u2014 it does NOT register
-  #   marketplaces. "+"To pre-register allowed marketplaces for users, also set
+  #   Note: this is a policy gate only - it does NOT register
+  #   marketplaces. To pre-register allowed marketplaces for users, also set
   #   extraKnownMarketplaces.
   #   strictKnownMarketplaces = [ ];                    # [array]
   #
@@ -788,8 +788,8 @@ assert
   #   tui = "default";                                  # [default | fullscreen]
   #
   #   Enable ultracode for the session: xhigh effort plus standing dynamic-
-  #   workflow orchestration. "+"Session-scoped \u2014 typically provided via
-  #   --settings or the apply_flag_settings control request; "+"interactive
+  #   workflow orchestration. Session-scoped - typically provided via
+  #   --settings or the apply_flag_settings control request; interactive
   #   toggles never persist it. Requires workflows to be enabled and an xhigh-
   #   capable model.
   #   ultracode = true;                                 # [boolean]

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -186,8 +186,12 @@ assert
     alwaysThinkingEnabled = true;
     # Persisted effort accepts low|medium|high|xhigh only. `max` is session-scoped
     # (/effort, --effort, CLAUDE_CODE_EFFORT_LEVEL) and rejected by the settings schema.
+    # Persisted effort accepts low|medium|high|xhigh only; `max` is silently
+    # dropped by the schema's .catch(). CLAUDE_CODE_EFFORT_LEVEL in `env` pins
+    # max and outranks this, which stays as the floor if that var is unset.
     effortLevel = "xhigh";
     enableAllProjectMcpServers = true;
+    fileCheckpointingEnabled = true; # Snapshot files before edits so /rewind can restore them
     language = "en"; # Language
     outputStyle = "Proactive"; # Output style
     respectGitignore = false; # Respect .gitignore in file picker
@@ -202,7 +206,6 @@ assert
     hasCompletedProjectOnboarding = true;
     bypassPermissionsModeAccepted = true;
     autoCompactEnabled = true; # Auto-compact
-    autocheckpointingEnabled = true; # Rewind code (checkpoints)
     autoConnectIde = false; # Auto-connect to IDE
     autoUpdates = false; # Auto-updates
     claudeInChromeDefaultEnabled = true; # Chrome enabled by default

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -200,8 +200,9 @@ assert
 
   # === Undocumented settings.json keys (2.1.222 binary schema) ==============
   # Present in the binary's settings schema but absent from the published settings
-  # docs. Descriptions are the schema's own .describe() text. Uncomment inside
-  # claudeSettingsBase to activate; leaving a key out keeps Claude's default.
+  # docs. Descriptions are the schema's own .describe() text. Activate a key by
+  # moving the line into claudeSettingsBase above; leaving it here keeps Claude's
+  # default.
   #   Enable background memory consolidation (auto-dream). When set, overrides
   #   the server-side default.
   #   autoDreamEnabled = true;  # [boolean]
@@ -298,7 +299,8 @@ assert
   # === Documented settings.json keys not set above (2.1.222 schema) =========
   # Every remaining top-level key in the binary's settings schema. Descriptions
   # are the schema's own .describe() text, falling back to the published docs.
-  # Uncomment inside claudeSettingsBase to activate; omitting keeps the default.
+  # Activate a key by moving the line into claudeSettingsBase above; omitting
+  # keeps the default.
   #   Advisor model for the server-side advisor tool.
   #   advisorModel = "";                                # [string]
   #
@@ -841,6 +843,11 @@ assert
   #   On native Windows the flag has no effect.
   #   wslInheritsWindowsSettings = true;                # [boolean]
   #
+
+  # Keys retired from existing ~/.claude.json files.
+  retired = {
+    claudeJson = [ "autocheckpointingEnabled" ];
+  };
 
   # UI preferences for ~/.claude.json (merged with existing config in _settings.nix)
   claudeJsonConfigBase = {

--- a/modules/agents/claude-code/_default-settings.nix
+++ b/modules/agents/claude-code/_default-settings.nix
@@ -184,8 +184,6 @@ assert
     };
     model = "claude-opus-5"; # Default model
     alwaysThinkingEnabled = true;
-    # Persisted effort accepts low|medium|high|xhigh only. `max` is session-scoped
-    # (/effort, --effort, CLAUDE_CODE_EFFORT_LEVEL) and rejected by the settings schema.
     # Persisted effort accepts low|medium|high|xhigh only; `max` is silently
     # dropped by the schema's .catch(). CLAUDE_CODE_EFFORT_LEVEL in `env` pins
     # max and outranks this, which stays as the floor if that var is unset.
@@ -199,6 +197,650 @@ assert
     terminalProgressBarEnabled = true; # Terminal progress bar
     useAutoModeDuringPlan = false; # Use auto mode during plan
   };
+
+  # === Undocumented settings.json keys (2.1.222 binary schema) ==============
+  # Present in the binary's settings schema but absent from the published settings
+  # docs. Descriptions are the schema's own .describe() text. Uncomment inside
+  # claudeSettingsBase to activate; leaving a key out keeps Claude's default.
+  #   Enable background memory consolidation (auto-dream). When set, overrides
+  #   the server-side default.
+  #   autoDreamEnabled = true;  # [boolean]
+  #
+  #   Mirror local sessions to claude.ai as view-only (no remote control)
+  #   autoUploadSessions = true;  # [boolean]
+  #
+  #   Show a friendly nudge after sustained continuous use (default false). Must
+  #   be true for the reminder to fire.
+  #   breakReminder = "";  # [object]
+  #
+  #   When no background service is running: 'transient' spawns one for this
+  #   login session; 'ask' offers to install it persistently
+  #   daemonColdStart = "transient";  # transient | ask
+  #
+  #   @internal When true, Claude keeps working until the PR is ready for you to
+  #   merge, a cron/Monitor is armed to resume later, or it hands you a self-
+  #   contained next step.
+  #   doneMeansMerged = true;  # [boolean]
+  #
+  #   Enable or disable the Workflows feature for this user. Unset = default by
+  #   plan once the feature is available.
+  #   enableWorkflows = true;  # [boolean]
+  #
+  #   Model-drafted feedback (the SendFeedback tool). "notify" (default) shows a
+  #   one-line notice when a draft is queued; "quiet" shows only the footer
+  #   counter; "off" disables the tool entirely so drafts are never queued.
+  #   feedbackDrafts = "notify";  # notify | quiet | off
+  #
+  #   Require explicit approval before SendMessage can reach a peer session on
+  #   another machine via Remote Control
+  #   isolatePeerMachines = true;  # [boolean]
+  #
+  #   Precompute the compaction summary in the background before it is needed.
+  #   Only applies when auto-compact is on.
+  #   precomputeCompactionEnabled = true;  # [boolean]
+  #
+  #   When false, prompt suggestions are disabled. When absent or true, prompt
+  #   suggestions are enabled.
+  #   promptSuggestionEnabled = true;  # [boolean]
+  #
+  #   Shell command that outputs a Proxy-Authorization header value (EAP)
+  #   proxyAuthHelper = "";  # [string]
+  #
+  #   Show a one-time nudge when you start or keep using the CLI inside your
+  #   quiet-hours window (default false).
+  #   quietHours = "";  # [object]
+  #
+  #   Stamp each message with its arrival time
+  #   showMessageTimestamps = true;  # [boolean]
+  #
+  #   @internal Whether the user has accepted the multi-agent workflow usage
+  #   warning. Until set, auto permission mode prompts before running a
+  #   workflow.
+  #   skipWorkflowUsageWarning = true;  # [boolean]
+  #
+  #   Custom per-subagent status line shown in the agent panel; receives row
+  #   context as JSON on stdin
+  #   subagentStatusLine = "";  # [object]
+  #
+  #   Whether /rename updates the terminal tab title (defaults to true). Set to
+  #   false to keep auto-generated topic titles.
+  #   terminalTitleFromRename = true;  # [boolean]
+  #
+  #   Enable the todo / task tracking panel
+  #   todoFeatureEnabled = true;  # [boolean]
+  #
+  #   @internal Emit a <total_tokens>N tokens left</total_tokens> block in the
+  #   system prompt, after each tool result, and (when
+  #   totalTokensReminderAfterUserTurn is on) after each regular user prompt.
+  #   'infinite' uses the literal value Infinite, 'fixed' uses 5000000,
+  #   'countdown' uses the live remaining context-window tokens, 'padded-
+  #   countdown' counts down from totalTokensReminderBudget (re-anchoring to the
+  #   full budget on each regular user prompt when
+  #   totalTokensReminderAfterUserTurn "+"is on \u2014 task-budget semantics).
+  #   Defaults to off. Env var "+"CLAUDE_CODE_TOTAL_TOKENS_REMINDER overrides.
+  #   totalTokensReminder = "off";  # off | infinite | fixed | countdown | padded-countdown
+  #
+  #   @internal When true, emit the totalTokensReminder block after each regular
+  #   user prompt and (for 'padded-countdown') re-anchor the task budget to the
+  #   full configured value at the start of each user turn. When false, the
+  #   reminder appears only in the system prompt and after each tool-result
+  #   batch, and 'padded-countdown' counts down over the whole session. Defaults
+  #   to off. Env var CLAUDE_CODE_TOTAL_TOKENS_REMINDER_AFTER_USER_TURN
+  #   overrides; server-controlled via GrowthBook tengu_lapis_anchor_user_turn.
+  #   totalTokensReminderAfterUserTurn = true;  # [boolean]
+  #
+  #   @internal Starting budget (tokens) for totalTokensReminder 'padded-
+  #   countdown' mode. Defaults to 15000000. Server-controlled via GrowthBook;
+  #   env var CLAUDE_CODE_TOTAL_TOKENS_REMINDER_BUDGET overrides.
+  #   totalTokensReminderBudget = 0;  # [number]
+  #
+
+  # === Documented settings.json keys not set above (2.1.222 schema) =========
+  # Every remaining top-level key in the binary's settings schema. Descriptions
+  # are the schema's own .describe() text, falling back to the published docs.
+  # Uncomment inside claudeSettingsBase to activate; omitting keeps the default.
+  #   Advisor model for the server-side advisor tool.
+  #   advisorModel = "";                                # [string]
+  #
+  #   Name of an agent (built-in or custom) to use for the main thread. Applies
+  #   the agent's system prompt, tool restrictions, and model.
+  #   agent = "";                                       # [string]
+  #
+  #   Allow Claude to push proactive mobile notifications
+  #   agentPushNotifEnabled = true;                     # [boolean]
+  #
+  #   When true (and set in managed settings), claude.ai cloud MCP connectors
+  #   load alongside managed-mcp.json instead of being suppressed by its
+  #   exclusive-control lockdown. Default off preserves the lockdown. Read from
+  #   managed settings only.
+  #   allowAllClaudeAiMcps = true;                      # [boolean]
+  #
+  #   When true (and set in managed settings), only hooks from managed settings
+  #   run. User, project, and local hooks are ignored.
+  #   allowManagedHooksOnly = true;                     # [boolean]
+  #
+  #   When true (and set in managed settings), allowedMcpServers is only read
+  #   from managed settings. deniedMcpServers still merges from all sources, so
+  #   users can deny servers for themselves. Users can still add their own MCP
+  #   servers, but only the admin-defined allowlist applies.
+  #   allowManagedMcpServersOnly = true;                # [boolean]
+  #
+  #   When true (and set in managed settings), only permission rules
+  #   (allow/deny/ask) from managed settings are respected. User, project,
+  #   local, and CLI argument permission rules are ignored.
+  #   allowManagedPermissionRulesOnly = true;           # [boolean]
+  #
+  #   Managed-org allowlist of channel plugins. When set, "+"replaces the
+  #   default Anthropic allowlist \u2014 admins decide which "+"plugins may push
+  #   inbound messages. Undefined falls back to the default. Requires
+  #   channelsEnabled: true.
+  #   allowedChannelPlugins = [ ];                      # [array]
+  #
+  #   Allowlist of URL patterns that HTTP hooks may target. Supports * as a
+  #   wildcard (e.g. "https://hooks.example.com/*"). When set, HTTP hooks with
+  #   non-matching URLs are blocked. If undefined, all URLs are allowed. If
+  #   empty array, no HTTP hooks are allowed. Arrays merge across settings
+  #   sources (same semantics as allowedMcpServers).
+  #   allowedHttpHookUrls = [ ];                        # [array]
+  #
+  #   Enterprise allowlist of MCP servers that can be used. Applies to all
+  #   scopes including enterprise servers from managed-mcp.json. If undefined,
+  #   all servers are allowed. If empty array, no servers are allowed. Denylist
+  #   takes precedence - if a server is on both lists, it is denied.
+  #   allowedMcpServers = [ ];                          # [array]
+  #
+  #   Path to a script that outputs authentication values
+  #   apiKeyHelper = "";                                # [string]
+  #
+  #   Idle time before Claude's questions auto-continue with any answers
+  #   "+"selected so far. Defaults to never \u2014 auto-continue only runs
+  #   "+"when explicitly set to 60s/5m/10m.
+  #   askUserQuestionTimeout = "60s";                   # [60s | 5m | 10m | never]
+  #
+  #   Attribution text for git commits, including any trailers. Empty string
+  #   hides attribution.
+  #   attribution = { };                                # [object]
+  #
+  #   Automatically compact conversation when context fills
+  #   autoCompactEnabled = true;                        # [boolean]
+  #
+  #   Auto-compact window size
+  #   autoCompactWindow = 0;                            # [number]
+  #
+  #   Custom directory path for auto-memory storage. Supports ~/ prefix for home
+  #   directory expansion. Ignored if set in projectSettings (checked-in
+  #   .claude/settings.json) for security. When unset, defaults to
+  #   ~/.claude/projects/<sanitized-cwd>/memory/.
+  #   autoMemoryDirectory = "";                         # [string]
+  #
+  #   Enable auto-memory for this project. When false, Claude will not read from
+  #   or write to the auto-memory directory.
+  #   autoMemoryEnabled = true;                         # [boolean]
+  #
+  #   Auto-scroll the conversation view to bottom (fullscreen mode only)
+  #   autoScrollEnabled = true;                         # [boolean]
+  #
+  #   Release channel for auto-updates (latest or stable)
+  #   autoUpdatesChannel = "latest";                    # [latest | stable | rc]
+  #
+  #   Allowlist of models that users can select. Accepts family aliases ("opus"
+  #   allows any opus version), version prefixes ("opus-4-5" allows only that
+  #   version), and full model IDs. If undefined, all models are available. If
+  #   empty array, only the default model is available. Typically set in managed
+  #   settings by enterprise administrators.
+  #   availableModels = [ ];                            # [array]
+  #
+  #   @internal When false, the session recap (shown when you return after being
+  #   away for 5+ minutes) is disabled. When absent or true, recap is enabled.
+  #   Hidden from public SDK types until external launch.
+  #   awaySummaryEnabled = true;                        # [boolean]
+  #
+  #   Path to a script that refreshes AWS authentication
+  #   awsAuthRefresh = "";                              # [string]
+  #
+  #   Path to a script that exports AWS credentials
+  #   awsCredentialExport = "";                         # [string]
+  #
+  #   Enterprise blocklist of marketplace sources. When set in managed settings,
+  #   these exact sources are blocked from being added as marketplaces. The
+  #   check happens BEFORE downloading, so blocked sources never touch the
+  #   filesystem.
+  #   blockedMarketplaces = [ ];                        # [array]
+  #
+  #   Managed-org opt-in for channel notifications (MCP servers with the
+  #   claude/channel capability pushing inbound messages). claude.ai
+  #   Teams/Enterprise: default off. Console: default on unless managed settings
+  #   exist. Set true to allow; users then select servers via --channels.
+  #   channelsEnabled = true;                           # [boolean]
+  #
+  #   CLAUDE.md-style instructions injected as organization-managed memory. Only
+  #   honored from managed/policy settings.
+  #   claudeMd = "";                                    # [string]
+  #
+  #   Glob patterns or absolute paths of CLAUDE.md files to exclude from
+  #   loading. Patterns are matched against absolute file paths using picomatch.
+  #   Only applies to User, Project, and Local memory types (Managed/policy
+  #   files cannot be excluded). Examples: "/home/user/monorepo/CLAUDE.md",
+  #   "**/code/CLAUDE.md", "**/some-dir/.claude/rules/**"
+  #   claudeMdExcludes = [ ];                           # [array]
+  #
+  #   Company announcements to display at startup (one will be randomly selected
+  #   if multiple are provided)
+  #   companyAnnouncements = [ ];                       # [array]
+  #
+  #   Default shell for input-box ! commands. Defaults to 'bash' on all
+  #   platforms (no Windows auto-flip).
+  #   defaultShell = "bash";                            # [bash | powershell]
+  #
+  #   Enterprise denylist of MCP servers that are explicitly blocked. If a
+  #   server is on the denylist, it will be blocked across all scopes including
+  #   enterprise. Denylist takes precedence over allowlist - if a server is on
+  #   both lists, it is denied.
+  #   deniedMcpServers = [ ];                           # [array]
+  #
+  #   Disable agent view (`claude agents`, `--bg`, /background, the on-demand
+  #   daemon). Typically set in managed settings. Equivalent to
+  #   CLAUDE_CODE_DISABLE_AGENT_VIEW=1.
+  #   disableAgentView = true;                          # [boolean]
+  #
+  #   Disable all hooks and statusLine execution
+  #   disableAllHooks = true;                           # [boolean]
+  #
+  #   Disable the Artifact tool (also via CLAUDE_CODE_DISABLE_ARTIFACT).
+  #   disableArtifact = true;                           # [boolean]
+  #
+  #   Disable auto mode
+  #   disableAutoMode = "disable";                      # [disable]
+  #
+  #   Disable the skills and workflows that ship with Claude Code: bundled
+  #   skills and workflows are removed entirely; built-in slash commands stay
+  #   typable but are hidden from the model. Plugins, .claude/skills/, and
+  #   .claude/commands/ are unaffected. Equivalent to
+  #   CLAUDE_CODE_DISABLE_BUNDLED_SKILLS=1.
+  #   disableBundledSkills = true;                      # [boolean]
+  #
+  #   When true in any settings source, claude.ai MCP cloud connectors are not
+  #   auto-fetched or connected. "+"Only gates auto-fetched connectors \u2014 a
+  #   claudeai-proxy server passed explicitly "+"(e.g. via --mcp-config or the
+  #   SDK mcpServers option) still follows the normal MCP config trust flow.
+  #   Any-source-true wins: a project can opt out, but a project-level false
+  #   cannot override a user-level true.
+  #   disableClaudeAiConnectors = true;                 # [boolean]
+  #
+  #   Disable Remote Control (claude.ai/code, `claude remote-control`,
+  #   `--remote-control`/`--rc`, auto-start, and the in-session toggle).
+  #   Typically set in managed settings.
+  #   disableRemoteControl = true;                      # [boolean]
+  #
+  #   When true (and set in managed settings), rejects the --plugin-dir,
+  #   --plugin-url, --agents, and non-sdk --mcp-config CLI flags at startup.
+  #   Closes the CLI-flag bypass of strictKnownMarketplaces. Pair with
+  #   allowedMcpServers for per-server MCP control; this setting does not gate
+  #   other MCP entry points (SDK setMcpServers, claude mcp add, .mcp.json).
+  #   Also blocks surfaces that spawn the CLI with these flags internally (see
+  #   settings documentation). Only honored from managed settings; ignored in
+  #   user/project/local settings.
+  #   disableSideloadFlags = true;                      # [boolean]
+  #
+  #   Disable inline shell execution in skills and custom slash commands from
+  #   user, project, or plugin sources. Commands are replaced with a placeholder
+  #   instead of being run.
+  #   disableSkillShellExecution = true;                # [boolean]
+  #
+  #   Disable the Workflows feature (also via CLAUDE_CODE_DISABLE_WORKFLOWS).
+  #   disableWorkflows = true;                          # [boolean]
+  #
+  #   List of rejected MCP servers from .mcp.json
+  #   disabledMcpjsonServers = [ ];                     # [array]
+  #
+  #   Key binding mode for the prompt input
+  #   editorMode = "";                                  # [enum]
+  #
+  #   When false, the :emoji: shortcode typeahead (the suggestion popup and the
+  #   :name: inline replacement) is disabled. When absent or true, it is
+  #   enabled.
+  #   emojiCompletionEnabled = true;                    # [boolean]
+  #
+  #   Enable or disable the Artifact tool for this user. Unset defaults to
+  #   enabled once the feature is available.
+  #   enableArtifact = true;                            # [boolean]
+  #
+  #   List of approved MCP servers from .mcp.json
+  #   enabledMcpjsonServers = [ ];                      # [array]
+  #
+  #   Enabled plugins using plugin-id@marketplace-id format. Example: {
+  #   "formatter@anthropic-tools": true }. Also supports extended format with
+  #   version constraints. Settings precedence is user < project < local < flag
+  #   < policy, so to disable a plugin that project settings enable, set it to
+  #   false in .claude/settings.local.json \u2014 setting false in
+  #   ~/.claude/settings.json is overridden by the project.
+  #   enabledPlugins = { };                             # [record]
+  #
+  #   When true and availableModels is a non-empty array, the Default model
+  #   selection is also constrained: if the default model for the user tier is
+  #   not in availableModels, Default resolves to the first allowed
+  #   availableModels entry instead. Has no effect when availableModels is unset
+  #   or an empty array. Typically set in managed settings by enterprise
+  #   administrators.
+  #   enforceAvailableModels = true;                    # [boolean]
+  #
+  #   Additional marketplaces to make available for this repository. Typically
+  #   used in repository .claude/settings.json to ensure team members have
+  #   required plugin sources.
+  #   extraKnownMarketplaces = { };                     # [record]
+  #
+  #   Fallback model(s) tried in order when the primary model is overloaded or
+  #   unavailable. Each element accepts a model name or alias; "default" expands
+  #   to the default model. CLI --fallback-model takes precedence.
+  #   fallbackModel = [ ];                              # [array]
+  #
+  #   When true, fast mode is enabled. When absent or false, fast mode is off.
+  #   fastMode = true;                                  # [boolean]
+  #
+  #   When true, fast mode does not persist across sessions. Each session starts
+  #   with fast mode off.
+  #   fastModePerSessionOptIn = true;                   # [boolean]
+  #
+  #   Probability (0\u20131) that the session quality survey appears when
+  #   eligible. 0.05 is a reasonable starting point.
+  #   feedbackSurveyRate = 0;                           # [number]
+  #
+  #   Custom file suggestion configuration for @ mentions
+  #   fileSuggestion = { };                             # [object]
+  #
+  #   Extra clickable footer badges that appear when a regex matches turn output
+  #   (tool results and assistant responses). Read from user, flag, and managed
+  #   settings only; ignored in project .claude/settings.json and local
+  #   .claude/settings.local.json. At most 5 badges render; the oldest is
+  #   displaced by newer matches and /clear removes them. Use to surface IDs
+  #   printed by project CLIs as session links.
+  #   footerLinksRegexes = [ ];                         # [array]
+  #
+  #   @internal Cloud gateway URL to pre-fill and auto-connect to during login.
+  #   Typically set in local managed settings alongside forceLoginMethod:
+  #   "gateway" so users never type the URL. Hidden from public SDK types until
+  #   Cloud gateway is documented.
+  #   forceLoginGatewayUrl = "";                        # [string]
+  #
+  #   Force a specific login method: "claudeai" for Claude Pro/Max, "console"
+  #   for Console billing, "gateway" for the Cloud gateway OIDC device flow
+  #   forceLoginMethod = "claudeai";                    # [claudeai | console | gateway]
+  #
+  #   Organization UUID to require for OAuth login. Accepts a single UUID string
+  #   or an array of UUIDs (any one is permitted). When set in managed settings,
+  #   login fails if the authenticated account does not belong to a listed
+  #   organization.
+  #   forceLoginOrgUUID = "";                           # [union]
+  #
+  #   When set in managed settings, the CLI blocks startup until remote managed
+  #   settings are freshly fetched, and exits if the fetch fails
+  #   forceRemoteSettingsRefresh = true;                # [boolean]
+  #
+  #   Command to refresh GCP authentication (e.g., gcloud auth application-
+  #   default login)
+  #   gcpAuthRefresh = "";                              # [string]
+  #
+  #   Custom commands to run before/after tool executions
+  #   hooks = "";                                       # [?]
+  #
+  #   Allowlist of environment variable names HTTP hooks may interpolate into
+  #   headers. When set, each hook's effective allowedEnvVars is the
+  #   intersection with this list. If undefined, no restriction is applied.
+  #   Arrays merge across settings sources (same semantics as
+  #   allowedMcpServers).
+  #   httpHookAllowedEnvVars = [ ];                     # [array]
+  #
+  #   Include built-in commit and PR workflow instructions in Claude's system
+  #   prompt (default: true)
+  #   includeGitInstructions = true;                    # [boolean]
+  #
+  #   Push to mobile when a permission prompt or question is waiting
+  #   inputNeededNotifEnabled = true;                   # [boolean]
+  #
+  #   Minimum version to stay on - prevents downgrades when switching to stable
+  #   channel
+  #   minimumVersion = "";                              # [string]
+  #
+  #   Override mapping from Anthropic model ID (e.g. "claude-opus-4-6") to
+  #   provider-specific model ID (e.g. a Bedrock inference profile ARN).
+  #   Typically set in managed settings by enterprise administrators.
+  #   modelOverrides = { };                             # [record]
+  #
+  #   Path to a script that outputs OpenTelemetry headers
+  #   otelHeadersHelper = "";                           # [string]
+  #
+  #   (Managed settings only) **Default**: `"first-wins"`. Controls whether
+  #   managed settings supplied programmatically by an embedding host process,
+  #   such as the Agent SDK or an IDE extension, apply when an admin-deployed
+  #   managed tier is also present. `"first-wins"`: the parent-supplied settings
+  #   are dropped and only the admin tier applies. `"merge"`: the parent-
+  #   supplied settings apply under the admin tier through a restrictive-only
+  #   filter. Only the highest-priority managed source's value of this key is
+  #   read. Unless the `allowManaged*Only` locks are set, allow-direction
+  #   entries such as permission allow rules and sandbox allowlists still apply;
+  #   see Restrict parent settings. Has no effect when no admin tier is
+  #   deployed, or when a `policyHelper` is configured: the helper's output
+  #   replaces every other managed source and parent settings are never merged.
+  #   Requires Claude Code v2.1.133 or later
+  #   parentSettingsBehavior = "first-wins";            # [first-wins | merge]
+  #
+  #   Custom directory for plan files, relative to project root. If not set,
+  #   defaults to ~/.claude/plans/
+  #   plansDirectory = "";                              # [string]
+  #
+  #   User configuration values for MCP servers keyed by server name
+  #   pluginConfigs = { };                              # [record]
+  #
+  #   Marketplace names whose plugins may surface as contextual install
+  #   suggestions (relevance-based tips). No marketplace-declared suggestions
+  #   surface without this allowlist; the built-in first-party frontend-design
+  #   tip is unaffected. Only honored when set in managed settings (policy
+  #   scope); the key is ignored in user, project, and local settings. A name
+  #   only takes effect when the marketplace is registered on the machine AND
+  #   its registered source is also declared in managed settings, either as the
+  #   extraKnownMarketplaces entry for that name or as an entry of
+  #   strictKnownMarketplaces. A marketplace registered from a different source
+  #   under an allowlisted name is ignored. The official marketplace is exempt
+  #   from the source requirement: allowlisting its name alone suffices, since
+  #   that name can only register from the official Anthropic source.
+  #   pluginSuggestionMarketplaces = [ ];               # [array]
+  #
+  #   Custom message to append to the plugin trust warning shown before
+  #   installation. Only read from policy settings (managed-settings.json /
+  #   MDM). Useful for enterprise administrators to add organization-specific
+  #   context (e.g., "All plugins from our internal marketplace are vetted and
+  #   approved.").
+  #   pluginTrustMessage = "";                          # [string]
+  #
+  #   Executable that computes managed settings at startup. Honored only from
+  #   admin-controlled policy sources.
+  #   policyHelper = "";                                # [?]
+  #
+  #   URL template for PR links in the footer link badges and inline messages.
+  #   The detected git PR is rendered as the first footer-link badge.
+  #   Placeholders: {host} {owner} {repo} {number} {url}. Example:
+  #   "https://reviews.example.com/{owner}/{repo}/pull/{number}"
+  #   prUrlTemplate = "";                               # [string]
+  #
+  #   Preferred OS notification channel
+  #   preferredNotifChannel = "";                       # [enum]
+  #
+  #   Reduce or disable animations for accessibility (spinner shimmer, flash
+  #   effects, etc.)
+  #   prefersReducedMotion = true;                      # [boolean]
+  #
+  #   Corporate launcher argv prefix for the background-agent supervisor, the
+  #   sessions and workers it hosts, and the other covered background processes
+  #   listed in the Claude Code corporate-launcher documentation. Equivalent to
+  #   the CLAUDE_CODE_PROCESS_WRAPPER environment variable, which takes
+  #   precedence when set. Honored from managed settings, a --settings/SDK-
+  #   supplied settings file, and user settings, in that precedence order;
+  #   project and local settings are ignored.
+  #   processWrapper = "";                              # [string]
+  #
+  #   Default environment ID to use for cloud sessions
+  #   remote = { };                                     # [object]
+  #
+  #   Start Remote Control bridge automatically each session
+  #   remoteControlAtStartup = true;                    # [boolean]
+  #
+  #   Maximum Claude Code version allowed to start. If the running version is
+  #   newer, Claude Code exits at startup with instructions to install an
+  #   approved version. Only enforced from managed (policy) settings.
+  #   requiredMaximumVersion = "";                      # [string]
+  #
+  #   Minimum Claude Code version required to start. If the running version is
+  #   older, Claude Code exits at startup with instructions to update. Only
+  #   enforced from managed (policy) settings.
+  #   requiredMinimumVersion = "";                      # [string]
+  #
+  #   Whether Claude responds after an input-box ! bash command runs. Set to
+  #   false to add the command output to context without a response. Default:
+  #   true.
+  #   respondToBashCommands = true;                     # [boolean]
+  #
+  #   `sandbox` still applies. Applies in v2.1.191 and later; before v2.1.221,
+  #   every invalid entry was stripped. |
+  #   sandbox = "";                                     # [?]
+  #
+  #   When true, the plan-approval dialog offers a "clear context" option.
+  #   Defaults to false.
+  #   showClearContextOnPlanAccept = true;              # [boolean]
+  #
+  #   Request API-side thinking summaries and show them in the conversation and
+  #   in the transcript view (ctrl+o). Set explicitly to override the default
+  #   for your install.
+  #   showThinkingSummaries = true;                     # [boolean]
+  #
+  #   Show "Cooked for Nm Ns" after each assistant turn
+  #   showTurnDuration = true;                          # [boolean]
+  #
+  #   Fraction of the context window (in characters) reserved for the skill
+  #   listing sent to Claude (default: 0.01 = 1%). When the listing exceeds
+  #   this, descriptions are shortened to fit. Raise to opt in to higher per-
+  #   turn context cost.
+  #   skillListingBudgetFraction = 0;                   # [number]
+  #
+  #   Per-skill description character cap in the skill listing sent to Claude
+  #   (default: 1536). Descriptions longer than this are truncated. Raise to opt
+  #   in to higher per-turn context cost.
+  #   skillListingMaxDescChars = 0;                     # [number]
+  #
+  #   Per-skill listing overrides keyed by skill name. "name-only" lists the
+  #   skill without its description; "user-invocable-only" hides it from the
+  #   model but keeps /name; "off" hides it from both. Absent = on.
+  #   skillOverrides = { };                             # [record]
+  #
+  #   Whether the user has accepted the bypass permissions mode dialog
+  #   skipDangerousModePermissionPrompt = true;         # [boolean]
+  #
+  #   Skip the WebFetch blocklist check for enterprise environments with
+  #   restrictive security policies
+  #   skipWebFetchPreflight = true;                     # [boolean]
+  #
+  #   Override spinner tips. tips: array of tip strings. excludeDefault: if
+  #   true, only show custom tips (default: false).
+  #   spinnerTipsOverride = { };                        # [object]
+  #
+  #   Customize spinner verbs. mode: "append" adds verbs to defaults, "replace"
+  #   uses only your verbs.
+  #   spinnerVerbs = { };                               # [object]
+  #
+  #   Unique identifier for this SSH config. Used to match configs across
+  #   settings sources.
+  #   sshConfigs = [ ];                                 # [array]
+  #
+  #   Re-run the status line command every N seconds in addition to event-driven
+  #   updates
+  #   statusLine = { };                                 # [object]
+  #
+  #   Enterprise strict list of allowed marketplace sources. When set in managed
+  #   settings, ONLY these exact sources can be added as marketplaces. The check
+  #   happens BEFORE downloading, so blocked sources never touch the filesystem.
+  #   "+"Note: this is a policy gate only \u2014 it does NOT register
+  #   marketplaces. "+"To pre-register allowed marketplaces for users, also set
+  #   extraKnownMarketplaces.
+  #   strictKnownMarketplaces = [ ];                    # [array]
+  #
+  #   (Managed settings only) Block skills, agents, hooks, and MCP servers from
+  #   user and project sources, so they can only come from plugins or managed
+  #   settings. `true` locks all four surfaces; an array locks only the named
+  #   ones. See `strictPluginOnlyCustomization`
+  #   strictPluginOnlyCustomization = "";               # [preprocess]
+  #
+  #   When safeguards flag a message, automatically switch to a different model
+  #   to keep chatting. When off, your session will pause instead.
+  #   switchModelsOnFlag = true;                        # [boolean]
+  #
+  #   Whether to disable syntax highlighting in diffs
+  #   syntaxHighlightingDisabled = true;                # [boolean]
+  #
+  #   How spawned teammates execute (tmux, iterm2, in-process, auto)
+  #   teammateMode = "";                                # [enum]
+  #
+  #   Color theme for the UI
+  #   theme = "";                                       # [union]
+  #
+  #   Terminal UI renderer. "fullscreen" uses the flicker-free alt-screen
+  #   renderer with virtualized scrollback (equivalent to
+  #   CLAUDE_CODE_NO_FLICKER=1). "default" uses the classic main-screen
+  #   renderer.
+  #   tui = "default";                                  # [default | fullscreen]
+  #
+  #   Enable ultracode for the session: xhigh effort plus standing dynamic-
+  #   workflow orchestration. "+"Session-scoped \u2014 typically provided via
+  #   --settings or the apply_flag_settings control request; "+"interactive
+  #   toggles never persist it. Requires workflows to be enabled and an xhigh-
+  #   capable model.
+  #   ultracode = true;                                 # [boolean]
+  #
+  #   Show full tool output instead of truncated summaries
+  #   verbose = true;                                   # [boolean]
+  #
+  #   Default transcript view mode on startup
+  #   viewMode = "default";                             # [default | verbose | focus]
+  #
+  #   Vim INSERT-mode key-sequence remaps, e.g. {"jj": "<Esc>"}. Each key is
+  #   exactly two printable characters typed in sequence; "<Esc>" (return to
+  #   NORMAL mode) is the only supported target. Applies when editorMode is
+  #   "vim".
+  #   vimInsertModeRemaps = { };                        # [record]
+  #
+  #   'hold' (default): hold to talk. 'tap': tap to start, tap to stop+submit.
+  #   voice = { };                                      # [object]
+  #
+  #   Ramp mouse-wheel scroll speed during fast scrolls (fullscreen mode only)
+  #   wheelScrollAccelerationEnabled = true;            # [boolean]
+  #
+  #   Enable the "ultracode" keyword trigger: including the keyword in a prompt
+  #   opts that turn into the Workflow tool. Set to false to disable the
+  #   trigger. Default: true.
+  #   workflowKeywordTriggerEnabled = true;             # [boolean]
+  #
+  #   Advisory size guideline for the dynamic workflows Claude writes: "small"
+  #   aims for fewer than 5 agents, "medium" (the default) fewer than 15,
+  #   "large" fewer than 50, and "unrestricted" sends no guideline. A value here
+  #   \u2014 including from managed settings \u2014 takes precedence over the
+  #   "Dynamic workflow size" choice in /config, and that /config row is hidden
+  #   while a settings file provides the key. This is a guideline, not an
+  #   enforced limit.
+  #   workflowSizeGuideline = "unrestricted";           # [unrestricted | small | medium | large]
+  #
+  #   Directories to symlink from main repository to worktrees to avoid disk
+  #   bloat. Must be explicitly configured - no directories are symlinked by
+  #   default. Common examples: "node_modules", ".cache", ".bin"
+  #   worktree = { };                                   # [object]
+  #
+  #   When set to true in either admin-only Windows source \u2014 the HKLM
+  #   SOFTWARE/Policies/ClaudeCode registry key or C:/Program
+  #   Files/ClaudeCode/managed-settings.json \u2014 WSL reads managed settings
+  #   from the full Windows policy chain (HKLM, C:/Program Files/ClaudeCode via
+  #   DrvFs, HKCU) in addition to /etc/claude-code. Windows sources take
+  #   priority. The flag is also required in HKCU itself for HKCU policy to
+  #   apply on WSL (double opt-in: admin enables the chain, user confirms HKCU).
+  #   On native Windows the flag has no effect.
+  #   wslInheritsWindowsSettings = true;                # [boolean]
+  #
 
   # UI preferences for ~/.claude.json (merged with existing config in _settings.nix)
   claudeJsonConfigBase = {

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -29,7 +29,6 @@ let
   binary = {
     DISABLE_AUTOUPDATER = "1";
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
-    CLAUDE_CODE_ENABLE_TELEMETRY = "0";
     DISABLE_ERROR_REPORTING = "1";
     DISABLE_TELEMETRY = "1";
     DISABLE_INSTALLATION_CHECKS = "1";
@@ -250,7 +249,7 @@ let
   # it again.
   # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "";   # ACTIVE above
   # Set to 1 to enable OpenTelemetry data collection for metrics and logging. [1 or unset]
-  # CLAUDE_CODE_ENABLE_TELEMETRY = "1";   # ACTIVE above
+  # CLAUDE_CODE_ENABLE_TELEMETRY = "1";
   # Maximum length of content-bearing OpenTelemetry attributes (model
   # responses, tool content, system prompts, raw API bodies), including the
   # truncation marker, in UTF-16 code units (default: 61440, or 60 KB).

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -63,13 +63,17 @@ let
     USE_BUILTIN_RIPGREP = "0";
   };
 
-  # Names removed from managed environment groups. These stay out of
-  # `settings` and `all`; activation and launch wrappers delete old values.
+  # Names permanently removed from managed environment groups. These stay out
+  # of `settings` and `all`; activation and launch wrappers always remove them.
   retired = [
-    "CLAUDE_CODE_DISABLE_TERMINAL_TITLE"
     "CLAUDE_CODE_ENABLE_TELEMETRY"
     "DISABLE_NON_ESSENTIAL_MODEL_CALLS"
   ];
+  # Invalid values from older generations are removed only when they match
+  # exactly, so documented user values remain available to Claude.
+  legacyEnvValues = {
+    CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "0";
+  };
   retiredButLive = builtins.filter (
     name: builtins.hasAttr name (binary // bashRuntime // modelRouting // shellOnly)
   ) retired;
@@ -467,7 +471,7 @@ let
   # Set to 1 to disable fullscreen rendering and use the classic main-screen renderer. [1 or unset]
   # CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN = "1";
   # Set to 1 to disable automatic terminal title updates based on conversation context. [1 or unset]
-  # CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";   # RETIRED below
+  # CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";
   # Set to 1 to hide the working directory in the startup logo. [1 or unset]
   # CLAUDE_CODE_HIDE_CWD = "1";
   # Override the host address used to connect to the IDE extension.
@@ -1271,7 +1275,7 @@ assert
   retiredButLive == [ ]
   || throw "modules/agents/claude-code/_env.nix: ${builtins.concatStringsSep ", " retiredButLive} are both retired and live; remove the name from retired or its live group";
 {
-  inherit binary retired;
+  inherit binary legacyEnvValues retired;
   settings = binary // bashRuntime // modelRouting;
   all = binary // bashRuntime // modelRouting // shellOnly;
 }

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -14,6 +14,12 @@
 
   Keeping the layers as one expression makes the belt-and-suspenders coverage
   explicit and removes the drift risk between sites.
+
+  The catalog below the active groups enumerates every environment variable
+  documented at https://code.claude.com/docs/en/env-vars for Claude Code
+  2.1.222, commented out with its accepted values and default. Activate one by
+  moving the line into a group above; leaving it commented keeps Claude's own
+  default. Read-only and deprecated entries are segregated at the end.
 */
 let
   # Privacy/telemetry/update disables baked into the binary.
@@ -55,9 +61,1082 @@ let
     USE_BUILTIN_RIPGREP = "0";
   };
 
-  # Optional knobs left unset by default (enable by adding to a group above):
-  #   ANTHROPIC_MODEL, MAX_THINKING_TOKENS = "32768",
-  #   CLAUDE_CODE_MAX_OUTPUT_TOKENS, MAX_MCP_OUTPUT_TOKENS = "32000"
+  # === Catalog: every documented Claude Code environment variable ===========
+  # Entries marked ACTIVE are already set in a group above.
+
+  # Authentication and providers (30)
+  # ------------------------------------
+  # API key sent as X-Api-Key header.
+  # ANTHROPIC_API_KEY = "";
+  # Custom value for the Authorization header (the value you set here will be prefixed with Bearer ).
+  # ANTHROPIC_AUTH_TOKEN = "";
+  # Workspace API key for Claude Platform on AWS, generated in the AWS Console.
+  # ANTHROPIC_AWS_API_KEY = "";
+  # Override the Claude Platform on AWS endpoint URL. Use for custom regions or when routing through an LLM gateway.
+  # ANTHROPIC_AWS_BASE_URL = "";
+  # Required for Claude Platform on AWS. Sent on every request as the anthropic-workspace-id header.
+  # ANTHROPIC_AWS_WORKSPACE_ID = "";
+  # Override the Amazon Bedrock endpoint URL. Use for custom Amazon Bedrock endpoints or when routing through an LLM gateway.
+  # ANTHROPIC_BEDROCK_BASE_URL = "";
+  # Override the Amazon Bedrock Mantle endpoint URL. See Mantle endpoint.
+  # ANTHROPIC_BEDROCK_MANTLE_BASE_URL = "";
+  # Amazon Bedrock service tier (default, flex, or priority).
+  # ANTHROPIC_BEDROCK_SERVICE_TIER = "";
+  # Comma-separated list of additional anthropic-beta header values to include in API requests.
+  # ANTHROPIC_BETAS = "";
+  # Custom headers to add to requests (Name: Value format, newline-separated for multiple headers).
+  # ANTHROPIC_CUSTOM_HEADERS = "";
+  # API key for Microsoft Foundry authentication (see Microsoft Foundry).
+  # ANTHROPIC_FOUNDRY_API_KEY = "";
+  # Bearer token for Microsoft Foundry authentication, such as a Microsoft Entra access token.
+  # ANTHROPIC_FOUNDRY_AUTH_TOKEN = "";
+  # Full base URL for the Microsoft Foundry resource (for example, https://my-resource.services.ai.azure.com/anthropic).
+  # ANTHROPIC_FOUNDRY_BASE_URL = "";
+  # Microsoft Foundry resource name (for example, my-resource).
+  # ANTHROPIC_FOUNDRY_RESOURCE = "";
+  # Override Google Cloud's Agent Platform endpoint URL. Use for custom Google Cloud's Agent Platform endpoints or when routing through an LLM gateway.
+  # ANTHROPIC_VERTEX_BASE_URL = "";
+  # GCP project ID for Google Cloud's Agent Platform requests.
+  # ANTHROPIC_VERTEX_PROJECT_ID = "";
+  # Workspace ID for workload identity federation.
+  # ANTHROPIC_WORKSPACE_ID = "";
+  # Amazon Bedrock API key for authentication (see Amazon Bedrock API keys).
+  # AWS_BEARER_TOKEN_BEDROCK = "";
+  # Skip client-side authentication for Claude Platform on AWS, for gateways that sign requests themselves.
+  # CLAUDE_CODE_SKIP_ANTHROPIC_AWS_AUTH = "";
+  # Skip AWS authentication for Amazon Bedrock (for example, when using an LLM gateway).
+  # CLAUDE_CODE_SKIP_BEDROCK_AUTH = "";
+  # Skip Azure authentication for Microsoft Foundry, for a proxy or gateway that injects its own Authorization header.
+  # CLAUDE_CODE_SKIP_FOUNDRY_AUTH = "";
+  # Skip AWS authentication for Amazon Bedrock Mantle (for example, when using an LLM gateway).
+  # CLAUDE_CODE_SKIP_MANTLE_AUTH = "";
+  # Skip Google authentication for Google Cloud's Agent Platform (for example, when using an LLM gateway).
+  # CLAUDE_CODE_SKIP_VERTEX_AUTH = "";
+  # Use Claude Platform on AWS.
+  # CLAUDE_CODE_USE_ANTHROPIC_AWS = "";
+  # Use Amazon Bedrock.
+  # CLAUDE_CODE_USE_BEDROCK = "";
+  # Use Microsoft Foundry.
+  # CLAUDE_CODE_USE_FOUNDRY = "";
+  # Use the Amazon Bedrock Mantle endpoint.
+  # CLAUDE_CODE_USE_MANTLE = "";
+  # Set to 1 to discover custom commands, subagents, and output styles using Node.js file APIs instead of ripgrep. [1 or unset]
+  # CLAUDE_CODE_USE_NATIVE_FILE_SEARCH = "1";
+  # Controls the PowerShell tool.
+  # CLAUDE_CODE_USE_POWERSHELL_TOOL = "";
+  # Use Google Cloud's Agent Platform.
+  # CLAUDE_CODE_USE_VERTEX = "";
+
+  # Model selection and routing (26)
+  # -----------------------------------
+  # Model ID to add as a custom entry in the /model picker.
+  # ANTHROPIC_CUSTOM_MODEL_OPTION = "";
+  # Display description for the custom model entry in the /model picker.
+  # ANTHROPIC_CUSTOM_MODEL_OPTION_DESCRIPTION = "";
+  # Display name for the custom model entry in the /model picker.
+  # ANTHROPIC_CUSTOM_MODEL_OPTION_NAME = "";
+  # Comma-separated list of capabilities the custom model supports, for example effort,thinking.
+  # ANTHROPIC_CUSTOM_MODEL_OPTION_SUPPORTED_CAPABILITIES = "";
+  # Model ID that the fable alias resolves to, and the ID Claude Code recognizes as Fable 5 for automatic model fallback on third-party providers.
+  # ANTHROPIC_DEFAULT_FABLE_MODEL = "";
+  # Display description for the pinned Fable model in the /model picker.
+  # ANTHROPIC_DEFAULT_FABLE_MODEL_DESCRIPTION = "";
+  # Display name for the pinned Fable model in the /model picker.
+  # ANTHROPIC_DEFAULT_FABLE_MODEL_NAME = "";
+  # Comma-separated list of capabilities the pinned Fable model supports, for example effort,thinking.
+  # ANTHROPIC_DEFAULT_FABLE_MODEL_SUPPORTED_CAPABILITIES = "";
+  # Model ID that the haiku alias resolves to, also used for background functionality.
+  # ANTHROPIC_DEFAULT_HAIKU_MODEL = "";   # ACTIVE above
+  # Display description for the pinned Haiku model in the /model picker.
+  # ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION = "";
+  # Display name for the pinned Haiku model in the /model picker.
+  # ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME = "";
+  # Comma-separated list of capabilities the pinned Haiku model supports, for example effort,thinking.
+  # ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES = "";
+  # Model ID that the opus alias resolves to, and that opusplan uses while Plan Mode is active.
+  # ANTHROPIC_DEFAULT_OPUS_MODEL = "";
+  # Display description for the pinned Opus model in the /model picker.
+  # ANTHROPIC_DEFAULT_OPUS_MODEL_DESCRIPTION = "";
+  # Display name for the pinned Opus model in the /model picker.
+  # ANTHROPIC_DEFAULT_OPUS_MODEL_NAME = "";
+  # Comma-separated list of capabilities the pinned Opus model supports, for example effort,thinking.
+  # ANTHROPIC_DEFAULT_OPUS_MODEL_SUPPORTED_CAPABILITIES = "";
+  # Model ID that the sonnet alias resolves to, and that opusplan uses when Plan Mode is not active.
+  # ANTHROPIC_DEFAULT_SONNET_MODEL = "";
+  # Display description for the pinned Sonnet model in the /model picker.
+  # ANTHROPIC_DEFAULT_SONNET_MODEL_DESCRIPTION = "";
+  # Display name for the pinned Sonnet model in the /model picker.
+  # ANTHROPIC_DEFAULT_SONNET_MODEL_NAME = "";
+  # Comma-separated list of capabilities the pinned Sonnet model supports, for example effort,thinking.
+  # ANTHROPIC_DEFAULT_SONNET_MODEL_SUPPORTED_CAPABILITIES = "";
+  # Name of the model setting to use (see Model Configuration).
+  # ANTHROPIC_MODEL = "";
+  # Override AWS region for the Haiku-class model when using Amazon Bedrock or Amazon Bedrock Mantle.
+  # ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION = "";
+  # Set to 1 to prevent automatic remapping of Opus 4.0 and 4.1 to the current Opus version on the Anthropic API. Use when you intentionally want to... [1 or unset]
+  # CLAUDE_CODE_DISABLE_LEGACY_MODEL_REMAP = "1";
+  # Set to 1 to populate the /model picker from your gateway's /v1/models endpoint when ANTHROPIC_BASE_URL points at an Anthropic-compatible gateway... [1 or unset]
+  # CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY = "1";
+  # The model Claude Code uses for all subagents, agent teams, and agents in a workflow.
+  # CLAUDE_CODE_SUBAGENT_MODEL = "";   # ACTIVE above
+  # Set to any non-empty value, such as 1, to make every model stop retrying with a repeated-overload error when no fallback model is configured...
+  # FALLBACK_FOR_ALL_PRIMARY_MODELS = "";
+
+  # Effort, thinking, context, memory (16)
+  # -----------------------------------------
+  # Set the percentage (1-100) of the auto-compact window at which auto-compaction triggers.
+  # CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "";
+  # Set to 1 to send the effort parameter with every request, even when Claude Code does not recognize the model ID as effort-capable. [1 or unset]
+  # CLAUDE_CODE_ALWAYS_ENABLE_EFFORT = "1";
+  # Set the auto-compact window in tokens, from 100000 to 1000000. [numeric]
+  # CLAUDE_CODE_AUTO_COMPACT_WINDOW = "";
+  # Set to 1 to disable 1M context window support. [1 or unset]
+  # CLAUDE_CODE_DISABLE_1M_CONTEXT = "1";
+  # Set to 1 to disable adaptive reasoning on Opus 4.6 and Sonnet 4.6 and fall back to the fixed thinking budget controlled by MAX_THINKING_TOKENS... [1 or unset]
+  # CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "1";
+  # Set to 1 to disable auto memory. [1 or unset]
+  # CLAUDE_CODE_DISABLE_AUTO_MEMORY = "1";
+  # Set to 1 to omit the thinking parameter from API requests entirely. [1 or unset]
+  # CLAUDE_CODE_DISABLE_THINKING = "1";
+  # Set the effort level for supported models.
+  # CLAUDE_CODE_EFFORT_LEVEL = "";   # ACTIVE above
+  # Override the default token limit for file reads.
+  # CLAUDE_CODE_FILE_READ_MAX_OUTPUT_TOKENS = "";
+  # Override the context window size Claude Code assumes for the active model.
+  # CLAUDE_CODE_MAX_CONTEXT_TOKENS = "";
+  # Set the maximum number of output tokens for most requests.
+  # CLAUDE_CODE_MAX_OUTPUT_TOKENS = "";
+  # Set to 1 to disable automatic compaction when approaching the context limit. [1 or unset]
+  # DISABLE_AUTO_COMPACT = "1";
+  # Set to 1 to disable all compaction: both automatic compaction and the manual /compact command. [1 or unset]
+  # DISABLE_COMPACT = "1";
+  # Set to 1 to prevent sending the interleaved-thinking beta header. [1 or unset]
+  # DISABLE_INTERLEAVED_THINKING = "1";
+  # Maximum number of tokens allowed in MCP tool responses.
+  # MAX_MCP_OUTPUT_TOKENS = "";
+  # Fixed token budget for extended thinking. [0 or unset]
+  # MAX_THINKING_TOKENS = "0";
+
+  # Privacy, telemetry, updates (25)
+  # -----------------------------------
+  # Set to any non-empty value, such as 1, to disable nonessential network traffic: auto-updates, telemetry, error reporting, the /feedback command,...
+  # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "";   # ACTIVE above
+  # Set to 1 to enable OpenTelemetry data collection for metrics and logging. [1 or unset]
+  # CLAUDE_CODE_ENABLE_TELEMETRY = "1";   # ACTIVE above
+  # Maximum length of content-bearing OpenTelemetry attributes (model responses, tool content, system prompts, raw API bodies), truncation marker...
+  # CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH = "";
+  # Set to 1 to write OpenTelemetry exporter diagnostic errors to stderr. [1 or unset]
+  # CLAUDE_CODE_OTEL_DIAG_STDERR = "1";
+  # Timeout in milliseconds for flushing pending OpenTelemetry spans (default: 5000). [numeric]
+  # CLAUDE_CODE_OTEL_FLUSH_TIMEOUT_MS = "";
+  # Interval for refreshing dynamic OpenTelemetry headers in milliseconds (default: 1740000 / 29 minutes). [numeric]
+  # CLAUDE_CODE_OTEL_HEADERS_HELPER_DEBOUNCE_MS = "";
+  # Timeout in milliseconds for the OpenTelemetry exporter to finish on shutdown (default: 2000). [numeric]
+  # CLAUDE_CODE_OTEL_SHUTDOWN_TIMEOUT_MS = "";
+  # Set to 1 to let Claude Code run your package manager's upgrade command in the background when a new version is available. [1 or unset]
+  # CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE = "1";
+  # Set to 1 to disable automatic background updates. [1 or unset]
+  # DISABLE_AUTOUPDATER = "1";   # ACTIVE above
+  # Set to any non-empty value, such as 1, to opt out of error reporting. **Setting it to 0 or false still opts out**, unlike most on/off variables;...
+  # DISABLE_ERROR_REPORTING = "";   # ACTIVE above
+  # Set to 1 to disable installation warnings. [1 or unset]
+  # DISABLE_INSTALLATION_CHECKS = "1";   # ACTIVE above
+  # Set to any non-empty value, such as 1, to opt out of telemetry. **Setting it to 0 or false still opts out**, unlike most on/off variables; unset...
+  # DISABLE_TELEMETRY = "";   # ACTIVE above
+  # Set to 1 to block all updates including manual claude update and claude install. [1 or unset]
+  # DISABLE_UPDATES = "1";
+  # Set to 1 to force plugin auto-updates even when the main auto-updater is disabled via DISABLE_AUTOUPDATER. [1 or unset]
+  # FORCE_AUTOUPDATE_PLUGINS = "1";
+  # Standard OpenTelemetry SDK limit on attribute value length.
+  # OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT = "";
+  # Set to 1 to include the model's response text on assistant_response OpenTelemetry log events. [1 or unset]
+  # OTEL_LOG_ASSISTANT_RESPONSES = "1";
+  # Emit Anthropic Messages API request and response JSON as api_request_body / api_response_body log events. [1 or unset]
+  # OTEL_LOG_RAW_API_BODIES = "1";
+  # Set to 1 to include tool input and output content in OpenTelemetry span events. [1 or unset]
+  # OTEL_LOG_TOOL_CONTENT = "1";
+  # Set to 1 to include tool input arguments, MCP server names, user-authored workflow names, raw error strings on tool failures, the refusal category... [1 or unset]
+  # OTEL_LOG_TOOL_DETAILS = "1";
+  # Set to 1 to include user prompt text in OpenTelemetry traces and logs. [1 or unset]
+  # OTEL_LOG_USER_PROMPTS = "1";
+  # Set to false to exclude account UUID from metrics attributes (default: included).
+  # OTEL_METRICS_INCLUDE_ACCOUNT_UUID = "";
+  # Set to true to include the session entrypoint in metrics attributes (default: excluded).
+  # OTEL_METRICS_INCLUDE_ENTRYPOINT = "";
+  # As of v2.1.161, Claude Code attaches OTEL_RESOURCE_ATTRIBUTES keys to metric datapoint labels.
+  # OTEL_METRICS_INCLUDE_RESOURCE_ATTRIBUTES = "";
+  # Set to false to exclude session ID from metrics attributes (default: included).
+  # OTEL_METRICS_INCLUDE_SESSION_ID = "";
+  # Set to true to include Claude Code version in metrics attributes (default: excluded).
+  # OTEL_METRICS_INCLUDE_VERSION = "";
+
+  # Bash, tools, sandbox (16)
+  # ----------------------------
+  # Default timeout for long-running bash commands (default: 120000, or 2 minutes).
+  # BASH_DEFAULT_TIMEOUT_MS = "";   # ACTIVE above
+  # Maximum number of characters of bash output that Claude Code reads back into a command's result (default: 30000; maximum: 150000).
+  # BASH_MAX_OUTPUT_LENGTH = "";   # ACTIVE above
+  # Maximum timeout the model can set for long-running bash commands (default: 600000, or 10 minutes).
+  # BASH_MAX_TIMEOUT_MS = "";   # ACTIVE above
+  # Return to the original working directory after each Bash or PowerShell command in the main session.
+  # CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "";   # ACTIVE above
+  # Set to 1 to disable the advisor tool. [1 or unset]
+  # CLAUDE_CODE_DISABLE_ADVISOR_TOOL = "1";
+  # Set to 1 to stop Claude Code from terminating background shell commands when the operating system reports memory pressure. [1 or unset]
+  # CLAUDE_CODE_DISABLE_BG_SHELL_PRESSURE_REAP = "1";
+  # Controls whether tool call inputs stream from the API as Claude generates them. [1 or unset]
+  # CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING = "1";
+  # Windows only: path to the Git Bash executable (bash.exe).
+  # CLAUDE_CODE_GIT_BASH_PATH = "";
+  # Idle timeout in milliseconds for MCP tool calls. [0 or unset]
+  # CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT = "0";
+  # Set to 1 to stop Claude Code from passing -ExecutionPolicy Bypass when spawning PowerShell for tool calls, hooks, and status line commands, and... [1 or unset]
+  # CLAUDE_CODE_POWERSHELL_RESPECT_EXECUTION_POLICY = "1";
+  # Set the shell Claude Code uses to run Bash tool commands.
+  # CLAUDE_CODE_SHELL = "";
+  # Command prefix that wraps shell commands Claude Code spawns: Bash tool calls, hook commands, status line commands, and stdio MCP server startup...
+  # CLAUDE_CODE_SHELL_PREFIX = "";
+  # Controls MCP tool search.
+  # ENABLE_TOOL_SEARCH = "";
+  # Timeout in milliseconds for MCP tool execution (default: 100000000, about 28 hours). [numeric]
+  # MCP_TOOL_TIMEOUT = "";
+  # Override the character budget for skill metadata shown to the Skill tool.
+  # SLASH_COMMAND_TOOL_CHAR_BUDGET = "";
+  # Set to 0 to use system-installed rg instead of rg included with Claude Code. [0 or unset]
+  # USE_BUILTIN_RIPGREP = "0";   # ACTIVE above
+
+  # MCP (11)
+  # -----------
+  # Set to 1 to skip the mcp__<server>__ prefix on tool names from SDK-created MCP servers. [1 or unset]
+  # CLAUDE_AGENT_SDK_MCP_NO_PREFIX = "1";
+  # Set to 1 to spawn stdio MCP servers with only a safe baseline environment plus the server's configured env, instead of inheriting your shell... [1 or unset]
+  # CLAUDE_CODE_MCP_ALLOWLIST_ENV = "1";
+  # Elapsed time in milliseconds before a still-running MCP tool call moves to a background task (default: 120000, or 2 minutes). [0 or unset]
+  # CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS = "0";
+  # Set to false to disable claude.ai MCP servers in Claude Code.
+  # ENABLE_CLAUDEAI_MCP_SERVERS = "";
+  # OAuth client secret for MCP servers that require pre-configured credentials.
+  # MCP_CLIENT_SECRET = "";
+  # Controls whether startup waits for MCP servers to connect before the first query. [0 or unset]
+  # MCP_CONNECTION_NONBLOCKING = "0";
+  # How long blocking MCP startup waits, in milliseconds, for the connection batch before snapshotting the tool list (default: 5000). [numeric]
+  # MCP_CONNECT_TIMEOUT_MS = "";
+  # Fixed port for the OAuth redirect callback, as an alternative to --callback-port when adding an MCP server with pre-configured credentials.
+  # MCP_OAUTH_CALLBACK_PORT = "";
+  # Maximum number of remote MCP servers (HTTP/SSE) to connect in parallel during startup (default: 20).
+  # MCP_REMOTE_SERVER_CONNECTION_BATCH_SIZE = "";
+  # Maximum number of local MCP servers (stdio) to connect in parallel during startup (default: 3).
+  # MCP_SERVER_CONNECTION_BATCH_SIZE = "";
+  # Timeout in milliseconds for MCP server startup (default: 30000, or 30 seconds). [numeric]
+  # MCP_TIMEOUT = "";
+
+  # Network, proxy, TLS, timeouts (24)
+  # -------------------------------------
+  # Override the API endpoint to route requests through a proxy or gateway.
+  # ANTHROPIC_BASE_URL = "";
+  # Override the 5-minute idle timeout that aborts a streaming model response when no bytes arrive. [1 or unset]
+  # API_FORCE_IDLE_TIMEOUT = "1";
+  # Timeout for API requests in milliseconds (default: 600000, or 10 minutes; maximum: 2147483647). [numeric]
+  # API_TIMEOUT_MS = "";
+  # How many milliseconds of idle time before an unanswered AskUserQuestion dialog auto-continues without you. [numeric]
+  # CLAUDE_AFK_TIMEOUT_MS = "";
+  # Stall timeout in milliseconds for background subagents. [numeric]
+  # CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS = "";
+  # Time in milliseconds Claude Code waits for the AWS default credential provider chain to produce credentials before the request fails with AWS... [numeric]
+  # CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS = "";
+  # Comma-separated list of CA certificate sources for TLS connections. bundled is the Mozilla CA set shipped with Claude Code. system is the...
+  # CLAUDE_CODE_CERT_STORE = "";
+  # Path to client certificate file for mTLS authentication.
+  # CLAUDE_CODE_CLIENT_CERT = "";
+  # Path to client private key file for mTLS authentication.
+  # CLAUDE_CODE_CLIENT_KEY = "";
+  # Passphrase for encrypted CLAUDE\_CODE\_CLIENT\_KEY (optional).
+  # CLAUDE_CODE_CLIENT_KEY_PASSPHRASE = "";
+  # Timeout in seconds for Glob tool file discovery.
+  # CLAUDE_CODE_GLOB_TIMEOUT_SECONDS = "";
+  # Timeout in milliseconds for git operations when installing or updating plugins (default: 120000). [numeric]
+  # CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS = "";
+  # Set to 1 to clone GitHub owner/repo shorthand sources over HTTPS instead of SSH. Applies to plugin install and update, and to /plugin marketplace... [1 or unset]
+  # CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1";
+  # Set to 1 to allow the proxy to perform DNS resolution instead of the caller. [1 or unset]
+  # CLAUDE_CODE_PROXY_RESOLVES_HOSTS = "1";
+  # Set to 1 for unattended sessions such as eval harnesses, CI jobs, or remote workers. [1 or unset]
+  # CLAUDE_CODE_RETRY_WATCHDOG = "1";
+  # Override the time budget in milliseconds for SessionEnd hooks. [numeric]
+  # CLAUDE_CODE_SESSIONEND_HOOKS_TIMEOUT_MS = "";
+  # Timeout in milliseconds for synchronous plugin installation. [numeric]
+  # CLAUDE_CODE_SYNC_PLUGIN_INSTALL_TIMEOUT_MS = "";
+  # Timeout in milliseconds for a mid-session skills resync when CLAUDE_CODE_SYNC_SKILLS is set (default: 30000). [numeric]
+  # CLAUDE_CODE_SYNC_SKILLS_INSTALL_TIMEOUT_MS = "";
+  # Timeout in milliseconds for the first query to wait on the initial skills sync when CLAUDE_CODE_SYNC_SKILLS is set (default: 5000). [numeric]
+  # CLAUDE_CODE_SYNC_SKILLS_WAIT_TIMEOUT_MS = "";
+  # Override, in milliseconds, how long a non-interactive session waits at exit for its agent team to finish tearing down. [numeric]
+  # CLAUDE_CODE_TEAM_TEARDOWN_PARK_TIMEOUT_MS = "";
+  # Timeout in milliseconds before the streaming idle watchdog closes a stalled connection. [numeric]
+  # CLAUDE_STREAM_IDLE_TIMEOUT_MS = "";
+  # Specify HTTPS proxy server for network connections.
+  # HTTPS_PROXY = "";
+  # Specify HTTP proxy server for network connections.
+  # HTTP_PROXY = "";
+  # List of domains and IPs to which requests will be directly issued, bypassing proxy.
+  # NO_PROXY = "";
+
+  # Terminal, rendering, accessibility (23)
+  # ------------------------------------------
+  # Set to 1 to render screen-reader friendly output: flat text without decorative borders or animations. [1 or unset]
+  # CLAUDE_AX_SCREEN_READER = "1";
+  # Set to 1 to keep the native terminal cursor visible and disable the inverted-text cursor indicator. [1 or unset]
+  # CLAUDE_CODE_ACCESSIBILITY = "1";
+  # Set to 1 to repaint the entire screen on every frame in fullscreen rendering instead of sending incremental updates. [1 or unset]
+  # CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT = "1";
+  # Override automatic IDE connection.
+  # CLAUDE_CODE_AUTO_CONNECT_IDE = "";
+  # Set to 1 to disable fullscreen rendering and use the classic main-screen renderer. [1 or unset]
+  # CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN = "1";
+  # Set to 1 to disable automatic terminal title updates based on conversation context. [1 or unset]
+  # CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";   # ACTIVE above
+  # Set to 1 to hide the working directory in the startup logo. [1 or unset]
+  # CLAUDE_CODE_HIDE_CWD = "1";
+  # Override the host address used to connect to the IDE extension.
+  # CLAUDE_CODE_IDE_HOST_OVERRIDE = "";
+  # Set to 1 to skip auto-installation of IDE extensions. [1 or unset]
+  # CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL = "1";   # ACTIVE above
+  # Set to 1 to skip validation of IDE lockfile entries during connection. [1 or unset]
+  # CLAUDE_CODE_IDE_SKIP_VALID_CHECK = "1";
+  # How many subagents can be running in one session before the Agent tool refuses to spawn another (default: 20).
+  # CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS = "";
+  # Override the number of times to retry failed API requests (default: 10).
+  # CLAUDE_CODE_MAX_RETRIES = "";
+  # Cap on the number of subagents one session can spawn with the Agent tool (default: 200).
+  # CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION = "";
+  # Number of subagent layers allowed below the main conversation (default: 3).
+  # CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "";
+  # Cap the number of agentic turns when no explicit limit is passed. [numeric]
+  # CLAUDE_CODE_MAX_TURNS = "";
+  # Cap on the total number of WebSearch calls one session can make (default: 200).
+  # CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION = "";
+  # Set to 1 to show the terminal's own cursor at the input caret instead of a drawn block. [1 or unset]
+  # CLAUDE_CODE_NATIVE_CURSOR = "1";
+  # Set to 1 to enable fullscreen rendering, a research preview that reduces flicker and keeps memory flat in long conversations. [1 or unset]
+  # CLAUDE_CODE_NO_FLICKER = "1";
+  # Set by host platforms that embed Claude Code and manage model provider routing on its behalf.
+  # CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = "";
+  # Set to false to disable syntax highlighting in diff output.
+  # CLAUDE_CODE_SYNTAX_HIGHLIGHT = "";
+  # Set to any non-empty value, such as 1, to allow 24-bit truecolor output inside tmux. **Setting it to 0 or false still allows truecolor**, unlike...
+  # CLAUDE_CODE_TMUX_TRUECOLOR = "";
+  # Number of times to retry when the model's response fails validation against the --json-schema in non-interactive mode (the -p flag).
+  # MAX_STRUCTURED_OUTPUT_RETRIES = "";
+  # Maximum number of characters in subagent output before truncation (default: 32000, maximum: 160000).
+  # TASK_MAX_OUTPUT_LENGTH = "";
+
+  # Feature toggles (55)
+  # -----------------------
+  # Set to 1 to disable all built-in subagent types such as Explore and Plan. [1 or unset]
+  # CLAUDE_AGENT_SDK_DISABLE_BUILTIN_AGENTS = "1";
+  # Set to 1 to turn off background agents and agent view: claude agents, --bg, /background, and the on-demand supervisor. [1 or unset]
+  # CLAUDE_CODE_DISABLE_AGENT_VIEW = "1";
+  # Set to 1 to disable the Artifact tool, which publishes session output as a private web page on claude.ai. [1 or unset]
+  # CLAUDE_CODE_DISABLE_ARTIFACT = "1";
+  # Set to 1 to disable attachment processing. [1 or unset]
+  # CLAUDE_CODE_DISABLE_ATTACHMENTS = "1";
+  # Set to 1 to disable all background task functionality, including the run_in_background parameter on Bash and subagent tools, auto-backgrounding,... [1 or unset]
+  # CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = "1";
+  # Set to 1 to skip the check that an Amazon Bedrock streaming response carries the application/vnd.amazon.eventstream content-type. [1 or unset]
+  # CLAUDE_CODE_DISABLE_BEDROCK_CONTENT_TYPE_GUARD = "1";
+  # Set to 1 to stop a background session's running background shell commands, dynamic workflows, and, as of v2.1.198, background subagents when the... [1 or unset]
+  # CLAUDE_CODE_DISABLE_BG_EXIT_HANDOFF = "1";
+  # Set to 1 to disable the skills and workflows included with Claude Code: bundled skills and workflows are removed entirely, while built-in commands... [1 or unset]
+  # CLAUDE_CODE_DISABLE_BUNDLED_SKILLS = "1";
+  # Set to 1 to prevent loading any CLAUDE.md memory files into context, including user, project, and auto-memory files. [1 or unset]
+  # CLAUDE_CODE_DISABLE_CLAUDE_MDS = "1";
+  # Set to 1 to disable scheduled tasks. [1 or unset]
+  # CLAUDE_CODE_DISABLE_CRON = "1";
+  # Set to 1 to strip Anthropic-specific anthropic-beta request headers and beta tool-schema fields (such as defer_loading and eager_input_streaming)... [1 or unset]
+  # CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS = "1";
+  # Set to 1 to disable the built-in Explore and Plan subagents. [1 or unset]
+  # CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS = "1";
+  # Set to 1 to disable fast mode. [1 or unset]
+  # CLAUDE_CODE_DISABLE_FAST_MODE = "1";
+  # Set to 1 to disable the "How is Claude doing?" session quality surveys. [1 or unset]
+  # CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY = "1";
+  # Set to 1 to disable file checkpointing. [1 or unset]
+  # CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING = "1";
+  # Set to 1 to remove built-in commit and PR workflow instructions and the git status snapshot from Claude's system prompt. [1 or unset]
+  # CLAUDE_CODE_DISABLE_GIT_INSTRUCTIONS = "1";
+  # Set to 1 to disable mouse tracking in fullscreen rendering. [1 or unset]
+  # CLAUDE_CODE_DISABLE_MOUSE = "1";
+  # Set to 1 to disable click, drag, and hover handling in fullscreen rendering while keeping mouse-wheel scrolling. [1 or unset]
+  # CLAUDE_CODE_DISABLE_MOUSE_CLICKS = "1";
+  # Set to 1 to disable the non-streaming fallback when a streaming request fails mid-stream. [1 or unset]
+  # CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK = "1";
+  # Set to 1 to send the PushNotification tool's desktop notification even while you are typing in or focused on the terminal. [1 or unset]
+  # CLAUDE_CODE_DISABLE_NOTIFICATION_PRESENCE_CHECK = "1";
+  # Set to 1 to disable automatic registration of the official plugin marketplace. [1 or unset]
+  # CLAUDE_CODE_DISABLE_OFFICIAL_MARKETPLACE_AUTOINSTALL = "1";
+  # Set to 1 to skip loading skills from the system-wide managed skills directory. [1 or unset]
+  # CLAUDE_CODE_DISABLE_POLICY_SKILLS = "1";
+  # Set to 1 to disable virtual scrolling in fullscreen rendering and render every message in the transcript. [1 or unset]
+  # CLAUDE_CODE_DISABLE_VIRTUAL_SCROLL = "1";
+  # Set to 1 to disable workflows. [1 or unset]
+  # CLAUDE_CODE_DISABLE_WORKFLOWS = "1";
+  # Set to 1 to enable appending extra text to the end of every subagent's system prompt. [1 or unset]
+  # CLAUDE_CODE_ENABLE_APPEND_SUBAGENT_PROMPT = "1";
+  # Accepted for compatibility with older releases and has no effect.
+  # CLAUDE_CODE_ENABLE_AUTO_MODE = "";
+  # Override session recap availability. [1 or unset]
+  # CLAUDE_CODE_ENABLE_AWAY_SUMMARY = "1";
+  # Set to 1 to refresh plugin state at turn boundaries in non-interactive mode after a background install completes. [1 or unset]
+  # CLAUDE_CODE_ENABLE_BACKGROUND_PLUGIN_REFRESH = "1";
+  # Set to 1 to route the "How is Claude doing?" session quality survey to your own OpenTelemetry collector when Anthropic-bound nonessential traffic... [1 or unset]
+  # CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL = "1";
+  # Set to false to disable prompt suggestions (the "Prompt suggestions" toggle in /config).
+  # CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION = "";
+  # Controls whether sessions use the structured Task tools (TaskCreate, TaskUpdate, TaskGet, TaskList) or the legacy TodoWrite tool. [0 or unset]
+  # CLAUDE_CODE_ENABLE_TASKS = "0";
+  # Set to 1 to turn off the in-process cache of credentials resolved from the AWS default credential provider chain, so Claude Code resolves the... [1 or unset]
+  # CLAUDE_CODE_SKIP_AWS_CRED_CACHE = "1";
+  # Set to 1 to treat a failed fast mode availability check as available, for networks that block the check's direct request to api.anthropic.com. [1 or unset]
+  # CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS = "1";
+  # Set to 1 to skip the client-side fast mode availability check, for proxies that intercept the check's request rather than refuse it. [1 or unset]
+  # CLAUDE_CODE_SKIP_FAST_MODE_ORG_CHECK = "1";
+  # Set to 1 to skip writing prompt history and session transcripts to disk. [1 or unset]
+  # CLAUDE_CODE_SKIP_PROMPT_HISTORY = "1";
+  # Set to 1 to stop in-flight background work instead of carrying it over when you background a session by pressing or with /background. [1 or unset]
+  # CLAUDE_DISABLE_ADOPT = "1";
+  # Set to 1 to force-enable the byte-level streaming idle watchdog, or set to 0 to force-disable it. [1 or unset]
+  # CLAUDE_ENABLE_BYTE_WATCHDOG = "1";
+  # Set to 1 to enable the byte-level streaming idle watchdog on Amazon Bedrock vnd.amazon.eventstream responses. [1 or unset]
+  # CLAUDE_ENABLE_BYTE_WATCHDOG_BEDROCK = "1";
+  # Set to 0 to force-disable the event-level streaming idle watchdog, or set to 1 to force-enable it. [0 or unset]
+  # CLAUDE_ENABLE_STREAM_WATCHDOG = "0";
+  # Set to 1 to disable cost warning messages. [1 or unset]
+  # DISABLE_COST_WARNINGS = "1";
+  # Set to 1 to hide the /doctor setup checkup skill and its /checkup alias. [1 or unset]
+  # DISABLE_DOCTOR_COMMAND = "1";
+  # Set to 1 to hide the /usage-credits command that lets users purchase additional usage beyond rate limits. [1 or unset]
+  # DISABLE_EXTRA_USAGE_COMMAND = "1";
+  # Set to 1 to disable the /feedback command. [1 or unset]
+  # DISABLE_FEEDBACK_COMMAND = "1";
+  # Set to 1 to disable GrowthBook feature-flag fetching and use code defaults for every flag. [1 or unset]
+  # DISABLE_GROWTHBOOK = "1";
+  # Set to 1 to hide the /install-github-app command. [1 or unset]
+  # DISABLE_INSTALL_GITHUB_APP_COMMAND = "1";
+  # Set to 1 to hide the /login command. [1 or unset]
+  # DISABLE_LOGIN_COMMAND = "1";
+  # Set to 1 to hide the /logout command. [1 or unset]
+  # DISABLE_LOGOUT_COMMAND = "1";
+  # Set to 1 to disable prompt caching for all models (takes precedence over per-model settings). [1 or unset]
+  # DISABLE_PROMPT_CACHING = "1";
+  # Set to 1 to disable prompt caching for Fable models. [1 or unset]
+  # DISABLE_PROMPT_CACHING_FABLE = "1";
+  # Set to 1 to disable prompt caching for Haiku models. [1 or unset]
+  # DISABLE_PROMPT_CACHING_HAIKU = "1";
+  # Set to 1 to disable prompt caching for Opus models. [1 or unset]
+  # DISABLE_PROMPT_CACHING_OPUS = "1";
+  # Set to 1 to disable prompt caching for Sonnet models. [1 or unset]
+  # DISABLE_PROMPT_CACHING_SONNET = "1";
+  # Set to 1 to hide the /upgrade command. [1 or unset]
+  # DISABLE_UPGRADE_COMMAND = "1";
+  # Set to 1 to request a 1-hour prompt cache TTL instead of the default 5 minutes. [1 or unset]
+  # ENABLE_PROMPT_CACHING_1H = "1";
+  # Deprecated.
+  # ENABLE_PROMPT_CACHING_1H_BEDROCK = "";
+
+  # Other (68)
+  # -------------
+  # Set to 1 to force claude --cloud to bundle and upload your local repository even when GitHub access is available. [1 or unset]
+  # CCR_FORCE_BUNDLE = "1";
+  # Set to 1 in subprocesses Claude Code spawns (Bash and PowerShell tools, tmux sessions, hook commands, status line commands, stdio MCP server... [1 or unset]
+  # CLAUDECODE = "1";
+  # How many milliseconds before auto-continue the on-screen countdown appears on an unanswered AskUserQuestion dialog. [numeric]
+  # CLAUDE_AFK_COUNTDOWN_MS = "";
+  # Set to 1 to force-enable automatic backgrounding of long-running agent tasks. [1 or unset]
+  # CLAUDE_AUTO_BACKGROUND_TASKS = "1";
+  # Path to a file that an external tool, such as a screen-lock listener, creates when you unlock your screen and deletes when you lock it.
+  # CLAUDE_CLIENT_PRESENCE_FILE = "";
+  # Set to 1 to load memory files from directories specified with --add-dir. [1 or unset]
+  # CLAUDE_CODE_ADDITIONAL_DIRECTORIES_CLAUDE_MD = "1";
+  # Interval in milliseconds at which credentials should be refreshed (when using apiKeyHelper). [numeric]
+  # CLAUDE_CODE_API_KEY_HELPER_TTL_MS = "";
+  # Set to 0 to stop Claude Code from opening the browser automatically when a new artifact is published. [0 or unset]
+  # CLAUDE_CODE_ARTIFACT_AUTO_OPEN = "0";
+  # Set to 0 to omit the attribution block, which carries the client version and a prompt fingerprint, from the start of the system prompt. [0 or unset]
+  # CLAUDE_CODE_ATTRIBUTION_HEADER = "0";
+  # Override the debug log file path.
+  # CLAUDE_CODE_DEBUG_LOGS_DIR = "";
+  # Minimum log level written to the debug log file.
+  # CLAUDE_CODE_DEBUG_LOG_LEVEL = "";
+  # Time in milliseconds to wait after the query loop becomes idle before automatically exiting. [numeric]
+  # CLAUDE_CODE_EXIT_AFTER_STOP_DELAY = "";
+  # Set to 1 to enable agent teams. [1 or unset]
+  # CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
+  # JSON object to merge into the top level of every API request body.
+  # CLAUDE_CODE_EXTRA_BODY = "";
+  # Set to 1 to force transcript persistence, prompt history, and claude agents registration even when this claude was launched from inside another... [1 or unset]
+  # CLAUDE_CODE_FORCE_SESSION_PERSISTENCE = "1";
+  # Set to 1 to force strikethrough rendering for ~~text~~ in Claude's responses when your terminal supports it but is not auto-detected, such as over... [1 or unset]
+  # CLAUDE_CODE_FORCE_STRIKETHROUGH = "1";
+  # Set to 1 to force-enable DEC private mode 2026 synchronized output when your terminal supports it but is not auto-detected. [1 or unset]
+  # CLAUDE_CODE_FORCE_SYNC_OUTPUT = "1";
+  # Set to 1 to let Claude spawn forked subagents, or 0 to disable them, overriding any server-side rollout. [1 or unset]
+  # CLAUDE_CODE_FORK_SUBAGENT = "1";
+  # Set to 1 to emit subagent text and thinking blocks in claude -p --output-format stream-json output, the same behavior as the... [1 or unset]
+  # CLAUDE_CODE_FORWARD_SUBAGENT_TEXT = "1";
+  # Set to false to exclude dotfiles from results when Claude invokes the Glob tool.
+  # CLAUDE_CODE_GLOB_HIDDEN = "";
+  # Set to false to make the Glob tool respect .gitignore patterns.
+  # CLAUDE_CODE_GLOB_NO_IGNORE = "";
+  # Set to 1 to make /init run an interactive setup flow. [1 or unset]
+  # CLAUDE_CODE_NEW_INIT = "1";
+  # OAuth refresh token for Claude.ai authentication.
+  # CLAUDE_CODE_OAUTH_REFRESH_TOKEN = "";
+  # Space-separated OAuth scopes the refresh token was issued with, such as "user:profile user:inference user:sessions:claude_code". Required when...
+  # CLAUDE_CODE_OAUTH_SCOPES = "";
+  # OAuth access token for Claude.ai authentication.
+  # CLAUDE_CODE_OAUTH_TOKEN = "";
+  # Set to 1 to enable Perforce-aware write protection. [1 or unset]
+  # CLAUDE_CODE_PERFORCE_MODE = "1";
+  # Override the plugins root directory.
+  # CLAUDE_CODE_PLUGIN_CACHE_DIR = "";
+  # Set to 1 to skip the re-clone attempt and keep using the existing marketplace cache when a git pull fails. [1 or unset]
+  # CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE = "1";
+  # Maximum time in milliseconds that non-interactive mode with the -p flag waits after the final turn for background subagents and workflows whose... [0 or unset | default 600000, or 10 minutes. When the cap is exceeded, remaining background tasks are terminated and the process exits. Set to 0 to wait indefinitely. This cap is separate from the five-second grace period that applies to plain background shells]
+  # CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS = "0";
+  # Launch the processes Claude Code starts from its own binary, such as the background service that hosts agent view sessions, through a corporate...
+  # CLAUDE_CODE_PROCESS_WRAPPER = "";
+  # Set to 1 to propagate W3C trace context when ANTHROPIC_BASE_URL points at a custom proxy. [1 or unset]
+  # CLAUDE_CODE_PROPAGATE_TRACEPARENT = "1";
+  # Set to 1 to automatically resume if the previous session ended mid-turn. [1 or unset]
+  # CLAUDE_CODE_RESUME_INTERRUPTED_TURN = "1";
+  # Override the continuation message injected when resuming a session that ended mid-turn.
+  # CLAUDE_CODE_RESUME_PROMPT = "";
+  # Set to 1 to start in safe mode: CLAUDE.md, skills, plugins, hooks, MCP servers, custom commands and agents, output styles, workflows, custom... [1 or unset]
+  # CLAUDE_CODE_SAFE_MODE = "1";
+  # JSON object limiting how many times specific scripts may be invoked per session when CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is set. [numeric]
+  # CLAUDE_CODE_SCRIPT_CAPS = "";
+  # Set the mouse wheel scroll multiplier in fullscreen rendering.
+  # CLAUDE_CODE_SCROLL_SPEED = "";
+  # Set to 1 to run with a minimal system prompt and only the Bash, file read, and file edit tools. [1 or unset]
+  # CLAUDE_CODE_SIMPLE = "1";
+  # Set to 1 to use a shorter system prompt and abbreviated tool descriptions on any model. [1 or unset]
+  # CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT = "1";
+  # Maximum number of consecutive times a Stop or SubagentStop hook may block the turn from ending before Claude Code overrides it and ends the turn... [0 or unset]
+  # CLAUDE_CODE_STOP_HOOK_BLOCK_CAP = "0";
+  # Set to 1 to strip Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP stdio servers). [1 or unset]
+  # CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = "1";
+  # Set to 1 in non-interactive mode (the -p flag) to wait for plugin installation to complete before the first query. [1 or unset]
+  # CLAUDE_CODE_SYNC_PLUGIN_INSTALL = "1";
+  # Set to 1 to download your enabled claude.ai skills into ~/.claude/skills/ before the first query and resync every 10 minutes. [1 or unset]
+  # CLAUDE_CODE_SYNC_SKILLS = "1";
+  # Share a task list across sessions.
+  # CLAUDE_CODE_TASK_LIST_ID = "";
+  # Override the temp directory used for internal temp files. [default /tmp on macOS, os.tmpdir() on Linux and Windows. As of v2.1.161, on macOS and Linux, sandboxed Bash subprocesses receive a short fallback $TMPDIR under the system default when your override is a long path, since some tools fail when temp paths get too long. Unsandboxed Bash commands inherit your shell's $TMPDIR unchanged. Claude Code's own temp files always use your override]
+  # CLAUDE_CODE_TMPDIR = "/tmp";
+  # Override the configuration directory (default: ~/.claude).
+  # CLAUDE_CONFIG_DIR = "";
+  # Path to a shell script whose contents Claude Code runs before each Bash command in the same shell process, so exports in the file are visible to...
+  # CLAUDE_ENV_FILE = "";
+  # Prefix for auto-generated Remote Control session names when no explicit name is provided.
+  # CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX = "";
+  # Set to 1 to enable debug mode, equivalent to launching with --debug. [1 or unset]
+  # DEBUG = "1";
+  # Set to 1 to opt out of telemetry, with the same effect as DISABLE_TELEMETRY, including making Remote Control unavailable. [1 or unset]
+  # DO_NOT_TRACK = "1";
+  # Set to 1 to enable clickable OSC 8 hyperlinks when your terminal supports them but isn't auto-detected, or 0 to disable them. [1 or unset]
+  # FORCE_HYPERLINK = "1";
+  # Set to 1 to force the 5-minute prompt cache TTL even when 1-hour TTL would otherwise apply. [1 or unset]
+  # FORCE_PROMPT_CACHING_5M = "1";
+  # Set to any non-empty value, such as 1, to enable demo mode: hides your email and organization name from the header and /status output, and skips...
+  # IS_DEMO = "";
+  # Override region for Claude 3.5 Haiku when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_3_5_HAIKU = "";
+  # Override region for Claude 3.5 Sonnet when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_3_5_SONNET = "";
+  # Override region for Claude 3.7 Sonnet when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_3_7_SONNET = "";
+  # Override region for Claude 4.0 Opus when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_4_0_OPUS = "";
+  # Override region for Claude 4.0 Sonnet when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_4_0_SONNET = "";
+  # Override region for Claude 4.1 Opus when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_4_1_OPUS = "";
+  # Override region for Claude Opus 4.5 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_4_5_OPUS = "";
+  # Override region for Claude Sonnet 4.5 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_4_5_SONNET = "";
+  # Override region for Claude Opus 4.6 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_4_6_OPUS = "";
+  # Override region for Claude Sonnet 4.6 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_4_6_SONNET = "";
+  # Override region for Claude Opus 4.7 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_4_7_OPUS = "";
+  # Override region for Claude Opus 4.8 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_4_8_OPUS = "";
+  # Override region for Claude Opus 5 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_5_OPUS = "";
+  # Override region for Claude Sonnet 5 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_5_SONNET = "";
+  # Override region for Claude Fable 5 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_FABLE_5 = "";
+  # Override region for Claude Haiku 4.5 when using Google Cloud's Agent Platform.
+  # VERTEX_REGION_CLAUDE_HAIKU_4_5 = "";
+
+  # Read-only (exported by Claude Code; do not set) (10)
+  # -------------------------------------------------------
+  # Set automatically in Bash tool and hook command subprocesses while the session has an active Remote Control connection, and removed when the...
+  # CLAUDE_CODE_BRIDGE_SESSION_ID = "";
+  # Set to 1 in subprocesses Claude Code spawns via the Bash, PowerShell, and Monitor tools, hook commands, and status line commands. [1 or unset]
+  # CLAUDE_CODE_CHILD_SESSION = "1";
+  # Maximum number of read-only tools and subagents that can execute in parallel (default: 10).
+  # CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY = "";
+  # Path to one or more read-only plugin seed directories, separated by : on Unix or ; on Windows.
+  # CLAUDE_CODE_PLUGIN_SEED_DIR = "";
+  # Set automatically to true when Claude Code is running as a cloud session.
+  # CLAUDE_CODE_REMOTE = "";
+  # Set automatically in cloud sessions to the current session's ID. Read this to construct a link back to the session transcript.
+  # CLAUDE_CODE_REMOTE_SESSION_ID = "";
+  # Maximum age in milliseconds of the last transcript message for a session that ended mid-turn to continue automatically on resume. [numeric]
+  # CLAUDE_CODE_RESUME_INTERRUPTED_TURN_MAX_AGE_MS = "";
+  # Set automatically to the current session ID in Bash and PowerShell tool subprocesses, hook command subprocesses, and stdio MCP server subprocesses.
+  # CLAUDE_CODE_SESSION_ID = "";
+  # Set automatically in Bash tool subprocesses and hook commands to the active effort level for the turn: low, medium, high, xhigh, or max.
+  # CLAUDE_EFFORT = "";
+  # Claude Code sets this to its own process ID in the subprocesses it spawns: Bash and PowerShell tool commands and hook commands.
+  # CLAUDE_PID = "";
+
+  # === Undocumented: read by the 2.1.222 binary, absent from the published docs ===
+  # Extracted from the binary's env accessor registry. The type is authoritative;
+  # there is no official description, so semantics are inferred from the name only
+  # and are unverified. Unsupported surface: it can change without a changelog entry.
+
+  # Auth, providers, gateway (53)
+  # AGENT_PROXY_AUTH_TOKEN = "";                                  # string
+  # ANTHROPIC_FEDERATION_RULE_ID = "";                            # string
+  # ANTHROPIC_GOOGLE_CLOUD_BASE_URL = "";                         # string
+  # ANTHROPIC_GOOGLE_CLOUD_LOCATION = "";                         # string
+  # ANTHROPIC_GOOGLE_CLOUD_PROJECT = "";                          # string
+  # ANTHROPIC_GOOGLE_CLOUD_WORKSPACE_ID = "";                     # string
+  # ANTHROPIC_ORGANIZATION_ID = "";                               # string
+  # ANTHROPIC_PROFILE = "";                                       # string
+  # CLAUDE_AI_OAUTH_SCOPES = "";                                  # unknown type
+  # CLAUDE_AI_PROFILE_SCOPE = "";                                 # unknown type
+  # CLAUDE_BG_AUTH_SNAPSHOT_PATH = "";                            # string
+  # CLAUDE_BG_CLAIM_AUTH = "";                                    # string
+  # CLAUDE_BG_PTY_AUTH = "";                                      # string
+  # CLAUDE_BG_RV_AUTH = "";                                       # string
+  # CLAUDE_BG_SOCKET_TOKENS_PATH = "";                            # string
+  # CLAUDE_BRIDGE_OAUTH_TOKEN = "";                               # string
+  # CLAUDE_CODE_API_KEY_FILE_DESCRIPTOR = "";                     # string
+  # CLAUDE_CODE_ARTIFACTS_API_TOKEN = "";                         # string
+  # CLAUDE_CODE_AUTH_FAIL_EXIT_MS = "";                           # int {min:0}
+  # CLAUDE_CODE_CUSTOM_OAUTH_URL = "";                            # string
+  # CLAUDE_CODE_DESIGN_OAUTH_CLIENT_ID = "";                      # string
+  # CLAUDE_CODE_ENABLE_PROXY_AUTH_HELPER = "";                    # bool
+  # CLAUDE_CODE_ENABLE_TOKEN_USAGE_ATTACHMENT = "";               # bool
+  # CLAUDE_CODE_HFI_BEARER_TOKEN = "";                            # string
+  # CLAUDE_CODE_HOST_AUTH_ENV_VAR = "";                           # string
+  # CLAUDE_CODE_HOST_AUTH_REFRESH_TIMEOUT_MS = "";                # int {min:1}
+  # CLAUDE_CODE_IDLE_TOKEN_THRESHOLD = "";                        # int
+  # CLAUDE_CODE_OAUTH_401_WAIT_MS = "";                           # int {min:0}
+  # CLAUDE_CODE_OAUTH_CLIENT_ID = "";                             # string
+  # CLAUDE_CODE_OAUTH_TOKEN_FILE_DESCRIPTOR = "";                 # string
+  # CLAUDE_CODE_ORGANIZATION_UUID = "";                           # string
+  # CLAUDE_CODE_PROFILE_QUERY = "";                               # bool
+  # CLAUDE_CODE_PROFILE_STARTUP = "";                             # bool
+  # CLAUDE_CODE_PROXY_AUTH_HELPER_TTL_MS = "";                    # int
+  # CLAUDE_CODE_RESUME_TOKEN_THRESHOLD = "";                      # int
+  # CLAUDE_CODE_SDK_HAS_HOST_AUTH_REFRESH = "";                   # bool
+  # CLAUDE_CODE_SDK_HAS_OAUTH_REFRESH = "";                       # bool
+  # CLAUDE_CODE_SESSION_ACCESS_TOKEN = "";                        # string
+  # CLAUDE_CODE_SKIP_ANTHROPIC_GOOGLE_CLOUD_AUTH = "";            # bool
+  # CLAUDE_CODE_TOTAL_TOKENS_REMINDER = "";                       # string
+  # CLAUDE_CODE_TOTAL_TOKENS_REMINDER_AFTER_USER_TURN = "";       # true | false | unset
+  # CLAUDE_CODE_TOTAL_TOKENS_REMINDER_BUDGET = "";                # int
+  # CLAUDE_CODE_USE_ANTHROPIC_GOOGLE_CLOUD = "";                  # bool
+  # CLAUDE_CODE_WEBSOCKET_AUTH_FILE_DESCRIPTOR = "";              # string
+  # CLAUDE_CODE_WORKFLOW_SIZE_WARNING_TOKENS = "";                # int {min:1}
+  # CLAUDE_LOCAL_OAUTH_API_BASE = "";                             # string
+  # CLAUDE_LOCAL_OAUTH_APPS_BASE = "";                            # string
+  # CLAUDE_LOCAL_OAUTH_CONSOLE_BASE = "";                         # string
+  # CLAUDE_SESSION_INGRESS_TOKEN_FILE = "";                       # string
+  # CLAUDE_TRUSTED_DEVICE_TOKEN = "";                             # string
+  # MAX_TOTAL_TAG_TOKENS = "";                                    # unknown type
+  # MCP_OAUTH_CLIENT_METADATA_URL = "";                           # string
+  # MCP_XAA_IDP_CLIENT_SECRET = "";                               # string
+
+  # Model, effort, thinking (6)
+  # CLAUDE_CODE_AUTO_MODE_MODEL = "";                             # string
+  # CLAUDE_CODE_BG_CLASSIFIER_MODEL = "";                         # string
+  # CLAUDE_CODE_DISABLE_REFUSAL_FALLBACK = "";                    # bool
+  # CLAUDE_CODE_NO_MODEL_FALLBACK = "";                           # bool
+  # CLAUDE_CODE_REFUSAL_FALLBACK_CATCH_ALL = "";                  # true | false | unset
+  # CLAUDE_CONTEXT_COLLAPSE_MODEL = "";                           # string
+
+  # Agents, tasks, workflows (36)
+  # AGENT_PROXY_URL = "";                                         # string
+  # AGENT_VIEW_RELAUNCH_ENV_KEY = "";                             # unknown type
+  # CCR_AGENT_PROXY_ENABLED = "";                                 # bool
+  # CCR_AGENT_PROXY_INCLUDE_HOSTS = "";                           # string
+  # CCR_AGENT_PROXY_RELAY_MODE = "";                              # string
+  # CLAUDE_AGENT = "";                                            # unknown type
+  # CLAUDE_AGENTS_SELECT = "";                                    # string
+  # CLAUDE_AGENT_SDK_CLIENT_APP = "";                             # string
+  # CLAUDE_AGENT_SDK_VERSION = "";                                # string
+  # CLAUDE_BG_BACKEND = "";                                       # string
+  # CLAUDE_BG_ISOLATION = "";                                     # string
+  # CLAUDE_BG_MEMORY_TOGGLED_OFF = "";                            # string
+  # CLAUDE_BG_POST_CLEAR_RESPAWN = "";                            # bool
+  # CLAUDE_BG_RENDEZVOUS_SOCK = "";                               # string
+  # CLAUDE_BG_SESSION_PERMISSION_RULES = "";                      # string
+  # CLAUDE_BG_SOURCE = "";                                        # string
+  # CLAUDE_BG_STARTUP_WEDGE_MS = "";                              # int
+  # CLAUDE_BG_TCC_DISCLAIMED = "";                                # string
+  # CLAUDE_CODE_AGENT = "";                                       # string
+  # CLAUDE_CODE_AGENT_PROXY_GH_SHIM = "";                         # bool
+  # CLAUDE_CODE_AGENT_PROXY_GIT_CONFIG = "";                      # bool
+  # CLAUDE_CODE_BG_TASKS_REPORT_RUNNING = "";                     # bool
+  # CLAUDE_CODE_EXPERIMENTAL_OBSERVER_AGENTS = "";                # bool
+  # CLAUDE_CODE_PLAN_V2_AGENT_COUNT = "";                         # int
+  # CLAUDE_CODE_PLAN_V2_EXPLORE_AGENT_COUNT = "";                 # int
+  # CLAUDE_CODE_SUBAGENT_CACHE_EVICT = "";                        # bool
+  # CLAUDE_CODE_WORKFLOWS = "";                                   # true | false | unset
+  # CLAUDE_CODE_WORKFLOW_SIZE_WARNING_AGENTS = "";                # int {min:1}
+  # CLAUDE_REMOTE_WORKFLOW_ARGS = "";                             # string
+  # CLAUDE_REMOTE_WORKFLOW_SCRIPT = "";                           # string
+  # CLAUDE_SUBAGENT_BG_SHELL_MAX_MS = "";                         # int {min:1}
+  # CLAUDE_WORKFLOW_NAME_ONLY = "";                               # bool
+  # ENABLE_SESSION_BACKGROUNDING = "";                            # bool
+  # MAX_TASK_OUTPUT_BYTES = "";                                   # unknown type
+  # MAX_TASK_OUTPUT_BYTES_DISPLAY = "";                           # unknown type
+  # MCP_TASK = "";                                                # unknown type
+
+  # Memory, context, compaction (31)
+  # CLAUDE_AFTER_LAST_COMPACT = "";                               # string
+  # CLAUDE_BRIDGE_REATTACH_SESSION = "";                          # string
+  # CLAUDE_BRIDGE_SESSION_INGRESS_URL = "";                       # string
+  # CLAUDE_CODE_COLD_COMPACT = "";                                # bool
+  # CLAUDE_CODE_DISABLE_MEMORY_BULK_INFLATE = "";                 # bool
+  # CLAUDE_CODE_DISABLE_MEMORY_MASS_DELETE_HOLD = "";             # bool
+  # CLAUDE_CODE_DISABLE_MEMORY_PERIODIC_RESYNC = "";              # bool
+  # CLAUDE_CODE_DISABLE_MEMORY_STREAM_LIST = "";                  # bool
+  # CLAUDE_CODE_DISABLE_ORG_MEMORY = "";                          # bool
+  # CLAUDE_CODE_DISABLE_PRECOMPACT_SKIP = "";                     # bool
+  # CLAUDE_CODE_EMIT_SESSION_STATE_EVENTS = "";                   # bool
+  # CLAUDE_CODE_ENABLE_SDK_FILE_CHECKPOINTING = "";               # bool
+  # CLAUDE_CODE_FORCE_EVALUATE_MEMORY = "";                       # bool
+  # CLAUDE_CODE_FORCE_MEMORY_SURVEY = "";                         # bool
+  # CLAUDE_CODE_MEMORY_PUSH_DELETE_MODE = "";                     # enum ["corroborate","immediate","never"]
+  # CLAUDE_CODE_REMOTE_MEMORY_DIR = "";                           # string
+  # CLAUDE_CODE_REMOTE_SESSION_ORIGIN = "";                       # string
+  # CLAUDE_CODE_RESUME_FROM_SESSION = "";                         # string
+  # CLAUDE_CODE_SESSION_KIND = "";                                # string
+  # CLAUDE_CODE_SESSION_LOG = "";                                 # string
+  # CLAUDE_CODE_SESSION_NAME = "";                                # string
+  # CLAUDE_CODE_SUPPRESS_SESSION_ATTRIBUTION = "";                # unknown type
+  # CLAUDE_CODE_SYNC_SESSION_REFS = "";                           # bool
+  # CLAUDE_CODE_TMUX_SESSION = "";                                # string
+  # CLAUDE_CONTEXT_COLLAPSE = "";                                 # bool
+  # CLAUDE_COWORK_MEMORY_EXTRA_GUIDELINES = "";                   # string
+  # CLAUDE_COWORK_MEMORY_GUIDELINES = "";                         # string
+  # CLAUDE_COWORK_MEMORY_INDEX_CONTENT = "";                      # string
+  # CLAUDE_COWORK_MEMORY_PATH_OVERRIDE = "";                      # string
+  # CLAUDE_MEMORY_STORES = "";                                    # unknown type
+  # ENABLE_SESSION_PERSISTENCE = "";                              # bool
+
+  # Tools, bash, sandbox (15)
+  # CLAUDE_CODE_BASH_SANDBOX_SHOW_INDICATOR = "";                 # bool
+  # CLAUDE_CODE_DIAGNOSTICS_FILE = "";                            # string
+  # CLAUDE_CODE_EMIT_TOOL_USE_SUMMARIES = "";                     # bool
+  # CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL = "";            # bool
+  # CLAUDE_CODE_ENABLE_REFRESH_MCP_TOOLS = "";                    # bool
+  # CLAUDE_CODE_HOST_CREDS_FILE = "";                             # unknown type
+  # CLAUDE_CODE_PEWTER_OWL_TOOL = "";                             # true | false | unset
+  # CLAUDE_CODE_REMOTE_RAW_EVENTS_FILE = "";                      # string
+  # CLAUDE_CODE_SANDBOXED = "";                                   # bool
+  # CLAUDE_CODE_TERMINAL_MCP_TOOLS = "";                          # string
+  # CLAUDE_IN_CHROME_DOMAIN_RULE_TOOL = "";                       # unknown type
+  # CLAUDE_STAGE_FILE_ROOT = "";                                  # string
+  # ENABLE_LSP_TOOL = "";                                         # bool
+  # ENABLE_MCP_LARGE_OUTPUT_FILES = "";                           # true | false | unset
+  # MAX_WORKING_FILE_BYTES = "";                                  # unknown type
+
+  # MCP (15)
+  # CLAUDE_CODE_SKIP_PLUGIN_MCP_SERVERS = "";                     # bool
+  # CLAUDE_CODE_SKIP_PLUGIN_MCP_SERVERS_EXCEPT = "";              # string
+  # CLAUDE_CODE_SYNC_PLUGINS_MCP_TIMEOUT_MS = "";                 # unknown type
+  # CLAUDE_IN_CHROME_MCP_SERVER_NAME = "";                        # unknown type
+  # MAX_MCP_CONFIG_BYTES = "";                                    # unknown type
+  # MCP_CLIENT_METADATA_URL = "";                                 # unknown type
+  # MCP_DISCOVERY_CACHE = "";                                     # true | false | unset
+  # MCP_DISCOVERY_CACHE_MAX_STALE_S = "";                         # int {min:1}
+  # MCP_DISCOVERY_CACHE_TTL_S = "";                               # int {min:1}
+  # MCP_PROTOCOL_NEGOTIATION = "";                                # string
+  # MCP_SCHEMA_BY_TYPE = "";                                      # unknown type
+  # MCP_SDK_GENERATION = "";                                      # string
+  # MCP_SETTINGS_SCOPES = "";                                     # unknown type
+  # MCP_TREE_ID = "";                                             # unknown type
+  # MCP_TRUNCATION_PROMPT_OVERRIDE = "";                          # string
+
+  # Network, proxy, timeouts (37)
+  # ANTHROPIC_UNIX_SOCKET = "";                                   # string
+  # CLAUDE_BRIDGE_BASE_URL = "";                                  # string
+  # CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS = "";                      # int {min:1}
+  # CLAUDE_CODE_API_BASE_URL = "";                                # string
+  # CLAUDE_CODE_ARTIFACTS_API_BASE_URL = "";                      # string
+  # CLAUDE_CODE_ARTIFACT_ASSET_BASE_URL = "";                     # string
+  # CLAUDE_CODE_ARTIFACT_LIVE_BASE_URL = "";                      # string
+  # CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL = "";                 # unknown type
+  # CLAUDE_CODE_DEV_RAW_CHANGELOG_URL = "";                       # string
+  # CLAUDE_CODE_FABLE_BRIDGE_DIALOG_TIMEOUT_MS = "";              # int
+  # CLAUDE_CODE_GB_BASE_URL = "";                                 # string
+  # CLAUDE_CODE_PWSH_PARSE_TIMEOUT_MS = "";                       # int
+  # CLAUDE_CODE_REPORT_FINDINGS = "";                             # bool
+  # CLAUDE_CODE_SIMULATE_PROXY_USAGE = "";                        # bool
+  # CLAUDE_CODE_SSE_PORT = "";                                    # int
+  # CLAUDE_CODE_SYNC_PLUGINS_INSTALL_TIMEOUT_MS = "";             # int {min:1}
+  # CLAUDE_CODE_USER_DIALOG_TIMEOUT_MS = "";                      # int
+  # CLAUDE_CODE_WEBFETCH_USE_CCR_PROXY = "";                      # bool
+  # CLAUDE_CODE_WEBSEARCH_USE_CCR_PROXY = "";                     # bool
+  # CLAUDE_IMPORT_CONVERSATIONS = "";                             # bool
+  # CLAUDE_SERVE_DRAIN_TIMEOUT_MS = "";                           # int {min:1}
+  # OTEL_EXPORTER_OTLP_ENDPOINT = "";                             # string
+  # OTEL_EXPORTER_OTLP_HEADERS = "";                              # string
+  # OTEL_EXPORTER_OTLP_LOGS_ENDPOINT = "";                        # string
+  # OTEL_EXPORTER_OTLP_LOGS_PROTOCOL = "";                        # string
+  # OTEL_EXPORTER_OTLP_METRICS_ENDPOINT = "";                     # string
+  # OTEL_EXPORTER_OTLP_METRICS_PROTOCOL = "";                     # string
+  # OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE = "";       # string
+  # OTEL_EXPORTER_OTLP_PROTOCOL = "";                             # string
+  # OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = "";                      # string
+  # OTEL_EXPORTER_OTLP_TRACES_PROTOCOL = "";                      # string
+  # OTEL_LOGS_EXPORTER = "";                                      # string
+  # OTEL_LOGS_EXPORT_INTERVAL = "";                               # int
+  # OTEL_METRICS_EXPORTER = "";                                   # string
+  # OTEL_METRIC_EXPORT_INTERVAL = "";                             # int
+  # OTEL_TRACES_EXPORTER = "";                                    # string
+  # OTEL_TRACES_EXPORT_INTERVAL = "";                             # int
+
+  # Terminal, UI, IDE (11)
+  # CLAUDE_CODE_BLOCKING_LIMIT_OVERRIDE = "";                     # string
+  # CLAUDE_CODE_EXIT_AFTER_FIRST_RENDER = "";                     # bool
+  # CLAUDE_CODE_FORCE_FULLSCREEN_UPSELL = "";                     # bool
+  # CLAUDE_CODE_HIDE_SETTINGS_HINT = "";                          # string
+  # CLAUDE_CODE_OVERRIDE_DATE = "";                               # string
+  # CLAUDE_CODE_RELAUNCH_TERMINAL_SIZE = "";                      # string
+  # CLAUDE_CODE_TERMINAL_RECORDING = "";                          # string
+  # CLAUDE_CODE_TUI_JUST_SWITCHED = "";                           # string
+  # CLAUDE_RUNNER_DISABLE_AWAITING_ACTION_OVERRIDE = "";          # bool
+  # FORCE_CODE_TERMINAL = "";                                     # bool
+  # FORCE_COLOR = "";                                             # string
+
+  # Telemetry, logging, debug (15)
+  # CLAUDE_CODE_COMMIT_LOG = "";                                  # string
+  # CLAUDE_CODE_DD_ERROR_TRACKING_FLUSH_INTERVAL_MS = "";         # int {min:1}
+  # CLAUDE_CODE_DEBUG_REPAINTS = "";                              # bool
+  # CLAUDE_CODE_ENHANCED_TELEMETRY_BETA = "";                     # bool
+  # CLAUDE_CODE_FORCE_FULL_LOGO = "";                             # bool
+  # CLAUDE_CODE_FRAME_TIMING_LOG = "";                            # string
+  # CLAUDE_CODE_GB_DISK_CACHE_WHEN_TELEMETRY_OFF = "";            # bool
+  # CLAUDE_CODE_PERFETTO_TRACE = "";                              # string
+  # CLAUDE_DEBUG = "";                                            # bool
+  # CLAUDE_GATEWAY_LOG_LEVEL = "";                                # string
+  # ENABLE_ENHANCED_TELEMETRY_BETA = "";                          # unknown type
+  # MAX_DECLARED_DIALOG_KINDS = "";                               # unknown type
+  # OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT = "";             # int {min:0}
+  # OTEL_RESOURCE_ATTRIBUTES = "";                                # string
+  # OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT = "";                  # int {min:0}
+
+  # Remote control, cloud, sharing (19)
+  # CCR_BYOC_BETA = "";                                           # unknown type
+  # CCR_ENABLE_BUNDLE = "";                                       # bool
+  # CCR_ON_BRANCH_DEFAULT_GUARD = "";                             # enum ["enforce","observe","off"]
+  # CLAUDE_BRIDGE_REATTACH_GROUPING = "";                         # string
+  # CLAUDE_BRIDGE_REATTACH_OUTBOUND_ONLY = "";                    # bool
+  # CLAUDE_BRIDGE_REATTACH_SEQ = "";                              # int
+  # CLAUDE_CODE_ARTIFACT = "";                                    # string
+  # CLAUDE_CODE_ARTIFACT_COMMENTS = "";                           # true | false | unset
+  # CLAUDE_CODE_ARTIFACT_COMMENTS_AUTOREACT = "";                 # true | false | unset
+  # CLAUDE_CODE_ARTIFACT_DIRECT_UPLOAD = "";                      # bool
+  # CLAUDE_CODE_ENABLE_REMOTE_RECAP = "";                         # true | false | unset
+  # CLAUDE_CODE_FORCE_BRIDGE = "";                                # bool
+  # CLAUDE_CODE_MOCK_REMOTE_SETTINGS = "";                        # bool
+  # CLAUDE_CODE_REMOTE_ENVIRONMENT_TYPE = "";                     # string
+  # CLAUDE_CODE_REMOTE_HERMETIC_MODE = "";                        # bool
+  # CLAUDE_CODE_REMOTE_SEND_KEEPALIVES = "";                      # bool
+  # CLAUDE_CODE_REMOTE_SETTINGS_PATH = "";                        # string
+  # CLAUDE_CODE_REMOTE_SETTINGS_POLL_MS = "";                     # int
+  # MAX_ARTIFACT_BYTES = "";                                      # unknown type
+
+  # Other (152)
+  # ANTHROPIC_CONFIG_DIR = "";                                    # string
+  # CLAUDE_AI_INFERENCE_SCOPE = "";                               # unknown type
+  # CLAUDE_API_SKILL_DESCRIPTION = "";                            # unknown type
+  # CLAUDE_AX_STARTUP_QUIET_MS = "";                              # int {min:0}
+  # CLAUDE_CHROME_CLASSIFIER_FLOOR = "";                          # true | false | unset
+  # CLAUDE_CHROME_PERMISSION_MODE = "";                           # string
+  # CLAUDE_CODE_ACCOUNT_TAGGED_ID = "";                           # string
+  # CLAUDE_CODE_ACCOUNT_UUID = "";                                # string
+  # CLAUDE_CODE_ACTION = "";                                      # string
+  # CLAUDE_CODE_ACT_DONT_REDERIVE = "";                           # true | false | unset
+  # CLAUDE_CODE_ADDITIONAL_PROTECTION = "";                       # bool
+  # CLAUDE_CODE_AMBER_ASTROLABE = "";                             # bool
+  # CLAUDE_CODE_AUTO_MODE_EXTERNAL_PERMISSIONS = "";              # bool
+  # CLAUDE_CODE_BASALT_COVE = "";                                 # bool
+  # CLAUDE_CODE_BASE_REF = "";                                    # string
+  # CLAUDE_CODE_BASE_REFS = "";                                   # string
+  # CLAUDE_CODE_BENCH_LIVE_COUNTS = "";                           # bool
+  # CLAUDE_CODE_BISON_CAIRN = "";                                 # bool
+  # CLAUDE_CODE_BRIEF = "";                                       # bool
+  # CLAUDE_CODE_BRIEF_UPLOAD = "";                                # bool
+  # CLAUDE_CODE_BUBBLEWRAP = "";                                  # bool
+  # CLAUDE_CODE_BYOC_ENABLE_DATADOG = "";                         # bool
+  # CLAUDE_CODE_CLASSIFIER_SUMMARY = "";                          # string
+  # CLAUDE_CODE_CONTAINER_ID = "";                                # string
+  # CLAUDE_CODE_DAEMON_COLD_START = "";                           # bool
+  # CLAUDE_CODE_DATADOG_FLUSH_INTERVAL_MS = "";                   # int {min:1}
+  # CLAUDE_CODE_DECSTBM = "";                                     # string
+  # CLAUDE_CODE_DISABLE_CLAUDE_API_SKILL = "";                    # bool
+  # CLAUDE_CODE_DISABLE_CLAUDE_CODE_SKILL = "";                   # bool
+  # CLAUDE_CODE_DISABLE_EXPLORE_INHERIT_CAP = "";                 # bool
+  # CLAUDE_CODE_DISABLE_LAUNCH_COMPOSER = "";                     # bool
+  # CLAUDE_CODE_DISABLE_NESTED_CHAIN_IDLE = "";                   # bool
+  # CLAUDE_CODE_DISABLE_WORKING_SYNC = "";                        # bool
+  # CLAUDE_CODE_DONT_INHERIT_ENV = "";                            # bool
+  # CLAUDE_CODE_EAGER_FLUSH = "";                                 # bool
+  # CLAUDE_CODE_ENABLE_CFC = "";                                  # true | false | unset
+  # CLAUDE_CODE_ENABLE_DESIGN_SYNC = "";                          # bool
+  # CLAUDE_CODE_ENABLE_LAUNCH_COMPOSER = "";                      # bool
+  # CLAUDE_CODE_ENABLE_MENU_KIND_LANES = "";                      # bool
+  # CLAUDE_CODE_ENABLE_XAA = "";                                  # bool
+  # CLAUDE_CODE_ENTRYPOINT = "";                                  # unknown type
+  # CLAUDE_CODE_ENVIRONMENT_KIND = "";                            # string
+  # CLAUDE_CODE_ENVIRONMENT_RUNNER_VERSION = "";                  # string
+  # CLAUDE_CODE_EXTRA_METADATA = "";                              # string
+  # CLAUDE_CODE_FLEETVIEW_SIMPLE = "";                            # bool
+  # CLAUDE_CODE_FORCE_MID_CONVERSATION_SYSTEM = "";               # bool
+  # CLAUDE_CODE_FORCE_TIP_ID = "";                                # string
+  # CLAUDE_CODE_FORCE_WINDOWS_CREDMAN = "";                       # string
+  # CLAUDE_CODE_FRAME_TIMING_SAMPLE_EVERY = "";                   # int
+  # CLAUDE_CODE_GAULT_KESTREL = "";                               # bool
+  # CLAUDE_CODE_GB_REFRESH_INTERVAL_MS = "";                      # int
+  # CLAUDE_CODE_GORSE_PLOVER = "";                                # bool
+  # CLAUDE_CODE_GZIP_REQUEST_BODIES = "";                         # true | false | unset
+  # CLAUDE_CODE_HERON_TALLOW = "";                                # bool
+  # CLAUDE_CODE_HOST_PLATFORM = "";                               # string
+  # CLAUDE_CODE_IDLE_THRESHOLD_MINUTES = "";                      # int
+  # CLAUDE_CODE_INCLUDE_PARTIAL_MESSAGES = "";                    # bool
+  # CLAUDE_CODE_INVESTIGATE_FIRST = "";                           # bool
+  # CLAUDE_CODE_IS_COWORK = "";                                   # bool
+  # CLAUDE_CODE_JSONL_TRANSCRIPT = "";                            # string
+  # CLAUDE_CODE_JUNIPER_SUNDIAL = "";                             # int {min:1,digitsOnly:!0}
+  # CLAUDE_CODE_KB_COHESION_FIXES = "";                           # bool
+  # CLAUDE_CODE_LANTERN_PRISM = "";                               # bool
+  # CLAUDE_CODE_LARCH_CISTERN = "";                               # unknown type
+  # CLAUDE_CODE_LOOP_KEEPALIVE = "";                              # bool
+  # CLAUDE_CODE_LOOP_PERSISTENT = "";                             # bool
+  # CLAUDE_CODE_MANAGED_SETTINGS_PATH = "";                       # string
+  # CLAUDE_CODE_MARL_CORMORANT = "";                              # bool
+  # CLAUDE_CODE_MOCK_TRIAL = "";                                  # bool
+  # CLAUDE_CODE_NANKEEN_KESTREL = "";                             # bool
+  # CLAUDE_CODE_PARKED_PERMISSION_WAIT_MS = "";                   # int {min:0}
+  # CLAUDE_CODE_PERFETTO_WRITE_INTERVAL_S = "";                   # int
+  # CLAUDE_CODE_PEWTER_OWL = "";                                  # true | false | unset
+  # CLAUDE_CODE_PLAN_MODE_REQUIRED = "";                          # bool
+  # CLAUDE_CODE_PLUGIN_BINARY_ASSETS = "";                        # bool
+  # CLAUDE_CODE_PLUGIN_USE_ZIP_CACHE = "";                        # bool
+  # CLAUDE_CODE_POWERUP_ONBOARDING = "";                          # string
+  # CLAUDE_CODE_PROACTIVE = "";                                   # bool
+  # CLAUDE_CODE_QUESTION_PREVIEW_FORMAT = "";                     # string
+  # CLAUDE_CODE_RATE_LIMIT_TIER = "";                             # string
+  # CLAUDE_CODE_REPL = "";                                        # true | false | unset
+  # CLAUDE_CODE_REPO_CHECKOUTS = "";                              # string
+  # CLAUDE_CODE_RESUME_SOURCE_ALIVE = "";                         # string
+  # CLAUDE_CODE_RESUME_THRESHOLD_MINUTES = "";                    # int
+  # CLAUDE_CODE_SEND_FEEDBACK = "";                               # true | false | unset
+  # CLAUDE_CODE_SKILL_NAME = "";                                  # unknown type
+  # CLAUDE_CODE_SKIP_HFI_VERSION_CHECK = "";                      # bool
+  # CLAUDE_CODE_SKIP_PROJECT_BACKFILL = "";                       # bool
+  # CLAUDE_CODE_SKIP_REPO_UPLOAD = "";                            # bool
+  # CLAUDE_CODE_SLOW_OPERATION_THRESHOLD_MS = "";                 # int
+  # CLAUDE_CODE_SPAWN_TIMESTAMP_MS = "";                          # int
+  # CLAUDE_CODE_SUBSCRIPTION_TYPE = "";                           # string
+  # CLAUDE_CODE_SUPERVISED = "";                                  # bool
+  # CLAUDE_CODE_SYNC_PLUGINS = "";                                # bool
+  # CLAUDE_CODE_SYNC_PLUGINS_BUFFERED_DOWNLOAD = "";              # bool
+  # CLAUDE_CODE_SYNC_PLUGINS_DOWNLOAD_STALL_MS = "";              # int {min:1}
+  # CLAUDE_CODE_SYSTEM_PROMPT_GB_FEATURE = "";                    # string
+  # CLAUDE_CODE_TAGS = "";                                        # string
+  # CLAUDE_CODE_TAG_ISMETA_MESSAGES = "";                         # bool
+  # CLAUDE_CODE_TEE_SDK_STDOUT = "";                              # bool
+  # CLAUDE_CODE_THISTLE_GREBE = "";                               # string
+  # CLAUDE_CODE_THRIFTY_SONIC = "";                               # true | false | unset
+  # CLAUDE_CODE_TMUX_PREFIX = "";                                 # string
+  # CLAUDE_CODE_TMUX_PREFIX_CONFLICTS = "";                       # bool
+  # CLAUDE_CODE_TODO_REMINDER_MODE = "";                          # enum ["baseline","off"]
+  # CLAUDE_CODE_TRANSCRIPT_LOCAL_GC = "";                         # true | false | unset
+  # CLAUDE_CODE_TRIGGER_ID = "";                                  # string
+  # CLAUDE_CODE_TWO_STAGE_CLASSIFIER = "";                        # bool
+  # CLAUDE_CODE_USER_EMAIL = "";                                  # string
+  # CLAUDE_CODE_USE_COWORK_PLUGINS = "";                          # bool
+  # CLAUDE_CODE_USE_GATEWAY = "";                                 # bool
+  # CLAUDE_CODE_VOICE_FORWARD_INTERIMS_TYPED = "";                # bool
+  # CLAUDE_CODE_WALNUT_SPIRE = "";                                # bool
+  # CLAUDE_CODE_WORKER_EPOCH = "";                                # int
+  # CLAUDE_CODE_WORKSPACE_HOST_PATHS = "";                        # string
+  # CLAUDE_FORCE_DISPLAY_SURVEY = "";                             # bool
+  # CLAUDE_GATEWAY_ALLOW_LOOPBACK = "";                           # bool
+  # CLAUDE_JOB_DIR = "";                                          # string
+  # CLAUDE_MOCK_HEADERLESS_429 = "";                              # bool
+  # CLAUDE_PREVIEW_CLASSIFIER_FLOOR = "";                         # true | false | unset
+  # CLAUDE_PROJECT_UUID = "";                                     # string
+  # CLAUDE_PTY_HEARTBEAT_MS = "";                                 # int {min:1}
+  # CLAUDE_PTY_HOST_EXEC = "";                                    # string
+  # CLAUDE_PTY_ORPHAN_CHECK_MS = "";                              # int {min:1}
+  # CLAUDE_PTY_RECORD = "";                                       # string
+  # CLAUDE_REPL_VARIANT = "";                                     # string
+  # CLAUDE_RUNNER_ACTIVITY_FD = "";                               # int {min:3}
+  # CLAUDE_RUNNER_FETCH_DEPTH = "";                               # string
+  # CLAUDE_SECURESTORAGE_CONFIG_DIR = "";                         # string
+  # CLAUDE_SLOW_FIRST_BYTE_MS = "";                               # int {min:1}
+  # CLAUDE_SNIP = "";                                             # string
+  # CLAUDE_SSH_LOCAL_BINARY = "";                                 # string
+  # CLAUDE_SSH_VERSION = "";                                      # string
+  # CLAUDE_TMPDIR = "";                                           # string
+  # DISABLE_BRIEF_MODE_STOP_HOOK = "";                            # bool
+  # DISABLE_BUG_COMMAND = "";                                     # bool
+  # DISABLE_PROMPT_CACHING_MYTHOS = "";                           # bool
+  # ENABLE_BETA_TRACING_DETAILED = "";                            # bool
+  # ENABLE_LOCKLESS_UPDATES = "";                                 # bool
+  # ENABLE_PID_BASED_VERSION_LOCKING = "";                        # true | false | unset
+  # FORCE_VCR = "";                                               # bool
+  # MAX_ESTIMATED_NESTING = "";                                   # unknown type
+  # MAX_LAUNCH_BUNDLE_BYTES = "";                                 # unknown type
+  # MAX_MARKDOWN_LENGTH = "";                                     # unknown type
+  # MAX_PERSIST_BINARY_BYTES = "";                                # unknown type
+  # MAX_QUEUED_EVENTS = "";                                       # unknown type
+  # MAX_SANE_EPOCH_MS = "";                                       # unknown type
+  # MAX_SANITIZED_LENGTH = "";                                    # unknown type
+  # MAX_SCAN_ENTRIES = "";                                        # unknown type
+  # MAX_SCAN_WORK = "";                                           # unknown type
+  # MAX_TOTAL_OPEN_TAGS = "";                                     # unknown type
+  # MAX_TRANSCRIPT_READ_BYTES = "";                               # unknown type
+
+  # Test-only harness hooks (7)
+  # CLAUDE_CODE_DOWNLOAD_DEADLINE_MS_FOR_TESTING = "";            # string
+  # CLAUDE_CODE_STALL_TIMEOUT_MS_FOR_TESTING = "";                # string
+  # CLAUDE_CODE_TEST_FIXTURES_ROOT = "";                          # string
+  # CLAUDE_CODE_TEST_FORCE_DENY = "";                             # bool
+  # CLAUDE_CODE_TEST_NO_GIT_BASH = "";                            # string
+  # CLAUDE_CODE_TEST_NO_PWSH = "";                                # string
+  # CLAUDE_CODE_ULTRAREVIEW_PREFLIGHT_FIXTURE = "";               # string
+
+  # Internal state markers (4)
+  # CLAUDE_CODE_3P_PROBE_WROTE_OPUS_DEFAULT = "";                 # string
+  # CLAUDE_CODE_3P_PROBE_WROTE_SONNET_DEFAULT = "";               # string
+  # CLAUDE_INTERNAL_ASSISTANT_TEAM_NAME = "";                     # string
+  # CLAUDE_INTERNAL_FC_OVERRIDES = "";                            # string
+
 in
 {
   inherit binary;

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -51,6 +51,7 @@ let
     # Repoints the `haiku` alias, which also backs background work the subagent
     # override does not reach (titles, summarization, classifiers).
     ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-sonnet-5";
+    ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME = "Sonnet 5";
   };
 
   # Shell-level vars not needed in settings.json.
@@ -306,7 +307,7 @@ let
   # Set to true to include Claude Code version in metrics attributes (default: excluded).
   # OTEL_METRICS_INCLUDE_VERSION = "";
 
-  # Bash, tools, sandbox (17)
+  # Bash, tools, sandbox (23)
   # ----------------------------
   # Default timeout for long-running bash commands (default: 120000, or 2 minutes).
   # BASH_DEFAULT_TIMEOUT_MS = "";   # ACTIVE above
@@ -318,6 +319,18 @@ let
   # parallel (default: 10). Higher values increase parallelism but consume
   # more resources.
   # CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY = "";
+  # How many subagents can be running in one session before the Agent tool refuses to spawn another (default: 20).
+  # CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS = "";
+  # Cap on the number of subagents one session can spawn with the Agent tool (default: 200).
+  # CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION = "";
+  # Number of subagent layers allowed below the main conversation (default: 3).
+  # CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "";
+  # Cap the number of agentic turns when no explicit limit is passed. [numeric]
+  # CLAUDE_CODE_MAX_TURNS = "";
+  # Cap on the total number of WebSearch calls one session can make (default: 200).
+  # CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION = "";
+  # Maximum number of characters in subagent output before truncation (default: 32000, maximum: 160000).
+  # TASK_MAX_OUTPUT_LENGTH = "";
   # Return to the original working directory after each Bash or PowerShell command in the main session.
   # CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "";   # ACTIVE above
   # Set to 1 to disable the advisor tool. [1 or unset]
@@ -377,7 +390,7 @@ let
   # Timeout in milliseconds for MCP server startup (default: 30000, or 30 seconds). [numeric]
   # MCP_TIMEOUT = "";
 
-  # Network, proxy, TLS, timeouts (24)
+  # Network, proxy, TLS, timeouts (25)
   # -------------------------------------
   # Override the API endpoint to route requests through a proxy or gateway.
   # ANTHROPIC_BASE_URL = "";
@@ -385,6 +398,8 @@ let
   # API_FORCE_IDLE_TIMEOUT = "1";
   # Timeout for API requests in milliseconds (default: 600000, or 10 minutes; maximum: 2147483647). [numeric]
   # API_TIMEOUT_MS = "";
+  # Override the number of times to retry failed API requests (default: 10).
+  # CLAUDE_CODE_MAX_RETRIES = "";
   # How many milliseconds of idle time before an unanswered AskUserQuestion dialog auto-continues without you. [numeric]
   # CLAUDE_AFK_TIMEOUT_MS = "";
   # Stall timeout in milliseconds for background subagents. [numeric]
@@ -436,7 +451,7 @@ let
   # List of domains and IPs to which requests will be directly issued, bypassing proxy.
   # NO_PROXY = "";
 
-  # Terminal, rendering, accessibility (23)
+  # Terminal, rendering, accessibility (16)
   # ------------------------------------------
   # Set to 1 to render screen-reader friendly output: flat text without decorative borders or animations. [1 or unset]
   # CLAUDE_AX_SCREEN_READER = "1";
@@ -458,18 +473,6 @@ let
   # CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL = "1";   # ACTIVE above
   # Set to 1 to skip validation of IDE lockfile entries during connection. [1 or unset]
   # CLAUDE_CODE_IDE_SKIP_VALID_CHECK = "1";
-  # How many subagents can be running in one session before the Agent tool refuses to spawn another (default: 20).
-  # CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS = "";
-  # Override the number of times to retry failed API requests (default: 10).
-  # CLAUDE_CODE_MAX_RETRIES = "";
-  # Cap on the number of subagents one session can spawn with the Agent tool (default: 200).
-  # CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION = "";
-  # Number of subagent layers allowed below the main conversation (default: 3).
-  # CLAUDE_CODE_MAX_SUBAGENT_SPAWN_DEPTH = "";
-  # Cap the number of agentic turns when no explicit limit is passed. [numeric]
-  # CLAUDE_CODE_MAX_TURNS = "";
-  # Cap on the total number of WebSearch calls one session can make (default: 200).
-  # CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION = "";
   # Set to 1 to show the terminal's own cursor at the input caret instead of a drawn block. [1 or unset]
   # CLAUDE_CODE_NATIVE_CURSOR = "1";
   # Set to 1 to enable fullscreen rendering, a research preview that reduces flicker and keeps memory flat in long conversations. [1 or unset]
@@ -485,8 +488,6 @@ let
   # CLAUDE_CODE_TMUX_TRUECOLOR = "";
   # Number of times to retry when the model's response fails validation against the --json-schema in non-interactive mode (the -p flag).
   # MAX_STRUCTURED_OUTPUT_RETRIES = "";
-  # Maximum number of characters in subagent output before truncation (default: 32000, maximum: 160000).
-  # TASK_MAX_OUTPUT_LENGTH = "";
 
   # Feature toggles (55)
   # -----------------------

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -20,7 +20,6 @@ let
   binary = {
     DISABLE_AUTOUPDATER = "1";
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
-    DISABLE_NON_ESSENTIAL_MODEL_CALLS = "1";
     DISABLE_TELEMETRY = "1";
     DISABLE_INSTALLATION_CHECKS = "1";
   };
@@ -30,6 +29,19 @@ let
     CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "1";
     BASH_DEFAULT_TIMEOUT_MS = "240000";
     BASH_MAX_TIMEOUT_MS = "4800000";
+  };
+
+  # Model/effort routing. CLAUDE_CODE_SUBAGENT_MODEL overrides every spawned
+  # subagent, including built-in agents whose definition pins `model: haiku`
+  # (review, claude-code-guide); it beats agent frontmatter, which is the only
+  # lever that reaches them. CLAUDE_CODE_EFFORT_LEVEL carries `max`, which the
+  # persisted `effortLevel` schema rejects (see _default-settings.nix).
+  modelRouting = {
+    CLAUDE_CODE_SUBAGENT_MODEL = "claude-sonnet-5";
+    CLAUDE_CODE_EFFORT_LEVEL = "max";
+    # Repoints the `haiku` alias, which also backs background work the subagent
+    # override does not reach (titles, summarization, classifiers).
+    ANTHROPIC_DEFAULT_HAIKU_MODEL = "claude-sonnet-5";
   };
 
   # Shell-level vars not needed in settings.json.
@@ -49,6 +61,6 @@ let
 in
 {
   inherit binary;
-  settings = binary // bashRuntime;
-  all = binary // bashRuntime // shellOnly;
+  settings = binary // bashRuntime // modelRouting;
+  all = binary // bashRuntime // modelRouting // shellOnly;
 }

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -67,6 +67,9 @@ let
   # Names removed from managed settings. These stay out of `settings` and
   # `all`; activation deletes them from existing files.
   retired = [ "DISABLE_NON_ESSENTIAL_MODEL_CALLS" ];
+  retiredButLive = builtins.filter (
+    name: builtins.hasAttr name (binary // bashRuntime // modelRouting // shellOnly)
+  ) retired;
 
   # === Catalog: every documented Claude Code environment variable ===========
   # Entries marked ACTIVE are already set in a group above.
@@ -1168,6 +1171,9 @@ let
   # MAX_TRANSCRIPT_READ_BYTES = "";
 
 in
+assert
+  retiredButLive == [ ]
+  || throw "modules/agents/claude-code/_env.nix: ${builtins.concatStringsSep ", " retiredButLive} are both retired and live; remove the name from retired or its live group";
 {
   inherit binary retired;
   settings = binary // bashRuntime // modelRouting;

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -58,7 +58,6 @@ let
   # Shell-level vars not needed in settings.json.
   shellOnly = {
     BASH_MAX_OUTPUT_LENGTH = "1024";
-    CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "0";
     CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL = "1";
     DISABLE_BUG_COMMAND = "1";
     USE_BUILTIN_RIPGREP = "0";
@@ -463,7 +462,7 @@ let
   # Set to 1 to disable fullscreen rendering and use the classic main-screen renderer. [1 or unset]
   # CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN = "1";
   # Set to 1 to disable automatic terminal title updates based on conversation context. [1 or unset]
-  # CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";   # ACTIVE above
+  # CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";
   # Set to 1 to hide the working directory in the startup logo. [1 or unset]
   # CLAUDE_CODE_HIDE_CWD = "1";
   # Override the host address used to connect to the IDE extension.

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -74,9 +74,15 @@ let
   legacyEnvValues = {
     CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "0";
   };
-  retiredButLive = builtins.filter (
-    name: builtins.hasAttr name (binary // bashRuntime // modelRouting // shellOnly)
-  ) retired;
+  activeEnv = binary // bashRuntime // modelRouting // shellOnly;
+  retiredButLive = builtins.filter (name: builtins.hasAttr name activeEnv) retired;
+  # A legacy name may be active with a replacement value, but an active value
+  # equal to its legacy value would be removed by every migration consumer.
+  legacyEnvValueConflicts = builtins.filter (
+    name:
+    builtins.hasAttr name activeEnv
+    && builtins.getAttr name activeEnv == builtins.getAttr name legacyEnvValues
+  ) (builtins.attrNames legacyEnvValues);
 
   # === Catalog: every documented Claude Code environment variable ===========
   # Entries marked ACTIVE are already set in a group above. Entries marked
@@ -1274,6 +1280,9 @@ in
 assert
   retiredButLive == [ ]
   || throw "modules/agents/claude-code/_env.nix: ${builtins.concatStringsSep ", " retiredButLive} are both retired and live; remove the name from retired or its live group";
+assert
+  legacyEnvValueConflicts == [ ]
+  || throw "modules/agents/claude-code/_env.nix: ${builtins.concatStringsSep ", " legacyEnvValueConflicts} are live with their legacy value; remove the name from its live group or update legacyEnvValues";
 {
   inherit binary legacyEnvValues retired;
   settings = binary // bashRuntime // modelRouting;

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -64,6 +64,10 @@ let
     USE_BUILTIN_RIPGREP = "0";
   };
 
+  # Names removed from managed settings. These stay out of `settings` and
+  # `all`; activation deletes them from existing files.
+  retired = [ "DISABLE_NON_ESSENTIAL_MODEL_CALLS" ];
+
   # === Catalog: every documented Claude Code environment variable ===========
   # Entries marked ACTIVE are already set in a group above.
 
@@ -1165,7 +1169,7 @@ let
 
 in
 {
-  inherit binary;
+  inherit binary retired;
   settings = binary // bashRuntime // modelRouting;
   all = binary // bashRuntime // modelRouting // shellOnly;
 }

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -75,7 +75,8 @@ let
   ) retired;
 
   # === Catalog: every documented Claude Code environment variable ===========
-  # Entries marked ACTIVE are already set in a group above.
+  # Entries marked ACTIVE are already set in a group above. Entries marked
+  # RETIRED are intentionally removed from managed environments and old files.
 
   # Authentication and providers (30)
   # ------------------------------------
@@ -252,7 +253,7 @@ let
   # it again.
   # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "";   # ACTIVE above
   # Set to 1 to enable OpenTelemetry data collection for metrics and logging. [1 or unset]
-  # CLAUDE_CODE_ENABLE_TELEMETRY = "1";
+  # CLAUDE_CODE_ENABLE_TELEMETRY = "1";   # RETIRED below
   # Maximum length of content-bearing OpenTelemetry attributes (model
   # responses, tool content, system prompts, raw API bodies), including the
   # truncation marker, in UTF-16 code units (default: 61440, or 60 KB).
@@ -466,7 +467,7 @@ let
   # Set to 1 to disable fullscreen rendering and use the classic main-screen renderer. [1 or unset]
   # CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN = "1";
   # Set to 1 to disable automatic terminal title updates based on conversation context. [1 or unset]
-  # CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";
+  # CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";   # RETIRED below
   # Set to 1 to hide the working directory in the startup logo. [1 or unset]
   # CLAUDE_CODE_HIDE_CWD = "1";
   # Override the host address used to connect to the IDE extension.

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -477,7 +477,7 @@ let
   # Set to 1 to disable fullscreen rendering and use the classic main-screen renderer. [1 or unset]
   # CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN = "1";
   # Set to 1 to disable automatic terminal title updates based on conversation context. [1 or unset]
-  # CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";
+  # CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "1";   # LEGACY "0" migrated below; documented values are 1 or unset
   # Set to 1 to hide the working directory in the startup logo. [1 or unset]
   # CLAUDE_CODE_HIDE_CWD = "1";
   # Override the host address used to connect to the IDE extension.

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -161,7 +161,7 @@ let
   # Display description for the pinned Haiku model in the /model picker.
   # ANTHROPIC_DEFAULT_HAIKU_MODEL_DESCRIPTION = "";
   # Display name for the pinned Haiku model in the /model picker.
-  # ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME = "";
+  # ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME = "";   # ACTIVE above
   # Comma-separated list of capabilities the pinned Haiku model supports, for example effort,thinking.
   # ANTHROPIC_DEFAULT_HAIKU_MODEL_SUPPORTED_CAPABILITIES = "";
   # Model ID that the opus alias resolves to, and that opusplan uses while Plan Mode is active.
@@ -349,7 +349,7 @@ let
   # Code bypasses execution policy at process scope. [1 or unset]
   # CLAUDE_CODE_POWERSHELL_RESPECT_EXECUTION_POLICY = "1";
   # Set the shell Claude Code uses to run Bash tool commands.
-  # CLAUDE_CODE_SHELL = "";
+  # CLAUDE_CODE_SHELL = "";   # SET BY _wrapper.nix (controlled bash + rm shim); do not activate here
   # Command prefix that wraps shell commands Claude Code spawns: Bash tool
   # calls, hook commands, status line commands, and stdio MCP server startup
   # commands. Useful for logging or auditing.

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -15,11 +15,14 @@
   Keeping the layers as one expression makes the belt-and-suspenders coverage
   explicit and removes the drift risk between sites.
 
-  The catalog below the active groups enumerates every environment variable
-  documented at https://code.claude.com/docs/en/env-vars for Claude Code
-  2.1.222, commented out with its accepted values and default. Activate one by
-  moving the line into a group above; leaving it commented keeps Claude's own
-  default. Read-only and deprecated entries are segregated at the end.
+  Two catalogs and an evidence list follow the active groups. The first
+  enumerates every environment variable documented at
+  https://code.claude.com/docs/en/env-vars for Claude Code 2.1.222, with its
+  accepted values and default. The second lists type-resolved variables read by
+  the 2.1.222 binary that the published docs do not mention. A final
+  unconfirmed-identifiers list preserves extraction names whose accessor type
+  could not be resolved. Activate a catalog entry by moving it into a group
+  above; leaving it commented keeps Claude's own default.
 */
 let
   # Privacy/telemetry/update disables baked into the binary.
@@ -705,12 +708,12 @@ let
   # Claude Code sets this to its own process ID in the subprocesses it spawns: Bash and PowerShell tool commands and hook commands.
   # CLAUDE_PID = "";
 
-  # === Undocumented: read by the 2.1.222 binary, absent from the published docs ===
-  # Extracted from the binary's env accessor registry. The type is authoritative;
-  # there is no official description, so semantics are inferred from the name only
-  # and are unverified. Unsupported surface: it can change without a changelog entry.
+  # === Undocumented: type-resolved variables read by the 2.1.222 binary =====
+  # Extracted from the binary's env accessor registry. There is no official
+  # description, so semantics are inferred from the name only and are
+  # unverified. Unsupported surface: it can change without a changelog entry.
 
-  # Auth, providers, gateway (53)
+  # Auth, providers, gateway (50)
   # AGENT_PROXY_AUTH_TOKEN = "";                                  # string
   # ANTHROPIC_FEDERATION_RULE_ID = "";                            # string
   # ANTHROPIC_GOOGLE_CLOUD_BASE_URL = "";                         # string
@@ -719,8 +722,6 @@ let
   # ANTHROPIC_GOOGLE_CLOUD_WORKSPACE_ID = "";                     # string
   # ANTHROPIC_ORGANIZATION_ID = "";                               # string
   # ANTHROPIC_PROFILE = "";                                       # string
-  # CLAUDE_AI_OAUTH_SCOPES = "";                                  # unknown type
-  # CLAUDE_AI_PROFILE_SCOPE = "";                                 # unknown type
   # CLAUDE_BG_AUTH_SNAPSHOT_PATH = "";                            # string
   # CLAUDE_BG_CLAIM_AUTH = "";                                    # string
   # CLAUDE_BG_PTY_AUTH = "";                                      # string
@@ -761,7 +762,6 @@ let
   # CLAUDE_LOCAL_OAUTH_CONSOLE_BASE = "";                         # string
   # CLAUDE_SESSION_INGRESS_TOKEN_FILE = "";                       # string
   # CLAUDE_TRUSTED_DEVICE_TOKEN = "";                             # string
-  # MAX_TOTAL_TAG_TOKENS = "";                                    # unknown type
   # MCP_OAUTH_CLIENT_METADATA_URL = "";                           # string
   # MCP_XAA_IDP_CLIENT_SECRET = "";                               # string
 
@@ -773,13 +773,11 @@ let
   # CLAUDE_CODE_REFUSAL_FALLBACK_CATCH_ALL = "";                  # true | false | unset
   # CLAUDE_CONTEXT_COLLAPSE_MODEL = "";                           # string
 
-  # Agents, tasks, workflows (36)
+  # Agents, tasks, workflows (31)
   # AGENT_PROXY_URL = "";                                         # string
-  # AGENT_VIEW_RELAUNCH_ENV_KEY = "";                             # unknown type
   # CCR_AGENT_PROXY_ENABLED = "";                                 # bool
   # CCR_AGENT_PROXY_INCLUDE_HOSTS = "";                           # string
   # CCR_AGENT_PROXY_RELAY_MODE = "";                              # string
-  # CLAUDE_AGENT = "";                                            # unknown type
   # CLAUDE_AGENTS_SELECT = "";                                    # string
   # CLAUDE_AGENT_SDK_CLIENT_APP = "";                             # string
   # CLAUDE_AGENT_SDK_VERSION = "";                                # string
@@ -807,11 +805,8 @@ let
   # CLAUDE_SUBAGENT_BG_SHELL_MAX_MS = "";                         # int {min:1}
   # CLAUDE_WORKFLOW_NAME_ONLY = "";                               # bool
   # ENABLE_SESSION_BACKGROUNDING = "";                            # bool
-  # MAX_TASK_OUTPUT_BYTES = "";                                   # unknown type
-  # MAX_TASK_OUTPUT_BYTES_DISPLAY = "";                           # unknown type
-  # MCP_TASK = "";                                                # unknown type
 
-  # Memory, context, compaction (31)
+  # Memory, context, compaction (29)
   # CLAUDE_AFTER_LAST_COMPACT = "";                               # string
   # CLAUDE_BRIDGE_REATTACH_SESSION = "";                          # string
   # CLAUDE_BRIDGE_SESSION_INGRESS_URL = "";                       # string
@@ -833,7 +828,6 @@ let
   # CLAUDE_CODE_SESSION_KIND = "";                                # string
   # CLAUDE_CODE_SESSION_LOG = "";                                 # string
   # CLAUDE_CODE_SESSION_NAME = "";                                # string
-  # CLAUDE_CODE_SUPPRESS_SESSION_ATTRIBUTION = "";                # unknown type
   # CLAUDE_CODE_SYNC_SESSION_REFS = "";                           # bool
   # CLAUDE_CODE_TMUX_SESSION = "";                                # string
   # CLAUDE_CONTEXT_COLLAPSE = "";                                 # bool
@@ -841,44 +835,33 @@ let
   # CLAUDE_COWORK_MEMORY_GUIDELINES = "";                         # string
   # CLAUDE_COWORK_MEMORY_INDEX_CONTENT = "";                      # string
   # CLAUDE_COWORK_MEMORY_PATH_OVERRIDE = "";                      # string
-  # CLAUDE_MEMORY_STORES = "";                                    # unknown type
   # ENABLE_SESSION_PERSISTENCE = "";                              # bool
 
-  # Tools, bash, sandbox (15)
+  # Tools, bash, sandbox (12)
   # CLAUDE_CODE_BASH_SANDBOX_SHOW_INDICATOR = "";                 # bool
   # CLAUDE_CODE_DIAGNOSTICS_FILE = "";                            # string
   # CLAUDE_CODE_EMIT_TOOL_USE_SUMMARIES = "";                     # bool
   # CLAUDE_CODE_ENABLE_EXPERIMENTAL_ADVISOR_TOOL = "";            # bool
   # CLAUDE_CODE_ENABLE_REFRESH_MCP_TOOLS = "";                    # bool
-  # CLAUDE_CODE_HOST_CREDS_FILE = "";                             # unknown type
   # CLAUDE_CODE_PEWTER_OWL_TOOL = "";                             # true | false | unset
   # CLAUDE_CODE_REMOTE_RAW_EVENTS_FILE = "";                      # string
   # CLAUDE_CODE_SANDBOXED = "";                                   # bool
   # CLAUDE_CODE_TERMINAL_MCP_TOOLS = "";                          # string
-  # CLAUDE_IN_CHROME_DOMAIN_RULE_TOOL = "";                       # unknown type
   # CLAUDE_STAGE_FILE_ROOT = "";                                  # string
   # ENABLE_LSP_TOOL = "";                                         # bool
   # ENABLE_MCP_LARGE_OUTPUT_FILES = "";                           # true | false | unset
-  # MAX_WORKING_FILE_BYTES = "";                                  # unknown type
 
-  # MCP (15)
+  # MCP (8)
   # CLAUDE_CODE_SKIP_PLUGIN_MCP_SERVERS = "";                     # bool
   # CLAUDE_CODE_SKIP_PLUGIN_MCP_SERVERS_EXCEPT = "";              # string
-  # CLAUDE_CODE_SYNC_PLUGINS_MCP_TIMEOUT_MS = "";                 # unknown type
-  # CLAUDE_IN_CHROME_MCP_SERVER_NAME = "";                        # unknown type
-  # MAX_MCP_CONFIG_BYTES = "";                                    # unknown type
-  # MCP_CLIENT_METADATA_URL = "";                                 # unknown type
   # MCP_DISCOVERY_CACHE = "";                                     # true | false | unset
   # MCP_DISCOVERY_CACHE_MAX_STALE_S = "";                         # int {min:1}
   # MCP_DISCOVERY_CACHE_TTL_S = "";                               # int {min:1}
   # MCP_PROTOCOL_NEGOTIATION = "";                                # string
-  # MCP_SCHEMA_BY_TYPE = "";                                      # unknown type
   # MCP_SDK_GENERATION = "";                                      # string
-  # MCP_SETTINGS_SCOPES = "";                                     # unknown type
-  # MCP_TREE_ID = "";                                             # unknown type
   # MCP_TRUNCATION_PROMPT_OVERRIDE = "";                          # string
 
-  # Network, proxy, timeouts (37)
+  # Network, proxy, timeouts (36)
   # ANTHROPIC_UNIX_SOCKET = "";                                   # string
   # CLAUDE_BRIDGE_BASE_URL = "";                                  # string
   # CLAUDE_BYTE_STREAM_IDLE_TIMEOUT_MS = "";                      # int {min:1}
@@ -886,7 +869,6 @@ let
   # CLAUDE_CODE_ARTIFACTS_API_BASE_URL = "";                      # string
   # CLAUDE_CODE_ARTIFACT_ASSET_BASE_URL = "";                     # string
   # CLAUDE_CODE_ARTIFACT_LIVE_BASE_URL = "";                      # string
-  # CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL = "";                 # unknown type
   # CLAUDE_CODE_DEV_RAW_CHANGELOG_URL = "";                       # string
   # CLAUDE_CODE_FABLE_BRIDGE_DIALOG_TIMEOUT_MS = "";              # int
   # CLAUDE_CODE_GB_BASE_URL = "";                                 # string
@@ -930,7 +912,7 @@ let
   # FORCE_CODE_TERMINAL = "";                                     # bool
   # FORCE_COLOR = "";                                             # string
 
-  # Telemetry, logging, debug (15)
+  # Telemetry, logging, debug (13)
   # CLAUDE_CODE_COMMIT_LOG = "";                                  # string
   # CLAUDE_CODE_DD_ERROR_TRACKING_FLUSH_INTERVAL_MS = "";         # int {min:1}
   # CLAUDE_CODE_DEBUG_REPAINTS = "";                              # bool
@@ -941,14 +923,11 @@ let
   # CLAUDE_CODE_PERFETTO_TRACE = "";                              # string
   # CLAUDE_DEBUG = "";                                            # bool
   # CLAUDE_GATEWAY_LOG_LEVEL = "";                                # string
-  # ENABLE_ENHANCED_TELEMETRY_BETA = "";                          # unknown type
-  # MAX_DECLARED_DIALOG_KINDS = "";                               # unknown type
   # OTEL_LOGRECORD_ATTRIBUTE_VALUE_LENGTH_LIMIT = "";             # int {min:0}
   # OTEL_RESOURCE_ATTRIBUTES = "";                                # string
   # OTEL_SPAN_ATTRIBUTE_VALUE_LENGTH_LIMIT = "";                  # int {min:0}
 
-  # Remote control, cloud, sharing (19)
-  # CCR_BYOC_BETA = "";                                           # unknown type
+  # Remote control, cloud, sharing (17)
   # CCR_ENABLE_BUNDLE = "";                                       # bool
   # CCR_ON_BRANCH_DEFAULT_GUARD = "";                             # enum ["enforce","observe","off"]
   # CLAUDE_BRIDGE_REATTACH_GROUPING = "";                         # string
@@ -966,12 +945,9 @@ let
   # CLAUDE_CODE_REMOTE_SEND_KEEPALIVES = "";                      # bool
   # CLAUDE_CODE_REMOTE_SETTINGS_PATH = "";                        # string
   # CLAUDE_CODE_REMOTE_SETTINGS_POLL_MS = "";                     # int
-  # MAX_ARTIFACT_BYTES = "";                                      # unknown type
 
-  # Other (152)
+  # Other (136)
   # ANTHROPIC_CONFIG_DIR = "";                                    # string
-  # CLAUDE_AI_INFERENCE_SCOPE = "";                               # unknown type
-  # CLAUDE_API_SKILL_DESCRIPTION = "";                            # unknown type
   # CLAUDE_AX_STARTUP_QUIET_MS = "";                              # int {min:0}
   # CLAUDE_CHROME_CLASSIFIER_FLOOR = "";                          # true | false | unset
   # CLAUDE_CHROME_PERMISSION_MODE = "";                           # string
@@ -1009,7 +985,6 @@ let
   # CLAUDE_CODE_ENABLE_LAUNCH_COMPOSER = "";                      # bool
   # CLAUDE_CODE_ENABLE_MENU_KIND_LANES = "";                      # bool
   # CLAUDE_CODE_ENABLE_XAA = "";                                  # bool
-  # CLAUDE_CODE_ENTRYPOINT = "";                                  # unknown type
   # CLAUDE_CODE_ENVIRONMENT_KIND = "";                            # string
   # CLAUDE_CODE_ENVIRONMENT_RUNNER_VERSION = "";                  # string
   # CLAUDE_CODE_EXTRA_METADATA = "";                              # string
@@ -1032,7 +1007,6 @@ let
   # CLAUDE_CODE_JUNIPER_SUNDIAL = "";                             # int {min:1,digitsOnly:!0}
   # CLAUDE_CODE_KB_COHESION_FIXES = "";                           # bool
   # CLAUDE_CODE_LANTERN_PRISM = "";                               # bool
-  # CLAUDE_CODE_LARCH_CISTERN = "";                               # unknown type
   # CLAUDE_CODE_LOOP_KEEPALIVE = "";                              # bool
   # CLAUDE_CODE_LOOP_PERSISTENT = "";                             # bool
   # CLAUDE_CODE_MANAGED_SETTINGS_PATH = "";                       # string
@@ -1054,7 +1028,6 @@ let
   # CLAUDE_CODE_RESUME_SOURCE_ALIVE = "";                         # string
   # CLAUDE_CODE_RESUME_THRESHOLD_MINUTES = "";                    # int
   # CLAUDE_CODE_SEND_FEEDBACK = "";                               # true | false | unset
-  # CLAUDE_CODE_SKILL_NAME = "";                                  # unknown type
   # CLAUDE_CODE_SKIP_HFI_VERSION_CHECK = "";                      # bool
   # CLAUDE_CODE_SKIP_PROJECT_BACKFILL = "";                       # bool
   # CLAUDE_CODE_SKIP_REPO_UPLOAD = "";                            # bool
@@ -1104,23 +1077,12 @@ let
   # CLAUDE_SSH_VERSION = "";                                      # string
   # CLAUDE_TMPDIR = "";                                           # string
   # DISABLE_BRIEF_MODE_STOP_HOOK = "";                            # bool
-  # DISABLE_BUG_COMMAND = "";                                     # bool
+  # DISABLE_BUG_COMMAND = "";                                     # bool   ACTIVE above
   # DISABLE_PROMPT_CACHING_MYTHOS = "";                           # bool
   # ENABLE_BETA_TRACING_DETAILED = "";                            # bool
   # ENABLE_LOCKLESS_UPDATES = "";                                 # bool
   # ENABLE_PID_BASED_VERSION_LOCKING = "";                        # true | false | unset
   # FORCE_VCR = "";                                               # bool
-  # MAX_ESTIMATED_NESTING = "";                                   # unknown type
-  # MAX_LAUNCH_BUNDLE_BYTES = "";                                 # unknown type
-  # MAX_MARKDOWN_LENGTH = "";                                     # unknown type
-  # MAX_PERSIST_BINARY_BYTES = "";                                # unknown type
-  # MAX_QUEUED_EVENTS = "";                                       # unknown type
-  # MAX_SANE_EPOCH_MS = "";                                       # unknown type
-  # MAX_SANITIZED_LENGTH = "";                                    # unknown type
-  # MAX_SCAN_ENTRIES = "";                                        # unknown type
-  # MAX_SCAN_WORK = "";                                           # unknown type
-  # MAX_TOTAL_OPEN_TAGS = "";                                     # unknown type
-  # MAX_TRANSCRIPT_READ_BYTES = "";                               # unknown type
 
   # Test-only harness hooks (7)
   # CLAUDE_CODE_DOWNLOAD_DEADLINE_MS_FOR_TESTING = "";            # string
@@ -1136,6 +1098,70 @@ let
   # CLAUDE_CODE_3P_PROBE_WROTE_SONNET_DEFAULT = "";               # string
   # CLAUDE_INTERNAL_ASSISTANT_TEAM_NAME = "";                     # string
   # CLAUDE_INTERNAL_FC_OVERRIDES = "";                            # string
+
+  # === Unconfirmed identifiers ==============================================
+  # These names appeared in the binary extraction, but their accessor type
+  # could not be resolved. They are retained as evidence only, not as
+  # environment variables. Do not activate them without verifying the binary.
+
+  # Auth, providers, gateway (3)
+  # CLAUDE_AI_OAUTH_SCOPES = "";
+  # CLAUDE_AI_PROFILE_SCOPE = "";
+  # MAX_TOTAL_TAG_TOKENS = "";
+
+  # Agents, tasks, workflows (5)
+  # AGENT_VIEW_RELAUNCH_ENV_KEY = "";
+  # CLAUDE_AGENT = "";
+  # MAX_TASK_OUTPUT_BYTES = "";
+  # MAX_TASK_OUTPUT_BYTES_DISPLAY = "";
+  # MCP_TASK = "";
+
+  # Memory, context, compaction (2)
+  # CLAUDE_CODE_SUPPRESS_SESSION_ATTRIBUTION = "";
+  # CLAUDE_MEMORY_STORES = "";
+
+  # Tools, bash, sandbox (3)
+  # CLAUDE_CODE_HOST_CREDS_FILE = "";
+  # CLAUDE_IN_CHROME_DOMAIN_RULE_TOOL = "";
+  # MAX_WORKING_FILE_BYTES = "";
+
+  # MCP (7)
+  # CLAUDE_CODE_SYNC_PLUGINS_MCP_TIMEOUT_MS = "";
+  # CLAUDE_IN_CHROME_MCP_SERVER_NAME = "";
+  # MAX_MCP_CONFIG_BYTES = "";
+  # MCP_CLIENT_METADATA_URL = "";
+  # MCP_SCHEMA_BY_TYPE = "";
+  # MCP_SETTINGS_SCOPES = "";
+  # MCP_TREE_ID = "";
+
+  # Network, proxy, timeouts (1)
+  # CLAUDE_CODE_ASSUME_FIRST_PARTY_BASE_URL = "";
+
+  # Telemetry, logging, debug (2)
+  # ENABLE_ENHANCED_TELEMETRY_BETA = "";
+  # MAX_DECLARED_DIALOG_KINDS = "";
+
+  # Remote control, cloud, sharing (2)
+  # CCR_BYOC_BETA = "";
+  # MAX_ARTIFACT_BYTES = "";
+
+  # Other (16)
+  # CLAUDE_AI_INFERENCE_SCOPE = "";
+  # CLAUDE_API_SKILL_DESCRIPTION = "";
+  # CLAUDE_CODE_ENTRYPOINT = "";
+  # CLAUDE_CODE_LARCH_CISTERN = "";
+  # CLAUDE_CODE_SKILL_NAME = "";
+  # MAX_ESTIMATED_NESTING = "";
+  # MAX_LAUNCH_BUNDLE_BYTES = "";
+  # MAX_MARKDOWN_LENGTH = "";
+  # MAX_PERSIST_BINARY_BYTES = "";
+  # MAX_QUEUED_EVENTS = "";
+  # MAX_SANE_EPOCH_MS = "";
+  # MAX_SANITIZED_LENGTH = "";
+  # MAX_SCAN_ENTRIES = "";
+  # MAX_SCAN_WORK = "";
+  # MAX_TOTAL_OPEN_TAGS = "";
+  # MAX_TRANSCRIPT_READ_BYTES = "";
 
 in
 {

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -183,16 +183,24 @@ let
   # ANTHROPIC_MODEL = "";
   # Override AWS region for the Haiku-class model when using Amazon Bedrock or Amazon Bedrock Mantle.
   # ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION = "";
-  # Set to 1 to prevent automatic remapping of Opus 4.0 and 4.1 to the current Opus version on the Anthropic API. Use when you intentionally want to... [1 or unset]
+  # Set to 1 to prevent automatic remapping of Opus 4.0 and 4.1 to the current
+  # Opus version on the Anthropic API. Use when you intentionally want to pin
+  # an older model. [1 or unset]
   # CLAUDE_CODE_DISABLE_LEGACY_MODEL_REMAP = "1";
-  # Set to 1 to populate the /model picker from your gateway's /v1/models endpoint when ANTHROPIC_BASE_URL points at an Anthropic-compatible gateway... [1 or unset]
+  # Set to 1 to populate the /model picker from your gateway's /v1/models
+  # endpoint when ANTHROPIC_BASE_URL points at an Anthropic-compatible gateway.
+  # Off by default because a shared gateway key could expose every model it can
+  # access. [1 or unset]
   # CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY = "1";
   # The model Claude Code uses for all subagents, agent teams, and agents in a workflow.
   # CLAUDE_CODE_SUBAGENT_MODEL = "";   # ACTIVE above
-  # Set to any non-empty value, such as 1, to make every model stop retrying with a repeated-overload error when no fallback model is configured...
+  # Set to any non-empty value, such as 1, to make every model stop retrying
+  # with a repeated-overload error when no fallback model is configured.
+  # Setting it to 0 or false still enables this, unlike most on/off variables;
+  # unset the variable to restore the default retry behavior.
   # FALLBACK_FOR_ALL_PRIMARY_MODELS = "";
 
-  # Effort, thinking, context, memory (16)
+  # Effort, thinking, context, memory (17)
   # -----------------------------------------
   # Set the percentage (1-100) of the auto-compact window at which auto-compaction triggers.
   # CLAUDE_AUTOCOMPACT_PCT_OVERRIDE = "";
@@ -202,7 +210,9 @@ let
   # CLAUDE_CODE_AUTO_COMPACT_WINDOW = "";
   # Set to 1 to disable 1M context window support. [1 or unset]
   # CLAUDE_CODE_DISABLE_1M_CONTEXT = "1";
-  # Set to 1 to disable adaptive reasoning on Opus 4.6 and Sonnet 4.6 and fall back to the fixed thinking budget controlled by MAX_THINKING_TOKENS... [1 or unset]
+  # Set to 1 to disable adaptive reasoning on Opus 4.6 and Sonnet 4.6 and fall
+  # back to the fixed thinking budget controlled by MAX_THINKING_TOKENS.
+  # [1 or unset]
   # CLAUDE_CODE_DISABLE_ADAPTIVE_THINKING = "1";
   # Set to 1 to disable auto memory. [1 or unset]
   # CLAUDE_CODE_DISABLE_AUTO_MEMORY = "1";
@@ -216,6 +226,9 @@ let
   # CLAUDE_CODE_MAX_CONTEXT_TOKENS = "";
   # Set the maximum number of output tokens for most requests.
   # CLAUDE_CODE_MAX_OUTPUT_TOKENS = "";
+  # Maximum age in milliseconds of the last transcript message for a session
+  # that ended mid-turn to continue automatically on resume. [numeric]
+  # CLAUDE_CODE_RESUME_INTERRUPTED_TURN_MAX_AGE_MS = "";
   # Set to 1 to disable automatic compaction when approaching the context limit. [1 or unset]
   # DISABLE_AUTO_COMPACT = "1";
   # Set to 1 to disable all compaction: both automatic compaction and the manual /compact command. [1 or unset]
@@ -229,11 +242,17 @@ let
 
   # Privacy, telemetry, updates (25)
   # -----------------------------------
-  # Set to any non-empty value, such as 1, to disable nonessential network traffic: auto-updates, telemetry, error reporting, the /feedback command,...
+  # Set to any non-empty value, such as 1, to disable nonessential network
+  # traffic: auto-updates, telemetry, error reporting, the /feedback command,
+  # release notes, model discovery refreshes, and availability checks. Setting
+  # it to 0 or false still disables this traffic; unset the variable to allow
+  # it again.
   # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "";   # ACTIVE above
   # Set to 1 to enable OpenTelemetry data collection for metrics and logging. [1 or unset]
   # CLAUDE_CODE_ENABLE_TELEMETRY = "1";   # ACTIVE above
-  # Maximum length of content-bearing OpenTelemetry attributes (model responses, tool content, system prompts, raw API bodies), truncation marker...
+  # Maximum length of content-bearing OpenTelemetry attributes (model
+  # responses, tool content, system prompts, raw API bodies), including the
+  # truncation marker, in UTF-16 code units (default: 61440, or 60 KB).
   # CLAUDE_CODE_OTEL_CONTENT_MAX_LENGTH = "";
   # Set to 1 to write OpenTelemetry exporter diagnostic errors to stderr. [1 or unset]
   # CLAUDE_CODE_OTEL_DIAG_STDERR = "1";
@@ -247,11 +266,15 @@ let
   # CLAUDE_CODE_PACKAGE_MANAGER_AUTO_UPDATE = "1";
   # Set to 1 to disable automatic background updates. [1 or unset]
   # DISABLE_AUTOUPDATER = "1";   # ACTIVE above
-  # Set to any non-empty value, such as 1, to opt out of error reporting. **Setting it to 0 or false still opts out**, unlike most on/off variables;...
+  # Set to any non-empty value, such as 1, to opt out of error reporting.
+  # **Setting it to 0 or false still opts out**, unlike most on/off variables;
+  # unset the variable to turn error reporting back on.
   # DISABLE_ERROR_REPORTING = "";   # ACTIVE above
   # Set to 1 to disable installation warnings. [1 or unset]
   # DISABLE_INSTALLATION_CHECKS = "1";   # ACTIVE above
-  # Set to any non-empty value, such as 1, to opt out of telemetry. **Setting it to 0 or false still opts out**, unlike most on/off variables; unset...
+  # Set to any non-empty value, such as 1, to opt out of telemetry. **Setting
+  # it to 0 or false still opts out**, unlike most on/off variables; unset the
+  # variable to turn telemetry back on.
   # DISABLE_TELEMETRY = "";   # ACTIVE above
   # Set to 1 to block all updates including manual claude update and claude install. [1 or unset]
   # DISABLE_UPDATES = "1";
@@ -265,7 +288,10 @@ let
   # OTEL_LOG_RAW_API_BODIES = "1";
   # Set to 1 to include tool input and output content in OpenTelemetry span events. [1 or unset]
   # OTEL_LOG_TOOL_CONTENT = "1";
-  # Set to 1 to include tool input arguments, MCP server names, user-authored workflow names, raw error strings on tool failures, the refusal category... [1 or unset]
+  # Set to 1 to include tool input arguments, MCP server names, user-authored
+  # workflow names, raw error strings on tool failures, refusal categories, and
+  # other tool details in OpenTelemetry traces and logs. Disabled by default to
+  # protect PII. [1 or unset]
   # OTEL_LOG_TOOL_DETAILS = "1";
   # Set to 1 to include user prompt text in OpenTelemetry traces and logs. [1 or unset]
   # OTEL_LOG_USER_PROMPTS = "1";
@@ -280,7 +306,7 @@ let
   # Set to true to include Claude Code version in metrics attributes (default: excluded).
   # OTEL_METRICS_INCLUDE_VERSION = "";
 
-  # Bash, tools, sandbox (16)
+  # Bash, tools, sandbox (17)
   # ----------------------------
   # Default timeout for long-running bash commands (default: 120000, or 2 minutes).
   # BASH_DEFAULT_TIMEOUT_MS = "";   # ACTIVE above
@@ -288,6 +314,10 @@ let
   # BASH_MAX_OUTPUT_LENGTH = "";   # ACTIVE above
   # Maximum timeout the model can set for long-running bash commands (default: 600000, or 10 minutes).
   # BASH_MAX_TIMEOUT_MS = "";   # ACTIVE above
+  # Maximum number of read-only tools and subagents that can execute in
+  # parallel (default: 10). Higher values increase parallelism but consume
+  # more resources.
+  # CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY = "";
   # Return to the original working directory after each Bash or PowerShell command in the main session.
   # CLAUDE_BASH_MAINTAIN_PROJECT_WORKING_DIR = "";   # ACTIVE above
   # Set to 1 to disable the advisor tool. [1 or unset]
@@ -300,11 +330,16 @@ let
   # CLAUDE_CODE_GIT_BASH_PATH = "";
   # Idle timeout in milliseconds for MCP tool calls. [0 or unset]
   # CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT = "0";
-  # Set to 1 to stop Claude Code from passing -ExecutionPolicy Bypass when spawning PowerShell for tool calls, hooks, and status line commands, and... [1 or unset]
+  # Set to 1 to stop Claude Code from passing -ExecutionPolicy Bypass when
+  # spawning PowerShell for tool calls, hooks, and status line commands, and
+  # respect the machine's effective execution policy instead. By default Claude
+  # Code bypasses execution policy at process scope. [1 or unset]
   # CLAUDE_CODE_POWERSHELL_RESPECT_EXECUTION_POLICY = "1";
   # Set the shell Claude Code uses to run Bash tool commands.
   # CLAUDE_CODE_SHELL = "";
-  # Command prefix that wraps shell commands Claude Code spawns: Bash tool calls, hook commands, status line commands, and stdio MCP server startup...
+  # Command prefix that wraps shell commands Claude Code spawns: Bash tool
+  # calls, hook commands, status line commands, and stdio MCP server startup
+  # commands. Useful for logging or auditing.
   # CLAUDE_CODE_SHELL_PREFIX = "";
   # Controls MCP tool search.
   # ENABLE_TOOL_SEARCH = "";
@@ -319,7 +354,9 @@ let
   # -----------
   # Set to 1 to skip the mcp__<server>__ prefix on tool names from SDK-created MCP servers. [1 or unset]
   # CLAUDE_AGENT_SDK_MCP_NO_PREFIX = "1";
-  # Set to 1 to spawn stdio MCP servers with only a safe baseline environment plus the server's configured env, instead of inheriting your shell... [1 or unset]
+  # Set to 1 to spawn stdio MCP servers with only a safe baseline environment
+  # plus the server's configured env, instead of inheriting your shell
+  # environment. [1 or unset]
   # CLAUDE_CODE_MCP_ALLOWLIST_ENV = "1";
   # Elapsed time in milliseconds before a still-running MCP tool call moves to a background task (default: 120000, or 2 minutes). [0 or unset]
   # CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS = "0";
@@ -352,9 +389,15 @@ let
   # CLAUDE_AFK_TIMEOUT_MS = "";
   # Stall timeout in milliseconds for background subagents. [numeric]
   # CLAUDE_ASYNC_AGENT_STALL_TIMEOUT_MS = "";
-  # Time in milliseconds Claude Code waits for the AWS default credential provider chain to produce credentials before the request fails with AWS... [numeric]
+  # Time in milliseconds Claude Code waits for the AWS default credential
+  # provider chain to produce credentials before the request fails with an AWS
+  # default-chain credential resolve timeout (default: 60000). Raise it when a
+  # chain step legitimately needs longer, such as browser-based SSO with MFA.
+  # [numeric]
   # CLAUDE_CODE_AWS_CHAIN_RESOLVE_TIMEOUT_MS = "";
-  # Comma-separated list of CA certificate sources for TLS connections. bundled is the Mozilla CA set shipped with Claude Code. system is the...
+  # Comma-separated list of CA certificate sources for TLS connections. bundled
+  # is the Mozilla CA set shipped with Claude Code. system is the operating
+  # system trust store. Default is bundled,system.
   # CLAUDE_CODE_CERT_STORE = "";
   # Path to client certificate file for mTLS authentication.
   # CLAUDE_CODE_CLIENT_CERT = "";
@@ -366,7 +409,9 @@ let
   # CLAUDE_CODE_GLOB_TIMEOUT_SECONDS = "";
   # Timeout in milliseconds for git operations when installing or updating plugins (default: 120000). [numeric]
   # CLAUDE_CODE_PLUGIN_GIT_TIMEOUT_MS = "";
-  # Set to 1 to clone GitHub owner/repo shorthand sources over HTTPS instead of SSH. Applies to plugin install and update, and to /plugin marketplace... [1 or unset]
+  # Set to 1 to clone GitHub owner/repo shorthand sources over HTTPS instead of
+  # SSH. Applies to plugin install and update, and to /plugin marketplace add
+  # and update. [1 or unset]
   # CLAUDE_CODE_PLUGIN_PREFER_HTTPS = "1";
   # Set to 1 to allow the proxy to perform DNS resolution instead of the caller. [1 or unset]
   # CLAUDE_CODE_PROXY_RESOLVES_HOSTS = "1";
@@ -433,7 +478,10 @@ let
   # CLAUDE_CODE_PROVIDER_MANAGED_BY_HOST = "";
   # Set to false to disable syntax highlighting in diff output.
   # CLAUDE_CODE_SYNTAX_HIGHLIGHT = "";
-  # Set to any non-empty value, such as 1, to allow 24-bit truecolor output inside tmux. **Setting it to 0 or false still allows truecolor**, unlike...
+  # Set to any non-empty value, such as 1, to allow 24-bit truecolor output
+  # inside tmux. **Setting it to 0 or false still allows truecolor**, unlike
+  # most on/off variables; unset the variable to restore the 256-color clamp.
+  # [1 or unset]
   # CLAUDE_CODE_TMUX_TRUECOLOR = "";
   # Number of times to retry when the model's response fails validation against the --json-schema in non-interactive mode (the -p flag).
   # MAX_STRUCTURED_OUTPUT_RETRIES = "";
@@ -450,19 +498,28 @@ let
   # CLAUDE_CODE_DISABLE_ARTIFACT = "1";
   # Set to 1 to disable attachment processing. [1 or unset]
   # CLAUDE_CODE_DISABLE_ATTACHMENTS = "1";
-  # Set to 1 to disable all background task functionality, including the run_in_background parameter on Bash and subagent tools, auto-backgrounding,... [1 or unset]
+  # Set to 1 to disable all background task functionality, including the
+  # run_in_background parameter on Bash and subagent tools, auto-backgrounding,
+  # and the Ctrl+B shortcut. [1 or unset]
   # CLAUDE_CODE_DISABLE_BACKGROUND_TASKS = "1";
   # Set to 1 to skip the check that an Amazon Bedrock streaming response carries the application/vnd.amazon.eventstream content-type. [1 or unset]
   # CLAUDE_CODE_DISABLE_BEDROCK_CONTENT_TYPE_GUARD = "1";
-  # Set to 1 to stop a background session's running background shell commands, dynamic workflows, and, as of v2.1.198, background subagents when the... [1 or unset]
+  # Set to 1 to stop a background session's running background shell commands,
+  # dynamic workflows, and background subagents when the supervisor stops,
+  # restarts, or updates that session's process, instead of handing them to the
+  # session's next process. [1 or unset]
   # CLAUDE_CODE_DISABLE_BG_EXIT_HANDOFF = "1";
-  # Set to 1 to disable the skills and workflows included with Claude Code: bundled skills and workflows are removed entirely, while built-in commands... [1 or unset]
+  # Set to 1 to disable the skills and workflows included with Claude Code.
+  # Bundled skills and workflows are removed entirely, while built-in commands
+  # remain available but hidden from the model. [1 or unset]
   # CLAUDE_CODE_DISABLE_BUNDLED_SKILLS = "1";
   # Set to 1 to prevent loading any CLAUDE.md memory files into context, including user, project, and auto-memory files. [1 or unset]
   # CLAUDE_CODE_DISABLE_CLAUDE_MDS = "1";
   # Set to 1 to disable scheduled tasks. [1 or unset]
   # CLAUDE_CODE_DISABLE_CRON = "1";
-  # Set to 1 to strip Anthropic-specific anthropic-beta request headers and beta tool-schema fields (such as defer_loading and eager_input_streaming)... [1 or unset]
+  # Set to 1 to strip Anthropic-specific anthropic-beta request headers and beta
+  # tool-schema fields, such as defer_loading and eager_input_streaming, from
+  # API requests. [1 or unset]
   # CLAUDE_CODE_DISABLE_EXPERIMENTAL_BETAS = "1";
   # Set to 1 to disable the built-in Explore and Plan subagents. [1 or unset]
   # CLAUDE_CODE_DISABLE_EXPLORE_PLAN_AGENTS = "1";
@@ -498,13 +555,18 @@ let
   # CLAUDE_CODE_ENABLE_AWAY_SUMMARY = "1";
   # Set to 1 to refresh plugin state at turn boundaries in non-interactive mode after a background install completes. [1 or unset]
   # CLAUDE_CODE_ENABLE_BACKGROUND_PLUGIN_REFRESH = "1";
-  # Set to 1 to route the "How is Claude doing?" session quality survey to your own OpenTelemetry collector when Anthropic-bound nonessential traffic... [1 or unset]
+  # Set to 1 to route the "How is Claude doing?" session quality survey to your
+  # own OpenTelemetry collector when Anthropic-bound nonessential traffic is
+  # blocked. Survey ratings are emitted only as OTEL events to your configured
+  # collector. [1 or unset]
   # CLAUDE_CODE_ENABLE_FEEDBACK_SURVEY_FOR_OTEL = "1";
   # Set to false to disable prompt suggestions (the "Prompt suggestions" toggle in /config).
   # CLAUDE_CODE_ENABLE_PROMPT_SUGGESTION = "";
   # Controls whether sessions use the structured Task tools (TaskCreate, TaskUpdate, TaskGet, TaskList) or the legacy TodoWrite tool. [0 or unset]
   # CLAUDE_CODE_ENABLE_TASKS = "0";
-  # Set to 1 to turn off the in-process cache of credentials resolved from the AWS default credential provider chain, so Claude Code resolves the... [1 or unset]
+  # Set to 1 to turn off the in-process cache of credentials resolved from the
+  # AWS default credential provider chain, so Claude Code resolves the chain on
+  # every API request. [1 or unset]
   # CLAUDE_CODE_SKIP_AWS_CRED_CACHE = "1";
   # Set to 1 to treat a failed fast mode availability check as available, for networks that block the check's direct request to api.anthropic.com. [1 or unset]
   # CLAUDE_CODE_SKIP_FAST_MODE_NETWORK_ERRORS = "1";
@@ -553,11 +615,14 @@ let
   # Deprecated.
   # ENABLE_PROMPT_CACHING_1H_BEDROCK = "";
 
-  # Other (68)
+  # Other (69)
   # -------------
   # Set to 1 to force claude --cloud to bundle and upload your local repository even when GitHub access is available. [1 or unset]
   # CCR_FORCE_BUNDLE = "1";
-  # Set to 1 in subprocesses Claude Code spawns (Bash and PowerShell tools, tmux sessions, hook commands, status line commands, stdio MCP server... [1 or unset]
+  # Set to 1 in subprocesses Claude Code spawns (Bash and PowerShell tools, tmux
+  # sessions, hook commands, status line commands, and stdio MCP server
+  # subprocesses). Use to detect when a script is running inside a subprocess
+  # spawned by Claude Code. [1 or unset]
   # CLAUDECODE = "1";
   # How many milliseconds before auto-continue the on-screen countdown appears on an unanswered AskUserQuestion dialog. [numeric]
   # CLAUDE_AFK_COUNTDOWN_MS = "";
@@ -583,15 +648,21 @@ let
   # CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS = "1";
   # JSON object to merge into the top level of every API request body.
   # CLAUDE_CODE_EXTRA_BODY = "";
-  # Set to 1 to force transcript persistence, prompt history, and claude agents registration even when this claude was launched from inside another... [1 or unset]
+  # Set to 1 to force transcript persistence, prompt history, and claude agents
+  # registration even when this claude was launched from inside another Claude
+  # Code session. [1 or unset]
   # CLAUDE_CODE_FORCE_SESSION_PERSISTENCE = "1";
-  # Set to 1 to force strikethrough rendering for ~~text~~ in Claude's responses when your terminal supports it but is not auto-detected, such as over... [1 or unset]
+  # Set to 1 to force strikethrough rendering for ~~text~~ in Claude's
+  # responses when your terminal supports it but is not auto-detected, such as
+  # over SSH without TERM_PROGRAM forwarded. [1 or unset]
   # CLAUDE_CODE_FORCE_STRIKETHROUGH = "1";
   # Set to 1 to force-enable DEC private mode 2026 synchronized output when your terminal supports it but is not auto-detected. [1 or unset]
   # CLAUDE_CODE_FORCE_SYNC_OUTPUT = "1";
   # Set to 1 to let Claude spawn forked subagents, or 0 to disable them, overriding any server-side rollout. [1 or unset]
   # CLAUDE_CODE_FORK_SUBAGENT = "1";
-  # Set to 1 to emit subagent text and thinking blocks in claude -p --output-format stream-json output, the same behavior as the... [1 or unset]
+  # Set to 1 to emit subagent text and thinking blocks in claude -p
+  # --output-format stream-json output, the same behavior as the
+  # --forward-subagent-text flag. [1 or unset]
   # CLAUDE_CODE_FORWARD_SUBAGENT_TEXT = "1";
   # Set to false to exclude dotfiles from results when Claude invokes the Glob tool.
   # CLAUDE_CODE_GLOB_HIDDEN = "";
@@ -601,7 +672,9 @@ let
   # CLAUDE_CODE_NEW_INIT = "1";
   # OAuth refresh token for Claude.ai authentication.
   # CLAUDE_CODE_OAUTH_REFRESH_TOKEN = "";
-  # Space-separated OAuth scopes the refresh token was issued with, such as "user:profile user:inference user:sessions:claude_code". Required when...
+  # Space-separated OAuth scopes the refresh token was issued with, such as
+  # "user:profile user:inference user:sessions:claude_code". Required when
+  # CLAUDE_CODE_OAUTH_REFRESH_TOKEN is set.
   # CLAUDE_CODE_OAUTH_SCOPES = "";
   # OAuth access token for Claude.ai authentication.
   # CLAUDE_CODE_OAUTH_TOKEN = "";
@@ -611,9 +684,22 @@ let
   # CLAUDE_CODE_PLUGIN_CACHE_DIR = "";
   # Set to 1 to skip the re-clone attempt and keep using the existing marketplace cache when a git pull fails. [1 or unset]
   # CLAUDE_CODE_PLUGIN_KEEP_MARKETPLACE_ON_FAILURE = "1";
-  # Maximum time in milliseconds that non-interactive mode with the -p flag waits after the final turn for background subagents and workflows whose... [0 or unset | default 600000, or 10 minutes. When the cap is exceeded, remaining background tasks are terminated and the process exits. Set to 0 to wait indefinitely. This cap is separate from the five-second grace period that applies to plain background shells]
+  # Path to one or more read-only plugin seed directories, separated by : on
+  # Unix or ; on Windows. Use this to bundle a pre-populated plugins directory
+  # into a container image.
+  # CLAUDE_CODE_PLUGIN_SEED_DIR = "";
+  # Maximum time in milliseconds that non-interactive mode with the -p flag
+  # waits after the final turn for background subagents and workflows whose
+  # result is part of the output. [0 or unset | default 600000, or 10 minutes.
+  # When the cap is exceeded, remaining background tasks are terminated and the
+  # process exits. Set to 0 to wait indefinitely. This cap is separate from the
+  # five-second grace period that applies to plain background shells]
   # CLAUDE_CODE_PRINT_BG_WAIT_CEILING_MS = "0";
-  # Launch the processes Claude Code starts from its own binary, such as the background service that hosts agent view sessions, through a corporate...
+  # Launch the processes Claude Code starts from its own binary, such as the
+  # background service that hosts agent view sessions, through a corporate
+  # launcher given as an argv prefix like /opt/corp/launcher. Set it in the env
+  # block of user or managed settings so the detached background service
+  # inherits it.
   # CLAUDE_CODE_PROCESS_WRAPPER = "";
   # Set to 1 to propagate W3C trace context when ANTHROPIC_BASE_URL points at a custom proxy. [1 or unset]
   # CLAUDE_CODE_PROPAGATE_TRACEPARENT = "1";
@@ -621,7 +707,10 @@ let
   # CLAUDE_CODE_RESUME_INTERRUPTED_TURN = "1";
   # Override the continuation message injected when resuming a session that ended mid-turn.
   # CLAUDE_CODE_RESUME_PROMPT = "";
-  # Set to 1 to start in safe mode: CLAUDE.md, skills, plugins, hooks, MCP servers, custom commands and agents, output styles, workflows, custom... [1 or unset]
+  # Set to 1 to start in safe mode: CLAUDE.md, skills, plugins, hooks, MCP
+  # servers, custom commands and agents, output styles, workflows, custom
+  # themes, custom keybindings, status line and file-suggestion commands, LSP
+  # servers, and auto-memory do not load. [1 or unset]
   # CLAUDE_CODE_SAFE_MODE = "1";
   # JSON object limiting how many times specific scripts may be invoked per session when CLAUDE_CODE_SUBPROCESS_ENV_SCRUB is set. [numeric]
   # CLAUDE_CODE_SCRIPT_CAPS = "";
@@ -631,7 +720,9 @@ let
   # CLAUDE_CODE_SIMPLE = "1";
   # Set to 1 to use a shorter system prompt and abbreviated tool descriptions on any model. [1 or unset]
   # CLAUDE_CODE_SIMPLE_SYSTEM_PROMPT = "1";
-  # Maximum number of consecutive times a Stop or SubagentStop hook may block the turn from ending before Claude Code overrides it and ends the turn... [0 or unset]
+  # Maximum number of consecutive times a Stop or SubagentStop hook may block
+  # the turn from ending before Claude Code overrides it and ends the turn
+  # anyway (default: 8). Set to 0 to disable the cap. [0 or unset]
   # CLAUDE_CODE_STOP_HOOK_BLOCK_CAP = "0";
   # Set to 1 to strip Anthropic and cloud provider credentials from subprocess environments (Bash tool, hooks, MCP stdio servers). [1 or unset]
   # CLAUDE_CODE_SUBPROCESS_ENV_SCRUB = "1";
@@ -645,7 +736,9 @@ let
   # CLAUDE_CODE_TMPDIR = "/tmp";
   # Override the configuration directory (default: ~/.claude).
   # CLAUDE_CONFIG_DIR = "";
-  # Path to a shell script whose contents Claude Code runs before each Bash command in the same shell process, so exports in the file are visible to...
+  # Path to a shell script whose contents Claude Code runs before each Bash
+  # command in the same shell process, so exports in the file are visible to
+  # the command. Use to persist virtualenv or conda activation across commands.
   # CLAUDE_ENV_FILE = "";
   # Prefix for auto-generated Remote Control session names when no explicit name is provided.
   # CLAUDE_REMOTE_CONTROL_SESSION_NAME_PREFIX = "";
@@ -657,7 +750,9 @@ let
   # FORCE_HYPERLINK = "1";
   # Set to 1 to force the 5-minute prompt cache TTL even when 1-hour TTL would otherwise apply. [1 or unset]
   # FORCE_PROMPT_CACHING_5M = "1";
-  # Set to any non-empty value, such as 1, to enable demo mode: hides your email and organization name from the header and /status output, and skips...
+  # Set to any non-empty value, such as 1, to enable demo mode: hides your email
+  # and organization name from the header and /status output, and skips
+  # onboarding. [1 or unset]
   # IS_DEMO = "";
   # Override region for Claude 3.5 Haiku when using Google Cloud's Agent Platform.
   # VERTEX_REGION_CLAUDE_3_5_HAIKU = "";
@@ -692,22 +787,19 @@ let
   # Override region for Claude Haiku 4.5 when using Google Cloud's Agent Platform.
   # VERTEX_REGION_CLAUDE_HAIKU_4_5 = "";
 
-  # Read-only (exported by Claude Code; do not set) (10)
+  # Read-only (exported by Claude Code; do not set) (7)
   # -------------------------------------------------------
-  # Set automatically in Bash tool and hook command subprocesses while the session has an active Remote Control connection, and removed when the...
+  # Set automatically in Bash tool and hook command subprocesses while the
+  # session has an active Remote Control connection, and removed when the
+  # connection ends. The value is the session ID in session_ form, which can
+  # link a script back to the session transcript.
   # CLAUDE_CODE_BRIDGE_SESSION_ID = "";
   # Set to 1 in subprocesses Claude Code spawns via the Bash, PowerShell, and Monitor tools, hook commands, and status line commands. [1 or unset]
   # CLAUDE_CODE_CHILD_SESSION = "1";
-  # Maximum number of read-only tools and subagents that can execute in parallel (default: 10).
-  # CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY = "";
-  # Path to one or more read-only plugin seed directories, separated by : on Unix or ; on Windows.
-  # CLAUDE_CODE_PLUGIN_SEED_DIR = "";
   # Set automatically to true when Claude Code is running as a cloud session.
   # CLAUDE_CODE_REMOTE = "";
   # Set automatically in cloud sessions to the current session's ID. Read this to construct a link back to the session transcript.
   # CLAUDE_CODE_REMOTE_SESSION_ID = "";
-  # Maximum age in milliseconds of the last transcript message for a session that ended mid-turn to continue automatically on resume. [numeric]
-  # CLAUDE_CODE_RESUME_INTERRUPTED_TURN_MAX_AGE_MS = "";
   # Set automatically to the current session ID in Bash and PowerShell tool subprocesses, hook command subprocesses, and stdio MCP server subprocesses.
   # CLAUDE_CODE_SESSION_ID = "";
   # Set automatically in Bash tool subprocesses and hook commands to the active effort level for the turn: low, medium, high, xhigh, or max.

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -63,9 +63,13 @@ let
     USE_BUILTIN_RIPGREP = "0";
   };
 
-  # Names removed from managed settings. These stay out of `settings` and
-  # `all`; activation deletes them from existing files.
-  retired = [ "DISABLE_NON_ESSENTIAL_MODEL_CALLS" ];
+  # Names removed from managed environment groups. These stay out of
+  # `settings` and `all`; activation and launch wrappers delete old values.
+  retired = [
+    "CLAUDE_CODE_DISABLE_TERMINAL_TITLE"
+    "CLAUDE_CODE_ENABLE_TELEMETRY"
+    "DISABLE_NON_ESSENTIAL_MODEL_CALLS"
+  ];
   retiredButLive = builtins.filter (
     name: builtins.hasAttr name (binary // bashRuntime // modelRouting // shellOnly)
   ) retired;

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -25,10 +25,12 @@
   above; leaving it commented keeps Claude's own default.
 */
 let
-  # Privacy/telemetry/update disables baked into the binary.
+  # Privacy, telemetry, error-reporting, and update disables baked into the binary.
   binary = {
     DISABLE_AUTOUPDATER = "1";
     CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC = "1";
+    CLAUDE_CODE_ENABLE_TELEMETRY = "0";
+    DISABLE_ERROR_REPORTING = "1";
     DISABLE_TELEMETRY = "1";
     DISABLE_INSTALLATION_CHECKS = "1";
   };
@@ -56,8 +58,6 @@ let
 
   # Shell-level vars not needed in settings.json.
   shellOnly = {
-    CLAUDE_CODE_ENABLE_TELEMETRY = "0";
-    DISABLE_ERROR_REPORTING = "1";
     BASH_MAX_OUTPUT_LENGTH = "1024";
     CLAUDE_CODE_DISABLE_TERMINAL_TITLE = "0";
     CLAUDE_CODE_IDE_SKIP_AUTO_INSTALL = "1";

--- a/modules/agents/claude-code/_env.nix
+++ b/modules/agents/claude-code/_env.nix
@@ -307,7 +307,7 @@ let
   # Set to true to include Claude Code version in metrics attributes (default: excluded).
   # OTEL_METRICS_INCLUDE_VERSION = "";
 
-  # Bash, tools, sandbox (23)
+  # Bash, tools, sandbox (20)
   # ----------------------------
   # Default timeout for long-running bash commands (default: 120000, or 2 minutes).
   # BASH_DEFAULT_TIMEOUT_MS = "";   # ACTIVE above
@@ -341,8 +341,6 @@ let
   # CLAUDE_CODE_ENABLE_FINE_GRAINED_TOOL_STREAMING = "1";
   # Windows only: path to the Git Bash executable (bash.exe).
   # CLAUDE_CODE_GIT_BASH_PATH = "";
-  # Idle timeout in milliseconds for MCP tool calls. [0 or unset]
-  # CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT = "0";
   # Set to 1 to stop Claude Code from passing -ExecutionPolicy Bypass when
   # spawning PowerShell for tool calls, hooks, and status line commands, and
   # respect the machine's effective execution policy instead. By default Claude
@@ -354,16 +352,12 @@ let
   # calls, hook commands, status line commands, and stdio MCP server startup
   # commands. Useful for logging or auditing.
   # CLAUDE_CODE_SHELL_PREFIX = "";
-  # Controls MCP tool search.
-  # ENABLE_TOOL_SEARCH = "";
-  # Timeout in milliseconds for MCP tool execution (default: 100000000, about 28 hours). [numeric]
-  # MCP_TOOL_TIMEOUT = "";
   # Override the character budget for skill metadata shown to the Skill tool.
   # SLASH_COMMAND_TOOL_CHAR_BUDGET = "";
   # Set to 0 to use system-installed rg instead of rg included with Claude Code. [0 or unset]
   # USE_BUILTIN_RIPGREP = "0";   # ACTIVE above
 
-  # MCP (11)
+  # MCP (14)
   # -----------
   # Set to 1 to skip the mcp__<server>__ prefix on tool names from SDK-created MCP servers. [1 or unset]
   # CLAUDE_AGENT_SDK_MCP_NO_PREFIX = "1";
@@ -373,8 +367,12 @@ let
   # CLAUDE_CODE_MCP_ALLOWLIST_ENV = "1";
   # Elapsed time in milliseconds before a still-running MCP tool call moves to a background task (default: 120000, or 2 minutes). [0 or unset]
   # CLAUDE_CODE_MCP_AUTO_BACKGROUND_MS = "0";
+  # Idle timeout in milliseconds for MCP tool calls. [0 or unset]
+  # CLAUDE_CODE_MCP_TOOL_IDLE_TIMEOUT = "0";
   # Set to false to disable claude.ai MCP servers in Claude Code.
   # ENABLE_CLAUDEAI_MCP_SERVERS = "";
+  # Controls MCP tool search.
+  # ENABLE_TOOL_SEARCH = "";
   # OAuth client secret for MCP servers that require pre-configured credentials.
   # MCP_CLIENT_SECRET = "";
   # Controls whether startup waits for MCP servers to connect before the first query. [0 or unset]
@@ -389,6 +387,8 @@ let
   # MCP_SERVER_CONNECTION_BATCH_SIZE = "";
   # Timeout in milliseconds for MCP server startup (default: 30000, or 30 seconds). [numeric]
   # MCP_TIMEOUT = "";
+  # Timeout in milliseconds for MCP tool execution (default: 100000000, about 28 hours). [numeric]
+  # MCP_TOOL_TIMEOUT = "";
 
   # Network, proxy, TLS, timeouts (25)
   # -------------------------------------

--- a/modules/agents/claude-code/_settings.nix
+++ b/modules/agents/claude-code/_settings.nix
@@ -11,8 +11,8 @@
       in _activation.nix.
 
   Note: attribute order is irrelevant for builtins.toJSON, so re-adding
-  enabledPlugins and mcpServers via `//` produces JSON byte-identical to a
-  monolithic attrset literal with `inherit`.
+  enabledPlugins, deniedMcpServers, and mcpServers via `//` produces JSON
+  byte-identical to a monolithic attrset literal with `inherit`.
 */
 {
   pkgs,

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -24,6 +24,12 @@ let
     lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") claudeEnv.all
   );
   retiredUnsets = lib.concatMapStringsSep "\n" (name: "unset ${name}") claudeEnv.retired;
+  legacyEnvValueUnsets = lib.concatStringsSep "\n" (
+    lib.mapAttrsToList (
+      name: value:
+      "if [ \"" + "$" + "{${name}:-}\" = ${lib.escapeShellArg value} ]; then unset ${name}; fi"
+    ) claudeEnv.legacyEnvValues
+  );
 
   # Claude runs its shell tool through this via CLAUDE_CODE_SHELL, which requires
   # the path to contain "bash" or "zsh", hence the `bash` name.
@@ -119,6 +125,7 @@ let
 
     ${envExports}
     ${retiredUnsets}
+    ${legacyEnvValueUnsets}
 
     # Shared scratch root for agent temp files.
     tmpDir="/tmp/agents"

--- a/modules/agents/claude-code/_wrapper.nix
+++ b/modules/agents/claude-code/_wrapper.nix
@@ -23,6 +23,7 @@ let
   envExports = lib.concatStringsSep "\n" (
     lib.mapAttrsToList (name: value: "export ${name}=${lib.escapeShellArg value}") claudeEnv.all
   );
+  retiredUnsets = lib.concatMapStringsSep "\n" (name: "unset ${name}") claudeEnv.retired;
 
   # Claude runs its shell tool through this via CLAUDE_CODE_SHELL, which requires
   # the path to contain "bash" or "zsh", hence the `bash` name.
@@ -117,6 +118,7 @@ let
     set -euo pipefail
 
     ${envExports}
+    ${retiredUnsets}
 
     # Shared scratch root for agent temp files.
     tmpDir="/tmp/agents"

--- a/modules/agents/claude-code/home-manager.nix
+++ b/modules/agents/claude-code/home-manager.nix
@@ -322,7 +322,9 @@
           pkgs
           osConfig
           config
+          claudeEnv
           ;
+        claudeDefaults = defaults;
         inherit (settings) claudeSettingsFile claudeJsonConfigFile;
       };
 

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -67,9 +67,11 @@ in
           # The pinned llm-agents package wraps bin/claude before this hook and
           # can export both retired and shared binary names. Strip those names
           # from the inner wrapper before adding the shared flags.
-          for name in ${lib.escapeShellArgs claudeEnv.retired}; do
-            sed -i "/^export $name=/c\unset $name" "$out/bin/claude"
-          done
+          ${lib.optionalString (claudeEnv.retired != [ ]) ''
+            for name in ${lib.escapeShellArgs claudeEnv.retired}; do
+              sed -i "/^export $name=/c\unset $name" "$out/bin/claude"
+            done
+          ''}
           for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
             sed -i "/^export $name=/d" "$out/bin/claude"
           done

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -67,11 +67,9 @@ in
           # The pinned llm-agents package wraps bin/claude before this hook and
           # can export both retired and shared binary names. Strip those names
           # from the inner wrapper before adding the shared flags.
-          if grep -q '^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=' "$out/bin/claude"; then
-            sed -i \
-              '/^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=/c\unset DISABLE_NON_ESSENTIAL_MODEL_CALLS' \
-              "$out/bin/claude"
-          fi
+          for name in ${lib.escapeShellArgs claudeEnv.retired}; do
+            sed -i "/^export $name=/c\unset $name" "$out/bin/claude"
+          done
           for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
             sed -i "/^export $name=/d" "$out/bin/claude"
           done

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -64,17 +64,26 @@ in
       retiredEnvFlags = lib.concatMapStringsSep " " (
         name: "--unset ${lib.escapeShellArg name}"
       ) claudeEnv.retired;
+      legacyEnvValueRuns = lib.concatStringsSep " " (
+        lib.mapAttrsToList (
+          name: value:
+          "--run "
+          + lib.escapeShellArg (
+            "if [ \"" + "$" + "{${name}:-}\" = ${lib.escapeShellArg value} ]; then unset ${name}; fi"
+          )
+        ) claudeEnv.legacyEnvValues
+      );
+      legacyEnvNames = builtins.attrNames claudeEnv.legacyEnvValues;
       binaryNames = lib.attrNames claudeEnv.binary;
 
       wrappedPackage = basePackage.overrideAttrs (old: {
         postFixup = (old.postFixup or "") + ''
           # The pinned llm-agents package wraps bin/claude before this hook and
-          # can export both retired and shared binary names. Strip shared names
-          # from the inner wrapper before applying the shared flags, and fail if
-          # a retired assignment survives because an outer unset cannot override
-          # an inner export. The outer wrapper also unsets retired names for
-          # direct package launches when the dependency has already stopped
-          # exporting them.
+          # can export retired, legacy, and shared binary names. Strip names
+          # owned by this module from the inner wrapper before applying shared
+          # flags. Permanent retired assignments fail closed because an outer
+          # unset cannot override an inner export. Legacy assignments are
+          # removed so the conditional outer run can preserve a user value.
           if [ "$(head -c 2 "$out/bin/claude")" != '#!' ]; then
             echo "claude-code: expected a textual inner wrapper at bin/claude; the pinned llm-agents wrapper shape changed" >&2
             exit 1
@@ -84,6 +93,17 @@ in
               sed -i "/^export $name=/c\unset $name" "$out/bin/claude"
               if grep -qF "$name=" "$out/bin/claude"; then
                 echo "claude-code: inner wrapper still assigns retired name $name after strip; the pinned llm-agents wrapper shape changed" >&2
+                exit 1
+              fi
+            done
+          ''}
+          ${lib.optionalString (legacyEnvNames != [ ]) ''
+            for name in ${lib.escapeShellArgs legacyEnvNames}; do
+              sed -i "/^export $name=/d" "$out/bin/claude"
+            done
+            for name in ${lib.escapeShellArgs legacyEnvNames}; do
+              if grep -qF "$name=" "$out/bin/claude"; then
+                echo "claude-code: inner wrapper still assigns legacy name $name after strip; the pinned llm-agents wrapper shape changed" >&2
                 exit 1
               fi
             done
@@ -100,7 +120,7 @@ in
             done
           ''}
           wrapProgram $out/bin/claude \
-            ${binaryEnvFlags} ${retiredEnvFlags}
+            ${binaryEnvFlags} ${retiredEnvFlags} ${legacyEnvValueRuns}
         '';
       });
     in

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -78,11 +78,12 @@ in
           name: value:
           let
             assignment = "export ${name}=${lib.escapeShellArg value}";
+            assignmentPattern = ''(^|[[:space:];])${name}=[\"']?${lib.escapeRegex value}[\"']?([[:space:];]|$)'';
           in
           ''
             sed -i "/^${assignment}$/d" "$out/bin/claude"
-            if grep -qFx ${lib.escapeShellArg assignment} "$out/bin/claude"; then
-              echo "claude-code: inner wrapper still assigns legacy value ${assignment} after strip; the pinned llm-agents wrapper shape changed" >&2
+            if grep -qE ${lib.escapeShellArg assignmentPattern} "$out/bin/claude"; then
+              echo "claude-code: inner wrapper still assigns legacy value ${name}=${value} after strip; the pinned llm-agents wrapper shape changed" >&2
               exit 1
             fi
           ''
@@ -97,8 +98,9 @@ in
           # owned by this module from the inner wrapper before applying shared
           # flags. Permanent retired assignments fail closed because an outer
           # unset cannot override an inner export. Legacy assignments are
-          # removed only for their exact value so a documented replacement
-          # value can survive the conditional outer run.
+          # removed for their exact value, then checked in shell assignment
+          # forms so wrapper serialization drift fails before a legacy value
+          # can survive the conditional outer run.
           if [ "$(head -c 2 "$out/bin/claude")" != '#!' ]; then
             echo "claude-code: expected a textual inner wrapper at bin/claude; the pinned llm-agents wrapper shape changed" >&2
             exit 1

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -75,18 +75,18 @@ in
           for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
             sed -i "/^export $name=/d" "$out/bin/claude"
           done
-          wrapProgram $out/bin/claude \
-            ${binaryEnvFlags}
-          if ! grep -h -q '^#!' "$out"/bin/.claude-wrapped* 2>/dev/null; then
-            echo "claude-code: expected a textual inner wrapper after wrapProgram; the pinned llm-agents wrapper shape changed" >&2
+          if [ "$(head -c 2 "$out/bin/claude")" != '#!' ]; then
+            echo "claude-code: expected a textual inner wrapper at bin/claude; the pinned llm-agents wrapper shape changed" >&2
             exit 1
           fi
           for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
-            if grep -h -qE "^export $name=" "$out"/bin/.claude-wrapped* 2>/dev/null; then
+            if grep -qE "^export $name=" "$out/bin/claude"; then
               echo "claude-code: inner wrapper still exports $name after strip; the pinned llm-agents wrapper shape changed" >&2
               exit 1
             fi
           done
+          wrapProgram $out/bin/claude \
+            ${binaryEnvFlags}
         '';
       });
     in

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -61,12 +61,18 @@ in
       binaryEnvFlags = lib.concatStringsSep " " (
         lib.mapAttrsToList (name: value: "--set ${name} ${lib.escapeShellArg value}") claudeEnv.binary
       );
+      retiredEnvFlags = lib.concatMapStringsSep " " (
+        name: "--unset ${lib.escapeShellArg name}"
+      ) claudeEnv.retired;
+      binaryNames = lib.attrNames claudeEnv.binary;
 
       wrappedPackage = basePackage.overrideAttrs (old: {
         postFixup = (old.postFixup or "") + ''
           # The pinned llm-agents package wraps bin/claude before this hook and
-          # can export both retired and shared binary names. Strip those names
-          # from the inner wrapper before adding the shared flags.
+          # can export both retired and shared binary names. Strip shared names
+          # from the inner wrapper before applying the shared flags. The outer
+          # wrapper also unsets retired names for direct package launches when
+          # the dependency has already stopped exporting them.
           if [ "$(head -c 2 "$out/bin/claude")" != '#!' ]; then
             echo "claude-code: expected a textual inner wrapper at bin/claude; the pinned llm-agents wrapper shape changed" >&2
             exit 1
@@ -76,17 +82,19 @@ in
               sed -i "/^export $name=/c\unset $name" "$out/bin/claude"
             done
           ''}
-          for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
-            sed -i "/^export $name=/d" "$out/bin/claude"
-          done
-          for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
-            if grep -qF "$name" "$out/bin/claude"; then
-              echo "claude-code: inner wrapper still references $name after strip; the pinned llm-agents wrapper shape changed" >&2
-              exit 1
-            fi
-          done
+          ${lib.optionalString (binaryNames != [ ]) ''
+            for name in ${lib.escapeShellArgs binaryNames}; do
+              sed -i "/^export $name=/d" "$out/bin/claude"
+            done
+            for name in ${lib.escapeShellArgs binaryNames}; do
+              if grep -qF "$name" "$out/bin/claude"; then
+                echo "claude-code: inner wrapper still references $name after strip; the pinned llm-agents wrapper shape changed" >&2
+                exit 1
+              fi
+            done
+          ''}
           wrapProgram $out/bin/claude \
-            ${binaryEnvFlags}
+            ${binaryEnvFlags} ${retiredEnvFlags}
         '';
       });
     in

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -64,7 +64,11 @@ in
 
       wrappedPackage = basePackage.overrideAttrs (old: {
         postFixup = (old.postFixup or "") + ''
-          wrapProgram $out/bin/claude ${binaryEnvFlags}
+          # The pinned llm-agents package still sets this removed legacy name;
+          # clear it in the final wrapper so _env.nix remains authoritative.
+          wrapProgram $out/bin/claude \
+            --unset DISABLE_NON_ESSENTIAL_MODEL_CALLS \
+            ${binaryEnvFlags}
         '';
       });
     in

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -65,13 +65,16 @@ in
       wrappedPackage = basePackage.overrideAttrs (old: {
         postFixup = (old.postFixup or "") + ''
           # The pinned llm-agents package wraps bin/claude before this hook and
-          # still exports the removed legacy name. Strip it from that inner
-          # wrapper before adding the shared binary environment flags.
+          # can export both retired and shared binary names. Strip those names
+          # from the inner wrapper before adding the shared flags.
           if grep -q '^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=' "$out/bin/claude"; then
             sed -i \
               '/^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=/c\unset DISABLE_NON_ESSENTIAL_MODEL_CALLS' \
               "$out/bin/claude"
           fi
+          for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
+            sed -i "/^export $name=/d" "$out/bin/claude"
+          done
           wrapProgram $out/bin/claude \
             ${binaryEnvFlags}
         '';

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -73,7 +73,21 @@ in
           )
         ) claudeEnv.legacyEnvValues
       );
-      legacyEnvNames = builtins.attrNames claudeEnv.legacyEnvValues;
+      legacyEnvCleanup = lib.concatStringsSep "\n" (
+        lib.mapAttrsToList (
+          name: value:
+          let
+            assignment = "export ${name}=${lib.escapeShellArg value}";
+          in
+          ''
+            sed -i "/^${assignment}$/d" "$out/bin/claude"
+            if grep -qFx ${lib.escapeShellArg assignment} "$out/bin/claude"; then
+              echo "claude-code: inner wrapper still assigns legacy value ${assignment} after strip; the pinned llm-agents wrapper shape changed" >&2
+              exit 1
+            fi
+          ''
+        ) claudeEnv.legacyEnvValues
+      );
       binaryNames = lib.attrNames claudeEnv.binary;
 
       wrappedPackage = basePackage.overrideAttrs (old: {
@@ -83,7 +97,8 @@ in
           # owned by this module from the inner wrapper before applying shared
           # flags. Permanent retired assignments fail closed because an outer
           # unset cannot override an inner export. Legacy assignments are
-          # removed so the conditional outer run can preserve a user value.
+          # removed only for their exact value so a documented replacement
+          # value can survive the conditional outer run.
           if [ "$(head -c 2 "$out/bin/claude")" != '#!' ]; then
             echo "claude-code: expected a textual inner wrapper at bin/claude; the pinned llm-agents wrapper shape changed" >&2
             exit 1
@@ -97,17 +112,7 @@ in
               fi
             done
           ''}
-          ${lib.optionalString (legacyEnvNames != [ ]) ''
-            for name in ${lib.escapeShellArgs legacyEnvNames}; do
-              sed -i "/^export $name=/d" "$out/bin/claude"
-            done
-            for name in ${lib.escapeShellArgs legacyEnvNames}; do
-              if grep -qF "$name=" "$out/bin/claude"; then
-                echo "claude-code: inner wrapper still assigns legacy name $name after strip; the pinned llm-agents wrapper shape changed" >&2
-                exit 1
-              fi
-            done
-          ''}
+          ${legacyEnvCleanup}
           ${lib.optionalString (binaryNames != [ ]) ''
             for name in ${lib.escapeShellArgs binaryNames}; do
               sed -i "/^export $name=/d" "$out/bin/claude"

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -77,6 +77,16 @@ in
           done
           wrapProgram $out/bin/claude \
             ${binaryEnvFlags}
+          if ! grep -h -q '^#!' "$out"/bin/.claude-wrapped* 2>/dev/null; then
+            echo "claude-code: expected a textual inner wrapper after wrapProgram; the pinned llm-agents wrapper shape changed" >&2
+            exit 1
+          fi
+          for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
+            if grep -h -qE "^export $name=" "$out"/bin/.claude-wrapped* 2>/dev/null; then
+              echo "claude-code: inner wrapper still exports $name after strip; the pinned llm-agents wrapper shape changed" >&2
+              exit 1
+            fi
+          done
         '';
       });
     in

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -79,9 +79,11 @@ in
           let
             assignment = "export ${name}=${lib.escapeShellArg value}";
             assignmentPattern = ''(^|[[:space:];])${name}=[\"']?${lib.escapeRegex value}[\"']?([[:space:];]|$)'';
+            sedPattern = lib.replaceStrings [ "/" ] [ "\\/" ] (lib.escapeRegex assignment);
+            sedExpression = "/^${sedPattern}$/d";
           in
           ''
-            sed -i "/^${assignment}$/d" "$out/bin/claude"
+            sed -i -E ${lib.escapeShellArg sedExpression} "$out/bin/claude"
             if grep -qE ${lib.escapeShellArg assignmentPattern} "$out/bin/claude"; then
               echo "claude-code: inner wrapper still assigns legacy value ${name}=${value} after strip; the pinned llm-agents wrapper shape changed" >&2
               exit 1

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -67,13 +67,11 @@ in
           # The pinned llm-agents package wraps bin/claude before this hook and
           # still exports the removed legacy name. Strip it from that inner
           # wrapper before adding the shared binary environment flags.
-          if ! grep -q '^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=' "$out/bin/claude"; then
-            echo "error: pinned claude-code wrapper no longer exports the removed legacy name" >&2
-            exit 1
+          if grep -q '^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=' "$out/bin/claude"; then
+            sed -i \
+              '/^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=/c\unset DISABLE_NON_ESSENTIAL_MODEL_CALLS' \
+              "$out/bin/claude"
           fi
-          sed -i \
-            '/^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=/c\unset DISABLE_NON_ESSENTIAL_MODEL_CALLS' \
-            "$out/bin/claude"
           wrapProgram $out/bin/claude \
             ${binaryEnvFlags}
         '';

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -67,6 +67,10 @@ in
           # The pinned llm-agents package wraps bin/claude before this hook and
           # can export both retired and shared binary names. Strip those names
           # from the inner wrapper before adding the shared flags.
+          if [ "$(head -c 2 "$out/bin/claude")" != '#!' ]; then
+            echo "claude-code: expected a textual inner wrapper at bin/claude; the pinned llm-agents wrapper shape changed" >&2
+            exit 1
+          fi
           ${lib.optionalString (claudeEnv.retired != [ ]) ''
             for name in ${lib.escapeShellArgs claudeEnv.retired}; do
               sed -i "/^export $name=/c\unset $name" "$out/bin/claude"
@@ -75,13 +79,9 @@ in
           for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
             sed -i "/^export $name=/d" "$out/bin/claude"
           done
-          if [ "$(head -c 2 "$out/bin/claude")" != '#!' ]; then
-            echo "claude-code: expected a textual inner wrapper at bin/claude; the pinned llm-agents wrapper shape changed" >&2
-            exit 1
-          fi
           for name in ${lib.escapeShellArgs (lib.attrNames claudeEnv.binary)}; do
-            if grep -qE "^export $name=" "$out/bin/claude"; then
-              echo "claude-code: inner wrapper still exports $name after strip; the pinned llm-agents wrapper shape changed" >&2
+            if grep -qF "$name" "$out/bin/claude"; then
+              echo "claude-code: inner wrapper still references $name after strip; the pinned llm-agents wrapper shape changed" >&2
               exit 1
             fi
           done

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -93,8 +93,8 @@ in
               sed -i "/^export $name=/d" "$out/bin/claude"
             done
             for name in ${lib.escapeShellArgs binaryNames}; do
-              if grep -qF "$name" "$out/bin/claude"; then
-                echo "claude-code: inner wrapper still references $name after strip; the pinned llm-agents wrapper shape changed" >&2
+              if grep -qF "$name=" "$out/bin/claude"; then
+                echo "claude-code: inner wrapper still assigns $name after strip; the pinned llm-agents wrapper shape changed" >&2
                 exit 1
               fi
             done

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -64,10 +64,17 @@ in
 
       wrappedPackage = basePackage.overrideAttrs (old: {
         postFixup = (old.postFixup or "") + ''
-          # The pinned llm-agents package still sets this removed legacy name;
-          # clear it in the final wrapper so _env.nix remains authoritative.
+          # The pinned llm-agents package wraps bin/claude before this hook and
+          # still exports the removed legacy name. Strip it from that inner
+          # wrapper before adding the shared binary environment flags.
+          if ! grep -q '^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=' "$out/bin/claude"; then
+            echo "error: pinned claude-code wrapper no longer exports the removed legacy name" >&2
+            exit 1
+          fi
+          sed -i \
+            '/^export DISABLE_NON_ESSENTIAL_MODEL_CALLS=/c\unset DISABLE_NON_ESSENTIAL_MODEL_CALLS' \
+            "$out/bin/claude"
           wrapProgram $out/bin/claude \
-            --unset DISABLE_NON_ESSENTIAL_MODEL_CALLS \
             ${binaryEnvFlags}
         '';
       });

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -195,9 +195,12 @@ in
             Additional non-LSP Claude Code plugins to enable, keyed by the
             `"<plugin>@<marketplace>"` identifier used in
             `~/.claude/settings.json`'s `enabledPlugins`. Set an entry to
-            `false` to keep the key registered but disabled, or override the
-            whole attrset to drop defaults entirely. The marketplace named in
-            the suffix must already be registered in
+            `false` to keep the key registered but disabled. Activation unions
+            this attrset with existing `enabledPlugins` entries, so removing a
+            key here does not remove a previously written key from
+            `~/.claude/settings.json`; delete stale entries there explicitly
+            when removing a plugin. The marketplace named in the suffix must
+            already be registered in
             `~/.claude/plugins/known_marketplaces.json` for the entry to take
             effect. LSP plugin keys (those that would collide with
             `lspPlugins.<key>@claude-plugins-official`) are rejected by

--- a/modules/apps/claude-code.nix
+++ b/modules/apps/claude-code.nix
@@ -70,9 +70,11 @@ in
         postFixup = (old.postFixup or "") + ''
           # The pinned llm-agents package wraps bin/claude before this hook and
           # can export both retired and shared binary names. Strip shared names
-          # from the inner wrapper before applying the shared flags. The outer
-          # wrapper also unsets retired names for direct package launches when
-          # the dependency has already stopped exporting them.
+          # from the inner wrapper before applying the shared flags, and fail if
+          # a retired assignment survives because an outer unset cannot override
+          # an inner export. The outer wrapper also unsets retired names for
+          # direct package launches when the dependency has already stopped
+          # exporting them.
           if [ "$(head -c 2 "$out/bin/claude")" != '#!' ]; then
             echo "claude-code: expected a textual inner wrapper at bin/claude; the pinned llm-agents wrapper shape changed" >&2
             exit 1
@@ -80,6 +82,10 @@ in
           ${lib.optionalString (claudeEnv.retired != [ ]) ''
             for name in ${lib.escapeShellArgs claudeEnv.retired}; do
               sed -i "/^export $name=/c\unset $name" "$out/bin/claude"
+              if grep -qF "$name=" "$out/bin/claude"; then
+                echo "claude-code: inner wrapper still assigns retired name $name after strip; the pinned llm-agents wrapper shape changed" >&2
+                exit 1
+              fi
             done
           ''}
           ${lib.optionalString (binaryNames != [ ]) ''


### PR DESCRIPTION
## Summary

Claude Code 2.1.222 dispatches its built-in review and `claude-code-guide` agents to `claude-haiku-4-5-20251001` regardless of the session model, because those agents ship `model:"haiku"` in their own definition and agent frontmatter outranks both `settings.model` and `ANTHROPIC_MODEL`. `CLAUDE_CODE_SUBAGENT_MODEL` is the only override that reaches them, so it now pins every spawned subagent to `claude-sonnet-5`. That blanket routing is intentional: the same variable also overrides the binary's `model:"inherit"` path for Explore and other spawned agents.

Two knobs cover what that variable cannot reach:

- `ANTHROPIC_DEFAULT_HAIKU_MODEL` repoints the `haiku` alias, which also backs background work that never passes through the Agent tool (titles, summarization, classifiers). `ANTHROPIC_DEFAULT_HAIKU_MODEL_NAME` keeps the model-picker display name aligned with the Sonnet target.
- `CLAUDE_CODE_EFFORT_LEVEL` carries `max`. The persisted `effortLevel` key cannot: its schema is `w.enum(["low","medium","high","xhigh"]).catch(void 0)` and the writer guards on that validator, so a `max` selection is discarded silently and the next session restarts at `xhigh`.

Two dead entries were removed. `DISABLE_NON_ESSENTIAL_MODEL_CALLS` has zero occurrences in the 2.1.222 binary and no docs entry; `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` is the surviving name and was already set. `autocheckpointingEnabled` is not a config key at all: in the binary `autocheckpointing` is a reminder-type identifier sitting beside `todo` and `task_progress`. The schema key for that intent is `fileCheckpointingEnabled`, and it belongs to `settings.json` rather than `~/.claude.json`, so it moved to `claudeSettingsBase` under the correct name. Home Manager activation now deletes both removed keys from existing managed files after the union merge, and the default catalog carries parallel retirement lists for top-level `settings.json` and `~/.claude.json` keys. The catalog marks `enabledPlugins` and `deniedMcpServers` as owned by `_settings.nix`, while retirement assertions cover both static and runtime-injected keys, including `mcpServers`. The repository-owned package wrapper chain strips permanent-retired and legacy environment assignments from the pinned dependency. Permanent retired names are unconditionally unset, while the legacy terminal-title value is cleared only when it is exactly 0, so hosts and Nix-installed binaries converge without blocking an explicit 1. The postFixup strips the regex-escaped exact makeWrapper legacy assignment and fails closed on any shell-form assignment of the legacy value; permanent-retired and binary-name drift checks match assignments, and the telemetry catalog entry is marked RETIRED while terminal-title remains a documented user knob.

The privacy value `DISABLE_ERROR_REPORTING=1` now belongs to the shared binary group as well as the Home Manager environment, so direct package launches and `settings.json` receive the same error-reporting control. `DISABLE_TELEMETRY=1` and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` remain the documented explicit telemetry opt-outs. `CLAUDE_CODE_ENABLE_TELEMETRY` remains unset because the 2.1.222 catalog accepts that enable flag as `1` or unset, not `0`. `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` also remains unset because its documented values are `1` or unset. The permanent retired names are in `claudeEnv.retired`. `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` instead has a value-sensitive legacy migration entry: activation and both launch wrappers remove exactly `0`, while an explicit `1` survives. This covers telemetry written by the intermediate configuration and terminal-title values retained by already-open shells without removing the documented user knob. The `extraPlugins` option documentation now matches activation's intentional `enabledPlugins` union: removing a key from Nix does not remove a previously written key, preserving user-managed entries; stale entries require explicit cleanup.

The catalog files now contain all 304 documented environment variables plus the 401 names returned by the 2.1.222 binary extraction. The undocumented catalog keeps the 360 entries with resolved accessor types; the other 41 names are preserved in a separate unconfirmed-identifiers list and are not presented as activatable environment variables. `_default-settings.nix` contains the 131 remaining top-level settings-schema keys. All 145 schema keys are now either live or catalogued.

## Test plan

- `nix flake check path:. --accept-flake-config --no-build --offline` on the branch: exit 0
- `nix fmt -- modules/apps/claude-code.nix modules/agents/claude-code/_default-settings.nix modules/agents/claude-code/_activation.nix modules/agents/claude-code/_wrapper.nix modules/agents/claude-code/_settings.nix modules/agents/claude-code/_env.nix`: 0 changed
- `nix eval` of both modules: `binary` 5, `settings` 12, `all` 16, `claudeSettingsBase` 15, `claudeJsonConfigBase` 14
- Targeted environment evaluation confirms `DISABLE_ERROR_REPORTING=1`, `DISABLE_TELEMETRY=1`, and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` are present in `binary`, `settings`, and `all`; `CLAUDE_CODE_ENABLE_TELEMETRY` and `CLAUDE_CODE_DISABLE_TERMINAL_TITLE` are absent from all three; the two permanent names are in `retired`, terminal-title `0` is in `legacyEnvValues`, and the value-aware overlap assertion accepts a replacement `1` while rejecting a same-value live assignment; the catalog marks the migrated `0` policy
- Scripted check that no settings-schema key is left uncovered by the catalogs
- Synthetic retirement-guard probe confirms an injected `enabledPlugins` key is rejected if added to `retired.settings`
- The `jq` activation-union probe confirms existing plugin entries survive when absent from the current Nix object, matching the documented user-preserving behavior
- Behaviour measured against a probe agent pinned to `model: haiku`, reading the model recorded in the subagent transcript:

  | Config | Resolved model |
  |---|---|
  | control | `claude-haiku-4-5-20251001` |
  | `CLAUDE_CODE_SUBAGENT_MODEL=claude-sonnet-5` | `claude-sonnet-5` |
  | `ANTHROPIC_DEFAULT_HAIKU_MODEL=claude-sonnet-5` (subagent override absent) | `claude-sonnet-5` |

- Effort read from `$CLAUDE_EFFORT`, which Claude Code exports to Bash post-downgrade: `settings.json` `effortLevel: "max"` resolved `xhigh` (discarded), while `CLAUDE_CODE_EFFORT_LEVEL=max` in the `env` block resolved `max`
- Explore verified separately: transcript metadata `agentType=Explore` on `claude-sonnet-5` with the main session on `claude-opus-5`
- Direct jq regression probes confirm activation removes both permanent retired environment names and terminal-title `0` while preserving an explicit terminal-title `1` and unrelated user fields
- `nix build path:.#nixosConfigurations.system76.config.programs.claude-code.extended.package --accept-flake-config --no-link` succeeds for Claude Code 2.1.222; the generated postFixup passes `bash -n`, strips the regex-escaped exact legacy terminal-title `0` assignment and guards alternate shell-form assignments, uses assignment-only drift checks for permanent and binary names, and verifies retired assignments do not survive stripping; Nix-generated sed probes keep dot, slash, asterisk, and bracket values literal; the realized package wrapper exports the three privacy-disable values, unsets permanent retired names, and conditionally clears terminal-title `0` while preserving `1`, and the inner wrapper contains none of the five shared binary exports
- Generated activation with synthetic settings values passes `bash -n`, removes both permanent retired environment keys and terminal-title `0`, preserves terminal-title `1`, removes the retired `~/.claude.json` key, and preserves unrelated user fields
- The postFixup cleanup loops are omitted when the shared binary catalog is empty, so the generated shell cannot contain an invalid empty `for` loop
- The realized Home Manager launch wrapper unsets the two permanent retired names and conditionally clears terminal-title `0` after exporting the active shared environment
- The Haiku alias ID and model-picker display name both resolve to Sonnet 5

## Notes for review

Cost increases on three axes at once: Sonnet 5 for every subagent, Sonnet 5 for background calls that were deliberately cheapest-tier, and `max` effort every turn. `ANTHROPIC_DEFAULT_HAIKU_MODEL` is the first to back off if that lands harder than expected, since title quality matters least.

The typed undocumented block in `_env.nix` is labelled unsupported: the accessor type is authoritative for those entries, but semantics are inferred from the name and unverified. The separate 41-name unconfirmed list has no resolved accessor type and must not be activated without binary verification. Both surfaces can change without a changelog entry.

The `enabledPlugins` merge intentionally preserves existing user entries. Removing a plugin from `extraPlugins` therefore requires explicit cleanup of the stale `settings.json` entry.

`_env.nix` is now 1290 lines and `_default-settings.nix` 914 lines, mostly catalog. Both blocks lift cleanly into `docs/reference/` with a pointer left behind if that reads better.