### PR TITLE
feat(apps): add patchelf module and document arwen

### DIFF
--- a/docs/csec/additional-tools-reference.md
+++ b/docs/csec/additional-tools-reference.md
@@ -2,9 +2,9 @@
 
 Reference catalog of cybersecurity tools that complement the active toolkit in [`toolkit.md`](toolkit.md). Most can be invoked ad-hoc through `nix run`, dropped into a `nix shell`, or promoted to a host by authoring a `modules/apps/<name>.nix` module and flipping the corresponding flag in `apps-enable.nix`.
 
-Each entry lists a representative run command, upstream repository, official documentation, and a one-line description. Verified against `nixpkgs` rev pinned in `flake.lock` on 2026-05-04. The companion smoke-test report lives in [`additional-tools-runtime-status.md`](additional-tools-runtime-status.md).
+Each entry lists a representative run command, upstream repository, official documentation, and a one-line description. Verified against `nixpkgs` rev pinned in `flake.lock` on 2026-05-04, except `arwen`, which was added and verified on 2026-08-05. The companion smoke-test report lives in [`additional-tools-runtime-status.md`](additional-tools-runtime-status.md).
 
-`Stat.` classifies upstream health as of 2026-06-02: **Maintained** (tagged release on/after 2025-01-01), **Maintenance mode** (mature/stable; active commits but no recent tagged release), or **Deprecated** (archived, abandoned, or officially superseded). GitHub-hosted release dates were refreshed via the GitHub release API on 2026-06-02; the `maltego` and SourceForge entries retain their 2026-05-04 manual check.
+`Stat.` classifies upstream health as of 2026-06-02: **Maintained** (tagged release on/after 2025-01-01), **Maintenance mode** (mature/stable; active commits but no recent tagged release), or **Deprecated** (archived, abandoned, or officially superseded). GitHub-hosted release dates were refreshed via the GitHub release API on 2026-06-02; the `maltego` and SourceForge entries retain their 2026-05-04 manual check. Entries added later carry their own verification date inline.
 
 ## Active Directory & Windows
 
@@ -541,6 +541,12 @@ Each entry lists a representative run command, upstream repository, official doc
   - Docs.: <https://upx.github.io/>
   - Desc.: Ultimate Packer for eXecutables; (un)packs PE/ELF/Mach-O binaries (commonly seen in malware analysis).
   - Stat.: Maintained (v5.1.1, 2026-03-05).
+- arwen
+  - run..: `nix run nixpkgs#arwen -- elf print-interpreter $binary`
+  - Repo.: <https://github.com/nichmor/arwen>
+  - Docs.: <https://nichmor.github.io/arwen/>
+  - Desc.: Rust replacement for `patchelf` and `install_name_tool`. The `elf` subcommand edits interpreter, RPATH/RUNPATH, `DT_NEEDED`, `DT_SONAME`, OS ABI, GNU_STACK exec flag, and dynamic symbol names; the `macho` subcommand handles rpaths, install names/IDs, and ad-hoc signing. Covers Mach-O samples and symbol renaming, neither of which `patchelf` in `toolkit.md` supports.
+  - Stat.: Maintained (v0.0.5, 2026-01-16; upstream commits through 2026-04-07). Verified 2026-08-05; nixpkgs ships `0.0.5-unstable-2026-04-07`.
 
 ## Forensics, Recovery & Imaging
 

--- a/docs/csec/additional-tools-runtime-status.md
+++ b/docs/csec/additional-tools-runtime-status.md
@@ -37,11 +37,16 @@ The remaining seven were re-run on 2026-08-04 against the current pin
 `maltego` was never a build defect either; it is genuinely unfree and gets its
 own category.
 
+`arwen` was added to the reference on 2026-08-05 and smoke-tested the same day
+against the pin current then (`arwen 0.0.5-unstable-2026-04-07`). It runs as
+documented, taking "run as documented" from 100 to 101 and the reference total
+from 127 to 128.
+
 ## Summary
 
 | Result                                                           | Count   |
 | ---------------------------------------------------------------- | ------- |
-| ✅ Run as documented                                             | 100     |
+| ✅ Run as documented                                             | 101     |
 | ⚠️ Documented as unavailable in the reference                    | 10      |
 | ⚠️ Build or evaluation error                                     | 3       |
 | ⚠️ Blocked by the unfree license gate                            | 1       |
@@ -51,7 +56,7 @@ own category.
 | ⚠️ External (non-nixpkgs) toolchain blocked                      | 1       |
 | ⚠️ Closure too large for smoke budget                            | 1       |
 | ⚠️ Documented uvx / PyPI invocation broken                       | 2       |
-| **Total entries in the reference**                               | **127** |
+| **Total entries in the reference**                               | **128** |
 
 The reference doc flags each unavailable tool inline (the entry's `run..:`
 field carries text such as `Not in nixpkgs ...` or `Must create a custom nixpkg`); there is no dedicated section for them. The groupings below are
@@ -145,6 +150,7 @@ no longer entries in the companion reference.
 - ✅ gef (gdb plugin; help command shows gdb usage)
 - ✅ python3Packages.ropgadget
 - ✅ upx
+- ✅ arwen (verified 2026-08-05; `elf print-interpreter` and `elf print-needed` both return real data on a store binary)
 
 ### Forensics, Recovery and Imaging
 

--- a/docs/csec/toolkit.md
+++ b/docs/csec/toolkit.md
@@ -337,6 +337,12 @@ Reference list trees shipped by the entries above (resolve with `nix eval --raw 
   - Docs.: <https://www.ltrace.org/>
   - Desc.: Library call tracer.
   - Stat.: Maintained (latest release 2025-09-16).
+- patchelf
+  - run..: `patchelf --print-interpreter --print-rpath --print-needed $binary`
+  - Repo.: <https://github.com/NixOS/patchelf>
+  - Docs.: <https://github.com/NixOS/patchelf#readme>
+  - Desc.: Rewrites the ELF interpreter, RPATH/RUNPATH, and DT_NEEDED records of prebuilt binaries so foreign or stripped samples load under a chosen loader and library set; nixpkgs pins this attribute to the 0.15.x stdenv series while `patchelfUnstable` carries the newer snapshot.
+  - Stat.: Maintained (latest release 0.19.1, 2026-07-06).
 - strace
   - run..: `strace $binary`
   - Repo.: <https://github.com/strace/strace>

--- a/modules/apps/patchelf.nix
+++ b/modules/apps/patchelf.nix
@@ -1,0 +1,62 @@
+/*
+  Package: patchelf
+  Description: Small utility to modify the dynamic linker and RPATH of ELF executables.
+  Homepage: nil
+  Documentation: nil
+  Repository: https://github.com/NixOS/patchelf
+
+  Summary:
+    * Rewrites the ELF `PT_INTERP` path and `DT_RPATH`/`DT_RUNPATH` entries of prebuilt binaries so they resolve against a chosen loader and library set.
+    * Edits `DT_NEEDED` and `DT_SONAME` records to add, drop, or substitute shared-library dependencies without rebuilding from source.
+
+  Options:
+    --print-interpreter: Report the dynamic loader recorded in `PT_INTERP`.
+    --set-interpreter: Point `PT_INTERP` at a different loader path.
+    --print-rpath: Report the current `DT_RPATH`/`DT_RUNPATH` search path.
+    --set-rpath: Replace the search path; `--add-rpath` appends and `--remove-rpath` clears it.
+    --shrink-rpath: Drop search-path entries that supply no needed library; `--allowed-rpath-prefixes` restricts which entries survive.
+    --force-rpath: Emit `DT_RPATH` instead of the default `DT_RUNPATH`.
+    --print-needed: List `DT_NEEDED` dependencies.
+    --add-needed: Record an extra shared-library dependency.
+    --remove-needed: Drop a `DT_NEEDED` entry.
+    --replace-needed: Swap one `DT_NEEDED` entry for another.
+    --print-soname: Report `DT_SONAME`; `--set-soname` writes it.
+    --clear-symbol-version: Strip the version requirement from a symbol.
+    --no-default-lib: Set `DF_1_NODEFLIB` so the default library directories are skipped.
+    --page-size: Override the assumed page size when relocating headers.
+    --output: Write the patched result to a new file instead of in place.
+
+  Notes:
+    * nixpkgs pins `patchelf` to the 0.15.x series used by the stdenv fixup hook; `patchelfUnstable` carries the newer upstream snapshot at low priority.
+*/
+_:
+let
+  PatchelfModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.patchelf.extended;
+    in
+    {
+      options.programs.patchelf.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable patchelf.";
+        };
+
+        package = lib.mkPackageOption pkgs "patchelf" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.patchelf = PatchelfModule;
+}

--- a/modules/apps/patchelf.nix
+++ b/modules/apps/patchelf.nix
@@ -49,7 +49,7 @@ let
           description = "Whether to enable patchelf.";
         };
 
-        package = lib.mkPackageOption pkgs "patchelf" { };
+        package = lib.mkPackageOption pkgs "patchelfUnstable" { };
       };
 
       config = lib.mkIf cfg.enable {

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -337,6 +337,7 @@ let
       pandoc.extended.enable = lib.mkOverride 1100 true;
       parted.extended.enable = lib.mkOverride 1100 true;
       patch.extended.enable = lib.mkOverride 1100 true;
+      patchelf.extended.enable = lib.mkOverride 1100 true;
       path.extended.enable = lib.mkOverride 1100 true;
       pciutils.extended.enable = lib.mkOverride 1100 true;
       picom.extended.enable = lib.mkOverride 1100 true;


### PR DESCRIPTION
## Summary

Two related binary-patching changes.

**patchelf as an app module.** Binary triage had no packaged way to inspect or rewrite an ELF loader path. `modules/apps/patchelf.nix` follows the standard skeleton in `docs/guides/apps-module-style-guide.md` (nixpkgs package, `programs.patchelf.extended` namespace, `lib.mkPackageOption`), the common baseline enables it at `lib.mkOverride 1100 true`, and `docs/csec/toolkit.md` gains an entry under Reverse Engineering & Dynamic Analysis.

The pinned nixpkgs resolves `patchelf` to 0.15.2 (the series `all-packages.nix` wires into the stdenv fixup hook) while upstream is at v0.19.1; `patchelfUnstable` carries 0.18.0-unstable-2025-08-13 at low priority. Both the module header and the toolkit entry record that pin so the version gap does not read as staleness.

No Home Manager module (`nix-community-home-manager/modules/programs/patchelf.nix` does not exist) and no stylix target, so those steps of the workflow are skipped.

**arwen as a reference-only entry.** The additional-tools reference covered no Mach-O load-command editor and no dynamic-symbol renamer. arwen is a Rust reimplementation of patchelf plus install_name_tool; its `elf` subcommand adds `rename-dynamic-symbols`, `set-os-abi`, and the GNU_STACK exec-flag commands patchelf lacks, and its `macho` subcommand covers rpaths, install names/IDs, and ad-hoc signing. Documented in `docs/csec/additional-tools-reference.md` and `docs/csec/additional-tools-runtime-status.md` only, deliberately not promoted to a `modules/apps/` module.

The runtime-status counts move from 100 to 101 "run as documented" and 127 to 128 total. Both reference-doc header claims that previously read as blanket 2026-05-04 / 2026-06-02 verification now scope themselves so the later entry does not inherit a date it was not checked on.

## Test plan

- `nix run path:.#formatter.x86_64-linux -- <changed files>` (0 changed)
- `hook-apps-catalog-sync` rc=0
- `nix develop path:. -c pre-commit run --hook-stage manual --files <changed files>` rc=0, every applicable hook Passed
- `nix flake check path:. --accept-flake-config --no-build --offline` rc=0
- `nix eval path:.#nixosConfigurations.<host>.options.programs.patchelf.extended.enable.type.description` -> `boolean`
- `nix eval path:.#nixosConfigurations.<host>.config.programs.patchelf.extended.enable` -> `true` on system76 and tpnix
- `nix eval ...config.environment.systemPackages --apply 'any (p: p.pname == "patchelf")'` -> `true` on both hosts
- `patchelf --print-interpreter --print-rpath --print-needed` on a copied store binary, rc=0, matching the invocation documented in the toolkit entry
- `nix run path:.#nixosConfigurations.system76.pkgs.arwen -- elf print-interpreter --help` rc=0; `arwen elf print-interpreter` and `elf print-needed` on the same binary returned the real loader path and `DT_NEEDED` list