### PR TITLE
fix(codex): install codex-code-mode-host and repair the workspace roots permission key

### DIFF
--- a/modules/agents/codex/_default-settings.nix
+++ b/modules/agents/codex/_default-settings.nix
@@ -26,6 +26,8 @@
     shell_snapshot = true;
     code_mode = false;
     code_mode_only = false;
+    # Spawns $out/bin/codex-code-mode-host, installed by ./_packaged-codex.nix.
+    code_mode_host = true;
     terminal_resize_reflow = true;
     standalone_web_search = false;
     runtime_metrics = false;

--- a/modules/agents/codex/_default-settings.nix
+++ b/modules/agents/codex/_default-settings.nix
@@ -26,7 +26,6 @@
     shell_snapshot = true;
     code_mode = false;
     code_mode_only = false;
-    # Spawns $out/bin/codex-code-mode-host, installed by ./_packaged-codex.nix.
     code_mode_host = true;
     terminal_resize_reflow = true;
     standalone_web_search = false;

--- a/modules/agents/codex/_default-settings.nix
+++ b/modules/agents/codex/_default-settings.nix
@@ -100,7 +100,6 @@
   model_provider = "openai";
   model_providers = { };
   # model_reasoning_effort = null;
-  # Disabled because gpt-5.4-spark returns 400 unsupported_parameter for `reasoning.summary`.
   # model_reasoning_summary = "auto";
   # model_supports_reasoning_summaries = null;
   model_verbosity = "medium";

--- a/modules/agents/codex/_default-settings.nix
+++ b/modules/agents/codex/_default-settings.nix
@@ -33,7 +33,6 @@
     runtime_metrics = false;
     memories = false;
     chronicle = false;
-    child_agents_md = false;
     apply_patch_streaming_events = false;
     exec_permission_approvals = false;
     hooks = true;
@@ -70,7 +69,6 @@
     fast_mode = true;
     realtime_conversation = false;
     prevent_idle_sleep = false;
-    responses_websocket_response_processed = false;
     remote_compaction_v2 = false;
     workspace_dependencies = true;
   };

--- a/modules/agents/codex/_packaged-codex.nix
+++ b/modules/agents/codex/_packaged-codex.nix
@@ -44,6 +44,13 @@ pkgs.runCommandLocal "${pname}-packaged-${version}"
     # codex-install-context dependency), so unlike .codex-wrapped it needs no
     # canonicalisation inside $out. Upstream codex is already in
     # environment.systemPackages fleet-wide, so this avoids duplicating 65 MiB.
+    # ln -s accepts a missing target and nix does not validate symlinks, so an
+    # upstream rename would build green and only surface as the runtime
+    # "host executable was not found" path. Assert the target instead.
+    if [ ! -x ${codexPkg}/bin/codex-code-mode-host ]; then
+      echo "codex-packaged: ${codexPkg}/bin/codex-code-mode-host is missing or not executable" >&2
+      exit 1
+    fi
     ln -s ${codexPkg}/bin/codex-code-mode-host $out/bin/codex-code-mode-host
 
     # New trampoline preserves the bubblewrap PATH prepend that upstream's

--- a/modules/agents/codex/_packaged-codex.nix
+++ b/modules/agents/codex/_packaged-codex.nix
@@ -34,19 +34,10 @@ pkgs.runCommandLocal "${pname}-packaged-${version}"
     cp -L ${codexPkg}/bin/.codex-wrapped $out/bin/.codex-wrapped
     chmod +w $out/bin/.codex-wrapped
 
-    # Standalone host for the code-mode tool surface. The models in use
-    # (gpt-5.6-luna, gpt-5.6-sol) are tool_mode = code_mode_only, so every tool
-    # call fails closed when this binary is absent.
-    # Symlinked, not copied: code_mode_host_program_from_exe only checks
-    # is_file(), which follows symlinks (upstream test
-    # code_mode_host_program_accepts_symlinks_to_files), and this binary never
-    # resolves its own current_exe (codex-rs/code-mode-host has no
-    # codex-install-context dependency), so unlike .codex-wrapped it needs no
-    # canonicalisation inside $out. Upstream codex is already in
-    # environment.systemPackages fleet-wide, so this avoids duplicating 65 MiB.
-    # ln -s accepts a missing target and nix does not validate symlinks, so an
-    # upstream rename would build green and only surface as the runtime
-    # "host executable was not found" path. Assert the target instead.
+    # Unlike .codex-wrapped, the host never resolves its own current_exe, and
+    # code_mode_host_program_from_exe accepts a symlink (is_file follows it), so
+    # it need not be copied into $out. Guarded because ln -s takes a missing
+    # target, deferring the failure to the first code_mode_only session.
     if [ ! -x ${codexPkg}/bin/codex-code-mode-host ]; then
       echo "codex-packaged: ${codexPkg}/bin/codex-code-mode-host is missing or not executable" >&2
       exit 1

--- a/modules/agents/codex/_packaged-codex.nix
+++ b/modules/agents/codex/_packaged-codex.nix
@@ -10,6 +10,9 @@ in
 # Invariants required by codex-rs/install-context/src/lib.rs:
 #   * $out/bin must be the parent of the resolved exe (canonicalised).
 #   * $out/codex-package.json must be a regular file (contents not parsed).
+#   * $out/bin/codex-code-mode-host must exist: with a package layout present,
+#     code_mode_host_program() resolves the host only from package_layout.bin_dir,
+#     never from PATH.
 # `codex-path/` and `codex-resources/` are intentionally omitted so codex falls
 # back to PATH-managed tools instead of package-local resources.
 pkgs.runCommandLocal "${pname}-packaged-${version}"
@@ -30,6 +33,13 @@ pkgs.runCommandLocal "${pname}-packaged-${version}"
     # at upstream's store path, which has no metadata file).
     cp -L ${codexPkg}/bin/.codex-wrapped $out/bin/.codex-wrapped
     chmod +w $out/bin/.codex-wrapped
+
+    # Standalone host for the code-mode tool surface. Copied rather than
+    # symlinked so the closure keeps a single 0.5 GiB codex copy; the models in
+    # use (gpt-5.6-luna, gpt-5.6-sol) are tool_mode = code_mode_only, so every
+    # tool call fails closed when this binary is absent.
+    cp -L ${codexPkg}/bin/codex-code-mode-host $out/bin/codex-code-mode-host
+    chmod +x $out/bin/codex-code-mode-host
 
     # New trampoline preserves the bubblewrap PATH prepend that upstream's
     # wrapProgram adds, so the default Linux sandbox keeps finding bwrap.

--- a/modules/agents/codex/_packaged-codex.nix
+++ b/modules/agents/codex/_packaged-codex.nix
@@ -34,12 +34,17 @@ pkgs.runCommandLocal "${pname}-packaged-${version}"
     cp -L ${codexPkg}/bin/.codex-wrapped $out/bin/.codex-wrapped
     chmod +w $out/bin/.codex-wrapped
 
-    # Standalone host for the code-mode tool surface. Copied rather than
-    # symlinked so the closure keeps a single 0.5 GiB codex copy; the models in
-    # use (gpt-5.6-luna, gpt-5.6-sol) are tool_mode = code_mode_only, so every
-    # tool call fails closed when this binary is absent.
-    cp -L ${codexPkg}/bin/codex-code-mode-host $out/bin/codex-code-mode-host
-    chmod +x $out/bin/codex-code-mode-host
+    # Standalone host for the code-mode tool surface. The models in use
+    # (gpt-5.6-luna, gpt-5.6-sol) are tool_mode = code_mode_only, so every tool
+    # call fails closed when this binary is absent.
+    # Symlinked, not copied: code_mode_host_program_from_exe only checks
+    # is_file(), which follows symlinks (upstream test
+    # code_mode_host_program_accepts_symlinks_to_files), and this binary never
+    # resolves its own current_exe (codex-rs/code-mode-host has no
+    # codex-install-context dependency), so unlike .codex-wrapped it needs no
+    # canonicalisation inside $out. Upstream codex is already in
+    # environment.systemPackages fleet-wide, so this avoids duplicating 65 MiB.
+    ln -s ${codexPkg}/bin/codex-code-mode-host $out/bin/codex-code-mode-host
 
     # New trampoline preserves the bubblewrap PATH prepend that upstream's
     # wrapProgram adds, so the default Linux sandbox keeps finding bwrap.

--- a/modules/agents/codex/_settings.nix
+++ b/modules/agents/codex/_settings.nix
@@ -119,7 +119,7 @@ let
         filesystem = {
           ":minimal" = "read";
           ":tmpdir" = "write";
-          ":project_roots" = {
+          ":workspace_roots" = {
             "." = "write";
           };
           "/nix/var/nix" = "read";

--- a/modules/agents/codex/_settings.nix
+++ b/modules/agents/codex/_settings.nix
@@ -94,6 +94,10 @@ let
 
     # Feature flags
     features = {
+      # Spawns bin/codex-code-mode-host, installed by ./_packaged-codex.nix.
+      # Pinned here rather than inherited from the upstream default mirrored in
+      # ./_default-settings.nix, so a defaults resync cannot silently drop it.
+      code_mode_host = true;
       default_mode_request_user_input = true;
       enable_request_compression = false;
       memories = true;

--- a/modules/agents/codex/_settings.nix
+++ b/modules/agents/codex/_settings.nix
@@ -94,7 +94,6 @@ let
 
     # Feature flags
     features = {
-      child_agents_md = true;
       default_mode_request_user_input = true;
       enable_request_compression = false;
       memories = true;


### PR DESCRIPTION
## Summary

Codex 0.147.0 prints on startup:

> Code Mode is unavailable because failed to spawn code-mode host `<store>/codex-packaged-0.147.0/bin/codex-code-mode-host`: host executable was not found. Code mode will fail closed; enable `features.code_mode_host` and install `codex-code-mode-host`.

Three independent defects, each surfaced while validating the one before it.

**1. Missing code-mode host binary.** `InstallContext::code_mode_host_program()` (codex-rs/install-context/src/lib.rs)
resolves the host from `package_layout.bin_dir` as soon as `$out/codex-package.json` marks a package layout, and never
consults PATH. `modules/agents/codex/_packaged-codex.nix` copied only `.codex-wrapped`, so the lookup landed on a
nonexistent path and `ProcessOwnedCodeModeSessionProvider::availability()` failed.

This is not cosmetic: `features.code_mode_host` is `Stage::Stable` with `default_enabled = true`, so the process-owned
provider is always selected, and the configured models (`gpt-5.6-luna`, `gpt-5.6-sol`) carry
`tool_mode = code_mode_only` in `models.json`. `effective_tool_mode` only degrades `CodeMode` to `Direct`, never
`CodeModeOnly`, so every tool call in those sessions failed closed.

The upstream llm-agents.nix package already builds the binary (`cargoBuildFlags` includes
`--package codex-code-mode-host`); it just was not carried into the repackaged layout. It is symlinked rather than
copied: `code_mode_host_program_from_exe` resolves the host with `is_file()`, which follows symlinks (upstream covers
this with `code_mode_host_program_accepts_symlinks_to_files`), and `codex-rs/code-mode-host` declares no
`codex-install-context` dependency and never calls `current_exe()`, so unlike `.codex-wrapped` it needs no
canonicalisation inside `$out`. `ln -s` accepts a missing target and nix does not validate symlinks, so the builder
asserts the target is executable before linking; otherwise an upstream rename would build green and leave a dangling
link that reproduces this same fail-closed startup path.

`features.code_mode_host = true` is pinned in `_settings.nix` rather than left to the upstream default mirrored in
`_default-settings.nix`, so the config states the dependency and a defaults resync (see defect 3) cannot silently drop
it. The two guards are independent: the builder catches a missing binary, the pin catches an unrequested one.

**2. Dropped `:project_roots` permission key.** Surfaced by `codex doctor` while validating the first fix.
`parse_special_path` (codex-rs/core/src/config/permissions.rs) recognizes only `:minimal`, `:workspace_roots`, and
`:tmpdir`. `:project_roots` compiled to `FileSystemSpecialPath::Unknown` and was discarded with a startup warning, so
the workspace profile granted write access only to the explicitly listed absolute roots.

**3. Feature keys codex 0.147.0 no longer defines.** codex 0.147.0 carries no `FeatureSpec` for `child_agents_md` or
`responses_websocket_response_processed`, so every config load logged `unknown feature key in config` for both (visible
in `~/.codex/logs_2.sqlite` under target `codex_features`). The `_settings.nix` override additionally flipped
`child_agents_md` to `true`, which never reached the runtime. Both keys are dropped.

## Test plan

- `nix build` of the repackaged derivation: `bin/codex-code-mode-host --help` exits 0 through the symlink, and
  `bin/codex --version` still reports `codex-cli 0.147.0` through the trampoline. `nix-store -q --references` goes from
  6 to 7 entries (adds `codex-0.147.0`), and the derivation's own NAR stays at 382323952 B against a 382323664 B
  pre-PR baseline. `modules/apps/codex.nix` already installs the raw `cfg.package` into `environment.systemPackages`
  for every common host, so the system-closure union drops 67642496 B (64.5 MiB) relative to copying the binary.
- Negative test for the symlink guard: `nix build` against a stub package carrying only `bin/.codex-wrapped` fails with
  exit code 1 and `codex-packaged: <path>/bin/codex-code-mode-host is missing or not executable`, so an upstream rename
  or drop of the host binary cannot produce a green build with a dangling link.
- `codex features list` against the generated `config.base.toml`: `code_mode_host  stable  true`.
- `codex --strict-config` accepted the generated config; `config.toml parse ok`.
- `codex doctor` against the regenerated config no longer emits the `:project_roots` startup warning. Remaining doctor
  failures are auth and TERMINFO, both artifacts of the isolated test `CODEX_HOME`.
- Remaining 50 feature keys cross-checked against the `FeatureSpec` table in `codex-rs/features/src/lib.rs` at
  `rust-v0.147.0`; no unknown keys left.
- `nix develop path:. -c treefmt` on the touched files; pre-commit hooks passed on every commit.



