### PR TITLE
feat(cloudflare-warp): declarative Zero Trust enrollment with per-host service modes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -72,14 +72,14 @@ jobs:
             - Testing and documentation gaps count only when substantive: new public API without docs, new branching logic without tests, new failure mode without coverage. Otherwise skip.
             - Do not restate the issue title in the body. Do not append a closing line summarizing the comment.
 
-            Output format:
-            - Inline comments for line-specific findings. Prefix with the bracketed tag.
+            Output:
+            - Return up to 8 candidate findings as a JSON array, each `{"file": "...", "line": <int or null>, "summary": "...", "failure_scenario": "concrete inputs/state that trigger it and the wrong output/crash"}`
+            - Rank most-severe first.
+            - If you find fewer than 8 real issues, return fewer — do not pad with speculative or trivial items. If nothing is found, post a single top-level comment containing exactly: "No issues found."
+            - Post inline comments for line-specific findings. Prefix with the bracketed tag.
             - Top-level comments only for cross-cutting findings that span multiple files or hunks.
             - Be terse. One finding per comment. No preamble. No sign-off.
             - When proposing a fix, embed a ```suggestion``` block with the exact replacement code only. No commentary inside the block. Preserve the exact leading whitespace of the replaced lines (spaces vs tabs, number of spaces). Do not introduce or remove outer indentation levels unless that is the actual fix.
-            - Keep each finding's line range as short as possible: pick the smallest subrange that pinpoints the problem.
-
-            If nothing actionable is found, post a single top-level comment containing exactly: "No issues found." Do not pad.
 
           claude_args: |
             --model claude-opus-5

--- a/docs/cloudflare/README.md
+++ b/docs/cloudflare/README.md
@@ -15,6 +15,12 @@ Technical documentation for Cloudflare's developer platform services.
 | [ACME DNS-01](./acme-cloudflare-sample.md)          | Configure ACME certificates with DNS-01 |
 | [Cloudflare Tunnel](./cloudflared-tunnel-sample.md) | Configure `cloudflared` ingress locally |
 
+## Zero Trust
+
+| Topic           | Purpose                                           |
+| --------------- | ------------------------------------------------- |
+| [WARP](./warp/) | Declarative WARP / Zero Trust enrollment on NixOS |
+
 ## Planned Documentation
 
 - Workers

--- a/docs/cloudflare/warp/README.md
+++ b/docs/cloudflare/warp/README.md
@@ -25,12 +25,15 @@ is enabled it:
    `CAP_NET_ADMIN` and opens the WARP UDP port (2408 by default).
 2. Declares three sops secrets (`organization`, `auth_client_id`,
    `auth_client_secret`) from `secrets/cloudflare-warp.yaml`, guarded by
-   `builtins.pathExists` so a missing secret warns and runs `warp-svc`
-   un-enrolled instead of failing evaluation. The connect-on-boot unit logs an
-   UN-ENROLLED notice and remains disconnected until the secret is available.
+   `builtins.pathExists` so a missing secret warns instead of failing
+   evaluation. Without it the host installs `warp-cli` alone: an unmanaged
+   `warp-svc` would hold `CAP_NET_ADMIN` and an open UDP port while serving only
+   consumer WARP, so neither the daemon nor the connect-on-boot unit exists.
 3. Renders `/var/lib/cloudflare-warp/mdm.xml` from non-secret options plus sops
-   placeholders, and installs it (mode 0600, root) via an `ExecStartPre` right
-   before `warp-svc` starts.
+   placeholders, parses the rendered fragment with `xmllint`, and installs it
+   (mode 0600, root) via `ExecStartPre` right before `warp-svc` starts. A
+   credential carrying an XML metacharacter fails the unit instead of silently
+   degrading the daemon to unmanaged mode.
 4. Leaves `networking.firewall.checkReversePath` to the shared
    `hosts-common` `vpn-defaults` owner. Hosts using this repository's common
    baseline receive `loose` for asymmetric VPN routing, and a host firewall
@@ -38,9 +41,10 @@ is enabled it:
    owner for this setting.
 5. Adds a best-effort `cloudflare-warp-connect` oneshot that waits for the daemon
    and runs `warp-cli connect` on boot only after the current WARP registration
-   matches the managed organization. Without the secret, it logs the UN-ENROLLED
-   state and exits without connecting; a missing or mismatched runtime registration
-   is also fail-closed.
+   matches the managed organization; a missing or mismatched runtime registration
+   is fail-closed. The oneshot is bound to `warp-svc` and upheld by it, so an
+   unexpected daemon respawn (`Restart=always`) re-runs the connect logic rather
+   than leaving the host untunneled until the next rebuild.
 
 When the wrapper is disabled, it emits a tmpfiles removal rule for the
 wrapper-owned `/var/lib/cloudflare-warp/mdm.xml`. The next NixOS activation
@@ -65,11 +69,11 @@ The common baseline (`modules/hosts/common/apps-enable.nix`) defaults the app
 OFF; enrollment is a deliberate per-host opt-in. `system76` enables the wrapper
 directly. `tpnix` gates `enable` on `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady`
 (currently `true` since repo-managed sops landed for tpnix in PR #305,
-`modules/tpnix/policy.nix`), like its other sops consumers, so both hosts run
-the wrapper un-enrolled and disconnected until `secrets/cloudflare-warp.yaml` is
-committed. The gate remains a kill switch: if tpnix ever loses its runtime key,
-flipping the flag back to `false` also drops the `cloudflare-warp/*` secret
-declarations that would otherwise fail activation on an un-decryptable payload.
+`modules/tpnix/policy.nix`), so both hosts ship `warp-cli` and no daemon until
+`secrets/cloudflare-warp.yaml` is committed. The gate remains a kill switch: if
+tpnix ever loses its runtime key, flipping the flag back to `false` also drops
+the `cloudflare-warp/*` secret declarations that would otherwise fail activation
+on an un-decryptable payload.
 
 ## Security model
 

--- a/docs/cloudflare/warp/README.md
+++ b/docs/cloudflare/warp/README.md
@@ -1,0 +1,96 @@
+# Cloudflare WARP (Zero Trust)
+
+Declarative Cloudflare WARP enrollment for this NixOS configuration. The
+`programs.cloudflare-warp.extended` module runs the `warp-svc` daemon and enrolls
+a device into the Cloudflare Zero Trust organization non-interactively, using a
+service token delivered through a managed deployment file (`mdm.xml`).
+
+## Documents
+
+| Document                      | Purpose                                                    |
+| ----------------------------- | ---------------------------------------------------------- |
+| [Deployment](./deployment.md) | Operator runbook: dashboard prerequisites, secret, rollout |
+| [Reference](./reference.md)   | Module options, mdm.xml parameters, sops layout            |
+| [Modes](./modes.md)           | WARP mode comparison, DNS tradeoffs, split tunnels         |
+| [Operations](./operations.md) | Runtime verification, coexistence checks, troubleshooting  |
+| [Cheatsheet](./cheatsheet.md) | `warp-cli`, `warp-diag`, and service inspection commands   |
+
+## What the module does
+
+`modules/apps/cloudflare-warp.nix` is a thin wrapper over the upstream
+`services.cloudflare-warp` NixOS service. When `programs.cloudflare-warp.extended`
+is enabled it:
+
+1. Enables `services.cloudflare-warp`, which runs `warp-svc` as root with
+   `CAP_NET_ADMIN` and opens the WARP UDP port (2408 by default).
+2. Declares three sops secrets (`organization`, `auth_client_id`,
+   `auth_client_secret`) from `secrets/cloudflare-warp.yaml`, guarded by
+   `builtins.pathExists` so a missing secret warns and runs `warp-svc`
+   un-enrolled instead of failing evaluation. The connect-on-boot unit logs an
+   UN-ENROLLED notice and remains disconnected until the secret is available.
+3. Renders `/var/lib/cloudflare-warp/mdm.xml` from non-secret options plus sops
+   placeholders, and installs it (mode 0600, root) via an `ExecStartPre` right
+   before `warp-svc` starts.
+4. Leaves `networking.firewall.checkReversePath` to the shared
+   `hosts-common` `vpn-defaults` owner. Hosts using this repository's common
+   baseline receive `loose` for asymmetric VPN routing, and a host firewall
+   module can override it when required. The WARP module does not add a second
+   owner for this setting.
+5. Adds a best-effort `cloudflare-warp-connect` oneshot that waits for the daemon
+   and runs `warp-cli connect` on boot only after the current WARP registration
+   matches the managed organization. Without the secret, it logs the UN-ENROLLED
+   state and exits without connecting; a missing or mismatched runtime registration
+   is also fail-closed.
+
+When the wrapper is disabled, it emits a tmpfiles removal rule for the
+wrapper-owned `/var/lib/cloudflare-warp/mdm.xml`. The next NixOS activation
+removes the runtime managed file instead of leaving the service token on disk.
+
+`service_mode` is authoritative through `mdm.xml`; the module never calls
+`warp-cli mode`, so the managed config and the local client cannot fight.
+
+## Enrolled hosts
+
+| Host       | Service mode         | Enable file                            |
+| ---------- | -------------------- | -------------------------------------- |
+| `tpnix`    | `tunnelonly`         | `modules/tpnix/cloudflare-warp.nix`    |
+| `system76` | `warp` (full tunnel) | `modules/system76/cloudflare-warp.nix` |
+
+`tpnix` uses `tunnelonly` because its private-DNS module selects NetworkManager
+dnsmasq for SignalX host mappings. This keeps those mappings under the host's
+DNS while retaining the WARP tunnel, HTTP filtering, network policies, and
+posture checks. `system76` has no competing local resolver and uses Full mode.
+
+The common baseline (`modules/hosts/common/apps-enable.nix`) defaults the app
+OFF; enrollment is a deliberate per-host opt-in. `system76` enables the wrapper
+directly. `tpnix` gates `enable` on `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady`
+(currently `true` since repo-managed sops landed for tpnix in PR #305,
+`modules/tpnix/policy.nix`), like its other sops consumers, so both hosts run
+the wrapper un-enrolled and disconnected until `secrets/cloudflare-warp.yaml` is
+committed. The gate remains a kill switch: if tpnix ever loses its runtime key,
+flipping the flag back to `false` also drops the `cloudflare-warp/*` secret
+declarations that would otherwise fail activation on an un-decryptable payload.
+
+## Security model
+
+- The team name (`organization`) and service-token credentials live only in
+  `secrets/cloudflare-warp.yaml` (sops, age). The rendered `mdm.xml` is produced
+  from sops placeholders, so neither the team name nor the credentials enter the
+  Nix store or git history.
+- `mdm.xml` is written to `/var/lib/cloudflare-warp/mdm.xml` as `0600 root:root`.
+- Disabling the wrapper removes the runtime `mdm.xml` during the next NixOS
+  activation, so the cleartext service-token cache does not remain after a
+  disable switch. This local cleanup does not delete the device registration; use
+  `warp-cli registration delete` and remove the device from the dashboard when
+  full Zero Trust de-enrollment is intended.
+- `secrets/` is a git submodule; the encrypted payload is committed there, the
+  Nix changes in the main repository.
+
+## References
+
+- [WARP client docs](https://developers.cloudflare.com/warp-client/)
+- [Get started on Linux](https://developers.cloudflare.com/warp-client/get-started/linux/)
+- [Deploy the client headless on Linux](https://developers.cloudflare.com/cloudflare-one/tutorials/deploy-client-headless-linux/)
+- [Managed deployment parameters](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/deployment/mdm-deployment/parameters/)
+- [Service tokens](https://developers.cloudflare.com/cloudflare-one/access-controls/service-auth/service-tokens/)
+- [NixOS option `services.cloudflare-warp`](https://search.nixos.org/options?query=services.cloudflare-warp)

--- a/docs/cloudflare/warp/README.md
+++ b/docs/cloudflare/warp/README.md
@@ -33,7 +33,9 @@ is enabled it:
    placeholders, parses the rendered fragment with `xmllint`, and installs it
    (mode 0600, root) via `ExecStartPre` right before `warp-svc` starts. A
    credential carrying an XML metacharacter fails the unit instead of silently
-   degrading the daemon to unmanaged mode.
+   degrading the daemon to unmanaged mode. xmllint's stderr is dropped and
+   replaced with a fixed message: it reports a parse error by echoing the
+   offending source line, which would put the credential in the journal.
 4. Leaves `networking.firewall.checkReversePath` to the shared
    `hosts-common` `vpn-defaults` owner. Hosts using this repository's common
    baseline receive `loose` for asymmetric VPN routing, and a host firewall

--- a/docs/cloudflare/warp/cheatsheet.md
+++ b/docs/cloudflare/warp/cheatsheet.md
@@ -1,0 +1,67 @@
+# Running WARP CLI commands
+
+Use these commands after the host has been deployed with
+`programs.cloudflare-warp.extended.enable = true`. The module installs the
+headless WARP package, so `warp-cli`, `warp-svc`, `warp-dex`, and `warp-diag`
+are available on enrolled hosts.
+
+## Check runtime state
+
+```bash
+systemctl status cloudflare-warp.service
+systemctl status cloudflare-warp-connect.service
+ls -l /var/lib/cloudflare-warp/mdm.xml
+warp-cli registration show
+warp-cli status
+warp-cli settings
+warp-cli tunnel stats
+curl -s https://www.cloudflare.com/cdn-cgi/trace | grep -E '^warp='
+```
+
+A healthy full-mode deployment shows the daemon running, the connect oneshot in
+its expected `active (exited)` lifecycle, a `0600 root:root` `mdm.xml`, an
+enrolled Zero Trust registration, `warp-cli status` as connected, and `warp=on`
+in the Cloudflare trace output. The oneshot state alone is not a tunnel health
+check.
+
+## Control the tunnel
+
+```bash
+warp-cli --accept-tos connect
+warp-cli --accept-tos disconnect
+warp-cli status
+```
+
+`disconnect` is temporary when the managed `mdm.xml` allows it. If
+`switch_locked` is true, the client prevents local disconnects.
+
+## Inspect managed settings
+
+```bash
+warp-cli settings
+warp-cli registration show
+warp-cli tunnel stats
+```
+
+`mdm.xml` is authoritative for `service_mode`. Do not use `warp-cli mode` for
+durable mode changes on a managed host. Change
+`programs.cloudflare-warp.extended.serviceMode` and rebuild instead.
+
+## Collect diagnostics
+
+```bash
+sudo warp-diag
+sudo warp-diag feedback
+journalctl -u cloudflare-warp.service -b
+journalctl -u cloudflare-warp-connect.service -b
+```
+
+The diagnostics bundle includes client settings, status, and daemon logs. Search
+the daemon log for `error`, `failed`, and `DNS connectivity check` to separate
+DNS setup problems from tunnel problems.
+
+## References
+
+- [Troubleshooting WARP](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/troubleshooting/)
+- [WARP diagnostic logs](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/troubleshooting/warp-diag/)
+- [Firewall and network ports](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/deployment/firewall/)

--- a/docs/cloudflare/warp/deployment.md
+++ b/docs/cloudflare/warp/deployment.md
@@ -61,16 +61,19 @@ required service mode:
 - `modules/system76/cloudflare-warp.nix` sets `enable = true` directly; system76
   has runtime SOPS decryption.
 - `modules/tpnix/cloudflare-warp.nix` sets `enable = sopsRuntimeReady`, gating on
-  `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady` (`modules/tpnix/policy.nix`) like
-  the other tpnix sops consumers (`duplicati.nix`, `printing.nix`, `fonts.nix`).
+  `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady` (`modules/tpnix/policy.nix`).
   The flag is currently `true` (repo-managed sops landed for tpnix in PR #305), so
-  the wrapper behaves like system76's: un-enrolled degraded mode with no
-  connect-on-boot action until `secrets/cloudflare-warp.yaml` is committed, then
-  non-interactive enrollment.
+  the wrapper behaves like system76's: `warp-cli` on `PATH` and no daemon until
+  `secrets/cloudflare-warp.yaml` is committed, then non-interactive enrollment.
   The gate remains a kill switch: if tpnix ever loses its runtime decryption key,
   flipping the flag back to `false` drops the `cloudflare-warp/*` secret
   declarations and removes the previously rendered runtime `mdm.xml` on the next
   activation, avoiding a stranded service-token cache.
+
+Until the secret exists, `enable = true` installs the client only. `warp-svc`
+holds `CAP_NET_ADMIN` and an open UDP port while serving nothing but consumer
+WARP without `mdm.xml`, so the wrapper does not start it and emits a build
+warning instead.
 
 A SOPS-ready host enables directly:
 
@@ -89,7 +92,7 @@ _: {
 ```
 
 tpnix keeps `enable` gated on `sopsRuntimeReady` as a kill switch. The flag is
-currently `true`, so tpnix behaves like a SOPS-ready host; if the tpnix
+currently `true`, so tpnix behaves like a SOPS-ready host. If the tpnix
 decryption key is ever lost, flipping the flag back to `false` in
 `modules/tpnix/policy.nix` drops the `cloudflare-warp/*` secret declarations and
 the mdm template with it, and the disabled wrapper removes the previously
@@ -128,5 +131,15 @@ connection, and coexistence with Tailscale and DNS.
 ## 5. Commit
 
 The encrypted secret is committed inside the submodule; the Nix changes in the
-main repository. Keep them as separate commits, then update the submodule pointer
-in the main repo.
+main repository. Keep them as separate commits.
+
+```bash
+git -C secrets commit -m "feat(cloudflare-warp): add Zero Trust service token"
+git -C secrets push                      # required before the pointer bump
+git add secrets && git commit -m "chore(secrets): bump pointer for cloudflare-warp"
+```
+
+Push the submodule before bumping the pointer. `flake.nix` sets
+`self.submodules = true`, so the main repo pins `secrets/` by commit rev: a local
+`nix build` still succeeds against the working tree, but `nix flake check` and CI
+fail with `Cannot find Git revision` while the pinned rev exists only locally.

--- a/docs/cloudflare/warp/deployment.md
+++ b/docs/cloudflare/warp/deployment.md
@@ -1,0 +1,132 @@
+# WARP Zero Trust Deployment
+
+Operator runbook to enroll a host into Cloudflare Zero Trust with this
+configuration. Dashboard steps target an Enterprise Zero Trust account.
+
+## 1. Dashboard prerequisites (one time)
+
+1. **Team name.** Note the `<team>` in `<team>.cloudflareaccess.com`. This becomes
+   the `organization` key in the sops secret (step 2). Use the bare team name,
+   not the full hostname.
+2. **Service token.** Settings/Access > Service Auth > Create Service Token.
+   Capture the **Client ID** (ends in `.access`) and the **Client Secret** (shown
+   once). These become `auth_client_id` / `auth_client_secret`.
+3. **Device-enrollment permission.** Settings > WARP Client > Device enrollment
+   permissions > Manage. Add a rule whose action is **Service Auth**, including
+   the service token from step 2. Required for token enrollment; without it the
+   daemon enrolls then fails policy.
+4. **Device profiles.** Assign a profile whose service mode matches each host:
+   **Gateway with WARP** (`service_mode = warp`) for system76, and **Secure Web
+   Gateway without DNS filtering** (`service_mode = tunnelonly`) for tpnix.
+   tpnix keeps its local NetworkManager dnsmasq mappings for private hosts.
+5. **Split Tunnels (Exclude IPs).** Keep the default RFC1918 ranges excluded and
+   ADD Tailscale's `100.64.0.0/10` so the tailnet keeps working under the WARP
+   tunnel. Confirm `10.0.0.0/8` (the LAN range used by the tpnix SSH firewall
+   rule) stays excluded.
+6. **Local Domain Fallback.** For Full-mode hosts, add internal/dev domains
+   (for example `local`, `internal`, corporate AD) so they resolve outside
+   Cloudflare DNS. tpnix keeps its private mappings in local NetworkManager
+   dnsmasq because it uses `tunnelonly`.
+
+## 2. Create the encrypted secret
+
+The secret lives in the `secrets/` submodule and is covered by the existing
+`.sops.yaml` catch-all rule. Copy `secrets/cloudflare-warp.yaml.example` for the
+expected key layout.
+
+```bash
+sops secrets/cloudflare-warp.yaml
+```
+
+Enter the team name and the service-token values:
+
+```yaml
+organization: <team>
+auth_client_id: <client-id>.access
+auth_client_secret: <client-secret>
+```
+
+Verify and stage inside the submodule:
+
+```bash
+sops -d secrets/cloudflare-warp.yaml          # shows all three keys
+git -C secrets add cloudflare-warp.yaml
+```
+
+## 3. Enable the host
+
+Each host opts in through a small file that enables the wrapper with its host's
+required service mode:
+
+- `modules/system76/cloudflare-warp.nix` sets `enable = true` directly; system76
+  has runtime SOPS decryption.
+- `modules/tpnix/cloudflare-warp.nix` sets `enable = sopsRuntimeReady`, gating on
+  `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady` (`modules/tpnix/policy.nix`) like
+  the other tpnix sops consumers (`duplicati.nix`, `printing.nix`, `fonts.nix`).
+  The flag is currently `true` (repo-managed sops landed for tpnix in PR #305), so
+  the wrapper behaves like system76's: un-enrolled degraded mode with no
+  connect-on-boot action until `secrets/cloudflare-warp.yaml` is committed, then
+  non-interactive enrollment.
+  The gate remains a kill switch: if tpnix ever loses its runtime decryption key,
+  flipping the flag back to `false` drops the `cloudflare-warp/*` secret
+  declarations and removes the previously rendered runtime `mdm.xml` on the next
+  activation, avoiding a stranded service-token cache.
+
+A SOPS-ready host enables directly:
+
+```nix
+_: {
+  configurations.nixos.<host>.module = {
+    programs.cloudflare-warp.extended = {
+      enable = true;
+      serviceMode = "warp";
+      autoConnect = 0;
+      switchLocked = false;
+      connectOnBoot = true;
+    };
+  };
+}
+```
+
+tpnix keeps `enable` gated on `sopsRuntimeReady` as a kill switch. The flag is
+currently `true`, so tpnix behaves like a SOPS-ready host; if the tpnix
+decryption key is ever lost, flipping the flag back to `false` in
+`modules/tpnix/policy.nix` drops the `cloudflare-warp/*` secret declarations and
+the mdm template with it, and the disabled wrapper removes the previously
+rendered runtime `mdm.xml` on the next activation:
+
+```nix
+{ config, ... }:
+let
+  inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
+in
+{
+  configurations.nixos.tpnix.module = {
+    programs.cloudflare-warp.extended = {
+      enable = sopsRuntimeReady;
+      serviceMode = "tunnelonly";
+      autoConnect = 0;
+      switchLocked = false;
+      connectOnBoot = true;
+    };
+  };
+}
+```
+
+## 4. Validate and deploy
+
+```bash
+nix fmt
+nix flake check --accept-flake-config --no-build --offline
+nix build .#nixosConfigurations.<host>.config.system.build.toplevel --no-link
+sudo nixos-rebuild switch --flake .#<host>
+```
+
+After switch, follow [Operations](./operations.md) to confirm enrollment,
+connection, and coexistence with Tailscale and DNS.
+
+## 5. Commit
+
+The encrypted secret is committed inside the submodule; the Nix changes in the
+main repository. Keep them as separate commits, then update the submodule pointer
+in the main repo.

--- a/docs/cloudflare/warp/modes.md
+++ b/docs/cloudflare/warp/modes.md
@@ -1,0 +1,73 @@
+# Choosing a WARP mode
+
+Choose the WARP mode before changing host configuration. The mode controls which
+Zero Trust features reach the device because each mode combines DNS, tunneling,
+and posture collection differently.
+
+System76 uses `Gateway with WARP`, which maps to `service_mode = "warp"` in
+`mdm.xml` and keeps DNS filtering, HTTP filtering, device posture, and
+domain-based split tunneling active. Tpnix uses `tunnelonly` because its local
+NetworkManager dnsmasq service owns private-host resolution.
+
+## Compare the client modes
+
+| Dashboard mode                           | `service_mode` | `warp-cli mode` | Traffic handled           | Gateway DNS | HTTP filtering | Posture |
+| ---------------------------------------- | -------------- | --------------- | ------------------------- | ----------- | -------------- | ------- |
+| Gateway with WARP                        | `warp`         | `warp+doh`      | All traffic and DNS       | Yes         | Yes            | Yes     |
+| Gateway with DoH                         | `1dot1`        | `doh`           | DNS only                  | Yes         | No             | No      |
+| Secure Web Gateway without DNS filtering | `tunnelonly`   | `tunnel_only`   | All traffic, OS keeps DNS | No          | Yes            | Yes     |
+| Proxy                                    | `proxy`        | `proxy`         | `127.0.0.1:40000` only    | No          | Yes            | No      |
+| Device Information Only                  | `postureonly`  | n/a             | None                      | No          | No             | Yes     |
+
+`warp-cli settings` reports the same modes as `WarpWithDnsOverHttps`,
+`DnsOverHttps`, `TunnelOnly`, `WarpProxy`, and `PostureOnly`.
+
+## Select full mode when no local resolver is active
+
+Use `Gateway with WARP` unless a host must keep an independent DNS resolver.
+Full mode makes WARP the system resolver, so Gateway DNS policies can block
+malware, phishing, and content categories before a connection starts.
+
+Full mode also preserves domain-based split tunneling because the client owns
+resolution. Internal names still work when their suffixes are configured in
+Local Domain Fallback.
+
+Use `tunnelonly` only when Cloudflare cannot control DNS on the device. It keeps
+the tunnel, HTTP filtering, network policies, and posture checks, but it removes
+Gateway DNS filtering, DNS query logs, and domain-based split tunneling.
+
+Tpnix intentionally uses `tunnelonly` so its SignalX private-host mappings stay
+available through NetworkManager dnsmasq. Do not change it to `warp` unless those
+mappings move to Zero Trust Local Domain Fallback first.
+
+## Avoid local DNS resolver conflicts
+
+Do not run a local resolver on `127.0.0.1:53` while using full mode. If a host
+enables `services.dnscrypt-proxy` or imports a module that provides a competing
+local resolver, switch WARP to `tunnelonly` or disable the local resolver.
+
+The current host modules do not enable `services.dnscrypt-proxy`. The shared
+private-DNS module selects NetworkManager dnsmasq only when the host declares
+private DNS keys, its SOPS runtime is ready, and `secrets/<host>.yaml` exists.
+`tpnix` currently meets those conditions for SignalX DNS, so inspect the
+evaluated host DNS setting before selecting full mode. Tpnix therefore uses
+`tunnelonly` and does not trigger the Full-mode resolver warning. Full mode is
+appropriate for system76 because no competing local resolver is active there.
+
+## Configure split tunnels
+
+Configure split tunnels in the Zero Trust device profile. Exclude mode sends all
+traffic through WARP except listed IPs and domains. Include mode sends only
+listed IPs and domains through WARP.
+
+Keep the default RFC1918 exclusions so local networks stay reachable. Also
+exclude Tailscale's `100.64.0.0/10` range on hosts that use the tailnet.
+
+`tunnelonly` and `postureonly` disable domain-based split tunneling. In those
+modes, split only by IP or CIDR.
+
+## References
+
+- [WARP modes](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/configure-warp/warp-modes/)
+- [Split tunnels](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/split-tunnels/)
+- [Local Domain Fallback](https://developers.cloudflare.com/cloudflare-one/team-and-resources/devices/warp/configure-warp/route-traffic/local-domains/)

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -147,8 +147,10 @@ encrypted sops secret before `warp-svc` starts and can enroll the device again.
   or unreadable organization secret logs `managed organization secret unavailable; cannot verify registration`, queries the daemon once so the tunnel's state is on record, then logs `managed organization secret unavailable; not connecting` before the unit exits without entering the retry loop. Both of those are `<3>` lines, visible to
   `journalctl -u cloudflare-warp-connect -p err`. A registration query that does
   not answer logs `registration check failed (exit <n>)`; exit 124 is the five-second
-  `timeout` firing on a busy `warp-svc`, and any other code is warp-cli's own, whose
-  stderr is left unredirected and lands in the journal beside it at info priority.
+  `timeout` firing on a busy `warp-svc` and 137 is the `-k 1s` SIGKILL for a call that
+  ignored the term signal, both pointing at the daemon rather than the CLI. Any other
+  code is warp-cli's own, whose stderr is left unredirected and lands in the journal
+  beside it at info priority.
   Inspect the daemon logs and rerun:
 
   `systemctl restart cloudflare-warp-connect.service`

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -38,8 +38,8 @@ line rather than the unit state:
 | `tunnel is up but its registration went unverified`       | Tunnel left connected; the registration check never answered                        |
 | `daemon reports no Zero Trust registration`               | No Teams registration; enrollment incomplete or rejected                            |
 | `daemon is registered outside the managed organization`   | Live registration belongs to another tenant                                         |
-| `tunnel is not connected after <n> attempts`              | Connect was requested and refused                                                   |
-| `connect never succeeded (daemon unreachable ...)`        | Registration never confirmed, so connect was never requested                        |
+| `tunnel is not connected after <n> attempts`              | Connect was accepted, but the tunnel never read `Connected` in the window           |
+| `connect never succeeded (daemon unreachable ...)`        | No connect ever succeeded: never requested, or refused on every attempt             |
 | `managed organization secret unavailable; not connecting` | Secret missing, unreadable, or whitespace-only; the run exits before the retry loop |
 
 The rows are mutually exclusive and reflect the state the run ended on, not

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -31,14 +31,15 @@ inside the unit's explicit `TimeoutStartSec=180`. The oneshot is best-effort: it
 exits 0 and reaches `active (exited)` in every outcome, so read the final log
 line rather than the unit state:
 
-| Final line                                              | Meaning                                                      |
-| ------------------------------------------------------- | ------------------------------------------------------------ |
-| (none)                                                  | Managed tunnel verified and up                               |
-| `tunnel is up but its registration went unverified`     | Tunnel left connected; the registration check never answered |
-| `daemon reports no Zero Trust registration`             | No Teams registration; enrollment incomplete or rejected     |
-| `daemon is registered outside the managed organization` | Live registration belongs to another tenant                  |
-| `tunnel is not connected after <n> attempts`            | Connect was requested and refused                            |
-| `connect never succeeded (daemon unreachable ...)`      | The daemon never answered                                    |
+| Final line                                                | Meaning                                                                             |
+| --------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| (none)                                                    | Managed tunnel verified and up                                                      |
+| `tunnel is up but its registration went unverified`       | Tunnel left connected; the registration check never answered                        |
+| `daemon reports no Zero Trust registration`               | No Teams registration; enrollment incomplete or rejected                            |
+| `daemon is registered outside the managed organization`   | Live registration belongs to another tenant                                         |
+| `tunnel is not connected after <n> attempts`              | Connect was requested and refused                                                   |
+| `connect never succeeded (daemon unreachable ...)`        | The daemon never answered                                                           |
+| `managed organization secret unavailable; not connecting` | Secret missing, unreadable, or whitespace-only; the run exits before the retry loop |
 
 The rows are mutually exclusive and reflect the state the run ended on, not
 anything observed along the way: a confirmed mismatch is reported ahead of the

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -22,7 +22,10 @@ or still-unregistered device reports, disconnects an already connected tunnel an
 logs at error priority. A registration check that does not answer within its
 five-second cap leaves an existing tunnel up, because an unanswered check is not
 evidence of an unmanaged tunnel; after three such observations on a live tunnel
-the loop stops, since nothing is left to request. An empty or unreadable
+the loop stops, since nothing is left to request. An unanswered check does not
+count against a run that already read the managed organization, because that
+value cannot change mid-run and the read is what allowed connect in the first
+place. An empty or unreadable
 organization secret cannot change while the unit runs, so the oneshot reports the
 current status once and exits instead of retrying a decision that can never open.
 The loop makes up to 30 attempts bounded by a 120-second deadline, with each

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -39,6 +39,12 @@ line rather than the unit state:
 | `tunnel is not connected after <n> attempts`            | Connect was requested and refused                            |
 | `connect never succeeded (daemon unreachable ...)`      | The daemon never answered                                    |
 
+The rows are mutually exclusive and reflect the state the run ended on, not
+anything observed along the way: a confirmed mismatch is reported ahead of the
+others, and the unverified line requires the last status query to have still
+read `Connected`. An earlier attempt that could not verify a tunnel therefore
+does not colour the final line once the run ends somewhere else.
+
 Use `warp-cli registration organization` and `warp-cli status` to confirm the
 managed tunnel is up. Without the sops secret the daemon and this unit do not
 exist; only `warp-cli` is installed.

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -1,0 +1,115 @@
+# WARP Operations
+
+Runtime verification, coexistence checks, and troubleshooting after
+`nixos-rebuild switch` on an enrolled host.
+
+## Verify the daemon and enrollment
+
+```bash
+systemctl status cloudflare-warp.service          # warp-svc running
+systemctl status cloudflare-warp-connect.service  # oneshot lifecycle (active/exited)
+ls -l /var/lib/cloudflare-warp/mdm.xml            # 0600 root:root, present
+warp-cli registration show                        # registration details
+warp-cli registration organization                # expected: <team>
+warp-cli status                                   # Connected
+```
+
+For an enrolled host, the `cloudflare-warp-connect` oneshot issues
+verifies `warp-cli registration organization` against the managed team before
+each connect request and polls `warp-cli status` on every attempt. A missing or
+mismatched registration prevents `warp-cli connect`; an already connected
+unmanaged tunnel is disconnected and logged at error priority. The loop makes up
+to 30 attempts bounded by a 120-second deadline, with each `warp-cli` call capped
+at five seconds. The retry window plus bounded registration/status checks remains
+inside the unit's explicit `TimeoutStartSec=180`. The oneshot is best-effort: it
+exits 0 and reaches `active (exited)` even when no request succeeds, logging
+`connect never succeeded`, or when requests succeed but the final status remains
+disconnected, logging `tunnel is not connected after <n> attempts`; use
+`warp-cli registration organization` and `warp-cli status` rather than the unit
+state to confirm the managed tunnel is up.
+Without the sops secret, it logs UN-ENROLLED at warning priority and exits without connecting.
+
+Confirm WARP is carrying traffic:
+
+```bash
+curl -s https://www.cloudflare.com/cdn-cgi/trace | grep -E '^warp='   # warp=on
+```
+
+## Zero Trust dashboard checks
+
+- The device appears under Team & Resources > Devices.
+- For system76, Gateway DNS/HTTP logs show this device's queries (confirms Full
+  mode + Gateway DNS).
+- For tpnix, HTTP/policy telemetry is expected while private-host lookups remain
+  served by the local NetworkManager dnsmasq configuration.
+
+## Coexistence checks
+
+- `tailscale status` is still reachable (confirms the `100.64.0.0/10`
+  split-tunnel exclude).
+- Internal / `.local` names resolve (confirms Local Domain Fallback).
+- On tpnix, SignalX private-host names resolve through NetworkManager dnsmasq;
+  this is expected because the host uses `tunnelonly`.
+
+## Reapplying managed config
+
+The `cloudflare-warp.service` carries a `restartTriggers` hash of the non-secret
+mdm fields (`serviceMode`, `autoConnect`, `switchLocked`). Changing any of them
+and rebuilding restarts `warp-svc`, which re-reads `mdm.xml`. The team name
+(`organization`) and the service token live in the sops secret; rotating either
+re-renders the `cloudflare-warp-mdm` template, whose `restartUnits` restarts
+`warp-svc` on the next activation.
+
+## Disable managed WARP
+
+Set `programs.cloudflare-warp.extended.enable = false` and rebuild the host. When
+the wrapper is disabled, its tmpfiles rule removes the wrapper-owned
+`/var/lib/cloudflare-warp/mdm.xml` during the next NixOS activation, clearing the
+runtime managed configuration and cached service token. This local cleanup does
+not delete the device registration from the Zero Trust tenant. If full
+de-enrollment is intended, run `sudo warp-cli registration delete` while the
+daemon is still enabled and remove the device from Team & Resources > Devices
+before disabling the module. Re-enabling the wrapper recreates `mdm.xml` from the
+encrypted sops secret before `warp-svc` starts and can enroll the device again.
+
+## Troubleshooting
+
+- **Enrollment fails / device shows then drops.** The service token likely lacks
+  device-enrollment permission. Add a Service Auth rule referencing the token
+  (Deployment, step 3). Collect a diagnostics bundle: `sudo warp-diag`.
+
+- **mdm.xml missing at boot (race).** `mdm.xml` is installed by an `ExecStartPre`
+  that copies the sops-rendered template. Ordering is wired into the module:
+  `cloudflare-warp.service` carries `after`/`requires` on the sops secret-install
+  dependency (`config.flake.lib.security.sopsInstallSecretsDeps`), so on
+  systemd-activation hosts the rendered template is present before `warp-svc`
+  starts. Activation-script hosts decrypt secrets before any unit ordering. The
+  connect oneshot waits for the daemon and makes up to 30 retry attempts within
+  a 120-second deadline. Registration, connect, and status calls each have a
+  five-second cap, and the oneshot has an explicit 180-second start timeout. The
+  final `warp-cli status` and managed-registration checks are logged; if no request
+  succeeds, managed registration is unavailable, or requests succeed while the
+  status remains disconnected, the `<3>` prefix makes `connect never succeeded`,
+  `managed enrollment is not ready`, or `tunnel is not connected after <n> attempts` visible to
+  `journalctl -u cloudflare-warp-connect -p err`. If an existing tunnel has no matching
+  managed registration, the unit logs `connected without managed Zero Trust registration; disconnecting`; a failed cleanup logs `failed to disconnect unmanaged tunnel`. An empty
+  or unreadable organization secret logs `managed organization secret unavailable; cannot verify registration`. The `<4>` UN-ENROLLED notice is visible to the
+  `journalctl -u cloudflare-warp-connect -p warning`. Inspect the daemon logs and rerun:
+
+  `systemctl restart cloudflare-warp-connect.service`
+
+  after enrollment is ready.
+
+- **No connectivity with strict rp_filter.** The shared `hosts-common`
+  `vpn-defaults` module sets `networking.firewall.checkReversePath = "loose"`
+  for hosts that opt into the common baseline. If a host firewall module forces
+  `strict`, the `CloudflareWARP` interface drops return traffic. The WARP module
+  does not add a second owner for this setting.
+
+- **DNS resolver conflict.** Full mode (`warp` / `1dot1`) makes WARP the DNS
+  resolver. Do not also enable `services.dnscrypt-proxy` or NetworkManager's
+  dnsmasq mode on `127.0.0.1:53`; the module warns when either local resolver
+  is selected. Tpnix avoids the conflict by using `tunnelonly`.
+
+- **General diagnostics.** `sudo warp-diag` writes a zip with logs and settings;
+  `sudo warp-diag feedback` is the same bundle framed for a support ticket.

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -82,8 +82,11 @@ re-reads `mdm.xml`. The unit carries no `restartTriggers` hash of its own: a
 second owner restarts `warp-svc` twice for one activation on hosts running
 `sops.useSystemdActivation`, dropping the tunnel twice.
 
-Each restart of `warp-svc` also re-runs `cloudflare-warp-connect` through
-`BindsTo=`/`Upholds=`, so the tunnel comes back without a manual step.
+Each restart of `warp-svc` also re-runs `cloudflare-warp-connect`, so the tunnel
+comes back without a manual step. An explicit restart, which is what sops issues
+when the rendered `mdm.xml` changes, reaches the oneshot through `BindsTo=`; an
+unexpected `warp-svc` exit reaches it through `Upholds=`, because `BindsTo=`
+stops the oneshot before the restart can propagate to it.
 
 ## Disable managed WARP
 

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -26,7 +26,8 @@ the loop stops, since nothing is left to request. An empty or unreadable
 organization secret cannot change while the unit runs, so the oneshot reports the
 current status once and exits instead of retrying a decision that can never open.
 The loop makes up to 30 attempts bounded by a 120-second deadline, with each
-`warp-cli` call capped at five seconds. The retry window plus bounded registration/status checks remains
+`warp-cli` call capped at five seconds and killed one second later if it ignores
+the term signal, so no call can outlast its cap. The retry window plus bounded registration/status checks remains
 inside the unit's explicit `TimeoutStartSec=180`. The oneshot is best-effort: it
 exits 0 and reaches `active (exited)` in every outcome, so read the final log
 line rather than the unit state:
@@ -126,7 +127,8 @@ encrypted sops secret before `warp-svc` starts and can enroll the device again.
   starts. Activation-script hosts decrypt secrets before any unit ordering. The
   connect oneshot waits for the daemon and makes up to 30 retry attempts within
   a 120-second deadline. Registration, connect, and status calls each have a
-  five-second cap, and the oneshot has an explicit 180-second start timeout. The
+  five-second cap (`timeout -k 1s 5s`, so a call that ignores the term signal is
+  killed rather than left running), and the oneshot has an explicit 180-second start timeout. The
   final `warp-cli status` and managed-registration checks are logged; if no request
   succeeds, managed registration is unavailable, or requests succeed while the
   status remains disconnected, the `<3>` prefix makes `connect never succeeded`
@@ -134,7 +136,8 @@ encrypted sops secret before `warp-svc` starts and can enroll the device again.
   `journalctl -u cloudflare-warp-connect -p err`. Each attempt that has not yet confirmed the
   managed registration instead logs `registration check failed (exit <n>)`,
   `managed Zero Trust registration unavailable`, or `managed enrollment is not ready; not connecting`
-  at `<4>`: the daemon IPC socket and the managed registration settle at different times, so a
+  at `<4>`, as do `status command failed` and `connect request failed`, which carry the daemon's
+  own reason for refusing a call: the daemon IPC socket and the managed registration settle at different times, so a
   healthy boot emits several of these before the run ends confirmed and connected. `-p err`
   therefore stays quiet through a normal warm-up, and `-p warning` shows the attempts.
   If an existing tunnel is confirmed to carry a

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -128,9 +128,15 @@ encrypted sops secret before `warp-svc` starts and can enroll the device again.
   five-second cap, and the oneshot has an explicit 180-second start timeout. The
   final `warp-cli status` and managed-registration checks are logged; if no request
   succeeds, managed registration is unavailable, or requests succeed while the
-  status remains disconnected, the `<3>` prefix makes `connect never succeeded`,
-  `managed enrollment is not ready`, or `tunnel is not connected after <n> attempts` visible to
-  `journalctl -u cloudflare-warp-connect -p err`. If an existing tunnel is confirmed to carry a
+  status remains disconnected, the `<3>` prefix makes `connect never succeeded`
+  or `tunnel is not connected after <n> attempts` visible to
+  `journalctl -u cloudflare-warp-connect -p err`. Each attempt that has not yet confirmed the
+  managed registration instead logs `registration check failed (exit <n>)`,
+  `managed Zero Trust registration unavailable`, or `managed enrollment is not ready; not connecting`
+  at `<4>`: the daemon IPC socket and the managed registration settle at different times, so a
+  healthy boot emits several of these before the run ends confirmed and connected. `-p err`
+  therefore stays quiet through a normal warm-up, and `-p warning` shows the attempts.
+  If an existing tunnel is confirmed to carry a
   registration other than the managed one, the unit logs `connected without managed Zero Trust registration; disconnecting`; a failed cleanup logs `failed to disconnect unmanaged tunnel`. When the
   registration check itself does not answer, the tunnel is left up and the unit
   logs `connected while the managed registration could not be verified; leaving the tunnel up` at warning priority. An empty

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -20,19 +20,28 @@ connect request and polls `warp-cli status` on every attempt. Only a confirmed
 match permits `warp-cli connect`. A confirmed mismatch, which is what a consumer
 or still-unregistered device reports, disconnects an already connected tunnel and
 logs at error priority. A registration check that does not answer within its
-five-second cap leaves an existing tunnel up and retries, because an unanswered
-check is not evidence of an unmanaged tunnel. An empty or unreadable
+five-second cap leaves an existing tunnel up, because an unanswered check is not
+evidence of an unmanaged tunnel; after three such observations on a live tunnel
+the loop stops, since nothing is left to request. An empty or unreadable
 organization secret cannot change while the unit runs, so the oneshot reports the
 current status once and exits instead of retrying a decision that can never open.
 The loop makes up to 30 attempts bounded by a 120-second deadline, with each
 `warp-cli` call capped at five seconds. The retry window plus bounded registration/status checks remains
 inside the unit's explicit `TimeoutStartSec=180`. The oneshot is best-effort: it
-exits 0 and reaches `active (exited)` even when no request succeeds, logging
-`connect never succeeded`, or when requests succeed but the final status remains
-disconnected, logging `tunnel is not connected after <n> attempts`; use
-`warp-cli registration organization` and `warp-cli status` rather than the unit
-state to confirm the managed tunnel is up.
-Without the sops secret, it logs UN-ENROLLED at warning priority and exits without connecting.
+exits 0 and reaches `active (exited)` in every outcome, so read the final log
+line rather than the unit state:
+
+| Final line                                              | Meaning                                                      |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| (none)                                                  | Managed tunnel verified and up                               |
+| `tunnel is up but its registration went unverified`     | Tunnel left connected; the registration check never answered |
+| `daemon is registered outside the managed organization` | Live registration belongs to another tenant                  |
+| `tunnel is not connected after <n> attempts`            | Connect was requested and refused                            |
+| `connect never succeeded (daemon unreachable ...)`      | The daemon never answered                                    |
+
+Use `warp-cli registration organization` and `warp-cli status` to confirm the
+managed tunnel is up. Without the sops secret the daemon and this unit do not
+exist; only `warp-cli` is installed.
 
 Confirm WARP is carrying traffic:
 
@@ -58,12 +67,16 @@ curl -s https://www.cloudflare.com/cdn-cgi/trace | grep -E '^warp='   # warp=on
 
 ## Reapplying managed config
 
-The `cloudflare-warp.service` carries a `restartTriggers` hash of the non-secret
-mdm fields (`serviceMode`, `autoConnect`, `switchLocked`). Changing any of them
-and rebuilding restarts `warp-svc`, which re-reads `mdm.xml`. The team name
-(`organization`) and the service token live in the sops secret; rotating either
-re-renders the `cloudflare-warp-mdm` template, whose `restartUnits` restarts
-`warp-svc` on the next activation.
+The `cloudflare-warp-mdm` template's `restartUnits` is the single restart owner
+for `warp-svc`. sops compares the rendered template between generations, so both
+a changed mdm field (`serviceMode`, `autoConnect`, `switchLocked`) and a rotated
+team name or service token restart the daemon on the next activation, which
+re-reads `mdm.xml`. The unit carries no `restartTriggers` hash of its own: a
+second owner restarts `warp-svc` twice for one activation on hosts running
+`sops.useSystemdActivation`, dropping the tunnel twice.
+
+Each restart of `warp-svc` also re-runs `cloudflare-warp-connect` through
+`BindsTo=`/`Upholds=`, so the tunnel comes back without a manual step.
 
 ## Disable managed WARP
 
@@ -100,7 +113,7 @@ encrypted sops secret before `warp-svc` starts and can enroll the device again.
   registration other than the managed one, the unit logs `connected without managed Zero Trust registration; disconnecting`; a failed cleanup logs `failed to disconnect unmanaged tunnel`. When the
   registration check itself does not answer, the tunnel is left up and the unit
   logs `connected while the managed registration could not be verified; leaving the tunnel up` at warning priority. An empty
-  or unreadable organization secret logs `managed organization secret unavailable; cannot verify registration`, then `managed organization secret unavailable; not connecting` before the unit exits without entering the retry loop. The `<4>` UN-ENROLLED notice is visible to the
+  or unreadable organization secret logs `managed organization secret unavailable; cannot verify registration`, then `managed organization secret unavailable; not connecting` before the unit exits without entering the retry loop. Those `<4>` notices are visible to
   `journalctl -u cloudflare-warp-connect -p warning`. Inspect the daemon logs and rerun:
 
   `systemctl restart cloudflare-warp-connect.service`

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -22,10 +22,12 @@ or still-unregistered device reports, disconnects an already connected tunnel an
 logs at error priority. A registration check that does not answer within its
 five-second cap leaves an existing tunnel up, because an unanswered check is not
 evidence of an unmanaged tunnel; after three such observations on a live tunnel
-the loop stops, since nothing is left to request. An unanswered check does not
-count against a run that already read the managed organization, because that
-value cannot change mid-run and the read is what allowed connect in the first
-place. An empty or unreadable
+the loop stops, since nothing is left to request. Neither an unanswered check nor an
+answer naming no organization counts against a run that already read the managed
+organization: that value cannot change mid-run, so both are missing information
+rather than evidence of a re-registration, and the read is what allowed connect
+in the first place. An answer naming a different team is still a mismatch and
+still disconnects. An empty or unreadable
 organization secret cannot change while the unit runs, so the oneshot reports the
 current status once and exits instead of retrying a decision that can never open.
 The loop makes up to 30 attempts bounded by a 120-second deadline, with each

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -114,7 +114,11 @@ encrypted sops secret before `warp-svc` starts and can enroll the device again.
   registration check itself does not answer, the tunnel is left up and the unit
   logs `connected while the managed registration could not be verified; leaving the tunnel up` at warning priority. An empty
   or unreadable organization secret logs `managed organization secret unavailable; cannot verify registration`, then `managed organization secret unavailable; not connecting` before the unit exits without entering the retry loop. Those `<4>` notices are visible to
-  `journalctl -u cloudflare-warp-connect -p warning`. Inspect the daemon logs and rerun:
+  `journalctl -u cloudflare-warp-connect -p warning`. A registration query that does
+  not answer logs `registration check failed (exit <n>)`; exit 124 is the five-second
+  `timeout` firing on a busy `warp-svc`, and any other code is warp-cli's own, whose
+  stderr is left unredirected and lands in the journal beside it at info priority.
+  Inspect the daemon logs and rerun:
 
   `systemctl restart cloudflare-warp-connect.service`
 

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -96,6 +96,17 @@ encrypted sops secret before `warp-svc` starts and can enroll the device again.
   device-enrollment permission. Add a Service Auth rule referencing the token
   (Deployment, step 3). Collect a diagnostics bundle: `sudo warp-diag`.
 
+- **`warp-svc` refuses to start after a credential rotation.** The first
+  `ExecStartPre` runs `xmllint --noout` over the rendered template, and
+  `cloudflare-warp.service` fails with
+  `cloudflare-warp: rendered mdm.xml is not well-formed; a credential likely contains an XML metacharacter`.
+  One of `organization`, `auth_client_id`, or `auth_client_secret` contains a
+  bare `&`, `<`, or an unterminated entity. xmllint's own diagnostic is
+  discarded rather than logged, because it reports a parse error by echoing the
+  offending source line, which is the credential itself. Re-issue the service
+  token, or `sops secrets/cloudflare-warp.yaml` and check the three values, then
+  rebuild. Compare against the decrypted payload rather than the journal.
+
 - **mdm.xml missing at boot (race).** `mdm.xml` is installed by an `ExecStartPre`
   that copies the sops-rendered template. Ordering is wired into the module:
   `cloudflare-warp.service` carries `after`/`requires` on the sops secret-install

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -39,7 +39,7 @@ line rather than the unit state:
 | `daemon reports no Zero Trust registration`               | No Teams registration; enrollment incomplete or rejected                            |
 | `daemon is registered outside the managed organization`   | Live registration belongs to another tenant                                         |
 | `tunnel is not connected after <n> attempts`              | Connect was requested and refused                                                   |
-| `connect never succeeded (daemon unreachable ...)`        | The daemon never answered                                                           |
+| `connect never succeeded (daemon unreachable ...)`        | Registration never confirmed, so connect was never requested                        |
 | `managed organization secret unavailable; not connecting` | Secret missing, unreadable, or whitespace-only; the run exits before the retry loop |
 
 The rows are mutually exclusive and reflect the state the run ended on, not

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -14,13 +14,18 @@ warp-cli registration organization                # expected: <team>
 warp-cli status                                   # Connected
 ```
 
-For an enrolled host, the `cloudflare-warp-connect` oneshot issues
-verifies `warp-cli registration organization` against the managed team before
-each connect request and polls `warp-cli status` on every attempt. A missing or
-mismatched registration prevents `warp-cli connect`; an already connected
-unmanaged tunnel is disconnected and logged at error priority. The loop makes up
-to 30 attempts bounded by a 120-second deadline, with each `warp-cli` call capped
-at five seconds. The retry window plus bounded registration/status checks remains
+For an enrolled host, the `cloudflare-warp-connect` oneshot verifies
+`warp-cli registration organization` against the managed team before each
+connect request and polls `warp-cli status` on every attempt. Only a confirmed
+match permits `warp-cli connect`. A confirmed mismatch, which is what a consumer
+or still-unregistered device reports, disconnects an already connected tunnel and
+logs at error priority. A registration check that does not answer within its
+five-second cap leaves an existing tunnel up and retries, because an unanswered
+check is not evidence of an unmanaged tunnel. An empty or unreadable
+organization secret cannot change while the unit runs, so the oneshot reports the
+current status once and exits instead of retrying a decision that can never open.
+The loop makes up to 30 attempts bounded by a 120-second deadline, with each
+`warp-cli` call capped at five seconds. The retry window plus bounded registration/status checks remains
 inside the unit's explicit `TimeoutStartSec=180`. The oneshot is best-effort: it
 exits 0 and reaches `active (exited)` even when no request succeeds, logging
 `connect never succeeded`, or when requests succeed but the final status remains
@@ -91,9 +96,11 @@ encrypted sops secret before `warp-svc` starts and can enroll the device again.
   succeeds, managed registration is unavailable, or requests succeed while the
   status remains disconnected, the `<3>` prefix makes `connect never succeeded`,
   `managed enrollment is not ready`, or `tunnel is not connected after <n> attempts` visible to
-  `journalctl -u cloudflare-warp-connect -p err`. If an existing tunnel has no matching
-  managed registration, the unit logs `connected without managed Zero Trust registration; disconnecting`; a failed cleanup logs `failed to disconnect unmanaged tunnel`. An empty
-  or unreadable organization secret logs `managed organization secret unavailable; cannot verify registration`. The `<4>` UN-ENROLLED notice is visible to the
+  `journalctl -u cloudflare-warp-connect -p err`. If an existing tunnel is confirmed to carry a
+  registration other than the managed one, the unit logs `connected without managed Zero Trust registration; disconnecting`; a failed cleanup logs `failed to disconnect unmanaged tunnel`. When the
+  registration check itself does not answer, the tunnel is left up and the unit
+  logs `connected while the managed registration could not be verified; leaving the tunnel up` at warning priority. An empty
+  or unreadable organization secret logs `managed organization secret unavailable; cannot verify registration`, then `managed organization secret unavailable; not connecting` before the unit exits without entering the retry loop. The `<4>` UN-ENROLLED notice is visible to the
   `journalctl -u cloudflare-warp-connect -p warning`. Inspect the daemon logs and rerun:
 
   `systemctl restart cloudflare-warp-connect.service`

--- a/docs/cloudflare/warp/operations.md
+++ b/docs/cloudflare/warp/operations.md
@@ -35,6 +35,7 @@ line rather than the unit state:
 | ------------------------------------------------------- | ------------------------------------------------------------ |
 | (none)                                                  | Managed tunnel verified and up                               |
 | `tunnel is up but its registration went unverified`     | Tunnel left connected; the registration check never answered |
+| `daemon reports no Zero Trust registration`             | No Teams registration; enrollment incomplete or rejected     |
 | `daemon is registered outside the managed organization` | Live registration belongs to another tenant                  |
 | `tunnel is not connected after <n> attempts`            | Connect was requested and refused                            |
 | `connect never succeeded (daemon unreachable ...)`      | The daemon never answered                                    |
@@ -130,8 +131,8 @@ encrypted sops secret before `warp-svc` starts and can enroll the device again.
   registration other than the managed one, the unit logs `connected without managed Zero Trust registration; disconnecting`; a failed cleanup logs `failed to disconnect unmanaged tunnel`. When the
   registration check itself does not answer, the tunnel is left up and the unit
   logs `connected while the managed registration could not be verified; leaving the tunnel up` at warning priority. An empty
-  or unreadable organization secret logs `managed organization secret unavailable; cannot verify registration`, then `managed organization secret unavailable; not connecting` before the unit exits without entering the retry loop. Those `<4>` notices are visible to
-  `journalctl -u cloudflare-warp-connect -p warning`. A registration query that does
+  or unreadable organization secret logs `managed organization secret unavailable; cannot verify registration`, queries the daemon once so the tunnel's state is on record, then logs `managed organization secret unavailable; not connecting` before the unit exits without entering the retry loop. Both of those are `<3>` lines, visible to
+  `journalctl -u cloudflare-warp-connect -p err`. A registration query that does
   not answer logs `registration check failed (exit <n>)`; exit 124 is the five-second
   `timeout` firing on a busy `warp-svc`, and any other code is warp-cli's own, whose
   stderr is left unredirected and lands in the journal beside it at info priority.

--- a/docs/cloudflare/warp/reference.md
+++ b/docs/cloudflare/warp/reference.md
@@ -1,0 +1,83 @@
+# WARP Module Reference
+
+## Module options (`programs.cloudflare-warp.extended`)
+
+| Option          | Type       | Default                                              | Description                                                                                                                                                         |
+| --------------- | ---------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enable`        | bool       | `false`                                              | Run `warp-svc` and enroll into Zero Trust.                                                                                                                          |
+| `package`       | package    | `pkgs.cloudflare-warp.override { headless = true; }` | WARP package; headless ships `warp-cli`/`warp-svc`/`warp-dex`/`warp-diag`.                                                                                          |
+| `serviceMode`   | enum       | `"warp"`                                             | `mdm.xml` `service_mode`: `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly`.                                                                                    |
+| `autoConnect`   | int 0-1440 | `0`                                                  | `mdm.xml` `auto_connect` minutes before reconnect after a manual disconnect.                                                                                        |
+| `switchLocked`  | bool       | `false`                                              | `mdm.xml` `switch_locked`; when true the user cannot disconnect.                                                                                                    |
+| `connectOnBoot` | bool       | `true`                                               | Best-effort oneshot that verifies managed registration, then performs up to 30 connect/status attempts within a 120-second deadline and a 180-second start timeout. |
+| `openFirewall`  | bool       | `true`                                               | Open the WARP UDP port.                                                                                                                                             |
+| `udpPort`       | port       | `2408`                                               | WARP UDP port to open.                                                                                                                                              |
+
+## mdm.xml parameters
+
+Linux reads the managed deployment file at `/var/lib/cloudflare-warp/mdm.xml`.
+The file is a bare `<dict>` plist fragment: no `<?xml ...?>` declaration, no
+DOCTYPE, and no `<plist>` wrapper. The module emits these keys:
+
+| Key                  | Type    | Values / format                                       | Source         |
+| -------------------- | ------- | ----------------------------------------------------- | -------------- |
+| `organization`       | string  | Zero Trust team name                                  | sops secret    |
+| `auth_client_id`     | string  | Service-token Client ID (`...access`)                 | sops secret    |
+| `auth_client_secret` | string  | Service-token Client Secret                           | sops secret    |
+| `service_mode`       | string  | `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly` | `serviceMode`  |
+| `auto_connect`       | integer | `0`-`1440` (minutes)                                  | `autoConnect`  |
+| `switch_locked`      | boolean | `<true/>` / `<false/>`                                | `switchLocked` |
+
+Other Cloudflare-documented keys not emitted by this module (add to `mdmContent`
+in `modules/apps/cloudflare-warp.nix` if needed): `support_url`,
+`warp_tunnel_protocol` (`masque` or `wireguard`), `enable_post_quantum`,
+`gateway_unique_id`, `display_name`. `unique_client_id` is iOS/Android/ChromeOS
+only and is not valid on Linux.
+
+Rendered example (placeholders shown; real values are injected by sops):
+
+```xml
+<dict>
+  <key>organization</key>
+  <string>REDACTED</string>
+  <key>auth_client_id</key>
+  <string>REDACTED.access</string>
+  <key>auth_client_secret</key>
+  <string>REDACTED</string>
+  <key>service_mode</key>
+  <string>warp</string>
+  <key>auto_connect</key>
+  <integer>0</integer>
+  <key>switch_locked</key>
+  <false/>
+</dict>
+```
+
+## sops layout
+
+| Item                   | Value                                                                                                  |
+| ---------------------- | ------------------------------------------------------------------------------------------------------ |
+| Encrypted file         | `secrets/cloudflare-warp.yaml`                                                                         |
+| Keys                   | `organization`, `auth_client_id`, `auth_client_secret`                                                 |
+| Secret names           | `cloudflare-warp/organization`, `cloudflare-warp/auth_client_id`, `cloudflare-warp/auth_client_secret` |
+| Template               | `sops.templates."cloudflare-warp-mdm"` (mode 0600)                                                     |
+| Rendered template path | `config.sops.templates."cloudflare-warp-mdm".path` (under `/run/secrets`)                              |
+| Installed runtime file | `/var/lib/cloudflare-warp/mdm.xml` (0600 root, via ExecStartPre)                                       |
+| `.sops.yaml` rule      | Covered by the existing catch-all (no policy change needed)                                            |
+
+## Keeping the team name private
+
+`organization` is not a credential, but it identifies the Zero Trust tenant, and
+this repository is public, so the team name is sourced from sops rather than Nix
+code:
+
+- `organization` is a key in `secrets/cloudflare-warp.yaml`, declared as
+  `sops.secrets."cloudflare-warp/organization"`.
+- `mdmContent` renders it through
+  `<string>${config.sops.placeholder."cloudflare-warp/organization"}</string>`,
+  so the team name never enters the Nix store or git history.
+- There is no per-host `organization` option; a host enrolls by providing the
+  secret (and, where enablement is gated on `sopsRuntimeReady` such as tpnix, once
+  that flag is `true`). On an enabled host without the secret, `warp-svc` runs
+  un-enrolled, warns, and leaves the connect-on-boot unit disconnected; a host
+  still gated by `sopsRuntimeReady` stays off entirely.

--- a/docs/cloudflare/warp/reference.md
+++ b/docs/cloudflare/warp/reference.md
@@ -2,16 +2,16 @@
 
 ## Module options (`programs.cloudflare-warp.extended`)
 
-| Option          | Type       | Default                                              | Description                                                                                                                                                         |
-| --------------- | ---------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enable`        | bool       | `false`                                              | Install the client; `warp-svc` and Zero Trust enrollment activate only with `secrets/cloudflare-warp.yaml`.                                                         |
-| `package`       | package    | `pkgs.cloudflare-warp.override { headless = true; }` | WARP package; headless ships `warp-cli`/`warp-svc`/`warp-dex`/`warp-diag`.                                                                                          |
-| `serviceMode`   | enum       | `"warp"`                                             | `mdm.xml` `service_mode`: `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly`.                                                                                    |
-| `autoConnect`   | int 0-1440 | `0`                                                  | `mdm.xml` `auto_connect` minutes before reconnect after a manual disconnect.                                                                                        |
-| `switchLocked`  | bool       | `false`                                              | `mdm.xml` `switch_locked`; when true the user cannot disconnect.                                                                                                    |
-| `connectOnBoot` | bool       | `true`                                               | Best-effort oneshot that verifies managed registration, then performs up to 30 connect/status attempts within a 120-second deadline and a 180-second start timeout. |
-| `openFirewall`  | bool       | `true`                                               | Open the WARP UDP port.                                                                                                                                             |
-| `udpPort`       | port       | `2408`                                               | WARP UDP port to open.                                                                                                                                              |
+| Option          | Type       | Default                                              | Description                                                                                                                                                            |
+| --------------- | ---------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `enable`        | bool       | `false`                                              | Install the client; `warp-svc` and Zero Trust enrollment activate only with `secrets/cloudflare-warp.yaml`.                                                            |
+| `package`       | package    | `pkgs.cloudflare-warp.override { headless = true; }` | WARP package; headless ships `warp-cli`/`warp-svc`/`warp-dex`/`warp-diag`.                                                                                             |
+| `serviceMode`   | enum       | `"warp"`                                             | `mdm.xml` `service_mode`: `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly`.                                                                                       |
+| `autoConnect`   | int 0-1440 | `0`                                                  | `mdm.xml` `auto_connect` minutes before reconnect after a manual disconnect.                                                                                           |
+| `switchLocked`  | bool       | `false`                                              | `mdm.xml` `switch_locked`; when true the user cannot disconnect. Also blocks the connect oneshot's fail-closed teardown, so a confirmed mismatch can only be reported. |
+| `connectOnBoot` | bool       | `true`                                               | Best-effort oneshot that verifies managed registration, then performs up to 30 connect/status attempts within a 120-second deadline and a 180-second start timeout.    |
+| `openFirewall`  | bool       | `true`                                               | Open the WARP UDP port.                                                                                                                                                |
+| `udpPort`       | port       | `2408`                                               | WARP UDP port to open.                                                                                                                                                 |
 
 ## mdm.xml parameters
 

--- a/docs/cloudflare/warp/reference.md
+++ b/docs/cloudflare/warp/reference.md
@@ -4,7 +4,7 @@
 
 | Option          | Type       | Default                                              | Description                                                                                                                                                         |
 | --------------- | ---------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `enable`        | bool       | `false`                                              | Run `warp-svc` and enroll into Zero Trust.                                                                                                                          |
+| `enable`        | bool       | `false`                                              | Install the client; `warp-svc` and Zero Trust enrollment activate only with `secrets/cloudflare-warp.yaml`.                                                         |
 | `package`       | package    | `pkgs.cloudflare-warp.override { headless = true; }` | WARP package; headless ships `warp-cli`/`warp-svc`/`warp-dex`/`warp-diag`.                                                                                          |
 | `serviceMode`   | enum       | `"warp"`                                             | `mdm.xml` `service_mode`: `warp`, `tunnelonly`, `1dot1`, `proxy`, `postureonly`.                                                                                    |
 | `autoConnect`   | int 0-1440 | `0`                                                  | `mdm.xml` `auto_connect` minutes before reconnect after a manual disconnect.                                                                                        |
@@ -78,6 +78,6 @@ code:
   so the team name never enters the Nix store or git history.
 - There is no per-host `organization` option; a host enrolls by providing the
   secret (and, where enablement is gated on `sopsRuntimeReady` such as tpnix, once
-  that flag is `true`). On an enabled host without the secret, `warp-svc` runs
-  un-enrolled, warns, and leaves the connect-on-boot unit disconnected; a host
-  still gated by `sopsRuntimeReady` stays off entirely.
+  that flag is `true`). On an enabled host without the secret, the wrapper warns,
+  installs `warp-cli`, and declares neither `warp-svc` nor the connect-on-boot
+  unit; a host still gated by `sopsRuntimeReady` stays off entirely.

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,18 @@
   - Sample NixOS configuration for ACME certificate management using Cloudflare DNS-01 challenge.
 - [cloudflare/cloudflared-tunnel-sample.md](cloudflare/cloudflared-tunnel-sample.md)
   - Sample NixOS configuration for Cloudflare Tunnel (cloudflared) with ingress rules and credential setup.
+- [cloudflare/warp/README.md](cloudflare/warp/README.md)
+  - Index for declarative Cloudflare WARP and Zero Trust enrollment on NixOS.
+- [cloudflare/warp/deployment.md](cloudflare/warp/deployment.md)
+  - Operator runbook for WARP dashboard prerequisites, service-token secrets, host rollout, and validation.
+- [cloudflare/warp/reference.md](cloudflare/warp/reference.md)
+  - Reference for `programs.cloudflare-warp.extended` options, `mdm.xml` parameters, and sops layout.
+- [cloudflare/warp/modes.md](cloudflare/warp/modes.md)
+  - Compact comparison of WARP modes, DNS ownership tradeoffs, and split-tunnel behavior.
+- [cloudflare/warp/operations.md](cloudflare/warp/operations.md)
+  - Runtime verification, coexistence checks, and troubleshooting for enrolled WARP hosts.
+- [cloudflare/warp/cheatsheet.md](cloudflare/warp/cheatsheet.md)
+  - Command reference for `warp-cli`, `warp-diag`, and WARP-related systemd services.
 - [cloudflare/containers/README.md](cloudflare/containers/README.md)
   - Technical documentation index for Cloudflare Containers.
 - [cloudflare/containers/architecture.md](cloudflare/containers/architecture.md)

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -188,16 +188,26 @@ let
           sleep 1
         done
         # Best-effort: name the state that ended the run and exit 0 so a user who
-        # legitimately keeps WARP off does not leave the unit failed.
+        # legitimately keeps WARP off does not leave the unit failed. unverified
+        # is cumulative and never reset, so it cannot gate this report: one early
+        # unanswered check on a leftover tunnel would outrank whatever the run
+        # actually ended on. Branch on the live registration_state and status.
         if [ -z "$connected" ]; then
-          if [ "$unverified" -gt 0 ]; then
-            echo "<4>cloudflare-warp-connect: tunnel is up but its registration went unverified in $attempt attempts; left it connected"
-          elif [ "$registration_state" = "mismatch" ]; then
+          if [ "$registration_state" = "mismatch" ]; then
             echo "<3>cloudflare-warp-connect: daemon is registered outside the managed organization after $attempt attempts"
-          elif [ -n "$connect_requested" ]; then
-            echo "<3>cloudflare-warp-connect: tunnel is not connected after $attempt attempts"
           else
-            echo "<3>cloudflare-warp-connect: connect never succeeded (daemon unreachable or registration incomplete)"
+            case "$status" in
+              *Connected*)
+                echo "<4>cloudflare-warp-connect: tunnel is up but its registration went unverified in $attempt attempts; left it connected"
+                ;;
+              *)
+                if [ -n "$connect_requested" ]; then
+                  echo "<3>cloudflare-warp-connect: tunnel is not connected after $attempt attempts"
+                else
+                  echo "<3>cloudflare-warp-connect: connect never succeeded (daemon unreachable or registration incomplete)"
+                fi
+                ;;
+            esac
           fi
         fi
       '';

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -119,7 +119,7 @@ let
           # name the failure in the journal next to the exit code.
           registration=""
           registration_status=0
-          registration="$(timeout 5s warp-cli --accept-tos registration organization)" ||
+          registration="$(timeout -k 1s 5s warp-cli --accept-tos registration organization)" ||
             registration_status=$?
           if [ "$registration_status" -ne 0 ]; then
             registration_state="unknown"
@@ -137,11 +137,14 @@ let
         }
 
         refresh_status() {
-          if status="$(timeout 5s warp-cli --accept-tos status 2>&1)"; then
+          if status="$(timeout -k 1s 5s warp-cli --accept-tos status 2>&1)"; then
             status="''${status:-status unavailable}"
           else
-            echo "cloudflare-warp-connect: status command failed: ''${status:-no response}"
-            status="''${status:-status unavailable}"
+            echo "<4>cloudflare-warp-connect: status command failed: ''${status:-no response}"
+            # The raw text is echoed above, so drop it rather than letting a
+            # failed query's error string reach the globs below as if it were a
+            # tunnel state.
+            status="status unavailable"
           fi
           echo "cloudflare-warp-connect: $status"
           case "$status" in
@@ -153,7 +156,7 @@ let
                   ;;
                 mismatch)
                   echo "<3>cloudflare-warp-connect: connected without managed Zero Trust registration; disconnecting"
-                  if disconnect_output="$(timeout 5s warp-cli --accept-tos disconnect 2>&1)"; then
+                  if disconnect_output="$(timeout -k 1s 5s warp-cli --accept-tos disconnect 2>&1)"; then
                     echo "cloudflare-warp-connect: disconnected unmanaged tunnel"
                   else
                     echo "<3>cloudflare-warp-connect: failed to disconnect unmanaged tunnel: ''${disconnect_output:-no response}"
@@ -192,11 +195,11 @@ let
             break
           fi
           if [ "$registration_state" = "confirmed" ]; then
-            if request_output="$(timeout 5s warp-cli --accept-tos connect 2>&1)"; then
+            if request_output="$(timeout -k 1s 5s warp-cli --accept-tos connect 2>&1)"; then
               connect_requested=1
               echo "cloudflare-warp-connect: connect requested"
             else
-              echo "cloudflare-warp-connect: connect request failed: ''${request_output:-no response}"
+              echo "<4>cloudflare-warp-connect: connect request failed: ''${request_output:-no response}"
             fi
           else
             echo "<4>cloudflare-warp-connect: managed enrollment is not ready; not connecting"

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -12,7 +12,7 @@
     * Renders /var/lib/cloudflare-warp/mdm.xml from sops-backed credentials, store-safe.
 
   Options:
-    enable: Run warp-svc; managed Zero Trust enrollment activates when secrets/cloudflare-warp.yaml exists.
+    enable: Install warp-cli; warp-svc runs only once secrets/cloudflare-warp.yaml supplies credentials.
     serviceMode: mdm.xml service_mode (warp | tunnelonly | 1dot1 | proxy | postureonly).
     autoConnect: mdm.xml auto_connect minutes (0-1440); 0 keeps the client off after a manual disconnect.
     switchLocked: mdm.xml switch_locked; when true the user cannot disconnect.
@@ -21,6 +21,8 @@
   Notes:
     * service_mode is authoritative via mdm.xml; the module never calls `warp-cli mode`.
     * Secrets (organization/auth_client_id/auth_client_secret) live in secrets/cloudflare-warp.yaml (sops).
+    * Without those credentials warp-svc would hold CAP_NET_ADMIN and an open UDP port while
+      serving only consumer WARP, so an un-enrolled host installs the CLI and no daemon.
     * Relies on the hosts-common vpn-defaults owner for networking.firewall.checkReversePath;
       the WARP interface trips strict rp_filter when that shared baseline is overridden.
     * Pairs with per-host enablement in modules/tpnix/cloudflare-warp.nix and modules/system76/cloudflare-warp.nix.
@@ -40,64 +42,15 @@ let
       cfg = config.programs.cloudflare-warp.extended;
       rootDir = config.services.cloudflare-warp.rootDir;
       secretsFile = secretsRoot + "/cloudflare-warp.yaml";
-      haveSecrets = builtins.pathExists secretsFile;
-      enrolling = haveSecrets;
+      enrolling = builtins.pathExists secretsFile;
+      # Managed enrollment is the only configuration that starts warp-svc.
+      managed = cfg.enable && enrolling;
       # Gate the sops-install-secrets.service dependency on
       # sops.useSystemdActivation: the unit only exists in that mode (issue #37);
       # activation-script hosts decrypt before any unit ordering, so this is [].
       installSecretsDeps = sopsInstallSecretsDeps config;
 
-      # Logged by the connect-on-boot oneshot when the device has no managed
-      # mdm.xml. The guard prevents an absent secret from selecting consumer WARP.
-      unenrolledGuard = lib.optionalString (!enrolling) ''
-        echo "<4>cloudflare-warp-connect: device is UN-ENROLLED (no managed mdm.xml); not connecting. Create secrets/cloudflare-warp.yaml to enroll."
-        exit 0
-      '';
-
-      managedRegistrationSetup = lib.optionalString enrolling ''
-        if managed_org="$(cat ${
-          config.sops.secrets."cloudflare-warp/organization".path
-        } 2>/dev/null)" && [ -n "$managed_org" ]; then
-          :
-        else
-          managed_org=""
-          echo "<3>cloudflare-warp-connect: managed organization secret unavailable; cannot verify registration"
-        fi
-
-        # registration_state is tri-state: confirmed (the daemon reported the
-        # managed team), mismatch (it reported another team or none, which is
-        # what an unmanaged/consumer registration returns), unknown (the check
-        # itself did not answer). Only a mismatch is evidence of an unmanaged
-        # tunnel; a timed-out or failed check must not tear a tunnel down.
-        refresh_registration() {
-          if [ -z "$managed_org" ]; then
-            registration_state="unknown"
-            return
-          fi
-          if registration="$(timeout 5s warp-cli --accept-tos registration organization 2>&1)"; then
-            if [ "$registration" = "$managed_org" ]; then
-              registration_state="confirmed"
-              echo "cloudflare-warp-connect: managed Zero Trust registration confirmed"
-            else
-              registration_state="mismatch"
-              echo "<3>cloudflare-warp-connect: managed Zero Trust registration unavailable"
-            fi
-          else
-            registration_state="unknown"
-            echo "<3>cloudflare-warp-connect: registration check failed: ''${registration:-no response}"
-          fi
-        }
-      '';
-
-      # managed_org is read once during setup, so an empty value keeps the
-      # connect gate shut for every attempt. Exit instead of polling a decision
-      # that cannot change before the deadline.
-      managedOrgGuard = lib.optionalString enrolling ''
-        if [ -z "$managed_org" ]; then
-          echo "<3>cloudflare-warp-connect: managed organization secret unavailable; not connecting"
-          exit 0
-        fi
-      '';
+      mdmTemplate = config.sops.templates."cloudflare-warp-mdm".path;
 
       # Linux mdm.xml is a bare <dict> plist fragment (no XML declaration, no
       # <plist> wrapper). Secret values are injected through sops placeholders so
@@ -118,13 +71,145 @@ let
           ${if cfg.switchLocked then "<true/>" else "<false/>"}
         </dict>
       '';
+
+      connectScript = ''
+        managed_org=""
+        registration_state="unknown"
+        connected=""
+        connect_requested=""
+        unverified=0
+        status=""
+        attempt=0
+        deadline=$((SECONDS + 120))
+
+        if managed_org="$(cat ${
+          config.sops.secrets."cloudflare-warp/organization".path
+        } 2>/dev/null)" && [ -n "$managed_org" ]; then
+          managed_org="''${managed_org//[[:space:]]/}"
+        else
+          managed_org=""
+          echo "<3>cloudflare-warp-connect: managed organization secret unavailable; cannot verify registration"
+        fi
+
+        # registration_state is tri-state: confirmed (the daemon reported the
+        # managed team), mismatch (it reported another team or none, which is
+        # what an unmanaged/consumer registration returns), unknown (the check
+        # itself did not answer). Only a mismatch is evidence of an unmanaged
+        # tunnel; a timed-out or failed check must not tear a tunnel down.
+        refresh_registration() {
+          if [ -z "$managed_org" ]; then
+            registration_state="unknown"
+            return
+          fi
+          # Read stdout alone: a banner or notice on stderr would fail the exact
+          # comparison below and report a correctly enrolled device as unmanaged.
+          registration=""
+          registration_status=0
+          registration="$(timeout 5s warp-cli --accept-tos registration organization 2>/dev/null)" ||
+            registration_status=$?
+          if [ "$registration_status" -ne 0 ]; then
+            registration_state="unknown"
+            echo "<3>cloudflare-warp-connect: registration check failed (exit $registration_status)"
+            return
+          fi
+          registration="''${registration//[[:space:]]/}"
+          if [ "$registration" = "$managed_org" ]; then
+            registration_state="confirmed"
+            echo "cloudflare-warp-connect: managed Zero Trust registration confirmed"
+          else
+            registration_state="mismatch"
+            echo "<3>cloudflare-warp-connect: managed Zero Trust registration unavailable"
+          fi
+        }
+
+        refresh_status() {
+          if status="$(timeout 5s warp-cli status 2>&1)"; then
+            status="''${status:-status unavailable}"
+          else
+            echo "cloudflare-warp-connect: status command failed: ''${status:-no response}"
+            status="''${status:-status unavailable}"
+          fi
+          echo "cloudflare-warp-connect: $status"
+          case "$status" in
+            *Disconnected* | *"status unavailable"*) ;;
+            *Connected*)
+              case "$registration_state" in
+                confirmed)
+                  connected=1
+                  ;;
+                mismatch)
+                  echo "<3>cloudflare-warp-connect: connected without managed Zero Trust registration; disconnecting"
+                  if disconnect_output="$(timeout 5s warp-cli disconnect 2>&1)"; then
+                    echo "cloudflare-warp-connect: disconnected unmanaged tunnel"
+                  else
+                    echo "<3>cloudflare-warp-connect: failed to disconnect unmanaged tunnel: ''${disconnect_output:-no response}"
+                  fi
+                  ;;
+                *)
+                  echo "<4>cloudflare-warp-connect: connected while the managed registration could not be verified; leaving the tunnel up"
+                  unverified=$((unverified + 1))
+                  ;;
+              esac
+              ;;
+          esac
+        }
+
+        # managed_org is read once above, so an empty value keeps the connect gate
+        # shut for every attempt. Exit instead of polling a decision that cannot
+        # change before the deadline.
+        if [ -z "$managed_org" ]; then
+          echo "<3>cloudflare-warp-connect: managed organization secret unavailable; not connecting"
+          exit 0
+        fi
+
+        # The daemon IPC socket and mdm.xml registration can settle at different
+        # times, so poll both during the bounded readiness window. Two terminal
+        # states end the run: a verified managed tunnel, and a live tunnel whose
+        # registration went unanswered three times, where nothing is left to
+        # request and the tunnel stays up.
+        while [ -z "$connected" ] && [ "$unverified" -lt 3 ] && [ "$attempt" -lt 30 ] && [ "$SECONDS" -lt "$deadline" ]; do
+          attempt=$((attempt + 1))
+          refresh_registration
+          refresh_status
+          if [ -n "$connected" ] || [ "$unverified" -ge 3 ]; then
+            break
+          fi
+          if [ "$registration_state" = "confirmed" ]; then
+            if request_output="$(timeout 5s warp-cli --accept-tos connect 2>&1)"; then
+              connect_requested=1
+              echo "cloudflare-warp-connect: connect requested"
+            else
+              echo "cloudflare-warp-connect: connect request failed: ''${request_output:-no response}"
+            fi
+          else
+            echo "<3>cloudflare-warp-connect: managed enrollment is not ready; not connecting"
+          fi
+          sleep 1
+        done
+        # Best-effort: name the state that ended the run and exit 0 so a user who
+        # legitimately keeps WARP off does not leave the unit failed.
+        if [ -z "$connected" ]; then
+          if [ "$unverified" -gt 0 ]; then
+            echo "<4>cloudflare-warp-connect: tunnel is up but its registration went unverified in $attempt attempts; left it connected"
+          elif [ "$registration_state" = "mismatch" ]; then
+            echo "<3>cloudflare-warp-connect: daemon is registered outside the managed organization after $attempt attempts"
+          elif [ -n "$connect_requested" ]; then
+            echo "<3>cloudflare-warp-connect: tunnel is not connected after $attempt attempts"
+          else
+            echo "<3>cloudflare-warp-connect: connect never succeeded (daemon unreachable or registration incomplete)"
+          fi
+        fi
+      '';
     in
     {
       options.programs.cloudflare-warp.extended = {
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Whether to run warp-svc and enroll into Cloudflare Zero Trust.";
+          description = ''
+            Whether to install the WARP client. warp-svc and Zero Trust
+            enrollment activate only when secrets/cloudflare-warp.yaml exists.
+          '';
         };
 
         package = lib.mkOption {
@@ -187,12 +272,29 @@ let
       };
 
       config = lib.mkMerge [
-        # Remove the wrapper-owned managed file when the wrapper is disabled.
+        # Remove the wrapper-owned managed file whenever this host is not running
+        # managed WARP. mdm.xml is authoritative for service_mode and caches the
+        # service token, so a stale file would keep warp-svc in managed mode.
         # Leave an independently configured upstream service's state untouched.
-        (lib.mkIf (!cfg.enable && !config.services.cloudflare-warp.enable) {
+        (lib.mkIf (!managed && !config.services.cloudflare-warp.enable) {
           systemd.tmpfiles.rules = [ "r ${rootDir}/mdm.xml" ];
         })
-        (lib.mkIf cfg.enable (
+
+        # No managed credentials: ship the CLI (warp-cli, warp-diag) without the
+        # privileged daemon.
+        (lib.mkIf (cfg.enable && !enrolling) {
+          environment.systemPackages = [ cfg.package ];
+
+          warnings = [
+            ''
+              programs.cloudflare-warp.extended: secrets/cloudflare-warp.yaml is missing, so warp-svc
+              is NOT started and only warp-cli is installed. Create the sops secret (see
+              docs/cloudflare/warp/deployment.md) and rebuild to enroll.
+            ''
+          ];
+        })
+
+        (lib.mkIf managed (
           lib.mkMerge [
             {
               services.cloudflare-warp = {
@@ -214,11 +316,6 @@ let
                     but a local resolver is bound to 127.0.0.1:53 (dnscrypt-proxy or NetworkManager
                     dnsmasq). Use serviceMode "tunnelonly"/"proxy" or disable the local resolver.
                   ''
-                ++ lib.optional (!haveSecrets) ''
-                  programs.cloudflare-warp.extended: secrets/cloudflare-warp.yaml is missing; running warp-svc
-                  WITHOUT managed enrollment (degraded). Create the sops secret (see
-                  docs/cloudflare/warp/deployment.md) and rebuild.
-                ''
                 ++
                   lib.optional
                     (
@@ -235,20 +332,7 @@ let
                       the hosts-common vpn-defaults baseline (shareCommon = true) or set
                       networking.firewall.checkReversePath = "loose" on this host.
                     '';
-            }
 
-            # When not enrolling (the sops secret is absent),
-            # remove any mdm.xml left by a previous enrollment. mdm.xml is
-            # authoritative for service_mode and caches the service token, so a stale
-            # file would keep warp-svc in managed mode instead of degrading to the
-            # un-enrolled daemon. rootDir is the upstream StateDirectory.
-            (lib.mkIf (!enrolling) {
-              systemd.services.cloudflare-warp.serviceConfig.ExecStartPre = [
-                "${pkgs.coreutils}/bin/rm -f ${rootDir}/mdm.xml"
-              ];
-            })
-
-            (lib.mkIf enrolling {
               sops = {
                 secrets = {
                   "cloudflare-warp/organization" = {
@@ -270,11 +354,12 @@ let
                 templates."cloudflare-warp-mdm" = {
                   content = mdmContent;
                   mode = "0600";
-                  # restartTriggers below only hash non-secret fields. Rotating
-                  # auth_client_id/auth_client_secret re-renders this template but
-                  # would not restart warp-svc, so the daemon would keep the old
-                  # token until reboot. Restart on rotation (matches the repo
-                  # pattern in usbguard.nix and duplicati-r2.nix).
+                  # Sole restart owner for this unit: sops compares the rendered
+                  # template between generations, so both a rotated service token
+                  # and a changed service_mode/auto_connect/switch_locked land
+                  # here. A second restartTriggers hash on the unit would restart
+                  # warp-svc twice for one activation under
+                  # sops.useSystemdActivation.
                   restartUnits = [ "cloudflare-warp.service" ];
                 };
               };
@@ -289,30 +374,31 @@ let
                 after = installSecretsDeps;
                 requires = installSecretsDeps;
                 serviceConfig.ExecStartPre = [
-                  "${pkgs.coreutils}/bin/install -D -m0600 -o root -g root ${
-                    config.sops.templates."cloudflare-warp-mdm".path
-                  } ${rootDir}/mdm.xml"
-                ];
-                # Re-apply managed config when any non-secret mdm field changes.
-                restartTriggers = [
-                  (builtins.toJSON {
-                    inherit (cfg)
-                      serviceMode
-                      autoConnect
-                      switchLocked
-                      ;
-                  })
+                  # Credentials are substituted after evaluation, so no Nix-side
+                  # quoting can escape them. An XML metacharacter in one would
+                  # otherwise leave warp-svc reading a truncated mdm.xml and
+                  # falling back to unmanaged mode; refuse to start instead.
+                  "${pkgs.libxml2.bin}/bin/xmllint --noout ${mdmTemplate}"
+                  "${pkgs.coreutils}/bin/install -D -m0600 -o root -g root ${mdmTemplate} ${rootDir}/mdm.xml"
                 ];
               };
-            })
+            }
 
             (lib.mkIf cfg.connectOnBoot {
+              # Upholds restarts the oneshot whenever warp-svc is active and the
+              # oneshot is not. Restart=always respawns warp-svc without an
+              # explicit restart job, which BindsTo alone would only propagate as
+              # a stop, leaving the host untunneled until the next rebuild.
+              systemd.services.cloudflare-warp.upholds = [ "cloudflare-warp-connect.service" ];
+
               systemd.services.cloudflare-warp-connect = {
                 description = "Cloudflare WARP connect on boot";
                 after = [ "cloudflare-warp.service" ];
-                requires = [ "cloudflare-warp.service" ];
-                partOf = [ "cloudflare-warp.service" ];
+                bindsTo = [ "cloudflare-warp.service" ];
                 wantedBy = [ "multi-user.target" ];
+                # This script fails closed around a registration check, so hold it
+                # to shellcheck plus errexit/nounset/pipefail.
+                enableStrictShellChecks = true;
                 path = [
                   pkgs.coreutils
                   cfg.package
@@ -324,82 +410,7 @@ let
                   # unit timeout covers the status queries and shell overhead.
                   TimeoutStartSec = 180;
                 };
-                script = ''
-                  ${unenrolledGuard}
-                  managed_org=""
-                  registration_state="unknown"
-                  ${managedRegistrationSetup}
-                  # The daemon IPC socket and mdm.xml registration can settle at
-                  # different times, so poll both during the bounded readiness window.
-                  connected=""
-                  connect_requested=""
-                  status=""
-                  attempt=0
-                  deadline=$((SECONDS + 120))
-
-                  refresh_status() {
-                    if status="$(timeout 5s warp-cli status 2>&1)"; then
-                      status="''${status:-status unavailable}"
-                    else
-                      echo "cloudflare-warp-connect: status command failed: ''${status:-no response}"
-                      status="''${status:-status unavailable}"
-                    fi
-                    echo "cloudflare-warp-connect: $status"
-                    case "$status" in
-                      *Disconnected* | *"status unavailable"*) ;;
-                      *Connected*)
-                        case "$registration_state" in
-                          confirmed)
-                            connected=1
-                            ;;
-                          mismatch)
-                            echo "<3>cloudflare-warp-connect: connected without managed Zero Trust registration; disconnecting"
-                            if disconnect_output="$(timeout 5s warp-cli disconnect 2>&1)"; then
-                              echo "cloudflare-warp-connect: disconnected unmanaged tunnel"
-                            else
-                              echo "<3>cloudflare-warp-connect: failed to disconnect unmanaged tunnel: ''${disconnect_output:-no response}"
-                            fi
-                            ;;
-                          *)
-                            echo "<4>cloudflare-warp-connect: connected while the managed registration could not be verified; leaving the tunnel up"
-                            ;;
-                        esac
-                        ;;
-                    esac
-                  }
-
-                  ${lib.optionalString enrolling "refresh_registration"}
-                  refresh_status
-                  ${managedOrgGuard}
-
-                  while [ -z "$connected" ] && [ "$attempt" -lt 30 ] && [ "$SECONDS" -lt "$deadline" ]; do
-                    attempt=$((attempt + 1))
-                    ${lib.optionalString enrolling "refresh_registration"}
-                    if [ "$registration_state" = "confirmed" ]; then
-                      if request_output="$(timeout 5s warp-cli --accept-tos connect 2>&1)"; then
-                        connect_requested=1
-                        echo "cloudflare-warp-connect: connect requested"
-                      else
-                        echo "cloudflare-warp-connect: connect request failed: ''${request_output:-no response}"
-                      fi
-                    else
-                      echo "<3>cloudflare-warp-connect: managed enrollment is not ready; not connecting"
-                    fi
-                    refresh_status
-                    if [ -z "$connected" ]; then
-                      sleep 1
-                    fi
-                  done
-                  # Best-effort: log the outcome and exit 0 so a user who legitimately
-                  # keeps WARP off does not leave the unit failed.
-                  if [ -z "$connected" ]; then
-                    if [ -z "$connect_requested" ]; then
-                      echo "<3>cloudflare-warp-connect: connect never succeeded (daemon unreachable or registration incomplete)"
-                    else
-                      echo "<3>cloudflare-warp-connect: tunnel is not connected after $attempt attempts"
-                    fi
-                  fi
-                '';
+                script = connectScript;
               };
             })
           ]

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -82,12 +82,14 @@ let
         attempt=0
         deadline=$((SECONDS + 120))
 
-        if managed_org="$(cat ${
-          config.sops.secrets."cloudflare-warp/organization".path
-        } 2>/dev/null)" && [ -n "$managed_org" ]; then
+        # Strip before testing. A secret holding only spaces survives a raw -n
+        # test and then strips to empty, which would skip this diagnostic and
+        # leave the journal blaming the connect gate instead of the secret.
+        # The assignment binds even when cat fails, so this is nounset-safe.
+        if managed_org="$(cat ${config.sops.secrets."cloudflare-warp/organization".path} 2>/dev/null)"; then
           managed_org="''${managed_org//[[:space:]]/}"
-        else
-          managed_org=""
+        fi
+        if [ -z "$managed_org" ]; then
           echo "<3>cloudflare-warp-connect: managed organization secret unavailable; cannot verify registration"
         fi
 
@@ -418,10 +420,14 @@ let
             }
 
             (lib.mkIf cfg.connectOnBoot {
-              # Upholds restarts the oneshot whenever warp-svc is active and the
-              # oneshot is not. Restart=always respawns warp-svc without an
-              # explicit restart job, which BindsTo alone would only propagate as
-              # a stop, leaving the host untunneled until the next rebuild.
+              # Two triggers, two mechanisms. An explicit restart, which is what
+              # sops issues for restartUnits (try-restart), reaches the oneshot
+              # through BindsTo alone. An unexpected warp-svc exit does not:
+              # BindsTo stops the oneshot the instant warp-svc goes inactive,
+              # ahead of the restart-dependency propagation for that same event,
+              # so the propagated job lands on an already-stopped unit. Upholds
+              # is what starts it again, and PartOf would not help, since BindsTo
+              # wins that race whether or not PartOf is also present.
               systemd.services.cloudflare-warp.upholds = [ "cloudflare-warp-connect.service" ];
 
               systemd.services.cloudflare-warp-connect = {

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -134,6 +134,14 @@ let
             registration_state="confirmed"
             confirmed_once=1
             echo "cloudflare-warp-connect: managed Zero Trust registration confirmed"
+          elif [ -z "$registration" ] && [ -n "$confirmed_once" ]; then
+            # An empty answer names no organization, so like a failed check it is
+            # missing information rather than evidence of a re-registration. The
+            # organization cannot change mid-run, and mismatch is the state that
+            # disconnects, so this must not tear down the tunnel that this run's
+            # own confirmation allowed. A non-empty foreign team still does.
+            registration_state="unknown"
+            echo "<4>cloudflare-warp-connect: registration check returned no organization; keeping this run's confirmation"
           else
             registration_state="mismatch"
             echo "<4>cloudflare-warp-connect: managed Zero Trust registration unavailable"

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -75,6 +75,11 @@ let
       connectScript = ''
         managed_org=""
         registration_state="unknown"
+        # Read by the terminal report. refresh_registration assigns it, but only
+        # past an early return, so initialise it here rather than relying on the
+        # loop body always running: under nounset an unset read aborts the unit
+        # on the one path whose job is to explain what went wrong.
+        registration=""
         connected=""
         connect_requested=""
         unverified=0

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -101,11 +101,12 @@ let
             registration_state="unknown"
             return
           fi
-          # Read stdout alone: a banner or notice on stderr would fail the exact
-          # comparison below and report a correctly enrolled device as unmanaged.
+          # Command substitution captures stdout alone, so the exact comparison
+          # below cannot see a banner; leave stderr unredirected and let warp-cli
+          # name the failure in the journal next to the exit code.
           registration=""
           registration_status=0
-          registration="$(timeout 5s warp-cli --accept-tos registration organization 2>/dev/null)" ||
+          registration="$(timeout 5s warp-cli --accept-tos registration organization)" ||
             registration_status=$?
           if [ "$registration_status" -ne 0 ]; then
             registration_state="unknown"

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -385,7 +385,13 @@ let
                   # quoting can escape them. An XML metacharacter in one would
                   # otherwise leave warp-svc reading a truncated mdm.xml and
                   # falling back to unmanaged mode; refuse to start instead.
-                  "${pkgs.libxml2.bin}/bin/xmllint --noout ${mdmTemplate}"
+                  #
+                  # xmllint reports a parse error by echoing the offending source
+                  # line, which here is the credential, and an unescaped `<` puts
+                  # a fragment of it in the message text too. StandardError is
+                  # unset, so that would reach the persistent journal. Drop its
+                  # stderr and name the condition instead.
+                  "${pkgs.runtimeShell} -c '${pkgs.libxml2.bin}/bin/xmllint --noout ${mdmTemplate} 2>/dev/null || { echo \"cloudflare-warp: rendered mdm.xml is not well-formed; a credential likely contains an XML metacharacter\" >&2; exit 1; }'"
                   "${pkgs.coreutils}/bin/install -D -m0600 -o root -g root ${mdmTemplate} ${rootDir}/mdm.xml"
                 ];
               };

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -1,38 +1,76 @@
 /*
   Package: cloudflare-warp
-  Variant: headless (warp-cli + warp-svc; no GUI taskbar, no XDG autostart)
-  Description: Cloudflare WARP client delivering encrypted consumer VPN and Zero Trust connectivity.
+  Variant: headless (warp-cli + warp-svc + warp-dex + warp-diag; no GUI taskbar)
+  Description: Cloudflare WARP client delivering encrypted VPN and Zero Trust connectivity.
   Homepage: https://developers.cloudflare.com/warp-client/
-  Documentation: https://developers.cloudflare.com/warp-client/get-started/linux/
+  Documentation: https://developers.cloudflare.com/cloudflare-one/connections/connect-devices/warp/
   Repository: https://github.com/cloudflare/warp
 
   Summary:
-    * Secures device traffic using WireGuard-based tunnels through Cloudflare's global edge network.
-    * Integrates with Cloudflare Zero Trust policies for split tunneling, device posture, and secure web gateway enforcement.
+    * Drives upstream services.cloudflare-warp to run warp-svc and enroll the device into
+      Cloudflare Zero Trust non-interactively via a service token in managed (mdm.xml) mode.
+    * Renders /var/lib/cloudflare-warp/mdm.xml from sops-backed credentials, store-safe.
 
   Options:
-    --accept-tos: Accept Cloudflare's Terms of Service non-interactively when registering with `warp-cli register --accept-tos`.
-    --warp: Select the full WARP mode using `warp-cli mode --warp` instead of the default Gateway-only mode.
-    --add --ip <cidr>: Extend split tunneling by combining `warp-cli split-tunnel --add --ip <cidr>`.
+    enable: Run warp-svc; managed Zero Trust enrollment activates when secrets/cloudflare-warp.yaml exists.
+    serviceMode: mdm.xml service_mode (warp | tunnelonly | 1dot1 | proxy | postureonly).
+    autoConnect: mdm.xml auto_connect minutes (0-1440); 0 keeps the client off after a manual disconnect.
+    switchLocked: mdm.xml switch_locked; when true the user cannot disconnect.
+
+  Notes:
+    * service_mode is authoritative via mdm.xml; the module never calls `warp-cli mode`.
+    * Secrets (organization/auth_client_id/auth_client_secret) live in secrets/cloudflare-warp.yaml (sops).
+    * Relies on the hosts-common vpn-defaults owner for networking.firewall.checkReversePath;
+      the WARP interface trips strict rp_filter when that shared baseline is overridden.
 */
-_:
+{ config, ... }:
 let
+  inherit (config.flake.lib.security) sopsInstallSecretsDeps;
   CloudflareWarpModule =
     {
       config,
       lib,
       pkgs,
+      secretsRoot,
       ...
     }:
     let
-      cfg = config.programs."cloudflare-warp".extended;
+      cfg = config.programs.cloudflare-warp.extended;
+      rootDir = config.services.cloudflare-warp.rootDir;
+      secretsFile = secretsRoot + "/cloudflare-warp.yaml";
+      haveSecrets = builtins.pathExists secretsFile;
+      enrolling = haveSecrets;
+      # Gate the sops-install-secrets.service dependency on
+      # sops.useSystemdActivation: the unit only exists in that mode (issue #37);
+      # activation-script hosts decrypt before any unit ordering, so this is [].
+      installSecretsDeps = sopsInstallSecretsDeps config;
+
+      # Linux mdm.xml is a bare <dict> plist fragment (no XML declaration, no
+      # <plist> wrapper). Secret values are injected through sops placeholders so
+      # the rendered file never enters the Nix store.
+      mdmContent = ''
+        <dict>
+          <key>organization</key>
+          <string>${config.sops.placeholder."cloudflare-warp/organization"}</string>
+          <key>auth_client_id</key>
+          <string>${config.sops.placeholder."cloudflare-warp/auth_client_id"}</string>
+          <key>auth_client_secret</key>
+          <string>${config.sops.placeholder."cloudflare-warp/auth_client_secret"}</string>
+          <key>service_mode</key>
+          <string>${cfg.serviceMode}</string>
+          <key>auto_connect</key>
+          <integer>${toString cfg.autoConnect}</integer>
+          <key>switch_locked</key>
+          ${if cfg.switchLocked then "<true/>" else "<false/>"}
+        </dict>
+      '';
     in
     {
       options.programs.cloudflare-warp.extended = {
         enable = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "Whether to enable cloudflare-warp.";
+          description = "Whether to run warp-svc and enroll into Cloudflare Zero Trust.";
         };
 
         package = lib.mkOption {
@@ -40,19 +78,176 @@ let
           default = pkgs.cloudflare-warp.override { headless = true; };
           defaultText = lib.literalExpression "pkgs.cloudflare-warp.override { headless = true; }";
           description = ''
-            Cloudflare WARP package. Defaults to the headless build, which
-            ships `warp-cli`, `warp-svc`, `warp-dex`, and `warp-diag` and
-            omits the GUI taskbar,
-            `etc/xdg/autostart/com.cloudflare.WarpTaskbar.desktop`, and the
-            `share/systemd/user/warp-taskbar.service` user unit. Set to
-            `pkgs.cloudflare-warp` to install the GUI variant.
+            Cloudflare WARP package. Defaults to the headless build, which ships
+            warp-cli, warp-svc, warp-dex, and warp-diag and omits the GUI taskbar.
           '';
+        };
+
+        serviceMode = lib.mkOption {
+          type = lib.types.enum [
+            "warp"
+            "tunnelonly"
+            "1dot1"
+            "proxy"
+            "postureonly"
+          ];
+          default = "warp";
+          description = ''
+            mdm.xml service_mode. "warp" is Full / Gateway with WARP (full tunnel
+            plus Gateway DNS/HTTP filtering).
+          '';
+        };
+
+        autoConnect = lib.mkOption {
+          type = lib.types.ints.between 0 1440;
+          default = 0;
+          description = ''
+            mdm.xml auto_connect: minutes before the client reconnects after a manual
+            disconnect. 0 keeps it off until the user reconnects.
+          '';
+        };
+
+        switchLocked = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "mdm.xml switch_locked; when true the user cannot disconnect WARP.";
+        };
+
+        openFirewall = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Open the WARP UDP port in the firewall.";
+        };
+
+        udpPort = lib.mkOption {
+          type = lib.types.port;
+          default = 2408;
+          description = "WARP UDP port to open when openFirewall is true.";
         };
       };
 
-      config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
-      };
+      config = lib.mkMerge [
+        # Remove the wrapper-owned managed file when the wrapper is disabled.
+        # Leave an independently configured upstream service's state untouched.
+        (lib.mkIf (!cfg.enable && !config.services.cloudflare-warp.enable) {
+          systemd.tmpfiles.rules = [ "r ${rootDir}/mdm.xml" ];
+        })
+        (lib.mkIf cfg.enable (
+          lib.mkMerge [
+            {
+              services.cloudflare-warp = {
+                enable = true;
+                inherit (cfg) package udpPort openFirewall;
+              };
+
+              warnings =
+                lib.optional
+                  (
+                    (config.services.dnscrypt-proxy.enable || config.networking.networkmanager.dns == "dnsmasq")
+                    && builtins.elem cfg.serviceMode [
+                      "warp"
+                      "1dot1"
+                    ]
+                  )
+                  ''
+                    programs.cloudflare-warp.extended.serviceMode "${cfg.serviceMode}" takes over DNS,
+                    but a local resolver is bound to 127.0.0.1:53 (dnscrypt-proxy or NetworkManager
+                    dnsmasq). Use serviceMode "tunnelonly"/"proxy" or disable the local resolver.
+                  ''
+                ++ lib.optional (!haveSecrets) ''
+                  programs.cloudflare-warp.extended: secrets/cloudflare-warp.yaml is missing; running warp-svc
+                  WITHOUT managed enrollment (degraded). Create the sops secret (see
+                  docs/cloudflare/warp/deployment.md) and rebuild.
+                ''
+                ++
+                  lib.optional
+                    (
+                      config.networking.firewall.enable
+                      && builtins.elem config.networking.firewall.checkReversePath [
+                        true
+                        "strict"
+                      ]
+                    )
+                    ''
+                      programs.cloudflare-warp.extended is enabled but
+                      networking.firewall.checkReversePath is strict; the CloudflareWARP
+                      interface routes asymmetrically, so return traffic is dropped. Import
+                      the hosts-common vpn-defaults baseline (shareCommon = true) or set
+                      networking.firewall.checkReversePath = "loose" on this host.
+                    '';
+            }
+
+            # When not enrolling (the sops secret is absent),
+            # remove any mdm.xml left by a previous enrollment. mdm.xml is
+            # authoritative for service_mode and caches the service token, so a stale
+            # file would keep warp-svc in managed mode instead of degrading to the
+            # un-enrolled daemon. rootDir is the upstream StateDirectory.
+            (lib.mkIf (!enrolling) {
+              systemd.services.cloudflare-warp.serviceConfig.ExecStartPre = [
+                "${pkgs.coreutils}/bin/rm -f ${rootDir}/mdm.xml"
+              ];
+            })
+
+            (lib.mkIf enrolling {
+              sops = {
+                secrets = {
+                  "cloudflare-warp/organization" = {
+                    sopsFile = secretsFile;
+                    key = "organization";
+                    mode = "0400";
+                  };
+                  "cloudflare-warp/auth_client_id" = {
+                    sopsFile = secretsFile;
+                    key = "auth_client_id";
+                    mode = "0400";
+                  };
+                  "cloudflare-warp/auth_client_secret" = {
+                    sopsFile = secretsFile;
+                    key = "auth_client_secret";
+                    mode = "0400";
+                  };
+                };
+                templates."cloudflare-warp-mdm" = {
+                  content = mdmContent;
+                  mode = "0600";
+                  # restartTriggers below only hash non-secret fields. Rotating
+                  # auth_client_id/auth_client_secret re-renders this template but
+                  # would not restart warp-svc, so the daemon would keep the old
+                  # token until reboot. Restart on rotation (matches the repo
+                  # pattern in usbguard.nix and duplicati-r2.nix).
+                  restartUnits = [ "cloudflare-warp.service" ];
+                };
+              };
+
+              # Install the rendered mdm.xml into rootDir right before warp-svc starts.
+              # rootDir already exists from the upstream tmpfiles rule, and the sops
+              # template is rendered during activation (before multi-user.target).
+              systemd.services.cloudflare-warp = {
+                # Order warp-svc after sops installs the secret/template so the
+                # ExecStartPre install of mdm.xml sees the rendered file. No-op on
+                # activation-script hosts (installSecretsDeps = []).
+                after = installSecretsDeps;
+                requires = installSecretsDeps;
+                serviceConfig.ExecStartPre = [
+                  "${pkgs.coreutils}/bin/install -D -m0600 -o root -g root ${
+                    config.sops.templates."cloudflare-warp-mdm".path
+                  } ${rootDir}/mdm.xml"
+                ];
+                # Re-apply managed config when any non-secret mdm field changes.
+                restartTriggers = [
+                  (builtins.toJSON {
+                    inherit (cfg)
+                      serviceMode
+                      autoConnect
+                      switchLocked
+                      ;
+                  })
+                ];
+              };
+            })
+          ]
+        ))
+      ];
     };
 in
 {

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -16,12 +16,14 @@
     serviceMode: mdm.xml service_mode (warp | tunnelonly | 1dot1 | proxy | postureonly).
     autoConnect: mdm.xml auto_connect minutes (0-1440); 0 keeps the client off after a manual disconnect.
     switchLocked: mdm.xml switch_locked; when true the user cannot disconnect.
+    connectOnBoot: run a best-effort oneshot that verifies managed registration before connecting.
 
   Notes:
     * service_mode is authoritative via mdm.xml; the module never calls `warp-cli mode`.
     * Secrets (organization/auth_client_id/auth_client_secret) live in secrets/cloudflare-warp.yaml (sops).
     * Relies on the hosts-common vpn-defaults owner for networking.firewall.checkReversePath;
       the WARP interface trips strict rp_filter when that shared baseline is overridden.
+    * Pairs with per-host enablement in modules/tpnix/cloudflare-warp.nix and modules/system76/cloudflare-warp.nix.
 */
 { config, ... }:
 let
@@ -44,6 +46,43 @@ let
       # sops.useSystemdActivation: the unit only exists in that mode (issue #37);
       # activation-script hosts decrypt before any unit ordering, so this is [].
       installSecretsDeps = sopsInstallSecretsDeps config;
+
+      # Logged by the connect-on-boot oneshot when the device has no managed
+      # mdm.xml. The guard prevents an absent secret from selecting consumer WARP.
+      unenrolledGuard = lib.optionalString (!enrolling) ''
+        echo "<4>cloudflare-warp-connect: device is UN-ENROLLED (no managed mdm.xml); not connecting. Create secrets/cloudflare-warp.yaml to enroll."
+        exit 0
+      '';
+
+      managedRegistrationSetup = lib.optionalString enrolling ''
+        if managed_org="$(cat ${
+          config.sops.secrets."cloudflare-warp/organization".path
+        } 2>/dev/null)" && [ -n "$managed_org" ]; then
+          :
+        else
+          managed_org=""
+          echo "<3>cloudflare-warp-connect: managed organization secret unavailable; cannot verify registration"
+        fi
+
+        refresh_registration() {
+          if [ -z "$managed_org" ]; then
+            managed_registration=""
+            return
+          fi
+          if registration="$(timeout 5s warp-cli --accept-tos registration organization 2>&1)"; then
+            if [ "$registration" = "$managed_org" ]; then
+              managed_registration=1
+              echo "cloudflare-warp-connect: managed Zero Trust registration confirmed"
+            else
+              managed_registration=""
+              echo "<3>cloudflare-warp-connect: managed Zero Trust registration unavailable"
+            fi
+          else
+            managed_registration=""
+            echo "<3>cloudflare-warp-connect: registration check failed: ''${registration:-no response}"
+          fi
+        }
+      '';
 
       # Linux mdm.xml is a bare <dict> plist fragment (no XML declaration, no
       # <plist> wrapper). Secret values are injected through sops placeholders so
@@ -111,6 +150,12 @@ let
           type = lib.types.bool;
           default = false;
           description = "mdm.xml switch_locked; when true the user cannot disconnect WARP.";
+        };
+
+        connectOnBoot = lib.mkOption {
+          type = lib.types.bool;
+          default = true;
+          description = "Run a best-effort oneshot `warp-cli connect` after the daemon starts.";
         };
 
         openFirewall = lib.mkOption {
@@ -243,6 +288,97 @@ let
                       ;
                   })
                 ];
+              };
+            })
+
+            (lib.mkIf cfg.connectOnBoot {
+              systemd.services.cloudflare-warp-connect = {
+                description = "Cloudflare WARP connect on boot";
+                after = [ "cloudflare-warp.service" ];
+                requires = [ "cloudflare-warp.service" ];
+                partOf = [ "cloudflare-warp.service" ];
+                wantedBy = [ "multi-user.target" ];
+                path = [
+                  pkgs.coreutils
+                  cfg.package
+                ];
+                serviceConfig = {
+                  Type = "oneshot";
+                  RemainAfterExit = true;
+                  # The script bounds each IPC call and its retry window; this larger
+                  # unit timeout covers the status queries and shell overhead.
+                  TimeoutStartSec = 180;
+                };
+                script = ''
+                  ${unenrolledGuard}
+                  managed_org=""
+                  managed_registration=""
+                  ${managedRegistrationSetup}
+                  # The daemon IPC socket and mdm.xml registration can settle at
+                  # different times, so poll both during the bounded readiness window.
+                  connected=""
+                  connect_requested=""
+                  status=""
+                  attempt=0
+                  deadline=$((SECONDS + 120))
+
+                  refresh_status() {
+                    if status="$(timeout 5s warp-cli status 2>&1)"; then
+                      status="''${status:-status unavailable}"
+                    else
+                      echo "cloudflare-warp-connect: status command failed: ''${status:-no response}"
+                      status="''${status:-status unavailable}"
+                    fi
+                    echo "cloudflare-warp-connect: $status"
+                    case "$status" in
+                      *Disconnected* | *"status unavailable"*) ;;
+                      *Connected*)
+                        if [ -n "$managed_org" ] && [ -n "$managed_registration" ]; then
+                          connected=1
+                        else
+                          echo "<3>cloudflare-warp-connect: connected without managed Zero Trust registration; disconnecting"
+                          if disconnect_output="$(timeout 5s warp-cli disconnect 2>&1)"; then
+                            echo "cloudflare-warp-connect: disconnected unmanaged tunnel"
+                          else
+                            echo "<3>cloudflare-warp-connect: failed to disconnect unmanaged tunnel: ''${disconnect_output:-no response}"
+                          fi
+                        fi
+                        ;;
+                    esac
+                  }
+
+                  ${lib.optionalString enrolling "refresh_registration"}
+                  refresh_status
+
+                  while [ -z "$connected" ] && [ "$attempt" -lt 30 ] && [ "$SECONDS" -lt "$deadline" ]; do
+                    attempt=$((attempt + 1))
+                    ${lib.optionalString enrolling "refresh_registration"}
+                    if [ -n "$managed_org" ] && [ -n "$managed_registration" ]; then
+                      if request_output="$(timeout 5s warp-cli --accept-tos connect 2>&1)"; then
+                        connect_requested=1
+                        echo "cloudflare-warp-connect: connect requested"
+                      else
+                        echo "cloudflare-warp-connect: connect request failed: ''${request_output:-no response}"
+                      fi
+                    else
+                      echo "<3>cloudflare-warp-connect: managed enrollment is not ready; not connecting"
+                    fi
+                    ${lib.optionalString enrolling "refresh_registration"}
+                    refresh_status
+                    if [ -z "$connected" ]; then
+                      sleep 1
+                    fi
+                  done
+                  # Best-effort: log the outcome and exit 0 so a user who legitimately
+                  # keeps WARP off does not leave the unit failed.
+                  if [ -z "$connected" ]; then
+                    if [ -z "$connect_requested" ]; then
+                      echo "<3>cloudflare-warp-connect: connect never succeeded (daemon unreachable or registration incomplete)"
+                    else
+                      echo "<3>cloudflare-warp-connect: tunnel is not connected after $attempt attempts"
+                    fi
+                  fi
+                '';
               };
             })
           ]

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -157,8 +157,11 @@ let
 
         # managed_org is read once above, so an empty value keeps the connect gate
         # shut for every attempt. Exit instead of polling a decision that cannot
-        # change before the deadline.
+        # change before the deadline. registration_state is still "unknown" here,
+        # so refresh_status can only report the tunnel; its connect and
+        # disconnect arms are unreachable.
         if [ -z "$managed_org" ]; then
+          refresh_status
           echo "<3>cloudflare-warp-connect: managed organization secret unavailable; not connecting"
           exit 0
         fi
@@ -194,7 +197,14 @@ let
         # actually ended on. Branch on the live registration_state and status.
         if [ -z "$connected" ]; then
           if [ "$registration_state" = "mismatch" ]; then
-            echo "<3>cloudflare-warp-connect: daemon is registered outside the managed organization after $attempt attempts"
+            # Both sub-cases are a mismatch, but they send the operator to
+            # different places: an empty answer is an enrollment that never
+            # completed, not a tenant to hunt for in the dashboard.
+            if [ -z "$registration" ]; then
+              echo "<3>cloudflare-warp-connect: daemon reports no Zero Trust registration after $attempt attempts"
+            else
+              echo "<3>cloudflare-warp-connect: daemon is registered outside the managed organization after $attempt attempts"
+            fi
           else
             case "$status" in
               *Connected*)

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -132,7 +132,7 @@ let
         }
 
         refresh_status() {
-          if status="$(timeout 5s warp-cli status 2>&1)"; then
+          if status="$(timeout 5s warp-cli --accept-tos status 2>&1)"; then
             status="''${status:-status unavailable}"
           else
             echo "cloudflare-warp-connect: status command failed: ''${status:-no response}"
@@ -148,7 +148,7 @@ let
                   ;;
                 mismatch)
                   echo "<3>cloudflare-warp-connect: connected without managed Zero Trust registration; disconnecting"
-                  if disconnect_output="$(timeout 5s warp-cli disconnect 2>&1)"; then
+                  if disconnect_output="$(timeout 5s warp-cli --accept-tos disconnect 2>&1)"; then
                     echo "cloudflare-warp-connect: disconnected unmanaged tunnel"
                   else
                     echo "<3>cloudflare-warp-connect: failed to disconnect unmanaged tunnel: ''${disconnect_output:-no response}"

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -15,7 +15,8 @@
     enable: Install warp-cli; warp-svc runs only once secrets/cloudflare-warp.yaml supplies credentials.
     serviceMode: mdm.xml service_mode (warp | tunnelonly | 1dot1 | proxy | postureonly).
     autoConnect: mdm.xml auto_connect minutes (0-1440); 0 keeps the client off after a manual disconnect.
-    switchLocked: mdm.xml switch_locked; when true the user cannot disconnect.
+    switchLocked: mdm.xml switch_locked; when true the user cannot disconnect, which also blocks
+      this module's own teardown of a mismatched tunnel.
     connectOnBoot: run a best-effort oneshot that verifies managed registration before connecting.
 
   Notes:
@@ -24,7 +25,8 @@
     * Without those credentials warp-svc would hold CAP_NET_ADMIN and an open UDP port while
       serving only consumer WARP, so an un-enrolled host installs the CLI and no daemon.
     * Relies on the hosts-common vpn-defaults owner for networking.firewall.checkReversePath;
-      the WARP interface trips strict rp_filter when that shared baseline is overridden.
+      the WARP interface trips strict rp_filter when that shared baseline is overridden, except
+      under serviceMode postureonly, which carries no traffic.
     * Pairs with per-host enablement in modules/tpnix/cloudflare-warp.nix and modules/system76/cloudflare-warp.nix.
 */
 { config, ... }:
@@ -82,6 +84,7 @@ let
         registration=""
         connected=""
         connect_requested=""
+        confirmed_once=""
         unverified=0
         status=""
         attempt=0
@@ -129,6 +132,7 @@ let
           registration="''${registration//[[:space:]]/}"
           if [ "$registration" = "$managed_org" ]; then
             registration_state="confirmed"
+            confirmed_once=1
             echo "cloudflare-warp-connect: managed Zero Trust registration confirmed"
           else
             registration_state="mismatch"
@@ -163,8 +167,18 @@ let
                   fi
                   ;;
                 *)
-                  echo "<4>cloudflare-warp-connect: connected while the managed registration could not be verified; leaving the tunnel up"
-                  unverified=$((unverified + 1))
+                  # An unanswered check does not un-confirm a registration this
+                  # run already read. The organization cannot change mid-run, and
+                  # that confirmation is what allowed connect to run at all, so
+                  # counting it as unverified would end a healthy run early and
+                  # then misreport it.
+                  if [ -n "$confirmed_once" ]; then
+                    echo "cloudflare-warp-connect: tunnel is up on a registration this run already confirmed"
+                    connected=1
+                  else
+                    echo "<4>cloudflare-warp-connect: connected while the managed registration could not be verified; leaving the tunnel up"
+                    unverified=$((unverified + 1))
+                  fi
                   ;;
               esac
               ;;
@@ -286,7 +300,12 @@ let
         switchLocked = lib.mkOption {
           type = lib.types.bool;
           default = false;
-          description = "mdm.xml switch_locked; when true the user cannot disconnect WARP.";
+          description = ''
+            mdm.xml switch_locked; when true the user cannot disconnect WARP.
+            That also blocks this module's own fail-closed teardown, since
+            `warp-cli disconnect` is a local disconnect: a confirmed registration
+            mismatch on a live tunnel can then only be reported, not enforced.
+          '';
         };
 
         connectOnBoot = lib.mkOption {
@@ -363,6 +382,9 @@ let
                   lib.optional
                     (
                       config.networking.firewall.enable
+                      # postureonly carries no traffic, so there is no
+                      # CloudflareWARP interface for strict rp_filter to affect.
+                      && cfg.serviceMode != "postureonly"
                       && builtins.elem config.networking.firewall.checkReversePath [
                         true
                         "strict"

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -306,7 +306,13 @@ let
               warnings =
                 lib.optional
                   (
-                    (config.services.dnscrypt-proxy.enable || config.networking.networkmanager.dns == "dnsmasq")
+                    (
+                      config.services.dnscrypt-proxy.enable
+                      # networkmanager.dns is declared unconditionally and only
+                      # reaches NetworkManager.conf under mkIf enable, so a stale
+                      # value on a systemd-networkd host binds nothing.
+                      || (config.networking.networkmanager.enable && config.networking.networkmanager.dns == "dnsmasq")
+                    )
                     && builtins.elem cfg.serviceMode [
                       "warp"
                       "1dot1"

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -98,6 +98,12 @@ let
         # what an unmanaged/consumer registration returns), unknown (the check
         # itself did not answer). Only a mismatch is evidence of an unmanaged
         # tunnel; a timed-out or failed check must not tear a tunnel down.
+        #
+        # Per-attempt states log at <4>. Upstream runs warp-svc as Type=simple,
+        # so the IPC socket and the managed registration both settle after the
+        # unit starts and a healthy boot passes through these on its way to
+        # confirmed. <3> is reserved for a state the run cannot recover from and
+        # for enforcement, so `journalctl -p err` stays quiet on a good boot.
         refresh_registration() {
           if [ -z "$managed_org" ]; then
             registration_state="unknown"
@@ -112,7 +118,7 @@ let
             registration_status=$?
           if [ "$registration_status" -ne 0 ]; then
             registration_state="unknown"
-            echo "<3>cloudflare-warp-connect: registration check failed (exit $registration_status)"
+            echo "<4>cloudflare-warp-connect: registration check failed (exit $registration_status)"
             return
           fi
           registration="''${registration//[[:space:]]/}"
@@ -121,7 +127,7 @@ let
             echo "cloudflare-warp-connect: managed Zero Trust registration confirmed"
           else
             registration_state="mismatch"
-            echo "<3>cloudflare-warp-connect: managed Zero Trust registration unavailable"
+            echo "<4>cloudflare-warp-connect: managed Zero Trust registration unavailable"
           fi
         }
 
@@ -188,7 +194,7 @@ let
               echo "cloudflare-warp-connect: connect request failed: ''${request_output:-no response}"
             fi
           else
-            echo "<3>cloudflare-warp-connect: managed enrollment is not ready; not connecting"
+            echo "<4>cloudflare-warp-connect: managed enrollment is not ready; not connecting"
           fi
           sleep 1
         done
@@ -432,7 +438,16 @@ let
 
               systemd.services.cloudflare-warp-connect = {
                 description = "Cloudflare WARP connect on boot";
-                after = [ "cloudflare-warp.service" ];
+                # Upstream orders warp-svc on network.target alone, which says
+                # nothing about an associated link, and 25.05 decoupled
+                # multi-user.target from network-online.target. Without this the
+                # whole retry budget can burn before Wi-Fi associates, and
+                # auto_connect = 0 means nothing reconnects afterwards.
+                after = [
+                  "cloudflare-warp.service"
+                  "network-online.target"
+                ];
+                wants = [ "network-online.target" ];
                 bindsTo = [ "cloudflare-warp.service" ];
                 wantedBy = [ "multi-user.target" ];
                 # This script fails closed around a registration check, so hold it

--- a/modules/apps/cloudflare-warp.nix
+++ b/modules/apps/cloudflare-warp.nix
@@ -64,24 +64,39 @@ let
           echo "<3>cloudflare-warp-connect: managed organization secret unavailable; cannot verify registration"
         fi
 
+        # registration_state is tri-state: confirmed (the daemon reported the
+        # managed team), mismatch (it reported another team or none, which is
+        # what an unmanaged/consumer registration returns), unknown (the check
+        # itself did not answer). Only a mismatch is evidence of an unmanaged
+        # tunnel; a timed-out or failed check must not tear a tunnel down.
         refresh_registration() {
           if [ -z "$managed_org" ]; then
-            managed_registration=""
+            registration_state="unknown"
             return
           fi
           if registration="$(timeout 5s warp-cli --accept-tos registration organization 2>&1)"; then
             if [ "$registration" = "$managed_org" ]; then
-              managed_registration=1
+              registration_state="confirmed"
               echo "cloudflare-warp-connect: managed Zero Trust registration confirmed"
             else
-              managed_registration=""
+              registration_state="mismatch"
               echo "<3>cloudflare-warp-connect: managed Zero Trust registration unavailable"
             fi
           else
-            managed_registration=""
+            registration_state="unknown"
             echo "<3>cloudflare-warp-connect: registration check failed: ''${registration:-no response}"
           fi
         }
+      '';
+
+      # managed_org is read once during setup, so an empty value keeps the
+      # connect gate shut for every attempt. Exit instead of polling a decision
+      # that cannot change before the deadline.
+      managedOrgGuard = lib.optionalString enrolling ''
+        if [ -z "$managed_org" ]; then
+          echo "<3>cloudflare-warp-connect: managed organization secret unavailable; not connecting"
+          exit 0
+        fi
       '';
 
       # Linux mdm.xml is a bare <dict> plist fragment (no XML declaration, no
@@ -312,7 +327,7 @@ let
                 script = ''
                   ${unenrolledGuard}
                   managed_org=""
-                  managed_registration=""
+                  registration_state="unknown"
                   ${managedRegistrationSetup}
                   # The daemon IPC socket and mdm.xml registration can settle at
                   # different times, so poll both during the bounded readiness window.
@@ -333,27 +348,34 @@ let
                     case "$status" in
                       *Disconnected* | *"status unavailable"*) ;;
                       *Connected*)
-                        if [ -n "$managed_org" ] && [ -n "$managed_registration" ]; then
-                          connected=1
-                        else
-                          echo "<3>cloudflare-warp-connect: connected without managed Zero Trust registration; disconnecting"
-                          if disconnect_output="$(timeout 5s warp-cli disconnect 2>&1)"; then
-                            echo "cloudflare-warp-connect: disconnected unmanaged tunnel"
-                          else
-                            echo "<3>cloudflare-warp-connect: failed to disconnect unmanaged tunnel: ''${disconnect_output:-no response}"
-                          fi
-                        fi
+                        case "$registration_state" in
+                          confirmed)
+                            connected=1
+                            ;;
+                          mismatch)
+                            echo "<3>cloudflare-warp-connect: connected without managed Zero Trust registration; disconnecting"
+                            if disconnect_output="$(timeout 5s warp-cli disconnect 2>&1)"; then
+                              echo "cloudflare-warp-connect: disconnected unmanaged tunnel"
+                            else
+                              echo "<3>cloudflare-warp-connect: failed to disconnect unmanaged tunnel: ''${disconnect_output:-no response}"
+                            fi
+                            ;;
+                          *)
+                            echo "<4>cloudflare-warp-connect: connected while the managed registration could not be verified; leaving the tunnel up"
+                            ;;
+                        esac
                         ;;
                     esac
                   }
 
                   ${lib.optionalString enrolling "refresh_registration"}
                   refresh_status
+                  ${managedOrgGuard}
 
                   while [ -z "$connected" ] && [ "$attempt" -lt 30 ] && [ "$SECONDS" -lt "$deadline" ]; do
                     attempt=$((attempt + 1))
                     ${lib.optionalString enrolling "refresh_registration"}
-                    if [ -n "$managed_org" ] && [ -n "$managed_registration" ]; then
+                    if [ "$registration_state" = "confirmed" ]; then
                       if request_output="$(timeout 5s warp-cli --accept-tos connect 2>&1)"; then
                         connect_requested=1
                         echo "cloudflare-warp-connect: connect requested"
@@ -363,7 +385,6 @@ let
                     else
                       echo "<3>cloudflare-warp-connect: managed enrollment is not ready; not connecting"
                     fi
-                    ${lib.optionalString enrolling "refresh_registration"}
                     refresh_status
                     if [ -z "$connected" ]; then
                       sleep 1

--- a/modules/apps/cloudflare-warp/cloudflare-warp-check-fixtures/cloudflare-warp.yaml
+++ b/modules/apps/cloudflare-warp/cloudflare-warp-check-fixtures/cloudflare-warp.yaml
@@ -1,0 +1,3 @@
+# Non-secret fixture. sops validation is disabled by the module check; this file
+# only makes builtins.pathExists take the managed-enrollment branch.
+{}

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -296,7 +296,8 @@
                   "tunnel is up but its registration went unverified"
                 ]
                 && lib.all (msg: lib.hasInfix "<3>cloudflare-warp-connect: ${msg}" enrolledConnectScript) [
-                  "managed organization secret unavailable"
+                  "managed organization secret unavailable; cannot verify registration"
+                  "managed organization secret unavailable; not connecting"
                   "connected without managed Zero Trust registration; disconnecting"
                   "failed to disconnect unmanaged tunnel"
                   "daemon reports no Zero Trust registration"

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -10,7 +10,7 @@
 {
   lib,
   inputs,
-  config,
+  nixosAppHelpers,
   ...
 }:
 {
@@ -19,37 +19,15 @@
     {
       checks."apps/cloudflare-warp-module-eval" =
         let
-          findModule =
-            name: module:
-            if builtins.isList module then
-              let
-                findIn =
-                  modules:
-                  if modules == [ ] then
-                    null
-                  else
-                    let
-                      candidate = findModule name (builtins.head modules);
-                    in
-                    if candidate != null then candidate else findIn (builtins.tail modules);
-              in
-              findIn module
-            else if builtins.isAttrs module then
-              if builtins.hasAttr name module then module.${name} else findModule name (module.imports or [ ])
-            else
-              null;
-          warpModule =
-            let
-              found = findModule "cloudflare-warp" config.flake.nixosModules.apps;
-            in
-            assert lib.assertMsg (
-              found != null
-            ) "apps/cloudflare-warp-module-eval: cloudflare-warp app export is missing";
-            found;
+          # Use the module argument, not config.flake.lib.nixos: the same helper
+          # read back through the flake.lib option merge returns a merged wrapper
+          # whose functionArgs are empty, so the module system cannot inject pkgs.
+          warpModule = nixosAppHelpers.getApp "cloudflare-warp";
           mkNixos =
             {
               secretsRoot,
               enable ? true,
+              extraSettings ? { },
             }:
             inputs.nixpkgs.lib.nixosSystem {
               system = "x86_64-linux";
@@ -65,7 +43,8 @@
                     autoConnect = 0;
                     switchLocked = false;
                     connectOnBoot = true;
-                  };
+                  }
+                  // extraSettings;
                   sops.validateSopsFiles = false;
                   sops.age.keyFile = "/dev/null";
                   system.stateVersion = "26.05";
@@ -73,8 +52,14 @@
               ];
               specialArgs = { inherit secretsRoot; };
             };
+          # Non-default port and firewall choice: both option defaults match
+          # upstream's, so only diverging values prove the wrapper forwards them.
           enrolled = mkNixos {
             secretsRoot = ./cloudflare-warp-check-fixtures;
+            extraSettings = {
+              udpPort = 24080;
+              openFirewall = false;
+            };
           };
           unenrolled = mkNixos {
             secretsRoot = "${./cloudflare-warp-check-fixtures}/missing";
@@ -83,15 +68,52 @@
             secretsRoot = "${./cloudflare-warp-check-fixtures}/missing";
             enable = false;
           };
-          enrolledConnectScript = enrolled.config.systemd.services.cloudflare-warp-connect.script;
+          hasWarpCli =
+            system:
+            lib.any (
+              drv: (lib.getName drv) == "cloudflare-warp-headless"
+            ) system.config.environment.systemPackages;
+          enrolledConnect = enrolled.config.systemd.services.cloudflare-warp-connect;
+          enrolledConnectScript = enrolledConnect.script;
+          enrolledWarp = enrolled.config.services.cloudflare-warp;
           enrolledAttrs =
             assert lib.assertMsg (builtins.hasAttr "cloudflare-warp/organization" enrolled.config.sops.secrets)
               "apps/cloudflare-warp-module-eval: enrolled branch must declare organization secret";
             assert lib.assertMsg (builtins.hasAttr "cloudflare-warp-mdm" enrolled.config.sops.templates)
               "apps/cloudflare-warp-module-eval: enrolled branch must declare mdm template";
+            assert lib.assertMsg enrolledWarp.enable
+              "apps/cloudflare-warp-module-eval: enrolled branch must enable upstream WARP";
             assert lib.assertMsg (
-              !lib.hasInfix "UN-ENROLLED" enrolledConnectScript
-            ) "apps/cloudflare-warp-module-eval: enrolled connect script must not carry the un-enrolled guard";
+              lib.getName enrolledWarp.package == "cloudflare-warp-headless"
+            ) "apps/cloudflare-warp-module-eval: enrolled branch must forward the headless package";
+            assert lib.assertMsg (
+              enrolledWarp.udpPort == 24080
+              && !enrolledWarp.openFirewall
+              && !(builtins.elem 24080 enrolled.config.networking.firewall.allowedUDPPorts)
+            ) "apps/cloudflare-warp-module-eval: enrolled branch must forward udpPort and openFirewall";
+            # sops compares the rendered template between generations, so it
+            # already covers every mdm field. A second restart owner on the unit
+            # restarts warp-svc twice for one activation.
+            assert lib.assertMsg (
+              enrolled.config.sops.templates."cloudflare-warp-mdm".restartUnits == [ "cloudflare-warp.service" ]
+              && enrolled.config.systemd.services.cloudflare-warp.restartTriggers == [ ]
+            ) "apps/cloudflare-warp-module-eval: the mdm template must be the only restart owner of warp-svc";
+            assert lib.assertMsg
+              (lib.hasInfix "xmllint --noout" (
+                lib.head enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre
+              ))
+              "apps/cloudflare-warp-module-eval: enrolled branch must parse the rendered mdm.xml before installing it";
+            # Restart=always respawns warp-svc without an explicit restart job,
+            # which PartOf does not propagate; Upholds re-runs the oneshot.
+            assert lib.assertMsg
+              (
+                enrolledConnect.bindsTo == [ "cloudflare-warp.service" ]
+                && enrolledConnect.partOf == [ ]
+                && enrolled.config.systemd.services.cloudflare-warp.upholds == [ "cloudflare-warp-connect.service" ]
+              )
+              "apps/cloudflare-warp-module-eval: connect oneshot must re-run after an unexpected warp-svc restart";
+            assert lib.assertMsg enrolledConnect.enableStrictShellChecks
+              "apps/cloudflare-warp-module-eval: connect script must be shellcheck-gated";
             assert lib.assertMsg
               (lib.hasInfix "warp-cli --accept-tos registration organization" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must verify managed registration";
@@ -111,65 +133,79 @@
                 "apps/cloudflare-warp-module-eval: enrolled connect script must gate connect on a confirmed registration";
             # An unanswered registration check must not be treated as an
             # unmanaged tunnel, so the disconnect belongs to the mismatch branch
-            # alone.
+            # alone. The length guard keeps a renamed marker from degrading this
+            # into a whole-script search that always passes.
             assert
               let
-                beforeDisconnect = lib.head (lib.splitString "warp-cli disconnect" enrolledConnectScript);
+                parts = lib.splitString "warp-cli disconnect" enrolledConnectScript;
+                beforeDisconnect = lib.head parts;
               in
               lib.assertMsg
                 (
-                  lib.hasInfix "mismatch)" beforeDisconnect && !lib.hasInfix "could not be verified" beforeDisconnect
+                  lib.length parts > 1
+                  && lib.hasInfix "mismatch)" beforeDisconnect
+                  && !lib.hasInfix "could not be verified" beforeDisconnect
                 )
                 "apps/cloudflare-warp-module-eval: enrolled connect script must disconnect only on a confirmed registration mismatch";
-            # One definition plus two call sites: once before the loop and once
-            # per attempt. warp-cli connect does not change the registration
-            # organization, so a second per-attempt check only spends IPC budget.
+            # One definition plus one call site at the top of each attempt.
+            # warp-cli connect does not change the registration organization, so
+            # a second check per attempt only spends IPC budget.
             assert lib.assertMsg
-              (lib.length (lib.splitString "refresh_registration" enrolledConnectScript) == 4)
+              (lib.length (lib.splitString "refresh_registration" enrolledConnectScript) == 3)
               "apps/cloudflare-warp-module-eval: enrolled connect script must refresh the registration once per attempt";
             assert
               let
-                beforeLoop = lib.head (lib.splitString "while [ -z \"$connected\" ]" enrolledConnectScript);
+                parts = lib.splitString "while [ -z \"$connected\" ]" enrolledConnectScript;
+                beforeLoop = lib.head parts;
               in
               lib.assertMsg
                 (
-                  lib.hasInfix "managed organization secret unavailable; not connecting" beforeLoop
+                  lib.length parts > 1
+                  && lib.hasInfix "managed organization secret unavailable; not connecting" beforeLoop
                   && lib.hasInfix "exit 0" beforeLoop
                 )
                 "apps/cloudflare-warp-module-eval: enrolled connect script must exit before the retry loop when the managed organization is empty";
+            # A live tunnel whose registration never answered is terminal: the
+            # loop has nothing left to request and must not spend its full budget.
+            assert lib.assertMsg
+              (
+                lib.hasInfix "unverified=$((unverified + 1))" enrolledConnectScript
+                && lib.hasInfix "[ \"$unverified\" -lt 3 ]" enrolledConnectScript
+              )
+              "apps/cloudflare-warp-module-eval: enrolled connect script must stop retrying once the tunnel is up and unverifiable";
             {
               execStartPre = enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre;
               templateContent = enrolled.config.sops.templates."cloudflare-warp-mdm".content;
               connectScript = enrolledConnectScript;
-              restartTriggers = enrolled.config.systemd.services.cloudflare-warp.restartTriggers;
             };
           unenrolledAttrs =
             assert lib.assertMsg (
               !builtins.hasAttr "cloudflare-warp/organization" unenrolled.config.sops.secrets
             ) "apps/cloudflare-warp-module-eval: un-enrolled branch must not declare organization secret";
-            assert
-              let
-                connectScript = unenrolled.config.systemd.services.cloudflare-warp-connect.script;
-                parts = lib.splitString "warp-cli --accept-tos connect" connectScript;
-                beforeConnect = lib.head parts;
-              in
-              lib.assertMsg
-                (
-                  lib.length parts > 1
-                  && lib.hasInfix "<4>cloudflare-warp-connect: device is UN-ENROLLED" beforeConnect
-                  && lib.hasInfix "exit 0" beforeConnect
-                )
-                "apps/cloudflare-warp-module-eval: un-enrolled connect script must warn and exit before warp-cli connect";
+            # warp-svc holds CAP_NET_ADMIN and an open UDP port, and without
+            # mdm.xml it serves only consumer WARP, so it must stay down.
+            assert lib.assertMsg (
+              !unenrolled.config.services.cloudflare-warp.enable
+            ) "apps/cloudflare-warp-module-eval: un-enrolled branch must not start warp-svc";
+            assert lib.assertMsg (
+              !builtins.hasAttr "cloudflare-warp-connect" unenrolled.config.systemd.services
+            ) "apps/cloudflare-warp-module-eval: un-enrolled branch must not declare the connect oneshot";
+            assert lib.assertMsg (hasWarpCli unenrolled)
+              "apps/cloudflare-warp-module-eval: un-enrolled branch must still install warp-cli";
+            assert lib.assertMsg
+              (builtins.elem "r /var/lib/cloudflare-warp/mdm.xml" unenrolled.config.systemd.tmpfiles.rules)
+              "apps/cloudflare-warp-module-eval: un-enrolled branch must remove a stale managed mdm.xml";
             {
-              connectScript = unenrolled.config.systemd.services.cloudflare-warp-connect.script;
-              execStartPre = unenrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre;
-              restartTriggers = unenrolled.config.systemd.services.cloudflare-warp.restartTriggers;
+              tmpfilesRules = unenrolled.config.systemd.tmpfiles.rules;
               warnings = unenrolled.config.warnings;
             };
           disabledAttrs =
             assert lib.assertMsg (
               !disabled.config.services.cloudflare-warp.enable
             ) "apps/cloudflare-warp-module-eval: disabled branch must not enable upstream WARP";
+            assert lib.assertMsg (
+              !(hasWarpCli disabled)
+            ) "apps/cloudflare-warp-module-eval: disabled branch must not install warp-cli";
             assert lib.assertMsg
               (builtins.elem "r /var/lib/cloudflare-warp/mdm.xml" disabled.config.systemd.tmpfiles.rules)
               "apps/cloudflare-warp-module-eval: disabled branch must remove managed mdm.xml";

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -77,8 +77,17 @@
           # Both managed-branch warnings are conditional and CI has no secrets
           # submodule, so nothing else in this repo ever reaches their
           # predicates. One fixture per trigger keeps the option paths behind
-          # them (networkmanager.dns, firewall.checkReversePath) honest.
+          # them (networkmanager.enable/dns, firewall.checkReversePath) honest.
           dnsConflict = mkNixos {
+            secretsRoot = ./cloudflare-warp-check-fixtures;
+            extraConfig.networking.networkmanager = {
+              enable = true;
+              dns = "dnsmasq";
+            };
+          };
+          # dns survives in the option even where NetworkManager never runs, so
+          # this fixture pins the half of the predicate that must stay silent.
+          staleDns = mkNixos {
             secretsRoot = ./cloudflare-warp-check-fixtures;
             extraConfig.networking.networkmanager.dns = "dnsmasq";
           };
@@ -213,11 +222,14 @@
             ) "apps/cloudflare-warp-module-eval: a managed host on the vpn-defaults baseline must not warn";
             assert lib.assertMsg (lib.any (lib.hasInfix "takes over DNS") dnsConflict.config.warnings)
               "apps/cloudflare-warp-module-eval: a local resolver under a DNS-owning service mode must warn";
+            assert lib.assertMsg (!lib.any (lib.hasInfix "takes over DNS") staleDns.config.warnings)
+              "apps/cloudflare-warp-module-eval: a stale networkmanager.dns without NetworkManager must not warn";
             assert lib.assertMsg
               (lib.any (lib.hasInfix "checkReversePath is strict") strictRpFilter.config.warnings)
               "apps/cloudflare-warp-module-eval: a strict checkReversePath must warn";
             {
               dnsConflict = dnsConflict.config.warnings;
+              staleDns = staleDns.config.warnings;
               strictRpFilter = strictRpFilter.config.warnings;
             };
           unenrolledAttrs =

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -292,6 +292,7 @@
                   "managed enrollment is not ready; not connecting"
                   "status command failed"
                   "connect request failed"
+                  "tunnel is up but its registration went unverified"
                 ]
                 && lib.all (msg: lib.hasInfix "<3>cloudflare-warp-connect: ${msg}" enrolledConnectScript) [
                   "managed organization secret unavailable"
@@ -299,6 +300,8 @@
                   "failed to disconnect unmanaged tunnel"
                   "daemon reports no Zero Trust registration"
                   "daemon is registered outside the managed organization"
+                  "tunnel is not connected after"
+                  "connect never succeeded"
                 ]
               )
               "apps/cloudflare-warp-module-eval: per-attempt states must log at <4> and unrecoverable or enforcement states at <3>";

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -109,6 +109,13 @@
             secretsRoot = ./cloudflare-warp-check-fixtures;
             extraConfig.networking.firewall.checkReversePath = "strict";
           };
+          # postureonly carries no traffic, so it holds the half of the rp_filter
+          # predicate that must stay silent.
+          posturePlusStrict = mkNixos {
+            secretsRoot = ./cloudflare-warp-check-fixtures;
+            extraSettings.serviceMode = "postureonly";
+            extraConfig.networking.firewall.checkReversePath = "strict";
+          };
           # connectOnBoot = false is its own mkIf branch that no other fixture
           # reaches, and the Upholds edge lives inside it.
           connectOff = mkNixos {
@@ -410,6 +417,22 @@
                 && lib.hasInfix "[ \"$unverified\" -lt 3 ]" enrolledConnectScript
               )
               "apps/cloudflare-warp-module-eval: enrolled connect script must stop retrying once the tunnel is up and unverifiable";
+            # The counter must not run against a run that already read the
+            # managed organization: the value cannot change mid-run, and that
+            # read is what allowed connect, so counting it would end a healthy
+            # run early and then report it as never verified.
+            assert
+              let
+                guarded = lib.last (lib.splitString ''if [ -n "$confirmed_once" ]; then'' enrolledConnectScript);
+                counted = lib.head (lib.splitString "unverified=$((unverified + 1))" guarded);
+              in
+              lib.assertMsg
+                (
+                  lib.hasInfix "confirmed_once=1" enrolledConnectScript
+                  && lib.length (lib.splitString ''if [ -n "$confirmed_once" ]; then'' enrolledConnectScript) == 2
+                  && lib.hasInfix "else" counted
+                )
+                "apps/cloudflare-warp-module-eval: an unanswered check must not count as unverified once this run confirmed the registration";
             {
               execStartPre = enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre;
               templateContent = enrolled.config.sops.templates."cloudflare-warp-mdm".content;
@@ -432,10 +455,14 @@
             assert lib.assertMsg
               (lib.any (lib.hasInfix "checkReversePath is strict") strictRpFilter.config.warnings)
               "apps/cloudflare-warp-module-eval: a strict checkReversePath must warn";
+            assert lib.assertMsg
+              (!lib.any (lib.hasInfix "checkReversePath is strict") posturePlusStrict.config.warnings)
+              "apps/cloudflare-warp-module-eval: postureonly carries no traffic, so a strict checkReversePath must not warn";
             {
               dnsConflict = dnsConflict.config.warnings;
               staleDns = staleDns.config.warnings;
               strictRpFilter = strictRpFilter.config.warnings;
+              posturePlusStrict = posturePlusStrict.config.warnings;
             };
           connectOffAttrs =
             assert lib.assertMsg (

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -261,12 +261,20 @@
                   && lib.hasInfix "daemon is registered outside the managed organization" mismatchReport
                 )
                 "apps/cloudflare-warp-module-eval: the terminal mismatch report must separate an empty registration from a foreign tenant";
-            # One definition plus one call site at the top of each attempt.
-            # warp-cli connect does not change the registration organization, so
-            # a second check per attempt only spends IPC budget.
-            assert lib.assertMsg
-              (lib.length (lib.splitString "refresh_registration" enrolledConnectScript) == 3)
-              "apps/cloudflare-warp-module-eval: enrolled connect script must refresh the registration once per attempt";
+            # One call site at the top of each attempt. warp-cli connect does not
+            # change the registration organization, so a second check per attempt
+            # only spends IPC budget. Scoped to the loop body: a whole-script
+            # count also matches the definition and any comment naming it.
+            assert
+              let
+                loopBody = lib.head (
+                  lib.splitString ''if [ -n "$connected" ]'' (
+                    lib.last (lib.splitString ''while [ -z "$connected" ]'' enrolledConnectScript)
+                  )
+                );
+              in
+              lib.assertMsg (lib.length (lib.splitString "refresh_registration" loopBody) == 2)
+                "apps/cloudflare-warp-module-eval: enrolled connect script must refresh the registration once per attempt";
             assert
               let
                 parts = lib.splitString "while [ -z \"$connected\" ]" enrolledConnectScript;

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -67,6 +67,16 @@
               openFirewall = false;
             };
           };
+          # Every mdm field the enrolled fixture renders sits at its option
+          # default, so only diverging values prove the template forwards them.
+          mdmVariant = mkNixos {
+            secretsRoot = ./cloudflare-warp-check-fixtures;
+            extraSettings = {
+              serviceMode = "tunnelonly";
+              autoConnect = 42;
+              switchLocked = true;
+            };
+          };
           unenrolled = mkNixos {
             secretsRoot = "${./cloudflare-warp-check-fixtures}/missing";
           };
@@ -118,6 +128,30 @@
               && !enrolledWarp.openFirewall
               && !(builtins.elem 24080 enrolled.config.networking.firewall.allowedUDPPorts)
             ) "apps/cloudflare-warp-module-eval: enrolled branch must forward udpPort and openFirewall";
+            # The managed branch sets no environment.systemPackages of its own;
+            # warp-cli reaches PATH only through upstream services.cloudflare-warp,
+            # which every command in the cheatsheet and operations runbook assumes.
+            assert lib.assertMsg (hasWarpCli enrolled)
+              "apps/cloudflare-warp-module-eval: enrolled branch must still install warp-cli";
+            # mdm.xml is authoritative for service_mode and the module never calls
+            # `warp-cli mode`, so a wrong field here is silent at runtime. Assert
+            # against mdmVariant's non-default values: the enrolled fixture's are
+            # all option defaults, so it would pass even against hardcoded output.
+            assert
+              let
+                rendered = mdmVariant.config.sops.templates."cloudflare-warp-mdm".content;
+              in
+              lib.assertMsg
+                (
+                  lib.hasInfix "<key>service_mode</key>\n  <string>tunnelonly</string>" rendered
+                  && lib.hasInfix "<key>auto_connect</key>\n  <integer>42</integer>" rendered
+                  && lib.hasInfix "<key>switch_locked</key>\n  <true/>" rendered
+                )
+                "apps/cloudflare-warp-module-eval: mdm.xml must render serviceMode, autoConnect, and switchLocked";
+            # switchLocked renders through a Nix `if`, so pin both arms.
+            assert lib.assertMsg (lib.hasInfix "<key>switch_locked</key>\n  <false/>"
+              enrolled.config.sops.templates."cloudflare-warp-mdm".content
+            ) "apps/cloudflare-warp-module-eval: switchLocked false must render <false/>";
             # sops compares the rendered template between generations, so it
             # already covers every mdm field. A second restart owner on the unit
             # restarts warp-svc twice for one activation.
@@ -236,6 +270,7 @@
               templateContent = enrolled.config.sops.templates."cloudflare-warp-mdm".content;
               connectScript = enrolledConnectScript;
               warnings = enrolled.config.warnings;
+              variantTemplateContent = mdmVariant.config.sops.templates."cloudflare-warp-mdm".content;
             };
           # Forcing the managed branch's warnings list forces both lib.optional
           # predicates, so a renamed option path there fails the check instead of

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -242,6 +242,21 @@
             assert lib.assertMsg
               (lib.hasInfix "warp-cli --accept-tos registration organization" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must verify managed registration";
+            # --accept-tos is a global warp-cli option, not a per-subcommand one,
+            # so every call carries it. Leaving it off disconnect in particular
+            # would make the fail-closed teardown the one call that can be
+            # refused, downgrading enforcement to a log line.
+            assert lib.assertMsg (
+              lib.all (sub: lib.hasInfix "warp-cli --accept-tos ${sub}" enrolledConnectScript) [
+                "registration organization"
+                "status"
+                "disconnect"
+                "connect"
+              ]
+              && !lib.hasInfix "warp-cli status" enrolledConnectScript
+              && !lib.hasInfix "warp-cli disconnect" enrolledConnectScript
+              && !lib.hasInfix "warp-cli connect" enrolledConnectScript
+            ) "apps/cloudflare-warp-module-eval: every warp-cli call must pass --accept-tos";
             # The capture is compared for exact equality, so 2>&1 would report an
             # enrolled device as unmanaged, and 2>/dev/null would drop warp-cli's
             # own reason for a failed check from the journal.
@@ -288,7 +303,7 @@
             # into a whole-script search that always passes.
             assert
               let
-                parts = lib.splitString "warp-cli disconnect" enrolledConnectScript;
+                parts = lib.splitString "warp-cli --accept-tos disconnect" enrolledConnectScript;
                 beforeDisconnect = lib.head parts;
               in
               lib.assertMsg

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -143,6 +143,26 @@
             # which every command in the cheatsheet and operations runbook assumes.
             assert lib.assertMsg (hasWarpCli enrolled)
               "apps/cloudflare-warp-module-eval: enrolled branch must still install warp-cli";
+            # The credential fields go through config.sops.placeholder so the
+            # plaintext never enters the store. Assert against that same live
+            # attribute, not a hand-typed token, so swapping it for
+            # sops.secrets.<x>.path or dropping a key/string pair fails here
+            # instead of shipping an mdm.xml with no credentials in it.
+            assert
+              let
+                rendered = enrolled.config.sops.templates."cloudflare-warp-mdm".content;
+                placeholderOf = name: enrolled.config.sops.placeholder."cloudflare-warp/${name}";
+              in
+              lib.assertMsg
+                (lib.all
+                  (name: lib.hasInfix "<key>${name}</key>\n  <string>${placeholderOf name}</string>" rendered)
+                  [
+                    "organization"
+                    "auth_client_id"
+                    "auth_client_secret"
+                  ]
+                )
+                "apps/cloudflare-warp-module-eval: mdm.xml must render the three credentials as sops placeholders";
             # mdm.xml is authoritative for service_mode and the module never calls
             # `warp-cli mode`, so a wrong field here is silent at runtime. Assert
             # against mdmVariant's non-default values: the enrolled fixture's are
@@ -184,6 +204,21 @@
                   && lib.hasInfix "exit 1" mdmValidation
                 )
                 "apps/cloudflare-warp-module-eval: enrolled branch must parse the rendered mdm.xml before installing it, without leaking xmllint's stderr";
+            # Only the xmllint guard above is pinned, so the step that actually
+            # writes mdm.xml into rootDir could be deleted with the check green,
+            # leaving warp-svc up on consumer WARP. lib.any over the list rather
+            # than lib.last: a third entry is a harmless change that should not
+            # break this, and xmllint is already pinned at lib.head.
+            assert lib.assertMsg
+              (lib.any (
+                step:
+                lib.hasInfix "/bin/install" step
+                && lib.hasInfix "-m0600" step
+                && lib.hasInfix "-o root" step
+                && lib.hasInfix "-g root" step
+                && lib.hasInfix "/var/lib/cloudflare-warp/mdm.xml" step
+              ) enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre)
+              "apps/cloudflare-warp-module-eval: enrolled branch must install the rendered mdm.xml into rootDir mode 0600 root:root";
             # partOf stays empty on purpose. BindsTo already carries an explicit
             # restart through to the oneshot, and on an unexpected warp-svc exit
             # BindsTo stops the oneshot before any restart-dependency
@@ -196,6 +231,12 @@
                 && enrolled.config.systemd.services.cloudflare-warp.upholds == [ "cloudflare-warp-connect.service" ]
               )
               "apps/cloudflare-warp-module-eval: connect oneshot must re-run after an unexpected warp-svc restart";
+            # nixpkgs only warns when after carries network-online.target without
+            # a matching wants, and abort-on-warn is off, so pin both halves.
+            assert lib.assertMsg (
+              builtins.elem "network-online.target" enrolledConnect.after
+              && builtins.elem "network-online.target" enrolledConnect.wants
+            ) "apps/cloudflare-warp-module-eval: the connect oneshot must wait for network-online.target";
             assert lib.assertMsg enrolledConnect.enableStrictShellChecks
               "apps/cloudflare-warp-module-eval: connect script must be shellcheck-gated";
             assert lib.assertMsg
@@ -210,6 +251,26 @@
             assert lib.assertMsg
               (lib.hasInfix "managed organization secret unavailable; cannot verify registration" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must reject an empty managed organization";
+            # A healthy boot passes through the per-attempt states on its way to
+            # confirmed, so logging them at <3> would make `journalctl -p err`
+            # report every good boot as broken. Reserve <3> for states the run
+            # cannot recover from and for enforcement.
+            assert lib.assertMsg
+              (
+                lib.all (msg: lib.hasInfix "<4>cloudflare-warp-connect: ${msg}" enrolledConnectScript) [
+                  "registration check failed"
+                  "managed Zero Trust registration unavailable"
+                  "managed enrollment is not ready; not connecting"
+                ]
+                && lib.all (msg: lib.hasInfix "<3>cloudflare-warp-connect: ${msg}" enrolledConnectScript) [
+                  "managed organization secret unavailable"
+                  "connected without managed Zero Trust registration; disconnecting"
+                  "failed to disconnect unmanaged tunnel"
+                  "daemon reports no Zero Trust registration"
+                  "daemon is registered outside the managed organization"
+                ]
+              )
+              "apps/cloudflare-warp-module-eval: per-attempt states must log at <4> and unrecoverable or enforcement states at <3>";
             assert
               let
                 parts = lib.splitString "warp-cli --accept-tos connect" enrolledConnectScript;

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -125,11 +125,21 @@
               enrolled.config.sops.templates."cloudflare-warp-mdm".restartUnits == [ "cloudflare-warp.service" ]
               && enrolled.config.systemd.services.cloudflare-warp.restartTriggers == [ ]
             ) "apps/cloudflare-warp-module-eval: the mdm template must be the only restart owner of warp-svc";
-            assert lib.assertMsg
-              (lib.hasInfix "xmllint --noout" (
-                lib.head enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre
-              ))
-              "apps/cloudflare-warp-module-eval: enrolled branch must parse the rendered mdm.xml before installing it";
+            # xmllint echoes the offending source line, which is the credential,
+            # so the guard has to stay fail-closed without reaching the journal:
+            # suppressing stderr without `exit 1` would install a malformed
+            # mdm.xml and drop warp-svc back to unmanaged mode silently.
+            assert
+              let
+                mdmValidation = lib.head enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre;
+              in
+              lib.assertMsg
+                (
+                  lib.hasInfix "xmllint --noout" mdmValidation
+                  && lib.hasInfix "2>/dev/null" mdmValidation
+                  && lib.hasInfix "exit 1" mdmValidation
+                )
+                "apps/cloudflare-warp-module-eval: enrolled branch must parse the rendered mdm.xml before installing it, without leaking xmllint's stderr";
             # Restart=always respawns warp-svc without an explicit restart job,
             # which PartOf does not propagate; Upholds re-runs the oneshot.
             assert lib.assertMsg

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -3,9 +3,10 @@
 
   CI intentionally has no secrets submodule, so normal host evaluation only
   takes the un-enrolled branch. Use an in-repo non-secret fixture to force the
-  managed branch and deep-force the template, secret-backed ExecStartPre, and
-  connect script. A missing fixture path keeps the un-enrolled assertions in
-  the same check.
+  managed branch and deep-force the template, secret-backed ExecStartPre,
+  connect script, and warnings. A missing fixture path keeps the un-enrolled
+  assertions in the same check, and one fixture per managed-branch warning
+  trigger proves each fires with its own text.
 */
 {
   lib,
@@ -28,6 +29,7 @@
               secretsRoot,
               enable ? true,
               extraSettings ? { },
+              extraConfig ? { },
             }:
             inputs.nixpkgs.lib.nixosSystem {
               system = "x86_64-linux";
@@ -36,7 +38,10 @@
                 warpModule
                 {
                   nixpkgs.config.allowUnfree = true;
-                  networking.firewall.checkReversePath = "loose";
+                  # Models a host on the hosts-common vpn-defaults baseline.
+                  # mkDefault so a fixture can force the strict rp_filter the
+                  # managed branch warns about.
+                  networking.firewall.checkReversePath = lib.mkDefault "loose";
                   programs.cloudflare-warp.extended = {
                     inherit enable;
                     serviceMode = "warp";
@@ -49,6 +54,7 @@
                   sops.age.keyFile = "/dev/null";
                   system.stateVersion = "26.05";
                 }
+                extraConfig
               ];
               specialArgs = { inherit secretsRoot; };
             };
@@ -67,6 +73,18 @@
           disabled = mkNixos {
             secretsRoot = "${./cloudflare-warp-check-fixtures}/missing";
             enable = false;
+          };
+          # Both managed-branch warnings are conditional and CI has no secrets
+          # submodule, so nothing else in this repo ever reaches their
+          # predicates. One fixture per trigger keeps the option paths behind
+          # them (networkmanager.dns, firewall.checkReversePath) honest.
+          dnsConflict = mkNixos {
+            secretsRoot = ./cloudflare-warp-check-fixtures;
+            extraConfig.networking.networkmanager.dns = "dnsmasq";
+          };
+          strictRpFilter = mkNixos {
+            secretsRoot = ./cloudflare-warp-check-fixtures;
+            extraConfig.networking.firewall.checkReversePath = "strict";
           };
           hasWarpCli =
             system:
@@ -183,6 +201,24 @@
               execStartPre = enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre;
               templateContent = enrolled.config.sops.templates."cloudflare-warp-mdm".content;
               connectScript = enrolledConnectScript;
+              warnings = enrolled.config.warnings;
+            };
+          # Forcing the managed branch's warnings list forces both lib.optional
+          # predicates, so a renamed option path there fails the check instead of
+          # an operator's rebuild once the sops payload lands.
+          warningsAttrs =
+            assert lib.assertMsg (
+              !lib.any (lib.hasInfix "takes over DNS") enrolled.config.warnings
+              && !lib.any (lib.hasInfix "checkReversePath is strict") enrolled.config.warnings
+            ) "apps/cloudflare-warp-module-eval: a managed host on the vpn-defaults baseline must not warn";
+            assert lib.assertMsg (lib.any (lib.hasInfix "takes over DNS") dnsConflict.config.warnings)
+              "apps/cloudflare-warp-module-eval: a local resolver under a DNS-owning service mode must warn";
+            assert lib.assertMsg
+              (lib.any (lib.hasInfix "checkReversePath is strict") strictRpFilter.config.warnings)
+              "apps/cloudflare-warp-module-eval: a strict checkReversePath must warn";
+            {
+              dnsConflict = dnsConflict.config.warnings;
+              strictRpFilter = strictRpFilter.config.warnings;
             };
           unenrolledAttrs =
             assert lib.assertMsg (
@@ -221,7 +257,12 @@
         in
         builtins.deepSeq
           {
-            inherit enrolledAttrs unenrolledAttrs disabledAttrs;
+            inherit
+              enrolledAttrs
+              unenrolledAttrs
+              disabledAttrs
+              warningsAttrs
+              ;
           }
           (
             pkgs.runCommandLocal "cloudflare-warp-module-eval-ok" { } ''

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -184,8 +184,11 @@
                   && lib.hasInfix "exit 1" mdmValidation
                 )
                 "apps/cloudflare-warp-module-eval: enrolled branch must parse the rendered mdm.xml before installing it, without leaking xmllint's stderr";
-            # Restart=always respawns warp-svc without an explicit restart job,
-            # which PartOf does not propagate; Upholds re-runs the oneshot.
+            # partOf stays empty on purpose. BindsTo already carries an explicit
+            # restart through to the oneshot, and on an unexpected warp-svc exit
+            # BindsTo stops the oneshot before any restart-dependency
+            # propagation can reach it, so PartOf would add nothing that Upholds
+            # is not already doing.
             assert lib.assertMsg
               (
                 enrolledConnect.bindsTo == [ "cloudflare-warp.service" ]

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -292,6 +292,7 @@
                   "managed enrollment is not ready; not connecting"
                   "status command failed"
                   "connect request failed"
+                  "connected while the managed registration could not be verified"
                   "tunnel is up but its registration went unverified"
                 ]
                 && lib.all (msg: lib.hasInfix "<3>cloudflare-warp-connect: ${msg}" enrolledConnectScript) [
@@ -464,6 +465,13 @@
             assert lib.assertMsg
               (builtins.elem "r /var/lib/cloudflare-warp/mdm.xml" unenrolled.config.systemd.tmpfiles.rules)
               "apps/cloudflare-warp-module-eval: un-enrolled branch must remove a stale managed mdm.xml";
+            # The build warning is the only signal that an enabled host installs
+            # warp-cli with no daemon behind it, which is the state both hosts
+            # are in until the sops payload lands. warp-cli on PATH otherwise
+            # makes an un-enrolled host look enrolled.
+            assert lib.assertMsg
+              (lib.any (lib.hasInfix "secrets/cloudflare-warp.yaml is missing") unenrolled.config.warnings)
+              "apps/cloudflare-warp-module-eval: un-enrolled branch must warn that warp-svc is not started";
             {
               tmpfilesRules = unenrolled.config.systemd.tmpfiles.rules;
               warnings = unenrolled.config.warnings;

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -284,6 +284,13 @@
                 ''request_output="$(timeout -k 1s 5s warp-cli --accept-tos connect 2>&1)"''
               ])
               "apps/cloudflare-warp-module-eval: every warp-cli call must pass --accept-tos with its bounded timeout and redirect";
+            # Every other anchor for this path matches diagnostic text, so
+            # pointing the read at a path that does not exist at runtime would
+            # take the empty-organization exit on every boot with the check
+            # green. Match the live sops attribute so it cannot drift.
+            assert lib.assertMsg
+              (lib.hasInfix "cat ${enrolled.config.sops.secrets."cloudflare-warp/organization".path}" enrolledConnectScript)
+              "apps/cloudflare-warp-module-eval: enrolled connect script must read the managed organization from its sops secret";
             assert lib.assertMsg
               (lib.hasInfix "managed organization secret unavailable; cannot verify registration" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must reject an empty managed organization";
@@ -299,6 +306,7 @@
                   "managed enrollment is not ready; not connecting"
                   "status command failed"
                   "connect request failed"
+                  "registration check returned no organization"
                   "connected while the managed registration could not be verified"
                   "tunnel is up but its registration went unverified"
                 ]
@@ -438,6 +446,9 @@
                   # first live tunnel this run never confirmed, which is a
                   # consumer-WARP tunnel reported as a healthy managed one.
                   lib.hasInfix ''confirmed_once=""'' initBlock
+                  # mismatch is the state that disconnects, so an empty answer
+                  # must route to unknown once this run confirmed, not to it.
+                  && lib.hasInfix ''elif [ -z "$registration" ] && [ -n "$confirmed_once" ]; then'' confirmedArm
                   && !lib.hasInfix "confirmed_once=1" initBlock
                   && lib.hasInfix "confirmed_once=1" confirmedArm
                   # Suppression direction: the guard must actually skip the count.

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -423,16 +423,28 @@
             # run early and then report it as never verified.
             assert
               let
+                initBlock = lib.head (lib.splitString "refresh_registration() {" enrolledConnectScript);
+                confirmedArm = lib.head (
+                  lib.splitString ''registration_state="mismatch"'' (
+                    lib.last (lib.splitString ''registration_state="confirmed"'' enrolledConnectScript)
+                  )
+                );
                 guarded = lib.last (lib.splitString ''if [ -n "$confirmed_once" ]; then'' enrolledConnectScript);
                 counted = lib.head (lib.splitString "unverified=$((unverified + 1))" guarded);
               in
               lib.assertMsg
                 (
-                  lib.hasInfix "confirmed_once=1" enrolledConnectScript
+                  # Fail-open direction: seeding the flag truthy would accept the
+                  # first live tunnel this run never confirmed, which is a
+                  # consumer-WARP tunnel reported as a healthy managed one.
+                  lib.hasInfix ''confirmed_once=""'' initBlock
+                  && !lib.hasInfix "confirmed_once=1" initBlock
+                  && lib.hasInfix "confirmed_once=1" confirmedArm
+                  # Suppression direction: the guard must actually skip the count.
                   && lib.length (lib.splitString ''if [ -n "$confirmed_once" ]; then'' enrolledConnectScript) == 2
                   && lib.hasInfix "else" counted
                 )
-                "apps/cloudflare-warp-module-eval: an unanswered check must not count as unverified once this run confirmed the registration";
+                "apps/cloudflare-warp-module-eval: confirmed_once must start empty, be set only where the registration is confirmed, and gate the unverified count";
             {
               execStartPre = enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre;
               templateContent = enrolled.config.sops.templates."cloudflare-warp-mdm".content;

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -239,6 +239,22 @@
             ) "apps/cloudflare-warp-module-eval: the connect oneshot must wait for network-online.target";
             assert lib.assertMsg enrolledConnect.enableStrictShellChecks
               "apps/cloudflare-warp-module-eval: connect script must be shellcheck-gated";
+            # The exit-0-everywhere design holds only while the unit outlives the
+            # retry window and warp-cli is on its PATH. DefaultTimeoutStartSec is
+            # 90s, under the script's 120s deadline, so dropping the explicit
+            # value SIGTERMs a run that reaches that deadline into `failed`, which
+            # Upholds then restarts in a loop. Dropping cfg.package turns every
+            # call into exit 127 while the unit still reports active (exited).
+            assert lib.assertMsg
+              (
+                # `or`: a deleted setting must reach the message below rather
+                # than aborting with a bare "attribute missing".
+                (enrolledConnect.serviceConfig.TimeoutStartSec or null) == 180
+                && (enrolledConnect.serviceConfig.RemainAfterExit or false)
+                && lib.hasInfix "deadline=$((SECONDS + 120))" enrolledConnectScript
+                && lib.any (entry: lib.hasInfix "cloudflare-warp" (toString entry)) enrolledConnect.path
+              )
+              "apps/cloudflare-warp-module-eval: the connect oneshot must outlive its retry deadline and carry warp-cli on PATH";
             assert lib.assertMsg
               (lib.hasInfix "warp-cli --accept-tos registration organization" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must verify managed registration";

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -80,8 +80,12 @@
           unenrolled = mkNixos {
             secretsRoot = "${./cloudflare-warp-check-fixtures}/missing";
           };
+          # enable = false with the secret present is the tpnix kill switch, and
+          # the only fixture where cfg.enable is the sole thing holding the
+          # managed branch shut. A missing secretsRoot here would leave every
+          # assertion below passing with `managed` gated on enrolling alone.
           disabled = mkNixos {
-            secretsRoot = "${./cloudflare-warp-check-fixtures}/missing";
+            secretsRoot = ./cloudflare-warp-check-fixtures;
             enable = false;
           };
           # Both managed-branch warnings are conditional and CI has no secrets

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -105,6 +105,12 @@
             secretsRoot = ./cloudflare-warp-check-fixtures;
             extraConfig.networking.firewall.checkReversePath = "strict";
           };
+          # connectOnBoot = false is its own mkIf branch that no other fixture
+          # reaches, and the Upholds edge lives inside it.
+          connectOff = mkNixos {
+            secretsRoot = ./cloudflare-warp-check-fixtures;
+            extraSettings.connectOnBoot = false;
+          };
           hasWarpCli =
             system:
             lib.any (
@@ -239,6 +245,22 @@
                   && !lib.hasInfix "\"$unverified\"" terminalReport
                 )
                 "apps/cloudflare-warp-module-eval: the terminal report must branch on the live registration and status, not the cumulative unverified counter";
+            # The assertion above still passes if the two mismatch sub-cases
+            # collapse back into one line, and they carry different remediation:
+            # an empty answer is an enrollment that never completed.
+            assert
+              let
+                parts = lib.splitString "if [ \"$registration_state\" = \"mismatch\" ]; then" enrolledConnectScript;
+                mismatchReport = lib.last parts;
+              in
+              lib.assertMsg
+                (
+                  lib.length parts > 1
+                  && lib.hasInfix "if [ -z \"$registration\" ]; then" mismatchReport
+                  && lib.hasInfix "daemon reports no Zero Trust registration" mismatchReport
+                  && lib.hasInfix "daemon is registered outside the managed organization" mismatchReport
+                )
+                "apps/cloudflare-warp-module-eval: the terminal mismatch report must separate an empty registration from a foreign tenant";
             # One definition plus one call site at the top of each attempt.
             # warp-cli connect does not change the registration organization, so
             # a second check per attempt only spends IPC budget.
@@ -257,6 +279,17 @@
                   && lib.hasInfix "exit 0" beforeLoop
                 )
                 "apps/cloudflare-warp-module-eval: enrolled connect script must exit before the retry loop when the managed organization is empty";
+            # That exit path skips the loop, so it is the only place a status
+            # line can come from; without it the journal has no record of the
+            # tunnel for this outcome.
+            assert
+              let
+                guarded = lib.last (lib.splitString ''if [ -z "$managed_org" ]; then'' enrolledConnectScript);
+                beforeExit = lib.head (
+                  lib.splitString "managed organization secret unavailable; not connecting" guarded
+                );
+              in
+              lib.assertMsg (lib.hasInfix "refresh_status" beforeExit) "apps/cloudflare-warp-module-eval: enrolled connect script must report status before exiting on an empty managed organization";
             # A live tunnel whose registration never answered is terminal: the
             # loop has nothing left to request and must not spend its full budget.
             assert lib.assertMsg
@@ -291,6 +324,18 @@
               dnsConflict = dnsConflict.config.warnings;
               staleDns = staleDns.config.warnings;
               strictRpFilter = strictRpFilter.config.warnings;
+            };
+          connectOffAttrs =
+            assert lib.assertMsg (
+              !builtins.hasAttr "cloudflare-warp-connect" connectOff.config.systemd.services
+            ) "apps/cloudflare-warp-module-eval: connectOnBoot = false must not declare the connect oneshot";
+            # Upholds is a Wants-strength edge, so a dangling target is inert
+            # rather than fatal, which is exactly why nothing else would catch
+            # it being hoisted out of the connectOnBoot branch.
+            assert lib.assertMsg (connectOff.config.systemd.services.cloudflare-warp.upholds == [ ])
+              "apps/cloudflare-warp-module-eval: connectOnBoot = false must not uphold an undeclared connect oneshot";
+            {
+              upholds = connectOff.config.systemd.services.cloudflare-warp.upholds;
             };
           unenrolledAttrs =
             assert lib.assertMsg (
@@ -334,6 +379,7 @@
               unenrolledAttrs
               disabledAttrs
               warningsAttrs
+              connectOffAttrs
               ;
           }
           (

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -255,10 +255,10 @@
             # warp-cli's own reason for a failed check from the journal.
             assert lib.assertMsg
               (lib.all (call: lib.hasInfix call enrolledConnectScript) [
-                ''registration="$(timeout 5s warp-cli --accept-tos registration organization)"''
-                ''status="$(timeout 5s warp-cli --accept-tos status 2>&1)"''
-                ''disconnect_output="$(timeout 5s warp-cli --accept-tos disconnect 2>&1)"''
-                ''request_output="$(timeout 5s warp-cli --accept-tos connect 2>&1)"''
+                ''registration="$(timeout -k 1s 5s warp-cli --accept-tos registration organization)"''
+                ''status="$(timeout -k 1s 5s warp-cli --accept-tos status 2>&1)"''
+                ''disconnect_output="$(timeout -k 1s 5s warp-cli --accept-tos disconnect 2>&1)"''
+                ''request_output="$(timeout -k 1s 5s warp-cli --accept-tos connect 2>&1)"''
               ])
               "apps/cloudflare-warp-module-eval: every warp-cli call must pass --accept-tos with its bounded timeout and redirect";
             assert lib.assertMsg
@@ -274,6 +274,8 @@
                   "registration check failed"
                   "managed Zero Trust registration unavailable"
                   "managed enrollment is not ready; not connecting"
+                  "status command failed"
+                  "connect request failed"
                 ]
                 && lib.all (msg: lib.hasInfix "<3>cloudflare-warp-connect: ${msg}" enrolledConnectScript) [
                   "managed organization secret unavailable"
@@ -451,6 +453,17 @@
             assert lib.assertMsg (
               !disabled.config.services.cloudflare-warp.enable
             ) "apps/cloudflare-warp-module-eval: disabled branch must not enable upstream WARP";
+            # The documented job of the kill switch is to stop declaring secrets
+            # the host can no longer decrypt, which is not the same property as
+            # keeping warp-svc down. Moving the sops block to `mkIf enrolling`
+            # would leave every other assertion here green while a host that lost
+            # its runtime key fails activation on the payload.
+            assert lib.assertMsg
+              (
+                !builtins.hasAttr "cloudflare-warp/organization" disabled.config.sops.secrets
+                && !builtins.hasAttr "cloudflare-warp-mdm" disabled.config.sops.templates
+              )
+              "apps/cloudflare-warp-module-eval: disabled branch must declare no sops secrets and no mdm template";
             assert lib.assertMsg (
               !(hasWarpCli disabled)
             ) "apps/cloudflare-warp-module-eval: disabled branch must not install warp-cli";

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -246,23 +246,21 @@
             # so every call carries it. Leaving it off disconnect in particular
             # would make the fail-closed teardown the one call that can be
             # refused, downgrading enforcement to a log line.
-            assert lib.assertMsg (
-              lib.all (sub: lib.hasInfix "warp-cli --accept-tos ${sub}" enrolledConnectScript) [
-                "registration organization"
-                "status"
-                "disconnect"
-                "connect"
-              ]
-              && !lib.hasInfix "warp-cli status" enrolledConnectScript
-              && !lib.hasInfix "warp-cli disconnect" enrolledConnectScript
-              && !lib.hasInfix "warp-cli connect" enrolledConnectScript
-            ) "apps/cloudflare-warp-module-eval: every warp-cli call must pass --accept-tos";
-            # The capture is compared for exact equality, so 2>&1 would report an
-            # enrolled device as unmanaged, and 2>/dev/null would drop warp-cli's
-            # own reason for a failed check from the journal.
+            # Match whole call sites, not the flag or the subcommand alone: a
+            # substring search hits prose too, and a comment naming a call would
+            # then fail an assertion whose message explains none of that. These
+            # also pin each call's timeout and redirect shape. The registration
+            # capture in particular is compared for exact equality, so 2>&1 would
+            # report an enrolled device as unmanaged, while 2>/dev/null would drop
+            # warp-cli's own reason for a failed check from the journal.
             assert lib.assertMsg
-              (lib.hasInfix ''registration="$(timeout 5s warp-cli --accept-tos registration organization)"'' enrolledConnectScript)
-              "apps/cloudflare-warp-module-eval: the registration capture must leave stderr unredirected";
+              (lib.all (call: lib.hasInfix call enrolledConnectScript) [
+                ''registration="$(timeout 5s warp-cli --accept-tos registration organization)"''
+                ''status="$(timeout 5s warp-cli --accept-tos status 2>&1)"''
+                ''disconnect_output="$(timeout 5s warp-cli --accept-tos disconnect 2>&1)"''
+                ''request_output="$(timeout 5s warp-cli --accept-tos connect 2>&1)"''
+              ])
+              "apps/cloudflare-warp-module-eval: every warp-cli call must pass --accept-tos with its bounded timeout and redirect";
             assert lib.assertMsg
               (lib.hasInfix "managed organization secret unavailable; cannot verify registration" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must reject an empty managed organization";

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -83,36 +83,64 @@
             secretsRoot = "${./cloudflare-warp-check-fixtures}/missing";
             enable = false;
           };
+          enrolledConnectScript = enrolled.config.systemd.services.cloudflare-warp-connect.script;
           enrolledAttrs =
             assert lib.assertMsg (builtins.hasAttr "cloudflare-warp/organization" enrolled.config.sops.secrets)
               "apps/cloudflare-warp-module-eval: enrolled branch must declare organization secret";
             assert lib.assertMsg (builtins.hasAttr "cloudflare-warp-mdm" enrolled.config.sops.templates)
               "apps/cloudflare-warp-module-eval: enrolled branch must declare mdm template";
             assert lib.assertMsg (
-              !lib.hasInfix "UN-ENROLLED" enrolled.config.systemd.services.cloudflare-warp-connect.script
+              !lib.hasInfix "UN-ENROLLED" enrolledConnectScript
             ) "apps/cloudflare-warp-module-eval: enrolled connect script must not carry the un-enrolled guard";
             assert lib.assertMsg
-              (lib.hasInfix "warp-cli --accept-tos registration organization" enrolled.config.systemd.services.cloudflare-warp-connect.script)
+              (lib.hasInfix "warp-cli --accept-tos registration organization" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must verify managed registration";
             assert lib.assertMsg
-              (lib.hasInfix "managed organization secret unavailable; cannot verify registration" enrolled.config.systemd.services.cloudflare-warp-connect.script)
+              (lib.hasInfix "managed organization secret unavailable; cannot verify registration" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must reject an empty managed organization";
             assert
               let
-                connectScript = enrolled.config.systemd.services.cloudflare-warp-connect.script;
-                parts = lib.splitString "warp-cli --accept-tos connect" connectScript;
+                parts = lib.splitString "warp-cli --accept-tos connect" enrolledConnectScript;
                 beforeConnect = lib.head parts;
               in
               lib.assertMsg
                 (
                   lib.length parts > 1
-                  && lib.hasInfix "if [ -n \"$managed_org\" ] && [ -n \"$managed_registration\" ]; then" beforeConnect
+                  && lib.hasInfix "if [ \"$registration_state\" = \"confirmed\" ]; then" beforeConnect
                 )
-                "apps/cloudflare-warp-module-eval: enrolled connect script must gate connect on managed enrollment";
+                "apps/cloudflare-warp-module-eval: enrolled connect script must gate connect on a confirmed registration";
+            # An unanswered registration check must not be treated as an
+            # unmanaged tunnel, so the disconnect belongs to the mismatch branch
+            # alone.
+            assert
+              let
+                beforeDisconnect = lib.head (lib.splitString "warp-cli disconnect" enrolledConnectScript);
+              in
+              lib.assertMsg
+                (
+                  lib.hasInfix "mismatch)" beforeDisconnect && !lib.hasInfix "could not be verified" beforeDisconnect
+                )
+                "apps/cloudflare-warp-module-eval: enrolled connect script must disconnect only on a confirmed registration mismatch";
+            # One definition plus two call sites: once before the loop and once
+            # per attempt. warp-cli connect does not change the registration
+            # organization, so a second per-attempt check only spends IPC budget.
+            assert lib.assertMsg
+              (lib.length (lib.splitString "refresh_registration" enrolledConnectScript) == 4)
+              "apps/cloudflare-warp-module-eval: enrolled connect script must refresh the registration once per attempt";
+            assert
+              let
+                beforeLoop = lib.head (lib.splitString "while [ -z \"$connected\" ]" enrolledConnectScript);
+              in
+              lib.assertMsg
+                (
+                  lib.hasInfix "managed organization secret unavailable; not connecting" beforeLoop
+                  && lib.hasInfix "exit 0" beforeLoop
+                )
+                "apps/cloudflare-warp-module-eval: enrolled connect script must exit before the retry loop when the managed organization is empty";
             {
               execStartPre = enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre;
               templateContent = enrolled.config.sops.templates."cloudflare-warp-mdm".content;
-              connectScript = enrolled.config.systemd.services.cloudflare-warp-connect.script;
+              connectScript = enrolledConnectScript;
               restartTriggers = enrolled.config.systemd.services.cloudflare-warp.restartTriggers;
             };
           unenrolledAttrs =

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -1,0 +1,162 @@
+/*
+  Check: force both SOPS branches of the Cloudflare WARP app module.
+
+  CI intentionally has no secrets submodule, so normal host evaluation only
+  takes the un-enrolled branch. Use an in-repo non-secret fixture to force the
+  managed branch and deep-force the template, secret-backed ExecStartPre, and
+  connect script. A missing fixture path keeps the un-enrolled assertions in
+  the same check.
+*/
+{
+  lib,
+  inputs,
+  config,
+  ...
+}:
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks."apps/cloudflare-warp-module-eval" =
+        let
+          findModule =
+            name: module:
+            if builtins.isList module then
+              let
+                findIn =
+                  modules:
+                  if modules == [ ] then
+                    null
+                  else
+                    let
+                      candidate = findModule name (builtins.head modules);
+                    in
+                    if candidate != null then candidate else findIn (builtins.tail modules);
+              in
+              findIn module
+            else if builtins.isAttrs module then
+              if builtins.hasAttr name module then module.${name} else findModule name (module.imports or [ ])
+            else
+              null;
+          warpModule =
+            let
+              found = findModule "cloudflare-warp" config.flake.nixosModules.apps;
+            in
+            assert lib.assertMsg (
+              found != null
+            ) "apps/cloudflare-warp-module-eval: cloudflare-warp app export is missing";
+            found;
+          mkNixos =
+            {
+              secretsRoot,
+              enable ? true,
+            }:
+            inputs.nixpkgs.lib.nixosSystem {
+              system = "x86_64-linux";
+              modules = [
+                inputs.sops-nix.nixosModules.sops
+                warpModule
+                {
+                  nixpkgs.config.allowUnfree = true;
+                  networking.firewall.checkReversePath = "loose";
+                  programs.cloudflare-warp.extended = {
+                    inherit enable;
+                    serviceMode = "warp";
+                    autoConnect = 0;
+                    switchLocked = false;
+                    connectOnBoot = true;
+                  };
+                  sops.validateSopsFiles = false;
+                  sops.age.keyFile = "/dev/null";
+                  system.stateVersion = "26.05";
+                }
+              ];
+              specialArgs = { inherit secretsRoot; };
+            };
+          enrolled = mkNixos {
+            secretsRoot = ./cloudflare-warp-check-fixtures;
+          };
+          unenrolled = mkNixos {
+            secretsRoot = "${./cloudflare-warp-check-fixtures}/missing";
+          };
+          disabled = mkNixos {
+            secretsRoot = "${./cloudflare-warp-check-fixtures}/missing";
+            enable = false;
+          };
+          enrolledAttrs =
+            assert lib.assertMsg (builtins.hasAttr "cloudflare-warp/organization" enrolled.config.sops.secrets)
+              "apps/cloudflare-warp-module-eval: enrolled branch must declare organization secret";
+            assert lib.assertMsg (builtins.hasAttr "cloudflare-warp-mdm" enrolled.config.sops.templates)
+              "apps/cloudflare-warp-module-eval: enrolled branch must declare mdm template";
+            assert lib.assertMsg (
+              !lib.hasInfix "UN-ENROLLED" enrolled.config.systemd.services.cloudflare-warp-connect.script
+            ) "apps/cloudflare-warp-module-eval: enrolled connect script must not carry the un-enrolled guard";
+            assert lib.assertMsg
+              (lib.hasInfix "warp-cli --accept-tos registration organization" enrolled.config.systemd.services.cloudflare-warp-connect.script)
+              "apps/cloudflare-warp-module-eval: enrolled connect script must verify managed registration";
+            assert lib.assertMsg
+              (lib.hasInfix "managed organization secret unavailable; cannot verify registration" enrolled.config.systemd.services.cloudflare-warp-connect.script)
+              "apps/cloudflare-warp-module-eval: enrolled connect script must reject an empty managed organization";
+            assert
+              let
+                connectScript = enrolled.config.systemd.services.cloudflare-warp-connect.script;
+                parts = lib.splitString "warp-cli --accept-tos connect" connectScript;
+                beforeConnect = lib.head parts;
+              in
+              lib.assertMsg
+                (
+                  lib.length parts > 1
+                  && lib.hasInfix "if [ -n \"$managed_org\" ] && [ -n \"$managed_registration\" ]; then" beforeConnect
+                )
+                "apps/cloudflare-warp-module-eval: enrolled connect script must gate connect on managed enrollment";
+            {
+              execStartPre = enrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre;
+              templateContent = enrolled.config.sops.templates."cloudflare-warp-mdm".content;
+              connectScript = enrolled.config.systemd.services.cloudflare-warp-connect.script;
+              restartTriggers = enrolled.config.systemd.services.cloudflare-warp.restartTriggers;
+            };
+          unenrolledAttrs =
+            assert lib.assertMsg (
+              !builtins.hasAttr "cloudflare-warp/organization" unenrolled.config.sops.secrets
+            ) "apps/cloudflare-warp-module-eval: un-enrolled branch must not declare organization secret";
+            assert
+              let
+                connectScript = unenrolled.config.systemd.services.cloudflare-warp-connect.script;
+                parts = lib.splitString "warp-cli --accept-tos connect" connectScript;
+                beforeConnect = lib.head parts;
+              in
+              lib.assertMsg
+                (
+                  lib.length parts > 1
+                  && lib.hasInfix "<4>cloudflare-warp-connect: device is UN-ENROLLED" beforeConnect
+                  && lib.hasInfix "exit 0" beforeConnect
+                )
+                "apps/cloudflare-warp-module-eval: un-enrolled connect script must warn and exit before warp-cli connect";
+            {
+              connectScript = unenrolled.config.systemd.services.cloudflare-warp-connect.script;
+              execStartPre = unenrolled.config.systemd.services.cloudflare-warp.serviceConfig.ExecStartPre;
+              restartTriggers = unenrolled.config.systemd.services.cloudflare-warp.restartTriggers;
+              warnings = unenrolled.config.warnings;
+            };
+          disabledAttrs =
+            assert lib.assertMsg (
+              !disabled.config.services.cloudflare-warp.enable
+            ) "apps/cloudflare-warp-module-eval: disabled branch must not enable upstream WARP";
+            assert lib.assertMsg
+              (builtins.elem "r /var/lib/cloudflare-warp/mdm.xml" disabled.config.systemd.tmpfiles.rules)
+              "apps/cloudflare-warp-module-eval: disabled branch must remove managed mdm.xml";
+            {
+              tmpfilesRules = disabled.config.systemd.tmpfiles.rules;
+            };
+        in
+        builtins.deepSeq
+          {
+            inherit enrolledAttrs unenrolledAttrs disabledAttrs;
+          }
+          (
+            pkgs.runCommandLocal "cloudflare-warp-module-eval-ok" { } ''
+              echo "ok: both Cloudflare WARP enrollment branches evaluated" > $out
+            ''
+          );
+    };
+}

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -117,6 +117,12 @@
             assert lib.assertMsg
               (lib.hasInfix "warp-cli --accept-tos registration organization" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must verify managed registration";
+            # The capture is compared for exact equality, so 2>&1 would report an
+            # enrolled device as unmanaged, and 2>/dev/null would drop warp-cli's
+            # own reason for a failed check from the journal.
+            assert lib.assertMsg
+              (lib.hasInfix ''registration="$(timeout 5s warp-cli --accept-tos registration organization)"'' enrolledConnectScript)
+              "apps/cloudflare-warp-module-eval: the registration capture must leave stderr unredirected";
             assert lib.assertMsg
               (lib.hasInfix "managed organization secret unavailable; cannot verify registration" enrolledConnectScript)
               "apps/cloudflare-warp-module-eval: enrolled connect script must reject an empty managed organization";

--- a/modules/apps/cloudflare-warp/module-check.nix
+++ b/modules/apps/cloudflare-warp/module-check.nix
@@ -190,6 +190,21 @@
                   && !lib.hasInfix "could not be verified" beforeDisconnect
                 )
                 "apps/cloudflare-warp-module-eval: enrolled connect script must disconnect only on a confirmed registration mismatch";
+            # unverified is never reset, so testing it in the terminal report
+            # would let one early unanswered check on a leftover tunnel outrank
+            # a live mismatch, or claim a tunnel is up after it was torn down.
+            assert
+              let
+                parts = lib.splitString "if [ -z \"$connected\" ]; then" enrolledConnectScript;
+                terminalReport = lib.last parts;
+              in
+              lib.assertMsg
+                (
+                  lib.length parts > 1
+                  && lib.hasInfix "if [ \"$registration_state\" = \"mismatch\" ]; then" terminalReport
+                  && !lib.hasInfix "\"$unverified\"" terminalReport
+                )
+                "apps/cloudflare-warp-module-eval: the terminal report must branch on the live registration and status, not the cumulative unverified counter";
             # One definition plus one call site at the top of each attempt.
             # warp-cli connect does not change the registration organization, so
             # a second check per attempt only spends IPC budget.

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -95,7 +95,7 @@ let
       "cloudflare-go-sdk".extended.enable = lib.mkOverride 1100 false;
       "cloudflare-python-sdk".extended.enable = lib.mkOverride 1100 false;
       "cloudflare-rs-sdk".extended.enable = lib.mkOverride 1100 false;
-      "cloudflare-warp".extended.enable = lib.mkOverride 1100 true;
+      "cloudflare-warp".extended.enable = lib.mkOverride 1100 false;
       cloudflared.extended.enable = lib.mkOverride 1100 true;
       cmake.extended.enable = lib.mkOverride 1100 true;
       codeburn.extended.enable = lib.mkOverride 1100 false;

--- a/modules/system76/cloudflare-warp.nix
+++ b/modules/system76/cloudflare-warp.nix
@@ -1,0 +1,22 @@
+/*
+  Per-host Cloudflare WARP (Zero Trust) enrollment for system76.
+
+  Enables the programs.cloudflare-warp.extended wrapper in Full mode
+  ("Gateway with WARP"). Credentials come from secrets/cloudflare-warp.yaml
+  (sops); see docs/cloudflare/warp/deployment.md for the dashboard prerequisites.
+
+  Note: the Zero Trust team name (organization) is identifying, and this repository
+  is public, so it lives in secrets/cloudflare-warp.yaml (sops) and is rendered into
+  mdm.xml through a placeholder; see docs/cloudflare/warp/reference.md.
+*/
+_: {
+  configurations.nixos.system76.module = {
+    programs.cloudflare-warp.extended = {
+      enable = true;
+      serviceMode = "warp";
+      autoConnect = 0;
+      switchLocked = false;
+      connectOnBoot = true;
+    };
+  };
+}

--- a/modules/system76/services.nix
+++ b/modules/system76/services.nix
@@ -99,11 +99,6 @@ in
       services = {
         cloudflared.enable = true;
 
-        cloudflare-warp = {
-          enable = true;
-          package = pkgs.cloudflare-warp.override { headless = true; };
-        };
-
         printing = {
           enable = lib.mkForce false;
           drivers = with pkgs; [

--- a/modules/tpnix/cloudflare-warp.nix
+++ b/modules/tpnix/cloudflare-warp.nix
@@ -10,16 +10,14 @@
   mappings while WARP supplies the tunnel, HTTP filtering, network policies,
   and posture checks. It intentionally does not use Gateway DNS.
 
-  Gated on tpnix's sopsRuntimeReady flag (modules/tpnix/policy.nix), matching the
-  other tpnix sops consumers (duplicati.nix, printing.nix, fonts.nix). Repo-managed
-  sops decryption is enabled for tpnix (PR #305), so the flag is true and the
-  wrapper behaves like system76's: un-enrolled degraded mode (build warning, no
-  managed mdm.xml) until secrets/cloudflare-warp.yaml is committed, then
-  non-interactive enrollment. The gate still matters as a kill switch: if tpnix
-  ever loses its runtime decryption key, flipping the flag back to false drops the
-  WARP stack with it, removes any previously rendered runtime mdm.xml on the next
-  activation, and ensures the sops.secrets."cloudflare-warp/*" declarations and the
-  cloudflare-warp-mdm template cannot fail activation on an un-decryptable payload.
+  Gated on tpnix's sopsRuntimeReady flag (modules/tpnix/policy.nix). The flag is
+  true, so this host installs warp-cli and starts nothing until
+  secrets/cloudflare-warp.yaml is committed, then enrolls non-interactively. The
+  gate is a kill switch: if tpnix ever loses its runtime decryption key, flipping
+  the flag back to false drops the WARP stack with it, removes any previously
+  rendered runtime mdm.xml on the next activation, and keeps the
+  sops.secrets."cloudflare-warp/*" declarations and the cloudflare-warp-mdm
+  template from failing activation on an un-decryptable payload.
 
   Note: the Zero Trust team name (organization) is identifying, and this repository
   is public, so it lives in secrets/cloudflare-warp.yaml (sops) and is rendered into

--- a/modules/tpnix/cloudflare-warp.nix
+++ b/modules/tpnix/cloudflare-warp.nix
@@ -1,0 +1,42 @@
+/*
+  Per-host Cloudflare WARP (Zero Trust) enrollment for tpnix.
+
+  Enables the programs.cloudflare-warp.extended wrapper in tunnel-only mode
+  ("Secure Web Gateway without DNS filtering"). Credentials come from
+  secrets/cloudflare-warp.yaml (sops); see docs/cloudflare/warp/deployment.md
+  for the dashboard prerequisites.
+
+  Tunnel-only mode preserves tpnix's NetworkManager dnsmasq private-host
+  mappings while WARP supplies the tunnel, HTTP filtering, network policies,
+  and posture checks. It intentionally does not use Gateway DNS.
+
+  Gated on tpnix's sopsRuntimeReady flag (modules/tpnix/policy.nix), matching the
+  other tpnix sops consumers (duplicati.nix, printing.nix, fonts.nix). Repo-managed
+  sops decryption is enabled for tpnix (PR #305), so the flag is true and the
+  wrapper behaves like system76's: un-enrolled degraded mode (build warning, no
+  managed mdm.xml) until secrets/cloudflare-warp.yaml is committed, then
+  non-interactive enrollment. The gate still matters as a kill switch: if tpnix
+  ever loses its runtime decryption key, flipping the flag back to false drops the
+  WARP stack with it, removes any previously rendered runtime mdm.xml on the next
+  activation, and ensures the sops.secrets."cloudflare-warp/*" declarations and the
+  cloudflare-warp-mdm template cannot fail activation on an un-decryptable payload.
+
+  Note: the Zero Trust team name (organization) is identifying, and this repository
+  is public, so it lives in secrets/cloudflare-warp.yaml (sops) and is rendered into
+  mdm.xml through a placeholder; see docs/cloudflare/warp/reference.md.
+*/
+{ config, ... }:
+let
+  inherit (config.flake.lib.nixos.hosts.tpnix) sopsRuntimeReady;
+in
+{
+  configurations.nixos.tpnix.module = {
+    programs.cloudflare-warp.extended = {
+      enable = sopsRuntimeReady;
+      serviceMode = "tunnelonly";
+      autoConnect = 0;
+      switchLocked = false;
+      connectOnBoot = true;
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Turns `cloudflare-warp` from a package-on-PATH into a declarative Cloudflare Zero Trust
enrollment, and moves enablement from the shared baseline to per-host modules.

Before this change the app module only put `warp-cli` on PATH, so enrolling a device meant
running `warp-cli register` by hand and the Zero Trust team name landed in shell history.
The shared baseline also switched every `shareCommon` host to `warp-svc` at
`mkOverride 1100`, even though service mode is a per-host decision.

**Managed enrollment (`modules/apps/cloudflare-warp.nix`)**

- Drives upstream `services.cloudflare-warp` and renders `/var/lib/cloudflare-warp/mdm.xml`
  from a sops template, so `organization`, `auth_client_id`, and `auth_client_secret` reach
  `warp-svc` without entering the Nix store.
- `mdm.xml` is authoritative for `service_mode`, so `serviceMode`, `autoConnect`, and
  `switchLocked` are exposed as options and `warp-cli mode` is never called.
- Branch selection is `builtins.pathExists (secretsRoot + "/cloudflare-warp.yaml")`. Without
  the secret the host installs `warp-cli` alone and declares neither `warp-svc` nor the
  connect oneshot: an unmanaged daemon holds `CAP_NET_ADMIN` and an open UDP port while
  serving only consumer WARP. A tmpfiles rule clears any stale `mdm.xml`, which would
  otherwise pin the old service mode and cached service token.
- `templates."cloudflare-warp-mdm".restartUnits` is the sole restart owner for
  `cloudflare-warp.service`. sops compares the rendered template between generations, so a
  rotated credential and a changed `serviceMode`/`autoConnect`/`switchLocked` both restart
  `warp-svc`. A second `restartTriggers` hash on the unit would restart it twice per
  activation on hosts running `sops.useSystemdActivation`.
- `ExecStartPre` parses the rendered fragment with `xmllint --noout` before installing it.
  Credentials are substituted after evaluation, so no Nix-side quoting can escape them; an
  XML metacharacter in one fails the unit instead of degrading `warp-svc` to unmanaged mode.
  xmllint's stderr is discarded and replaced with a fixed message, because it reports a parse
  error by echoing the offending source line, which is the credential, and neither this module
  nor upstream sets `StandardError`.
- `after`/`requires` use `flake.lib.security.sopsInstallSecretsDeps`, which resolves to `[]`
  on activation-script hosts because `sops-install-secrets.service` only exists under
  `sops.useSystemdActivation` (issue #37).
- Warnings cover three configuration interactions that otherwise become silent: a local resolver
  on `127.0.0.1:53` fighting Gateway DNS, a missing `secrets/cloudflare-warp.yaml` leaving the
  host with the CLI and no daemon, and strict `checkReversePath` dropping asymmetric return
  traffic on the `CloudflareWARP` interface. `services.dnscrypt-proxy.enable` triggers the resolver
  warning independently. Its NetworkManager dnsmasq branch requires
  `networking.networkmanager.enable` alongside `dns = "dnsmasq"`, since that option is declared
  unconditionally but only reaches `NetworkManager.conf` under `mkIf enable`. `switchLocked`
  deliberately remains documentation-only: it is a Cloudflare policy choice that legitimately
  combines with `connectOnBoot`, but it makes mismatch teardown report-only. The module summary,
  option description, reference row, and cheatsheet record that tradeoff.

**Connect-on-boot guard**

`warp-svc` starts idle (`auto_connect` only governs reconnect after a manual disconnect), so
an enrolled device stays outside the tunnel until someone connects. A best-effort oneshot
performs that connect, gated so it can never select consumer WARP: `warp-cli connect` on an
un-enrolled daemon registers against Cloudflare's consumer service, a different security
posture than Zero Trust. The first `warp-cli connect` requires `warp-cli registration organization` to match the
sops-provisioned organization. A later unanswered response may reuse that same-run confirmation only while no successful empty response is
held and no later successful response has recorded a mismatch. A successful empty response opens a bounded readiness
hold, so it cannot verify the tunnel or authorize another connect request. The script
disconnects a tunnel that reached `Connected` without a confirmed managed registration.

`registration_state` is tri-state (`confirmed` / `mismatch` / `unknown`) because
warp-cli 2026.3.846.0 answers `registration organization` with exit 0 and an empty string when
the device carries no Teams registration. Collapsing the two would let one `timeout 5s` firing
on a busy `warp-svc` disconnect a healthy managed tunnel, so only `mismatch` disconnects while
`unknown` leaves the tunnel up. A successful empty answer opens a bounded readiness hold only while no conclusive mismatch is retained. A fresh managed confirmation resets its three-answer window.
A later failed query cannot cancel that hold, because it has no organization result to resolve the
state. This keeps an interleaved timeout from consuming the unverified budget before a fourth empty
answer reaches `mismatch` and tears down consumer WARP. A retained mismatch instead keeps a later empty answer on the existing mismatch path, so it cannot
suppress enforcement of a foreign tunnel. After a failed cleanup, it also preserves the remaining
attempt and deadline budget for a fresh successful response to retry cleanup, without treating a
failed registration query itself as disconnect evidence. Command substitution captures stdout alone and
the check strips
whitespace from both sides, so a banner on stderr cannot turn a correctly enrolled device into a
`mismatch` without a redirect suppressing it; stderr is therefore left to reach the journal as
warp-cli's own reason for a failed check. An
empty managed organization, read once at startup, exits after the first status report instead
of spinning until the deadline. The confirmation branch also requires that configured organization
to be nonempty, so a future control-flow refactor cannot classify two empty strings as `confirmed`
and authorize consumer WARP.

The terminal log line normally names the state the run ended on. A conclusive mismatch remains
the exception: a later unanswered registration check cannot prove it resolved, so the terminal
diagnostic retains only its empty-or-foreign classification until a successful managed confirmation
clears it. This retained classification cannot turn a failed check into disconnect evidence, but it prevents an
earlier `confirmed_once` result from accepting a later `Connected` tunnel or authorizing a later
`connect` retry, and prevents a later successful empty answer from reopening the readiness hold until
a successful managed confirmation clears the mismatch. With neither a pending empty-answer hold nor a retained mismatch, `unverified` counts
unanswered checks against a live tunnel and is never reset. A hold persists until a successful registration response resolves
it, so intermittent failures cannot pre-empt the fourth empty answer reaching `mismatch`.
`unverified` also cannot gate that report: one early unanswered check on a leftover tunnel would
otherwise outrank a mismatch confirmed later, logging `tunnel is up ... left it connected` at `<4>`
for a tunnel the run had just torn down, with nothing at `<3>` to send the operator to the
dashboard. The report branches on the live `registration_state` or that retained mismatch
classification, then on the last `warp-cli status`, so the unverified line only prints while the
tunnel really is up. A mismatch is split by its retained empty-or-foreign classification, because
a device whose enrollment never completed reports no registration rather than a foreign tenant,
and the two send an operator to different places. The empty-organization exit runs a status query
before it leaves, so that outcome is not the one path with no record of the tunnel in the journal.

The unit is `BindsTo=` and `Upholds=` `cloudflare-warp.service`, which cover different triggers.
An explicit restart, which is what sops issues for `restartUnits` (`try-restart`), reaches the
oneshot through `BindsTo=` alone. An unexpected exit does not, because `BindsTo=` stops the
oneshot ahead of the restart-dependency propagation for that same event, so `Upholds=` is what
starts it again. `PartOf=` adds nothing either way and stays unset, since `BindsTo=` wins that
race whether or not `PartOf=` is also present. Verified against systemd 261.1 from this flake's
pin, with `try-restart` (the verb `sops-install-secrets` issues) as well as `restart`.

The oneshot also waits on `network-online.target`. Upstream orders `warp-svc` on `network.target`,
which says nothing about an associated link, and 25.05 decoupled `multi-user.target` from
`network-online.target`, so the retry budget could otherwise burn before Wi-Fi associates and
`auto_connect = 0` would leave nothing to reconnect. Per-attempt states log at `<4>` and only
unrecoverable or enforcement states at `<3>`, so `journalctl -p err` stays quiet on a healthy
boot rather than reporting every warm-up as broken. Every connect-script `warp-cli` call passes
`--accept-tos`, which is a global option on 2026.3.846.0, so the fail-closed `disconnect` cannot
be the one call that gets refused.

Bounds: `timeout -k 1s 5s` per IPC call, since a bare `timeout` sends only SIGTERM and waits, 30 attempts or a 120s deadline, `TimeoutStartSec=180`, and
exit 0 after logging so a user who deliberately keeps WARP off does not boot into a failed
unit. With neither a pending empty-answer hold nor a retained mismatch, a live tunnel whose
registration goes unanswered three times is terminal, since nothing is left to request. A pending
hold remains until a successful response resolves it, and a retained mismatch keeps the existing
attempt/deadline budget open until a fresh successful response resolves or retries cleanup. The final log
line normally names the state that ended the run. A conclusive mismatch remains its terminal
diagnostic across later unanswered checks until a successful managed confirmation clears it
(unverified registration, no registration at all, wrong organization, refused connect, or
unreachable daemon).
`enableStrictShellChecks = true` routes the script through `writeShellApplication`, so
ShellCheck and `errexit`/`nounset`/`pipefail` cover this fail-closed guard.

**Per-host enablement**

| Host | Mode | Reason |
| --- | --- | --- |
| songbird | `warp` (Full / Gateway with WARP) | No local resolver bound to `127.0.0.1:53`, so Gateway DNS does not collide. The raw `services.cloudflare-warp` block in `services.nix` is removed because a second definition of `package` would conflict. |
| tpnix | `tunnelonly` | NetworkManager runs `dns = "dnsmasq"` for private-host mappings, which `warp` would break. WARP still supplies the tunnel, HTTP filtering, network policies, and posture checks. |

tpnix gates `enable` on `flake.lib.nixos.hosts.tpnix.sopsRuntimeReady`. The flag is true since
PR #305, so the gate is a kill switch rather than what keeps the host un-enrolled: losing the
runtime decryption key drops the WARP stack with it and keeps the
`sops.secrets."cloudflare-warp/*"` declarations from failing activation on an un-decryptable
payload.

**Coverage**

CI has no secrets submodule, so host evaluation only ever takes the un-enrolled path.
`checks."apps/cloudflare-warp-module-eval"` evaluates the module against an in-repo
non-secret fixture to force the managed branch and against a missing path for the un-enrolled
branch, deep-forcing the sops template content, the install `ExecStartPre`, and the connect
script text so a regression in the registration guard cannot reach `main` unnoticed. An exact
source-derived assertion requires a nonempty configured organization before confirmation assigns
`confirmed_once` and resets the empty-response readiness window. It also asserts that `package`/`enable`/`udpPort`/`openFirewall` reach
`services.cloudflare-warp` (headless selection has no other test now that `services.nix` no longer
sets it). The `enrolled` fixture covers non-default UDP 24080 with `openFirewall = false`;
`mdmVariant` covers default UDP 2408 with `openFirewall = true` and requires the port in
`allowedUDPPorts`, so a hardcoded false cannot leave managed hosts closed. The check also asserts
that the template is the only restart owner, the `BindsTo`/`Upholds` wiring, the shellcheck gate,
and that the un-enrolled branch declares no daemon and no connect unit. The fixture holds
placeholder values only and is not sops-encrypted: the check needs the path to exist and the
three keys to resolve, not real credentials.

Both managed-branch warnings are conditional, so forcing only the template and script text left
their predicates unreachable by any evaluation in this repo: a rename of
`services.dnscrypt-proxy.enable`, `networking.networkmanager.dns`, or
`networking.firewall.checkReversePath` would have surfaced first on an operator's rebuild after
the sops payload landed. The check now forces the managed `warnings` list with independent
fixtures: dnscrypt-proxy and NetworkManager dnsmasq under DNS-owning `serviceMode "warp"` must
warn; dnscrypt-proxy under `tunnelonly` must stay silent; and dnscrypt-proxy under `1dot1` must
warn. The independent `checkReversePath = "strict"` fixture also requires its warning. A baseline
host stays silent, and a `staleDns` fixture holds the NetworkManager negative case: `dns =
"dnsmasq"` with NetworkManager off must not warn.

The rendered `mdm.xml` is asserted against a `mdmVariant` fixture that diverges on `serviceMode`,
`autoConnect`, and `switchLocked`, since the enrolled fixture holds all three at their option
defaults and would pass against hardcoded output; the enrolled fixture pins the other arm of
`switchLocked`'s Nix `if`. `warp-cli` on PATH is asserted for the managed branch too, the one
branch where the module does not place the package itself.

Three further assertions pin properties that the previous substring matches let through. The
registration capture is matched whole, so neither `2>&1` (which would compare an enrolled
device as unmanaged) nor `2>/dev/null` (which would drop warp-cli's reason for a failed check
from the journal) can return. The `xmllint` guard must carry both the stderr redirect and
`exit 1`, since suppressing the leak without the exit would install a malformed `mdm.xml`
silently. The terminal report must preserve a conclusive mismatch across later failed checks
with an empty-or-foreign classification, and it must not reference `unverified`. The scoped assertions prove that a retained mismatch blocks stale `confirmed_once` acceptance and
reopening the readiness hold, preserves the attempt and deadline budget for fresh cleanup, but
cannot make a failed check enter the live `mismatch)` disconnect enforcement. Readiness assertions pin the bounded empty-answer producer, reset it on a fresh confirmation,
and preserve it across failed checks. They require `held_empty` to block stale `confirmed_once`
acceptance and connection retries, retain mismatch gates, and prohibit `connected=1` in the held
or ordinary unverified paths. Thus an interleaved timeout cannot pre-empt the fourth empty
response reaching `mismatch` or accept consumer WARP. Three more
cover the round after that: the
status query on the empty-organization exit, the split mismatch report, and a `connectOff` fixture
for `connectOnBoot = false`, the one managed sub-branch no fixture reached. Each was verified by
injecting the regression it targets and confirming it is the assertion that fails.

**Docs**

New pages under `docs/cloudflare/warp/`: deployment (dashboard prerequisites, the
`secrets/cloudflare-warp.yaml` payload, and pushing the submodule before bumping its pointer),
modes (which mode each host runs and which collide with a local resolver), operations
(verifying registration, reading `cloudflare-warp-connect` logs, recovering a stale
`mdm.xml`), reference (option to `mdm.xml` key mapping), and cheatsheet. Linked from
`docs/cloudflare/README.md` and `docs/index.md`.

## Test plan

- `nix flake check path:. --accept-flake-config --no-build --offline` (exit 0)
- `nix build 'path:.#checks.x86_64-linux."apps/cloudflare-warp-module-eval"'` (exit 0, both
  sops branches forced)
- Built `unit-script-cloudflare-warp-connect-start`; ShellCheck 0.11.0 passes on the connect
  script
- Ran that built script against a stub `warp-cli` across eight states: verified tunnel,
  connected but unverifiable, connected to the wrong organization, banner on stderr,
  whitespace in the organization value, connect requested and refused, unreachable daemon,
  and empty organization secret
- Modeled a foreign registration mismatch followed by a successful empty response: the retained
  mismatch prevents a readiness hold and routes a `Connected` tunnel through existing mismatch
  cleanup; the first three initial and post-confirmation empty responses remain held, then a
  fourth successful empty response routes to mismatch cleanup
- Modeled a failed cleanup followed by three failed registration probes: retained mismatch leaves
  `unverified` unchanged and keeps the existing attempt/deadline budget open for a fresh successful
  response to retry cleanup without using stale state as disconnect evidence
- Modeled an unanswered probe after same-run confirmation: it permits status acceptance or a
  connection retry only while neither a successful empty-response hold nor a mismatch is retained
- Modeled a successful empty response after same-run confirmation: it stays held without status
  acceptance or a connect retry, and the fourth success reaches mismatch cleanup
- Temporarily removed the retained-mismatch clause from the same-run connect gate and the nonempty
  managed-organization clause from confirmation. Each mutation failed
  `apps/cloudflare-warp-module-eval` on its focused assertion; the exact guards were restored
- Temporarily reintroduced the post-confirmation empty-response bypass, removed each held-empty
  guard, and removed the confirmation reset. Each mutation failed
  `apps/cloudflare-warp-module-eval` on its focused assertion; the exact state guards were restored
- Ran a strict shell state model for confirmed-to-empty settling, fourth-empty mismatch, timeout
  retry, held-empty plus timeout, retained mismatch, and readiness reset.
- Replaced the production `inherit (cfg) package udpPort openFirewall;` temporarily with
  `openFirewall = false;`: `apps/cloudflare-warp-module-eval` failed with
  `openFirewall = true must open udpPort`
- Temporarily removed the DNS mode gate and the `"1dot1"` allow-list member; the target
  evaluation failed on the tunnelonly and `1dot1` assertions, respectively
- Scanned executable WARP documentation commands: no `warp-cli` command omits `--accept-tos`
- Rendered both units to confirm `BindsTo=`/`Upholds=` and the absence of
  `X-Restart-Triggers=`
- `nix eval path:.#nixosConfigurations.songbird.config.programs.cloudflare-warp.extended.serviceMode`
  -> `warp`
- `nix eval path:.#nixosConfigurations.tpnix.config.programs.cloudflare-warp.extended.serviceMode`
  -> `tunnelonly`
- `nix eval path:.#nixosConfigurations.tpnix.config.programs.cloudflare-warp.extended.enable`
  -> `true`
- `treefmt --fail-on-change --no-cache` (0 changed)
- Pre-push hooks: apps-catalog-sync, flake-checker, gitleaks, managed-files-drift all passed

Note: `secrets/cloudflare-warp.yaml` is not committed, so both hosts currently build with
`warp-cli` installed, no daemon, and the build warning by design. Committing the sops payload
described in `docs/cloudflare/warp/deployment.md` switches them to managed enrollment with no
further module change.
