### PR TITLE
feat(networking): add captive-portal helper for tailnet-owned DNS

### DIFF
--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -425,7 +425,9 @@ reboot finds no snapshot. That run re-enables tailnet DNS, which is the safe
 direction, and leaves the run state alone: nothing recorded that the node was
 up, and starting one that was stopped on purpose is not a restore. DNS goes back
 before the run state for the same reason, so a node that refuses to come back up
-still gets its resolvers.
+still gets its resolvers. That run reports the stopped node rather than the
+operator pref, which the DNS write it just completed had already cleared, and it
+exits 4 keeping the snapshot so `--restore` can be retried once the node starts.
 
 ## Sign in by hand
 

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -386,9 +386,11 @@ a real upstream resolver and enforce at the gateway do. The sign-in URL is taken
 from what a link, form, or meta refresh in the page points at, falling back to
 the address the canary resolved to.
 
-Loopback is not one of those addresses. A resolver that sinkholes blocklisted
-names to `127.0.0.1` answers a probe host that way, and that is this machine
-rather than a portal. Nor is a `Location` header trusted for its scheme: only
+A canary that resolves to this machine is dropped before the request goes out. A
+resolver that sinkholes blocklisted names answers `127.0.0.1` or `0.0.0.0`, which
+Pi-hole, AdGuard Home and a bare dnsmasq `address=/host/` all do by default, and
+`curl --resolve` sends either to the local port 80. Whatever answers there is not
+a portal. Nor is a `Location` header trusted for its scheme: only
 `http` and `https` targets are ever printed or opened, since everything here is
 chosen by an untrusted network and reaches `xdg-open`. The probes also pass
 `--noproxy '*'`, because an inherited `http_proxy` would send them somewhere

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -376,17 +376,18 @@ URL rather than launch a browser.
 Only the portal URL goes to stdout; every diagnostic goes to stderr, and the
 exit status names the outcome, so a wrapper can act on it:
 
-| Status | Meaning                                                         |
-| ------ | --------------------------------------------------------------- |
-| 0      | a portal was found and its URL was printed                      |
-| 1      | no portal: this network answers the probes normally             |
-| 2      | invalid usage                                                   |
-| 3      | probes inconclusive; a gateway guess is printed when one exists |
-| 4      | the network could not be inspected, or prefs could not be read  |
+| Status | Meaning                                                        |
+| ------ | -------------------------------------------------------------- |
+| 0      | a portal was found and its URL was printed                     |
+| 1      | no portal: this network answers the probes normally            |
+| 2      | invalid usage                                                  |
+| 3      | probes inconclusive; a gateway guess is printed, never opened  |
+| 4      | the network could not be inspected, or prefs could not be read |
 
 Status 3 is a guess, not a detection. The address printed is the network's
 gateway, which on a network that merely blocks the probe hosts is the local
-router rather than a portal.
+router rather than a portal, so it is only printed: the browser is launched for
+a confirmed portal and nothing else.
 
 ```bash
 if url=$(captive-portal --probe); then

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -420,7 +420,9 @@ fi
 ```
 
 The helper saves `CorpDNS` and `WantRunning` under `$XDG_RUNTIME_DIR` before
-changing anything, and `--restore` replays exactly those values. The snapshot is
+changing anything, and `--restore` replays exactly those values. A snapshot it
+cannot write stops the run with status 4 before any DNS change: releasing DNS
+with no record of what to put back is the one state this helper must not leave. The snapshot is
 taken once and kept until `--restore` consumes it, so retrying after a failed
 sign-in still restores the state the first run found. A run that finds nothing
 to sign in to restores DNS before it exits; only a run that found a portal
@@ -433,9 +435,11 @@ reboot finds no snapshot. That run re-enables tailnet DNS, which is the safe
 direction, and leaves the run state alone: nothing recorded that the node was
 up, and starting one that was stopped on purpose is not a restore. DNS goes back
 before the run state for the same reason, so a node that refuses to come back up
-still gets its resolvers. That run reports the stopped node rather than the
-operator pref, which the DNS write it just completed had already cleared, and it
-exits 4 keeping the snapshot so `--restore` can be retried once the node starts.
+still gets its resolvers. That run reports the run state rather than the operator
+pref, which the DNS write it just completed had already cleared, and it exits 4
+keeping the snapshot so `--restore` can be retried. An unreadable
+`tailscale debug prefs` ends the same way rather than assuming the node is
+already running, because a read that failed is not an answer.
 
 ## Sign in by hand
 

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -391,9 +391,11 @@ resolver that sinkholes blocklisted names answers `127.0.0.1` or `0.0.0.0`, whic
 Pi-hole, AdGuard Home and a bare dnsmasq `address=/host/` all do by default, and
 `curl --resolve` sends either to the local port 80. Whatever answers there is not
 a portal. A `Location` header or an extracted link gets the same two checks:
-only `http` and `https` targets are ever printed or opened, and one naming this
-machine, `localhost`, or `::1` is dropped the same way, since everything here is
-chosen by an untrusted network and reaches `xdg-open`. The probes also pass
+only `http` and `https` targets are ever printed or opened, one naming this
+machine, `localhost`, or `::1` is dropped the same way, and control bytes are
+excluded from extracted targets, while a `Location` target containing one is
+rejected. Everything here is chosen by an untrusted network and reaches
+`xdg-open`. The probes also pass
 `--noproxy '*'`, because an inherited `http_proxy` would send them somewhere
 other than the address the access point's resolver named, which is the whole
 basis of the classification.

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -420,6 +420,13 @@ leaves DNS released, because signing in needs it. An interrupted run cannot
 restore, so it prints the `--restore` reminder instead of leaving DNS released
 in silence.
 
+`$XDG_RUNTIME_DIR` is cleared at the last logout, so a `--restore` run after a
+reboot finds no snapshot. That run re-enables tailnet DNS, which is the safe
+direction, and leaves the run state alone: nothing recorded that the node was
+up, and starting one that was stopped on purpose is not a restore. DNS goes back
+before the run state for the same reason, so a node that refuses to come back up
+still gets its resolvers.
+
 ## Sign in by hand
 
 ```bash

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -373,16 +373,32 @@ the portal URL even while Tailscale still owns DNS. Add `--down` to stop
 Tailscale entirely instead of only releasing DNS, and `--no-open` to print the
 URL rather than launch a browser.
 
+Releasing and restoring DNS writes to tailscaled, which takes a state change only
+from root and from the Unix user named by its operator pref. Reading is not
+gated the same way, so `tailscale debug prefs` answering is no evidence that
+`tailscale set` will. `programs.tailscale.extended.operator` declares that user,
+defaults to `flake.lib.meta.owner.username`, and reaches the daemon through
+`services.tailscale.extraSetFlags`, which nixpkgs replays from a root oneshot on
+every boot. Confirm it landed:
+
+```bash
+tailscale debug prefs | jq -r .OperatorUser
+```
+
+An empty answer means only root can change DNS: the helper stops with status 4
+before it changes anything rather than stranding a half-finished release, and
+`sudo` is the workaround until the next switch applies the pref.
+
 Only the portal URL goes to stdout; every diagnostic goes to stderr, and the
 exit status names the outcome, so a wrapper can act on it:
 
-| Status | Meaning                                                        |
-| ------ | -------------------------------------------------------------- |
-| 0      | a portal was found and its URL was printed                     |
-| 1      | no portal: this network answers the probes normally            |
-| 2      | invalid usage                                                  |
-| 3      | probes inconclusive; a gateway guess is printed, never opened  |
-| 4      | the network could not be inspected, or prefs could not be read |
+| Status | Meaning                                                                             |
+| ------ | ----------------------------------------------------------------------------------- |
+| 0      | a portal was found and its URL was printed                                          |
+| 1      | no portal: this network answers the probes normally                                 |
+| 2      | invalid usage                                                                       |
+| 3      | probes inconclusive; a gateway guess is printed, never opened                       |
+| 4      | the network could not be inspected, or Tailscale state could not be read or changed |
 
 Status 3 is a guess, not a detection. The address printed is the network's
 gateway, which on a network that merely blocks the probe hosts is the local
@@ -416,9 +432,12 @@ dig +short "@$resolver" A detectportal.firefox.com
 curl -sSI http://detectportal.firefox.com/success.txt | head -5
 ```
 
-The device is discovered rather than named because the two hosts name it
+The device is discovered rather than named because each host names it
 differently: `modules/tpnix/networking.nix` pins tpnix's wireless NIC to
 `wifi0`, while system76 keeps the kernel's `wlan0`.
+
+Both `tailscale set` calls need the same write access as the helper: run them as
+the operator user, or under `sudo`.
 
 A private address in the `dig` answer, or a `Location:` header pointing off
 site, is the portal. Open that URL, sign in, then run:

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -293,3 +293,90 @@ NetworkManager or `.link` policy.
 Changing a MAC address reduces one identifier exposed to a local network. It
 does not prevent tracking through Wi-Fi network names, IP-level identifiers,
 browser fingerprints, or account activity.
+
+# Sign in to a captive portal
+
+Hotel, airport, and campus networks hold a new client in a walled garden until
+it authenticates. The sign-in page is discovered through DNS: the access point's
+resolver answers every name with an address it controls, and the first
+plain-HTTP request lands on the portal. Hosts in this repository never receive
+that answer, so the portal stays invisible.
+
+## Why the portal never appears
+
+Three modules compose into a resolver path that skips the access point:
+
+1. `modules/hosts/common/networking.nix` enables NetworkManager.
+2. `modules/hosts/common/private-dns-hosts.nix` selects `dns=dnsmasq`, so
+   NetworkManager runs dnsmasq on `127.0.0.1` and forwards to the resolver DHCP
+   supplied.
+3. `modules/apps/tailscale.nix` runs tailscaled, which by default accepts the
+   tailnet's DNS configuration.
+
+tailscaled registers its own resolvconf entry and that entry supersedes
+NetworkManager's, so `/etc/resolv.conf` carries only `100.100.100.100` and the
+dnsmasq at `127.0.0.1` is shadowed. Verify both facts:
+
+```bash
+resolvconf -l | grep -E 'resolv.conf from|nameserver'
+grep '^nameserver' /etc/resolv.conf
+```
+
+`resolvconf -l` lists NetworkManager's `nameserver 127.0.0.1`, while
+`/etc/resolv.conf` carries only the Tailscale addresses.
+
+`tailscale dns status` then shows where those queries go. With MagicDNS and
+split DNS both off, the tailnet pushes global resolvers such as `194.242.2.2`
+and `1.1.1.1`, so `100.100.100.100` forwards everything to the public internet.
+A portal drops those upstreams before authentication, so queries time out rather
+than being hijacked: nothing resolves, no redirect fires, and NetworkManager's
+connectivity check reports `limited` instead of `portal`.
+
+## Use the captive-portal helper
+
+`captive-portal` (`packages/captive-portal`, enabled from
+`modules/hosts/common/apps-enable.nix`) drives the whole sequence:
+
+```bash
+captive-portal --probe    # report portal state and URL, change nothing
+captive-portal            # release DNS, locate the portal, open it
+captive-portal --restore  # return DNS to Tailscale after signing in
+```
+
+`--probe` queries the access point's resolver directly with `dig`, so it reports
+the portal URL even while Tailscale still owns `/etc/resolv.conf`. Add `--down`
+to stop Tailscale entirely instead of only releasing DNS, and `--no-open` to
+print the URL rather than launch a browser.
+
+The helper saves `CorpDNS` and `WantRunning` under `$XDG_RUNTIME_DIR` before
+changing anything, and `--restore` replays exactly those values.
+
+## Sign in by hand
+
+```bash
+tailscale set --accept-dns=false
+nmcli general reload dns-full
+resolver=$(nmcli -t -f IP4.DNS device show wifi0 | sed 's/^IP4\.DNS\[[0-9]*\]://' | head -1)
+dig +short "@$resolver" A detectportal.firefox.com
+curl -sSI http://detectportal.firefox.com/success.txt | head -5
+```
+
+A private address in the `dig` answer, or a `Location:` header pointing off
+site, is the portal. Open that URL, sign in, then run:
+
+```bash
+tailscale set --accept-dns=true
+nmcli general reload dns-full
+```
+
+## Two portal traps specific to these hosts
+
+LibreWolf is the default browser and ships with
+`network.captive-portal-service.enabled` false, so it never raises a "Log in to
+network" bar. Open the portal URL directly, and use a private window: portals
+reject cached HSTS upgrades and stale cookies from an earlier session.
+
+Portals bind an authenticated session to a MAC address. The shared baseline sets
+`wifi.macAddress = "stable"`, which is deterministic per connection profile, so
+reconnecting keeps the session. Deleting and re-creating the profile re-keys the
+address and forces a fresh sign-in. See the MAC address policy section above.

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -429,10 +429,11 @@ exit status names the outcome, so a wrapper can act on it:
 | 0      | a portal was found and its URL was printed                                          |
 | 1      | no portal: this network answers the probes normally                                 |
 | 2      | invalid usage                                                                       |
-| 3      | probes inconclusive; a gateway guess is printed, never opened                       |
+| 3      | probes inconclusive; a gateway guess is printed if there is one, never opened       |
 | 4      | the network could not be inspected, or Tailscale state could not be read or changed |
 
-Status 3 is a guess, not a detection. The address printed is the network's
+Status 3 is a guess, not a detection, and prints nothing if the network gave no
+default route to guess from. When one is printed, the address is the network's
 gateway, which on a network that merely blocks the probe hosts is the local
 router rather than a portal, so it is only printed: the browser is launched for
 a confirmed portal and nothing else.

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -373,6 +373,10 @@ the portal URL even while Tailscale still owns DNS. Add `--down` to stop
 Tailscale entirely instead of only releasing DNS, and `--no-open` to print the
 URL rather than launch a browser.
 
+`--probe` and `--restore` each name the whole purpose of a run, so they cannot be
+combined, and `--down` belongs to a login run, the only one that stops anything.
+Either pairing exits 2 rather than silently dropping one of the two.
+
 A portal counts as confirmed on any of four answers to the probe hosts: a
 redirect, a page served in place of the expected payload, RFC 6585's
 `511 Network Authentication Required`, or a canary resolving to an address on

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -390,8 +390,9 @@ A canary that resolves to this machine is dropped before the request goes out. A
 resolver that sinkholes blocklisted names answers `127.0.0.1` or `0.0.0.0`, which
 Pi-hole, AdGuard Home and a bare dnsmasq `address=/host/` all do by default, and
 `curl --resolve` sends either to the local port 80. Whatever answers there is not
-a portal. Nor is a `Location` header trusted for its scheme: only
-`http` and `https` targets are ever printed or opened, since everything here is
+a portal. A `Location` header or an extracted link gets the same two checks:
+only `http` and `https` targets are ever printed or opened, and one naming this
+machine, `localhost`, or `::1` is dropped the same way, since everything here is
 chosen by an untrusted network and reaches `xdg-open`. The probes also pass
 `--noproxy '*'`, because an inherited `http_proxy` would send them somewhere
 other than the address the access point's resolver named, which is the whole

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -373,6 +373,15 @@ the portal URL even while Tailscale still owns DNS. Add `--down` to stop
 Tailscale entirely instead of only releasing DNS, and `--no-open` to print the
 URL rather than launch a browser.
 
+A portal counts as confirmed on any of four answers to the probe hosts: a
+redirect, a page served in place of the expected payload, RFC 6585's
+`511 Network Authentication Required`, or a canary resolving to an address on
+this LAN. The last is the DNS hijack; the first three also catch a proxy that
+intercepts HTTP and leaves DNS alone, which is what guest networks that hand out
+a real upstream resolver and enforce at the gateway do. The sign-in URL is taken
+from what a link, form, or meta refresh in the page points at, falling back to
+the address the canary resolved to.
+
 Releasing and restoring DNS writes to tailscaled, which takes a state change only
 from root and from the Unix user named by its operator pref. Reading is not
 gated the same way, so `tailscale debug prefs` answering is no evidence that

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -387,7 +387,15 @@ tailscale debug prefs | jq -r .OperatorUser
 
 An empty answer means only root can change DNS: the helper stops with status 4
 before it changes anything rather than stranding a half-finished release, and
-`sudo` is the workaround until the next switch applies the pref.
+`sudo` is the workaround until the next switch applies the pref. One thing still
+changes under it. `sudo-rs` enforces `env_reset` with no opt-out and
+`modules/hosts/common/sudo.nix` keeps only `SSH_AUTH_SOCK`, so root inherits no
+`DISPLAY`, no Wayland socket and no session bus: the backgrounded `xdg-open`
+cannot reach your browser and fails silently. Pass `--no-open` and open the URL
+yourself, which is printed either way. The snapshot does follow you: the same
+reset drops `XDG_RUNTIME_DIR`, so the helper falls back to `SUDO_UID`'s runtime
+directory rather than root's, and a plain `captive-portal --restore` afterwards
+finds what the `sudo` run saved.
 
 Only the portal URL goes to stdout; every diagnostic goes to stderr, and the
 exit status names the outcome, so a wrapper can act on it:

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -382,6 +382,15 @@ a real upstream resolver and enforce at the gateway do. The sign-in URL is taken
 from what a link, form, or meta refresh in the page points at, falling back to
 the address the canary resolved to.
 
+Loopback is not one of those addresses. A resolver that sinkholes blocklisted
+names to `127.0.0.1` answers a probe host that way, and that is this machine
+rather than a portal. Nor is a `Location` header trusted for its scheme: only
+`http` and `https` targets are ever printed or opened, since everything here is
+chosen by an untrusted network and reaches `xdg-open`. The probes also pass
+`--noproxy '*'`, because an inherited `http_proxy` would send them somewhere
+other than the address the access point's resolver named, which is the whole
+basis of the classification.
+
 Releasing and restoring DNS writes to tailscaled, which takes a state change only
 from root and from the Unix user named by its operator pref. Reading is not
 gated the same way, so `tailscale debug prefs` answering is no evidence that

--- a/docs/networking/README.md
+++ b/docs/networking/README.md
@@ -304,18 +304,30 @@ that answer, so the portal stays invisible.
 
 ## Why the portal never appears
 
-Three modules compose into a resolver path that skips the access point:
+Three modules compose into a resolver path that skips the access point, and the
+middle one applies to one host today:
 
-1. `modules/hosts/common/networking.nix` enables NetworkManager.
-2. `modules/hosts/common/private-dns-hosts.nix` selects `dns=dnsmasq`, so
-   NetworkManager runs dnsmasq on `127.0.0.1` and forwards to the resolver DHCP
-   supplied.
+1. `modules/hosts/common/networking.nix` enables NetworkManager everywhere.
+2. `modules/hosts/common/private-dns-hosts.nix` selects `dns=dnsmasq` and turns
+   `services.resolved` off, but only for hosts that declare
+   `privateDnsHostsSecretKeys` in the registry. tpnix is the only one, so tpnix
+   forwards through dnsmasq on `127.0.0.1` while system76 keeps
+   systemd-resolved and `dns=systemd-resolved`.
 3. `modules/apps/tailscale.nix` runs tailscaled, which by default accepts the
    tailnet's DNS configuration.
 
-tailscaled registers its own resolvconf entry and that entry supersedes
-NetworkManager's, so `/etc/resolv.conf` carries only `100.100.100.100` and the
-dnsmasq at `127.0.0.1` is shadowed. Verify both facts:
+Which of the two local resolvers a host runs decides what the evidence looks
+like, so establish that first:
+
+```bash
+readlink -f /etc/resolv.conf
+```
+
+A path under `/run/systemd/resolve/` is the systemd-resolved host.
+
+On the dnsmasq host, tailscaled registers its own resolvconf entry, that entry
+supersedes NetworkManager's, and `/etc/resolv.conf` ends up carrying only
+`100.100.100.100`, so the dnsmasq at `127.0.0.1` is shadowed. Verify both facts:
 
 ```bash
 resolvconf -l | grep -E 'resolv.conf from|nameserver'
@@ -324,6 +336,19 @@ grep '^nameserver' /etc/resolv.conf
 
 `resolvconf -l` lists NetworkManager's `nameserver 127.0.0.1`, while
 `/etc/resolv.conf` carries only the Tailscale addresses.
+
+On the systemd-resolved host none of that shows: `/etc/resolv.conf` is a static
+symlink to the `127.0.0.53` stub, and it reads the same before and after
+anything below changes DNS. tailscaled hands its configuration to resolved
+instead, so read it there:
+
+```bash
+resolvectl status
+resolvectl dns
+```
+
+The tailnet resolvers appear against the `tailscale0` link, together with the
+`~.` routing domain that claims every query.
 
 `tailscale dns status` then shows where those queries go. With MagicDNS and
 split DNS both off, the tailnet pushes global resolvers such as `194.242.2.2`
@@ -344,22 +369,55 @@ captive-portal --restore  # return DNS to Tailscale after signing in
 ```
 
 `--probe` queries the access point's resolver directly with `dig`, so it reports
-the portal URL even while Tailscale still owns `/etc/resolv.conf`. Add `--down`
-to stop Tailscale entirely instead of only releasing DNS, and `--no-open` to
-print the URL rather than launch a browser.
+the portal URL even while Tailscale still owns DNS. Add `--down` to stop
+Tailscale entirely instead of only releasing DNS, and `--no-open` to print the
+URL rather than launch a browser.
+
+Only the portal URL goes to stdout; every diagnostic goes to stderr, and the
+exit status names the outcome, so a wrapper can act on it:
+
+| Status | Meaning                                                         |
+| ------ | --------------------------------------------------------------- |
+| 0      | a portal was found and its URL was printed                      |
+| 1      | no portal: this network answers the probes normally             |
+| 2      | invalid usage                                                   |
+| 3      | probes inconclusive; a gateway guess is printed when one exists |
+| 4      | the network could not be inspected, or prefs could not be read  |
+
+Status 3 is a guess, not a detection. The address printed is the network's
+gateway, which on a network that merely blocks the probe hosts is the local
+router rather than a portal.
+
+```bash
+if url=$(captive-portal --probe); then
+  echo "sign in at $url"
+fi
+```
 
 The helper saves `CorpDNS` and `WantRunning` under `$XDG_RUNTIME_DIR` before
-changing anything, and `--restore` replays exactly those values.
+changing anything, and `--restore` replays exactly those values. The snapshot is
+taken once and kept until `--restore` consumes it, so retrying after a failed
+sign-in still restores the state the first run found. A run that finds nothing
+to sign in to restores DNS before it exits; only a run that found a portal
+leaves DNS released, because signing in needs it. An interrupted run cannot
+restore, so it prints the `--restore` reminder instead of leaving DNS released
+in silence.
 
 ## Sign in by hand
 
 ```bash
 tailscale set --accept-dns=false
 nmcli general reload dns-full
-resolver=$(nmcli -t -f IP4.DNS device show wifi0 | sed 's/^IP4\.DNS\[[0-9]*\]://' | head -1)
+device=$(nmcli -t -f DEVICE,TYPE,STATE device status |
+  awk -F: '$3 == "connected" && $2 == "wifi" { print $1; exit }')
+resolver=$(nmcli -t -f IP4.DNS device show "$device" | sed 's/^IP4\.DNS\[[0-9]*\]://' | head -1)
 dig +short "@$resolver" A detectportal.firefox.com
 curl -sSI http://detectportal.firefox.com/success.txt | head -5
 ```
+
+The device is discovered rather than named because the two hosts name it
+differently: `modules/tpnix/networking.nix` pins tpnix's wireless NIC to
+`wifi0`, while system76 keeps the kernel's `wlan0`.
 
 A private address in the `dig` answer, or a `Location:` header pointing off
 site, is the portal. Open that URL, sign in, then run:

--- a/modules/apps/captive-portal.nix
+++ b/modules/apps/captive-portal.nix
@@ -1,0 +1,56 @@
+/*
+  Package: captive-portal
+  Description: Sign in to a captive portal on a host whose DNS is claimed by Tailscale.
+  Homepage: https://github.com/Bad3r/nixos
+  Documentation: docs/networking/README.md
+  Repository: https://github.com/Bad3r/nixos
+
+  Summary:
+    * Releases DNS from Tailscale back to NetworkManager's dnsmasq so the access point's resolver answers again.
+    * Locates the sign-in page through the access point's own resolver and HTTP probes, then opens it.
+    * Restores the saved Tailscale DNS and run state once the portal accepts the session.
+
+  Options:
+    captive-portal: Release DNS, find the portal, and open it in the default browser.
+    captive-portal --probe: Report portal state and URL without changing DNS.
+    captive-portal --restore: Hand DNS back to Tailscale after signing in.
+    --device DEV: Inspect a specific device instead of the first connected wifi/ethernet.
+    --no-open: Print the portal URL instead of launching a browser.
+    --down: Stop Tailscale entirely rather than only releasing DNS.
+
+  Example Usage:
+    * `captive-portal --probe` -- Check whether the current network intercepts DNS or HTTP.
+    * `captive-portal` -- Sign in to a hotel or campus network.
+    * `captive-portal --restore` -- Return to tailnet DNS after the portal accepts the session.
+*/
+_:
+let
+  CaptivePortalModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.captive-portal.extended;
+    in
+    {
+      options.programs.captive-portal.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable captive-portal.";
+        };
+
+        package = lib.mkPackageOption pkgs "captive-portal" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.captive-portal = CaptivePortalModule;
+}

--- a/modules/apps/tailscale.nix
+++ b/modules/apps/tailscale.nix
@@ -17,6 +17,9 @@
     authKeyFile: Optional file path containing a reusable auth key for non-interactive node registration.
     extraSetFlags: Additional arguments passed to `tailscale set` after daemon startup.
     interfaceName: Override the network interface name used by tailscaled (default `tailscale0`).
+    operator: Unix user allowed to change tailscaled state without root, applied as
+      `tailscale set --operator`. Defaults to `flake.lib.meta.owner.username`; null
+      leaves `tailscale up`, `down`, and `set` to root.
     sshHostAlias: Host alias written to `~/.ssh/hosts/<alias>` when tailscale is enabled.
     sshHostName: HostName used in the generated SSH match block (IP or MagicDNS name).
       Defaults to the `tailnetIp` of the registry host marked `primary` in
@@ -25,6 +28,7 @@
 { config, lib, ... }:
 let
   fleetHosts = config.flake.lib.nixos.hosts or { };
+  ownerUsername = config.flake.lib.meta.owner.username or null;
   primaryTailnetIp = lib.findFirst (ip: ip != null) null (
     lib.mapAttrsToList (_: host: host.tailnetIp or null) (
       lib.filterAttrs (_: host: host.primary or false) fleetHosts
@@ -68,6 +72,17 @@ let
           description = "Network interface name used for the tailscale tunnel.";
         };
 
+        operator = lib.mkOption {
+          type = lib.types.nullOr lib.types.str;
+          default = ownerUsername;
+          description = ''
+            Unix user allowed to change tailscaled state without root, passed as
+            `tailscale set --operator`. Without it `tailscale up`, `tailscale down`
+            and `tailscale set` answer only root, so user-facing tooling such as
+            captive-portal cannot release or restore DNS. null keeps that default.
+          '';
+        };
+
         sshHostAlias = lib.mkOption {
           type = lib.types.str;
           default = "tailscale";
@@ -88,10 +103,22 @@ let
       config = lib.mkIf cfg.enable {
         environment.systemPackages = [ cfg.package ];
 
+        # `tailscale set --operator` names a Unix user, and tailscaled resolves it
+        # at runtime: a name no host account carries fails the tailscaled-set unit
+        # after the switch instead of at eval.
+        assertions = lib.optional (cfg.operator != null) {
+          assertion = config.users.users ? ${cfg.operator};
+          message = "programs.tailscale.extended.operator is '${cfg.operator}', which is not a declared user.";
+        };
+
         services.tailscale = lib.mkMerge [
           {
             enable = true;
-            inherit (cfg) package interfaceName extraSetFlags;
+            inherit (cfg) package interfaceName;
+            # nixpkgs runs `tailscale set` from a root oneshot only when this list
+            # is non-empty, so the operator pref is re-applied on every boot.
+            extraSetFlags =
+              cfg.extraSetFlags ++ lib.optional (cfg.operator != null) "--operator=${cfg.operator}";
           }
           (lib.mkIf (cfg.authKeyFile != null) {
             inherit (cfg) authKeyFile;

--- a/modules/custom-overlays/captive-portal.nix
+++ b/modules/custom-overlays/captive-portal.nix
@@ -1,0 +1,20 @@
+_:
+let
+  Overlay =
+    { config, lib, ... }:
+    let
+      cfg = config.programs.captive-portal.extended;
+    in
+    {
+      config = lib.mkIf cfg.enable {
+        nixpkgs.overlays = [
+          (final: _prev: {
+            captive-portal = final.callPackage ../../packages/captive-portal { };
+          })
+        ];
+      };
+    };
+in
+{
+  flake.customOverlays.captive-portal = Overlay;
+}

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -71,6 +71,7 @@ let
       bzip2.extended.enable = lib.mkOverride 1100 true;
       bzmenu.extended.enable = lib.mkOverride 1100 true;
       cachix.extended.enable = lib.mkOverride 1100 true;
+      "captive-portal".extended.enable = lib.mkOverride 1100 true;
       cargo.extended.enable = lib.mkOverride 1100 true;
       certbot.extended.enable = lib.mkOverride 1100 true;
       cewl.extended.enable = lib.mkOverride 1100 true;

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -124,6 +124,25 @@
 
           digStub = pkgs.writeShellScriptBin "dig" ''
             host="''${!#}"
+            resolver=""
+            for arg in "$@"; do
+              case "$arg" in
+              @*) resolver="''${arg#@}" ;;
+              esac
+            done
+            # @resolver is to dig what --resolve is to curl: it is what makes an
+            # answer the access point's rather than the one Tailscale still owns.
+            # This stub answers from the host name alone, so dropping the flag
+            # would leave every scenario green while --probe queried
+            # 100.100.100.100 and $answer stopped describing what the access
+            # point returned.
+            case "$resolver" in
+            "''${DIG_RESOLVER-192.168.1.1}") ;;
+            *)
+              echo "dig stub: the probe must query the access-point resolver via @''${DIG_RESOLVER-192.168.1.1}, got '$resolver'" >&2
+              exit 1
+              ;;
+            esac
             case "$host" in
             detectportal.firefox.com) printf '%s\n' "''${DIG_FIREFOX-203.0.113.10}" ;;
             captive.apple.com) printf '%s\n' "''${DIG_APPLE-203.0.113.11}" ;;

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -82,6 +82,14 @@
               fi
               printf '%b\n' "''${NM_DNS-IP4.DNS[1]:192.168.1.1}"
               ;;
+            *"general reload"*)
+              printf 'nmcli %s\n' "$*" >>"$CP_LOG"
+              # A reload can be refused by polkit for a caller outside the
+              # networkmanager group, or fail while NetworkManager restarts.
+              if [ -n "''${NM_RELOAD_FAIL-}" ]; then
+                exit "$NM_RELOAD_FAIL"
+              fi
+              ;;
             *)
               printf 'nmcli %s\n' "$*" >>"$CP_LOG"
               ;;
@@ -329,6 +337,20 @@
               [ "$rc" -eq 0 ] || fail "a marker inside an interception page must not clear the canary (exit $rc)"
               [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
                 fail "the answering address must be the portal URL, got '$(cat "$work/out")'"
+            )
+
+            # The reload is the one failure the run is meant to survive rather
+            # than stop for: the release already happened, so a stale resolver is
+            # reported and the run carries on. Nothing pinned either half, so a
+            # future bare call, which errexit would abort on right after DNS was
+            # released, would have passed.
+            (
+              reset
+              rc=$(NM_RELOAD_FAIL=1 run --no-open)
+              [ "$rc" -eq 1 ] || fail "a failed DNS reload must not stop the run (exit $rc)"
+              restored || fail "a failed reload must not keep a clean network from its restore"
+              grep -q 'nmcli general reload dns-full' "$work/err" ||
+                fail "a failed reload must print the command to finish it by hand"
             )
 
             # A canary that answered correctly from a private address. The

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -506,6 +506,26 @@
               )
             done
 
+            # A sinkholed canary is dropped before the request, not judged after
+            # it. Removing 127.* from is_private_v4 only covered the path where
+            # the transfer failed: with something listening on the local port 80
+            # the 200 arm returns before the hijack check is consulted, so the
+            # run graded the user's own page. 0.0.0.0 is the commoner sinkhole
+            # and was never covered at all.
+            for sinkhole in 127.0.0.1 0.0.0.0; do
+              (
+                reset
+                export DIG_FIREFOX="$sinkhole"
+                export FF_STATUS=200
+                export FF_BODY='<html><body><p>A local dashboard listening on port 80, padded past the bound the clean test applies.</p><a href="http://localhost/admin">admin</a></body></html>'
+                export AP_STATUS=000 GS_STATUS=000
+                rc=$(run --probe)
+                [ "$rc" -eq 3 ] || fail "a canary sinkholed to $sinkhole must not be a portal (exit $rc)"
+                [ "$(cat "$work/out")" = "http://192.168.1.1" ] ||
+                  fail "$sinkhole must reach the gateway guess, got '$(cat "$work/out")'"
+              )
+            done
+
             # The mirror image. Reaching the hijack check is not the same as
             # being a hijack: a canary that never answered, from an address that
             # is nobody's LAN, has to end in the gateway guess instead. 127.0.0.1

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -412,6 +412,10 @@
 
             # `tailscale up` used to run first and gate the DNS restore, so a node
             # that would not come back up kept its resolvers off for no reason.
+            # It no longer does, so the rest of the restore must not behave as if
+            # it had: the failure is reported as its own, not as the operator wall
+            # the DNS write had already cleared, and the reload that finishes the
+            # DNS half still runs even though the run exits nonzero.
             (
               reset
               mkdir -p "$(dirname "$state")"
@@ -420,6 +424,12 @@
               [ "$rc" -eq 4 ] || fail "a refused up must still exit 4 (exit $rc)"
               restored || fail "a refused up must not keep DNS from Tailscale"
               [ -s "$state" ] || fail "an incomplete restore must keep the snapshot"
+              ! grep -q 'operator' "$work/err" ||
+                fail "a refused up is not the operator wall and must not name it"
+              ! grep -q 'DNS is still released' "$work/err" ||
+                fail "a refused up must not report DNS it just handed back as released"
+              grep -qxF 'nmcli general reload dns-full' "$work/log" ||
+                fail "a restored resolver still needs the NetworkManager reload"
             )
 
             # Absence of a snapshot is not evidence the node was ever up: the

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -982,10 +982,10 @@
                 fail "a 511 with no link must fall back to the answering address"
             )
 
-            # The scratch file for the probe payload is created after login mode
-            # has already released DNS. Unguarded, mktemp's own 1 came back as
-            # this script's "no portal", with nothing on screen saying so and the
-            # release left standing.
+            # The scratch file is created before the release, so a full or
+            # read-only TMPDIR cannot reach a point where DNS has been handed
+            # over: mktemp's own 1, which this script documents as "no portal",
+            # used to end the run there with the release standing.
             (
               reset
               tmp_denied="$work/denied-tmp"
@@ -994,8 +994,7 @@
               rc=$(TMPDIR="$tmp_denied" run --no-open)
               chmod 700 "$tmp_denied"
               [ "$rc" -eq 4 ] || fail "a scratch file that cannot be created must exit 4 (exit $rc)"
-              released || fail "login mode releases DNS before the probe runs"
-              restored || fail "a failed scratch file must not strand the release"
+              ! released || fail "a run that cannot even hold the payload must not release DNS"
               grep -q '^captive-portal: could not create a scratch file' "$work/err" ||
                 fail "the run must say the scratch file could not be created"
             )

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -338,7 +338,7 @@
             # URL is the second half: the address itself has to be what comes
             # back, not a gateway guess that happens to share the exit status.
             for hijack in \
-              10.0.0.1 127.0.0.1 192.168.1.7 \
+              10.0.0.1 192.168.1.7 \
               172.16.0.1 172.20.0.1 172.31.0.1 \
               169.254.7.7 \
               100.64.0.1 100.99.0.1 100.100.64.9 100.127.0.1; do
@@ -355,16 +355,21 @@
 
             # The mirror image. Reaching the hijack check is not the same as
             # being a hijack: a canary that never answered, from an address that
-            # is nobody's LAN, has to end in the gateway guess instead.
-            (
-              reset
-              export DIG_FIREFOX=203.0.113.50
-              export FF_STATUS=000 AP_STATUS=000 GS_STATUS=000
-              rc=$(run --probe)
-              [ "$rc" -eq 3 ] || fail "a public address must not be reported as a hijack (exit $rc)"
-              [ "$(cat "$work/out")" = "http://192.168.1.1" ] ||
-                fail "a public address must fall back to the gateway guess"
-            )
+            # is nobody's LAN, has to end in the gateway guess instead. 127.0.0.1
+            # belongs here rather than in the loop above, because it is this
+            # machine: a resolver sinkholing a blocklisted canary there had the
+            # run report the user's own host as the portal and open it.
+            for miss in 203.0.113.50 127.0.0.1; do
+              (
+                reset
+                export DIG_FIREFOX="$miss"
+                export FF_STATUS=000 AP_STATUS=000 GS_STATUS=000
+                rc=$(run --probe)
+                [ "$rc" -eq 3 ] || fail "$miss must not be reported as a hijack (exit $rc)"
+                [ "$(cat "$work/out")" = "http://192.168.1.1" ] ||
+                  fail "$miss must fall back to the gateway guess, got '$(cat "$work/out")'"
+              )
+            done
 
             # Login mode on a network that turns out to be clean: the release is
             # undone before the run exits, and the snapshot is consumed.

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -254,18 +254,46 @@
               [ "$rc" -eq 1 ] || fail "a correct answer from a private address is not a hijack (exit $rc)"
             )
 
-            # 100.64.0.0/10 and 169.254.0.0/16 are where a portal answers on
-            # carrier and lease-less networks, and neither counted as private.
-            for hijack in 100.100.64.9 169.254.7.7; do
+            # One address per arm of is_private_v4, including each alternative of
+            # the 100.64.0.0/10 pattern, which is where a portal answers on
+            # carrier networks, and 169.254.0.0/16, which is where it answers
+            # before it has issued a lease.
+            #
+            # All three canaries are forced to 000 so no arm of probe_portal's
+            # case matches and the hijack check is what decides. A 200 whose body
+            # misses its expected string returns from that arm before reaching
+            # is_private_v4, so the earlier form of this loop passed unchanged
+            # with those ranges deleted from is_private_v4 outright. Asserting the
+            # URL is the second half: the address itself has to be what comes
+            # back, not a gateway guess that happens to share the exit status.
+            for hijack in \
+              10.0.0.1 127.0.0.1 192.168.1.7 \
+              172.16.0.1 172.20.0.1 172.31.0.1 \
+              169.254.7.7 \
+              100.64.0.1 100.99.0.1 100.100.64.9 100.127.0.1; do
               (
                 reset
                 export DIG_FIREFOX="$hijack"
-                export FF_STATUS=200 FF_BODY='<html>portal</html>'
-                export AP_STATUS=000 GS_STATUS=000
+                export FF_STATUS=000 AP_STATUS=000 GS_STATUS=000
                 rc=$(run --probe)
                 [ "$rc" -eq 0 ] || fail "an answer in $hijack's range is a hijack (exit $rc)"
+                [ "$(cat "$work/out")" = "http://$hijack" ] ||
+                  fail "the hijacked address must be the portal URL, got '$(cat "$work/out")'"
               )
             done
+
+            # The mirror image. Reaching the hijack check is not the same as
+            # being a hijack: a canary that never answered, from an address that
+            # is nobody's LAN, has to end in the gateway guess instead.
+            (
+              reset
+              export DIG_FIREFOX=203.0.113.50
+              export FF_STATUS=000 AP_STATUS=000 GS_STATUS=000
+              rc=$(run --probe)
+              [ "$rc" -eq 3 ] || fail "a public address must not be reported as a hijack (exit $rc)"
+              [ "$(cat "$work/out")" = "http://192.168.1.1" ] ||
+                fail "a public address must fall back to the gateway guess"
+            )
 
             # Login mode on a network that turns out to be clean: the release is
             # undone before the run exits, and the snapshot is consumed.

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -1,0 +1,341 @@
+/*
+  Check: captive-portal classifies a network correctly, and every path that
+  released DNS gives it back (packages/captive-portal/captive-portal.sh).
+
+  Nothing executed this script before. It is instantiated only through the host
+  overlay in modules/custom-overlays/captive-portal.nix, so a host build lints it
+  with shellcheck and stops there, while its decisions all depend on what dig,
+  curl, nmcli, ip and tailscale answer on a network that cannot be reached from a
+  build.
+
+  Those five are package arguments, so callPackage substitutes stubs for them and
+  writeShellApplication's PATH prefix puts the stubs ahead of anything in the
+  sandbox: the packaged script runs unmodified against a scripted network.
+
+  Both halves of the contract are load-bearing and both have already been wrong.
+  A misclassification either strands the user behind a portal it reported as
+  absent, or reports the router as a portal. A missed restore leaves Tailscale
+  DNS off after the run exits, which is invisible until the next tailnet name
+  fails to resolve.
+
+  /etc/resolv.conf does not exist in the sandbox, which is also what a portal
+  that hands out no lease produces. The login scenarios below therefore cover the
+  unguarded `grep '^nameserver' /etc/resolv.conf` that used to abort the run
+  between releasing DNS and probing for the portal.
+*/
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks."packages/captive-portal-runtime" =
+        let
+          # Answers `debug prefs` from the environment and records every state
+          # change, so a scenario can assert on what the run did to DNS.
+          tailscaleStub = pkgs.writeShellScriptBin "tailscale" ''
+            if [ "$*" = "debug prefs" ]; then
+              printf '{"CorpDNS":%s,"WantRunning":%s}\n' \
+                "''${TS_CORP_DNS-true}" "''${TS_WANT_RUNNING-true}"
+              exit 0
+            fi
+            printf 'tailscale %s\n' "$*" >>"$CP_LOG"
+          '';
+
+          nmcliStub = pkgs.writeShellScriptBin "nmcli" ''
+            case "$*" in
+            *"DEVICE,TYPE,STATE device status")
+              printf '%b\n' "''${NM_DEVICES-wifi0:wifi:connected}"
+              ;;
+            *"IP4.DNS device show"*)
+              printf '%b\n' "''${NM_DNS-IP4.DNS[1]:192.168.1.1}"
+              ;;
+            *)
+              printf 'nmcli %s\n' "$*" >>"$CP_LOG"
+              ;;
+            esac
+          '';
+
+          # Unset means a normal via route; empty means a link with no default
+          # route at all, which is what leaves the run without a fallback.
+          ipStub = pkgs.writeShellScriptBin "ip" ''
+            printf '%b' "''${IP_ROUTE-default via 192.168.1.1 dev wifi0 proto dhcp metric 600\n}"
+          '';
+
+          digStub = pkgs.writeShellScriptBin "dig" ''
+            host="''${!#}"
+            case "$host" in
+            detectportal.firefox.com) printf '%s\n' "''${DIG_FIREFOX-203.0.113.10}" ;;
+            captive.apple.com) printf '%s\n' "''${DIG_APPLE-203.0.113.11}" ;;
+            connectivity-check.gstatic.com) printf '%s\n' "''${DIG_GSTATIC-203.0.113.12}" ;;
+            esac
+          '';
+
+          # Status 000 stands for a request that never completed, which is what
+          # the walled garden does to a host it has not authenticated.
+          curlStub = pkgs.writeShellScriptBin "curl" ''
+            out=""
+            url=""
+            while [ "$#" -gt 0 ]; do
+              case "$1" in
+              -o)
+                out="$2"
+                shift 2
+                ;;
+              http://*)
+                url="$1"
+                shift
+                ;;
+              *) shift ;;
+              esac
+            done
+            case "$url" in
+            *success.txt)
+              status="''${FF_STATUS-200}"
+              body="''${FF_BODY-success}"
+              redirect="''${FF_REDIRECT-}"
+              ;;
+            *hotspot-detect.html)
+              status="''${AP_STATUS-200}"
+              body="''${AP_BODY-<HTML><BODY>Success</BODY></HTML>}"
+              redirect="''${AP_REDIRECT-}"
+              ;;
+            *generate_204)
+              status="''${GS_STATUS-204}"
+              body="''${GS_BODY-}"
+              redirect="''${GS_REDIRECT-}"
+              ;;
+            *)
+              echo "curl stub: unexpected url: $url" >&2
+              exit 1
+              ;;
+            esac
+            [ "$status" = 000 ] && exit 7
+            printf '%s' "$body" >"$out"
+            printf '%s %s' "$status" "$redirect"
+          '';
+
+          xdgStub = pkgs.writeShellScriptBin "xdg-open" ''
+            printf 'xdg-open %s\n' "$*" >>"$CP_LOG"
+          '';
+
+          portal = pkgs.callPackage ../../packages/captive-portal {
+            curl = curlStub;
+            dnsutils = digStub;
+            iproute2 = ipStub;
+            networkmanager = nmcliStub;
+            tailscale = tailscaleStub;
+            xdg-utils = xdgStub;
+          };
+        in
+        pkgs.runCommand "captive-portal-runtime-check"
+          {
+            passthru.runtimeCheck = true;
+            nativeBuildInputs = [ pkgs.coreutils ];
+          }
+          ''
+            set -o errexit -o nounset -o pipefail
+
+            work="$PWD/check"
+            mkdir -p "$work/run"
+            portal=${portal}/bin/captive-portal
+            state="$work/run/captive-portal/tailscale-prefs"
+            export XDG_RUNTIME_DIR="$work/run"
+            export CP_LOG="$work/log"
+
+            fail() {
+              echo "packages/captive-portal-runtime: $1" >&2
+              echo "--- stdout ---" >&2
+              cat "$work/out" >&2
+              echo "--- stderr ---" >&2
+              cat "$work/err" >&2
+              echo "--- tailscale/nmcli calls ---" >&2
+              cat "$work/log" >&2
+              exit 1
+            }
+
+            reset() {
+              rm -f "$state" "$work/log"
+              : >"$work/log"
+            }
+
+            run() {
+              rc=0
+              "$portal" "$@" >"$work/out" 2>"$work/err" || rc=$?
+              printf '%s' "$rc"
+            }
+
+            released() {
+              grep -qxF 'tailscale set --accept-dns=false' "$work/log"
+            }
+
+            restored() {
+              grep -qxF 'tailscale set --accept-dns=true' "$work/log"
+            }
+
+            # --device swallowing the next flag left the run in login mode, so a
+            # request that asked to change nothing released real DNS.
+            (
+              reset
+              rc=$(run --device --probe)
+              [ "$rc" -eq 2 ] || fail "--device --probe must be rejected as usage (exit $rc)"
+              ! released || fail "--device --probe must not touch DNS"
+            )
+
+            # A clean network, and the run that must leave it alone: probe mode
+            # touches no DNS, and stdout stays empty so a caller reading it gets
+            # a URL only when there is one.
+            (
+              reset
+              rc=$(run --probe)
+              [ "$rc" -eq 1 ] || fail "a clean network must exit 1 from --probe (exit $rc)"
+              [ ! -s "$work/out" ] || fail "a clean network must print no URL"
+              ! released || fail "--probe must not release DNS"
+            )
+
+            # The URL is the whole of stdout: every diagnostic goes to stderr.
+            (
+              reset
+              export AP_STATUS=200
+              export AP_BODY='<html><a href="http://portal.lan/login">Sign in</a></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "an intercepted canary must exit 0 (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/login" ] ||
+                fail "stdout must carry the portal URL alone"
+            )
+
+            # A portal that answers /generate_204 with 200 and its own page
+            # instead of redirecting. The status is the whole answer for that
+            # URL, and treating any 200 as clean reported the network as open.
+            (
+              reset
+              export FF_STATUS=000 AP_STATUS=000
+              export GS_STATUS=200
+              export GS_BODY='<html>Please <a href="http://portal.lan/login">sign in</a></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a 200 from generate_204 is the portal, not a clean network (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/login" ] ||
+                fail "the inline portal page must yield its own sign-in URL"
+            )
+
+            # A canary that answered correctly from a private address. The
+            # hijack check used to run anyway and overrule the payload that had
+            # just proved there was no interception.
+            (
+              reset
+              export DIG_FIREFOX=192.168.1.50
+              rc=$(run --probe)
+              [ "$rc" -eq 1 ] || fail "a correct answer from a private address is not a hijack (exit $rc)"
+            )
+
+            # 100.64.0.0/10 and 169.254.0.0/16 are where a portal answers on
+            # carrier and lease-less networks, and neither counted as private.
+            for hijack in 100.100.64.9 169.254.7.7; do
+              (
+                reset
+                export DIG_FIREFOX="$hijack"
+                export FF_STATUS=200 FF_BODY='<html>portal</html>'
+                export AP_STATUS=000 GS_STATUS=000
+                rc=$(run --probe)
+                [ "$rc" -eq 0 ] || fail "an answer in $hijack's range is a hijack (exit $rc)"
+              )
+            done
+
+            # Login mode on a network that turns out to be clean: the release is
+            # undone before the run exits, and the snapshot is consumed.
+            (
+              reset
+              rc=$(run --no-open)
+              [ "$rc" -eq 1 ] || fail "login mode on a clean network must exit 1 (exit $rc)"
+              released || fail "login mode must release DNS"
+              restored || fail "a clean network must get DNS back before exit"
+              [ ! -e "$state" ] || fail "a completed restore must consume the snapshot"
+            )
+
+            # Probes inconclusive and no default route to guess from. This path
+            # exited on the spot, leaving Tailscale DNS off with no portal
+            # found, no restore, and no reminder.
+            (
+              reset
+              export IP_ROUTE=""
+              export DIG_FIREFOX="" DIG_APPLE="" DIG_GSTATIC=""
+              rc=$(run --no-open)
+              [ "$rc" -eq 3 ] || fail "an inconclusive probe with no gateway must exit 3 (exit $rc)"
+              released || fail "login mode must release DNS"
+              restored || fail "an inconclusive probe must not strand the release"
+              [ ! -e "$state" ] || fail "a completed restore must consume the snapshot"
+            )
+
+            # An on-link default route has no via, and reading the third field
+            # produced http://wifi0 as the portal URL.
+            (
+              reset
+              export IP_ROUTE='default dev wifi0 scope link\n'
+              export DIG_FIREFOX="" DIG_APPLE="" DIG_GSTATIC=""
+              rc=$(run --no-open)
+              [ "$rc" -eq 3 ] || fail "an on-link default route leaves no gateway to guess (exit $rc)"
+              ! grep -q wifi0 "$work/out" || fail "a device name must never be printed as a portal URL"
+            )
+
+            # Retrying after a failed sign-in re-snapshotted the released prefs
+            # as the originals, and the eventual --restore then read CorpDNS
+            # false and left Tailscale DNS off while reporting success.
+            (
+              reset
+              export AP_STATUS=200 AP_BODY='<html><a href="http://portal.lan/">x</a></html>'
+              rc=$(run --no-open)
+              [ "$rc" -eq 0 ] || fail "a detected portal must exit 0 (exit $rc)"
+              [ -e "$state" ] || fail "a detected portal must leave the snapshot for --restore"
+
+              # The retry sees the state the first run created.
+              rc=$(TS_CORP_DNS=false run --no-open)
+              [ "$rc" -eq 0 ] || fail "a retry must still report the portal (exit $rc)"
+              [ "$(cat "$state")" = "$(printf 'true\ttrue')" ] ||
+                fail "a retry must not overwrite the original prefs with the released ones"
+
+              : >"$work/log"
+              rc=$(TS_CORP_DNS=false run --restore)
+              [ "$rc" -eq 0 ] || fail "--restore must succeed after a retry (exit $rc)"
+              restored || fail "--restore after a retry must hand DNS back"
+            )
+
+            # A snapshot truncated by a failed `tailscale debug prefs` used to
+            # kill --restore on the unguarded read, before it restored anything,
+            # and every later --restore repeated the abort.
+            for content in "" "garbage" "true"; do
+              (
+                reset
+                mkdir -p "$(dirname "$state")"
+                printf '%s' "$content" >"$state"
+                rc=$(run --restore)
+                [ "$rc" -eq 0 ] || fail "--restore must survive a state file holding '$content' (exit $rc)"
+                restored || fail "an unusable state file must restore DNS rather than assume it stays off"
+                [ ! -e "$state" ] || fail "--restore must consume the unusable state file"
+              )
+            done
+
+            # An honest snapshot is still replayed exactly: a host that had
+            # accept-dns off before the run must not have it turned on.
+            (
+              reset
+              mkdir -p "$(dirname "$state")"
+              printf 'false\ttrue\n' >"$state"
+              rc=$(run --restore)
+              [ "$rc" -eq 0 ] || fail "--restore must succeed for a saved false (exit $rc)"
+              ! restored || fail "a saved CorpDNS false must not be turned on"
+            )
+
+            # A docked laptop holds two links, and only one can be behind the
+            # portal. The pick used to follow nmcli's listing order.
+            (
+              reset
+              export NM_DEVICES='eth0:ethernet:connected\nwifi0:wifi:connected'
+              rc=$(run --probe)
+              [ "$rc" -eq 1 ] || fail "two connected devices must still probe (exit $rc)"
+              grep -q 'device wifi0,' "$work/err" || fail "wifi must win over ethernet"
+              grep -q 'also connected: eth0' "$work/err" ||
+                fail "the devices passed over must be named"
+            )
+
+            touch "$out"
+          '';
+    };
+}

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -121,22 +121,34 @@
               status="''${FF_STATUS-200}"
               body="''${FF_BODY-success}"
               redirect="''${FF_REDIRECT-}"
+              abort="''${FF_ABORT-}"
               ;;
             *hotspot-detect.html)
               status="''${AP_STATUS-200}"
               body="''${AP_BODY-<HTML><BODY>Success</BODY></HTML>}"
               redirect="''${AP_REDIRECT-}"
+              abort="''${AP_ABORT-}"
               ;;
             *generate_204)
               status="''${GS_STATUS-204}"
               body="''${GS_BODY-}"
               redirect="''${GS_REDIRECT-}"
+              abort="''${GS_ABORT-}"
               ;;
             *)
               echo "curl stub: unexpected url: $url" >&2
               exit 1
               ;;
             esac
+            # The third shape, between "answered" and "never connected": the
+            # response line arrived and -m then fired. Real curl writes the -w
+            # output, with no terminator, leaves -o untouched, and exits 28.
+            # Per-canary like the vars above, because the loop calls curl once per
+            # canary and one flag for all three could not place the failure.
+            if [ -n "$abort" ]; then
+              printf '%s %s' "$status" "$redirect"
+              exit 28
+            fi
             [ "$status" = 000 ] && exit 7
             printf '%s' "$body" >"$out"
             printf '%s %s' "$status" "$redirect"
@@ -615,6 +627,34 @@
               [ "$rc" -eq 0 ] || fail "a 302 to the portal must exit 0 (exit $rc)"
               [ "$(cat "$work/out")" = "http://portal.lan/welcome" ] ||
                 fail "the redirect target must be the portal URL"
+            )
+
+            # A transfer that died after the response line. curl had already
+            # written its unterminated -w output, so `|| echo '000 '` landed on
+            # that same line: `read` took curl's http_code as the status and the
+            # fallback's own text as the redirect, and the 30x arm printed
+            # http://portal.lan/welcome000 as the portal. Nothing a failed
+            # transfer printed may decide the run.
+            (
+              reset
+              export FF_STATUS=302 FF_REDIRECT=http://portal.lan/welcome FF_ABORT=1
+              rc=$(run --probe)
+              [ "$rc" -eq 1 ] || fail "an aborted canary must not decide the run (exit $rc)"
+              [ ! -s "$work/out" ] ||
+                fail "an aborted transfer must print no URL, got '$(cat "$work/out")'"
+            )
+
+            # Dropping what it printed is not the same as dropping the canary: the
+            # DNS answer stands, and an answer on this LAN is the hijack the probe
+            # exists to find, so the fall-through has to reach that check.
+            (
+              reset
+              export DIG_FIREFOX=192.168.1.42 FF_ABORT=1
+              export AP_STATUS=000 GS_STATUS=000
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "an aborted canary must still reach the hijack check (exit $rc)"
+              [ "$(cat "$work/out")" = "http://192.168.1.42" ] ||
+                fail "the hijacked address must still be the portal URL"
             )
 
             # A 30x with no Location is no answer at all: the canary falls through

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -1021,6 +1021,25 @@
                 fail "nothing may be written through the symlink into $target"
             )
 
+            # save_prefs refuses to write through a symlinked state directory;
+            # restore_dns reads and unlinks through the same path and needs the
+            # identical guard, on the half that most often runs as root.
+            (
+              reset
+              runtime="$work/restore-symlink"
+              target="$work/restore-symlink-target"
+              mkdir -p "$runtime" "$target"
+              ln -s "$target" "$runtime/captive-portal"
+              printf 'true\ttrue\n' >"$target/tailscale-prefs"
+              rc=$(XDG_RUNTIME_DIR="$runtime" run --restore)
+              [ "$rc" -eq 4 ] || fail "a symlinked state directory must refuse --restore (exit $rc)"
+              grep -q '^captive-portal: cannot use .*: it is a symlink' "$work/err" ||
+                fail "the run must say the state directory is a symlink"
+              ! restored || fail "a snapshot behind the symlink must not be read and replayed"
+              [ -e "$target/tailscale-prefs" ] ||
+                fail "nothing may be unlinked through the symlink from $target"
+            )
+
             # Absence of a snapshot is not evidence the node was ever up: the
             # WantRunning default started a node the user had stopped on purpose.
             (

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -117,6 +117,7 @@
             out=""
             url=""
             noproxy=""
+            maxsize=""
             while [ "$#" -gt 0 ]; do
               case "$1" in
               -o)
@@ -125,6 +126,10 @@
                 ;;
               --noproxy)
                 noproxy="$2"
+                shift 2
+                ;;
+              --max-filesize)
+                maxsize="$2"
                 shift 2
                 ;;
               http://*)
@@ -141,6 +146,13 @@
             # here: every scenario fails the moment the probe stops pinning it.
             if [ "$noproxy" != "*" ]; then
               echo "curl stub: the probe must pass --noproxy '*'" >&2
+              exit 1
+            fi
+            # Same shape, for the same reason: -m caps time and not bytes, and
+            # nothing this stub can answer would show an unbounded body filling
+            # a disk-backed /tmp.
+            if [ -z "$maxsize" ]; then
+              echo "curl stub: the probe must bound the body with --max-filesize" >&2
               exit 1
             fi
             case "$url" in

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -936,6 +936,28 @@
                 fail "the run must say the snapshot could not be written"
             )
 
+            # A symlink at the state directory's name is the documented `sudo
+            # captive-portal` path (docs/networking/README.md), not a contrived
+            # one: 23f44cd put that path inside a tree the invoking user under
+            # sudo already owns, and hand_state_to_invoker's chown follows
+            # whatever mktemp/mv just wrote through it. Refusing before either
+            # runs keeps a planted link from moving the snapshot, and root's
+            # chown, into a directory that was never meant to receive them.
+            (
+              reset
+              runtime="$work/denied-symlink"
+              target="$work/symlink-target"
+              mkdir -p "$runtime" "$target"
+              ln -s "$target" "$runtime/captive-portal"
+              rc=$(XDG_RUNTIME_DIR="$runtime" run --no-open)
+              [ "$rc" -eq 4 ] || fail "a symlinked state directory must exit 4 (exit $rc)"
+              ! released || fail "a run that refuses a symlinked state directory must not release DNS"
+              grep -q '^captive-portal: cannot use .*: it is a symlink' "$work/err" ||
+                fail "the run must say the state directory is a symlink"
+              [ -z "$(ls -A "$target")" ] ||
+                fail "nothing may be written through the symlink into $target"
+            )
+
             # Absence of a snapshot is not evidence the node was ever up: the
             # WantRunning default started a node the user had stopped on purpose.
             (

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -724,6 +724,24 @@
                 fail "a 511 with no link must fall back to the answering address"
             )
 
+            # The scratch file for the probe payload is created after login mode
+            # has already released DNS. Unguarded, mktemp's own 1 came back as
+            # this script's "no portal", with nothing on screen saying so and the
+            # release left standing.
+            (
+              reset
+              tmp_denied="$work/denied-tmp"
+              mkdir -p "$tmp_denied"
+              chmod 500 "$tmp_denied"
+              rc=$(TMPDIR="$tmp_denied" run --no-open)
+              chmod 700 "$tmp_denied"
+              [ "$rc" -eq 4 ] || fail "a scratch file that cannot be created must exit 4 (exit $rc)"
+              released || fail "login mode releases DNS before the probe runs"
+              restored || fail "a failed scratch file must not strand the release"
+              grep -q '^captive-portal: could not create a scratch file' "$work/err" ||
+                fail "the run must say the scratch file could not be created"
+            )
+
             # A 30x with no Location is no answer at all: the canary falls through
             # to the hijack check rather than counting as a detection.
             (

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -62,9 +62,16 @@
             esac
           '';
 
+          # NM_FAIL is a status rather than a flag because the guard's wording
+          # depends on which one nmcli returned, and an empty NM_DEVICES cannot
+          # stand in for it: that already means "nmcli answered, nothing is
+          # connected", which is the case the failure has to be told apart from.
           nmcliStub = pkgs.writeShellScriptBin "nmcli" ''
             case "$*" in
             *"DEVICE,TYPE,STATE device status")
+              if [ -n "''${NM_FAIL-}" ]; then
+                exit "$NM_FAIL"
+              fi
               printf '%b\n' "''${NM_DEVICES-wifi0:wifi:connected}"
               ;;
             *"IP4.DNS device show"*)
@@ -632,6 +639,56 @@
               [ "$rc" -eq 0 ] || fail "--restore must survive a missing resolv.conf (exit $rc)"
               grep -q 'carries no nameserver line' "$work/err" ||
                 fail "a resolv.conf with no nameserver must be reported, not fatal"
+            )
+
+            # nmcli's own exit codes are not this script's. Under pipefail the
+            # unguarded assignment ended the run with nmcli's 8 and no output at
+            # all: no note, no usage, nothing, past a table that stops at 4.
+            (
+              reset
+              rc=$(NM_FAIL=8 run --probe)
+              [ "$rc" -eq 4 ] || fail "a failed device listing must exit 4, not leak nmcli's status (exit $rc)"
+              grep -q '^captive-portal: NetworkManager is not running' "$work/err" ||
+                fail "nmcli's exit 8 must be reported as the daemon being down"
+              ! released || fail "a run that could not list devices must not release DNS"
+            )
+
+            # Any other nmcli failure is named by its status rather than guessed
+            # at, and must not read as the daemon being down.
+            (
+              reset
+              rc=$(NM_FAIL=2 run --probe)
+              [ "$rc" -eq 4 ] || fail "an unknown nmcli failure must exit 4 (exit $rc)"
+              grep -q '^captive-portal: nmcli could not list devices (exit 2)' "$work/err" ||
+                fail "an unknown nmcli failure must name its status"
+            )
+
+            # The companion: nmcli answers and nothing is connected. That is the
+            # case the two above have to stay distinguishable from.
+            (
+              reset
+              export NM_DEVICES=""
+              rc=$(run --probe)
+              [ "$rc" -eq 4 ] || fail "zero connected devices must exit 4 (exit $rc)"
+              grep -qxF 'captive-portal: no connected wifi or ethernet device' "$work/err" ||
+                fail "an empty device list must keep its own wording"
+            )
+
+            # The restore worked and then the run crashed on the cleanup: rm's
+            # status 1 is this script's "no portal", reported for a --restore
+            # that had already handed DNS back.
+            (
+              reset
+              runtime="$work/denied-unlink"
+              mkdir -p "$runtime/captive-portal"
+              printf 'true\ttrue\n' >"$runtime/captive-portal/tailscale-prefs"
+              chmod 555 "$runtime/captive-portal"
+              rc=$(XDG_RUNTIME_DIR="$runtime" run --restore)
+              chmod 755 "$runtime/captive-portal"
+              [ "$rc" -eq 0 ] || fail "a snapshot that cannot be unlinked must not fail the restore (exit $rc)"
+              restored || fail "the restore itself must still happen"
+              grep -q '^captive-portal: could not remove' "$work/err" ||
+                fail "a snapshot left behind must be reported, since the next run replays it"
             )
 
             # A docked laptop holds two links, and only one can be behind the

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -274,6 +274,33 @@
                 fail "the inline portal page must yield its own sign-in URL"
             )
 
+            # The sign-in URL is not simply the first one in the page. An
+            # intercepted page served as XHTML opens with the w3.org DTD in its
+            # DOCTYPE, and a CDN script tag sits above the form, so matching
+            # anywhere in the body launched a browser at w3.org.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml"><head><script src="http://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script></head><body><form action="http://portal.lan/login"></form></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "an intercepted XHTML page is still a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/login" ] ||
+                fail "the form target must beat the DTD and the CDN, got '$(cat "$work/out")'"
+            )
+
+            # When the only absolute URL a link points at is a validator badge,
+            # finding nothing is the better answer: the address that answered the
+            # hijacked lookup is at least the host serving the page.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><body><form action="/login"></form><a href="http://validator.w3.org/check?uri=referer">Valid</a></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a relative form target is still a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "with no usable link the canary's own address must be the URL"
+            )
+
             # A canary that answered correctly from a private address. The
             # hijack check used to run anyway and overrule the payload that had
             # just proved there was no interception.

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -685,6 +685,35 @@
                 fail "nothing a network chose the scheme of may be handed to xdg-open"
             )
 
+            # Location is as network-chosen as the canary's DNS answer, and a
+            # sinkholed resolver or a filtering proxy in front of it can point
+            # it at this machine as readily as at itself. The scheme check above
+            # let all four of these through before the host was also checked.
+            for loopback in 'http://127.0.0.1/' 'http://0.0.0.0:8080/' 'http://localhost/admin' 'http://[::1]/'; do
+              (
+                reset
+                export FF_STATUS=302 FF_REDIRECT="$loopback"
+                export AP_STATUS=000 GS_STATUS=000
+                rc=$(run --probe)
+                [ "$rc" -eq 3 ] || fail "a Location naming this machine ($loopback) is no answer (exit $rc)"
+                [ "$(cat "$work/out")" = "http://192.168.1.1" ] ||
+                  fail "$loopback must never be printed as the portal, got '$(cat "$work/out")'"
+              )
+            done
+
+            # The same gap on the other site: extract_url constrains the scheme
+            # and nothing else, so a portal page can point its own submit target
+            # at this machine too.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><body><form action="http://127.0.0.1/pwn"></form></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "an intercepted canary must still exit 0 (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "a form target naming this machine must fall back to the answering address, got '$(cat "$work/out")'"
+            )
+
             # Login mode on a network that turns out to be clean: the release is
             # undone before the run exits, and the snapshot is consumed.
             (

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -553,6 +553,20 @@
                 fail "the sign-in URL must be entity-decoded, got '$(cat "$work/out")'"
             )
 
+            # 204 is the whole answer only for the canary that expects no
+            # payload. Clearing any canary on it let a filter that answers a
+            # blocklisted name with an empty 204 read as a clean network, which
+            # is the direction that hands DNS back on a network with a portal.
+            (
+              reset
+              export FF_STATUS=204 FF_BODY=""
+              export AP_STATUS=000 GS_STATUS=000
+              rc=$(run --probe)
+              [ "$rc" -eq 3 ] || fail "a 204 for a canary expecting a payload must not clear it (exit $rc)"
+              [ "$(cat "$work/out")" = "http://192.168.1.1" ] ||
+                fail "nothing answered, so the gateway guess is the only URL, got '$(cat "$work/out")'"
+            )
+
             # The mirror image. Reaching the hijack check is not the same as
             # being a hijack: a canary that never answered, from an address that
             # is nobody's LAN, has to end in the gateway guess instead. 127.0.0.1

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -526,6 +526,19 @@
               )
             done
 
+            # A stylesheet or preconnect hint reached through a real href sits
+            # ahead of the form in <head> on plenty of portal pages, and one pass
+            # over every attribute name cannot tell it from the sign-in link.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><head><link rel="stylesheet" href="http://cdn.example.com/style.css"></head><body><form action="http://portal.lan/login"></form><p>Padded past the bound the clean test applies, so this page is judged as the interception page it stands for.</p></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a page with a stylesheet ahead of the form is still a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/login" ] ||
+                fail "a stylesheet href must not beat the form target, got '$(cat "$work/out")'"
+            )
+
             # The mirror image. Reaching the hijack check is not the same as
             # being a hijack: a canary that never answered, from an address that
             # is nobody's LAN, has to end in the gateway guess instead. 127.0.0.1

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -75,6 +75,11 @@
               printf '%b\n' "''${NM_DEVICES-wifi0:wifi:connected}"
               ;;
             *"IP4.DNS device show"*)
+              # 10 is nmcli's "device does not exist", which is a different
+              # answer from a device that exists and has no DNS (NM_DNS="").
+              if [ -n "''${NM_SHOW_FAIL-}" ]; then
+                exit "$NM_SHOW_FAIL"
+              fi
               printf '%b\n' "''${NM_DNS-IP4.DNS[1]:192.168.1.1}"
               ;;
             *)
@@ -736,6 +741,29 @@
               restored || fail "the restore itself must still happen"
               grep -q '^captive-portal: could not remove' "$work/err" ||
                 fail "a snapshot left behind must be reported, since the next run replays it"
+            )
+
+            # A --device name nmcli does not know reached the resolver guard as
+            # "no resolver", so the run sent the user to check a DHCP lease for
+            # an interface that is not there. The hosts disagree on the wireless
+            # NIC's name, so that is the typo --device invites.
+            (
+              reset
+              rc=$(NM_SHOW_FAIL=10 run --probe --device wlan0)
+              [ "$rc" -eq 4 ] || fail "an unknown device must exit 4 (exit $rc)"
+              grep -q '^captive-portal: nmcli knows no device named wlan0' "$work/err" ||
+                fail "an unknown device must be named as unknown, not as leaseless"
+            )
+
+            # The companion, which the wording above has to stay distinct from:
+            # the device is real and simply has no resolver yet.
+            (
+              reset
+              export NM_DNS=""
+              rc=$(run --probe)
+              [ "$rc" -eq 4 ] || fail "a device with no resolver must exit 4 (exit $rc)"
+              grep -q 'is the lease up' "$work/err" ||
+                fail "a device that exists but has no resolver must keep its own wording"
             )
 
             # A docked laptop holds two links, and only one can be behind the

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -310,6 +310,43 @@
                 fail "the form target must beat the DTD and the CDN, got '$(cat "$work/out")'"
             )
 
+            # A portal page most often parks the address that was originally
+            # asked for in a query parameter, and an unanchored `url=` matched
+            # that as readily as a meta refresh: the canary's own URL was printed
+            # as the portal while the form two elements later went unseen.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><body><p>You are being redirected to the sign-in page. This notice is padded so the page is the size a real interception page is, rather than short enough to pass for a canary payload.</p><a href="/login?url=http://detectportal.firefox.com/success.txt">continue</a><form action="http://portal.lan/auth"></form></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "an interception page with a query parameter is still a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/auth" ] ||
+                fail "a url= query parameter must not beat the form target, got '$(cat "$work/out")'"
+            )
+
+            # The badge filter needed the leading dot optional and the trailing
+            # slash relaxed: w3.org without a www, and www.w3.org without a path,
+            # both walked past the pattern that exists to drop them.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><body><form action="/login"></form><a href="http://w3.org/TR/xhtml1">Valid</a><p>Padded past the bound the clean test applies, so this page is judged as the interception page it is meant to stand for.</p></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a badge-only page is still a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "w3.org without a www must not be the portal URL, got '$(cat "$work/out")'"
+            )
+
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><body><form action="/login"></form><a href="http://www.w3.org">Valid</a><p>Padded past the bound the clean test applies, so this page is judged as the interception page it is meant to stand for.</p></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a badge-only page with no path is still a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "w3.org with no trailing slash must not be the portal URL, got '$(cat "$work/out")'"
+            )
+
             # When the only absolute URL a link points at is a validator badge,
             # finding nothing is the better answer: the address that answered the
             # hijacked lookup is at least the host serving the page.

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -462,6 +462,23 @@
               [ "$rc" -eq 0 ] || fail "--restore after --down must succeed (exit $rc)"
               grep -qxF 'tailscale up' "$work/log" ||
                 fail "--restore must start the node --down stopped"
+              # The pair to the refused-up scenario: where that one proves DNS
+              # goes back even when the node does not, this one proves a
+              # succeeding `up` still leaves the DNS half and the snapshot done.
+              restored || fail "--restore must hand DNS back when --down stopped the node"
+              [ ! -e "$state" ] || fail "a completed restore must consume the snapshot"
+            )
+
+            # --down on a network that turns out clean. Stopping the node is the
+            # whole of what --down changes: adding an accept-dns release on top
+            # would be a second undo for --restore to get wrong.
+            (
+              reset
+              rc=$(run --no-open --down)
+              [ "$rc" -eq 1 ] || fail "--down on a clean network must exit 1 (exit $rc)"
+              grep -qxF 'tailscale down' "$work/log" ||
+                fail "--down must stop the node rather than release DNS"
+              ! released || fail "--down must not also set accept-dns=false"
             )
 
             # A portal that redirects rather than serving its page inline. Neither

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -260,6 +260,27 @@
               ! released || fail "--device --probe must not touch DNS"
             )
 
+            # mode was last-wins, so the second of these decided it: --probe
+            # --restore ran restore and changed the state the named subcommand
+            # promises not to. Both orders, because either could be the slip.
+            for combo in "--probe --restore" "--restore --probe"; do
+              (
+                reset
+                # shellcheck disable=SC2086  # the pair is the input under test
+                rc=$(run $combo)
+                [ "$rc" -eq 2 ] || fail "'$combo' must be rejected as usage (exit $rc)"
+                ! restored || fail "'$combo' must not touch DNS"
+                [ ! -s "$work/out" ] || fail "'$combo' must print no URL"
+              )
+            done
+
+            # Repeating one is a slip, not a conflict, and must still run.
+            (
+              reset
+              rc=$(run --probe --probe)
+              [ "$rc" -eq 1 ] || fail "a repeated --probe must still probe (exit $rc)"
+            )
+
             # A clean network, and the run that must leave it alone: probe mode
             # touches no DNS, and stdout stays empty so a caller reading it gets
             # a URL only when there is one.

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -548,6 +548,20 @@
               )
             done
 
+            # The same page shape a WISPr gateway serves: no absolute form
+            # action, a stylesheet in <head>, and the real target in a meta
+            # refresh behind it. Positional order took the stylesheet, so the
+            # refresh needs a tier of its own rather than sharing href's.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><head><link rel="stylesheet" href="http://cdn.example/p.css"><meta http-equiv="refresh" content="0; url=http://portal.lan/login?res=notyet"></head><body><p>Padded past the bound the clean test applies, so this page is judged as the interception page it stands for.</p></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a meta-refresh gateway page is still a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/login?res=notyet" ] ||
+                fail "the refresh target must beat a stylesheet, got '$(cat "$work/out")'"
+            )
+
             # A stylesheet or preconnect hint reached through a real href sits
             # ahead of the form in <head> on plenty of portal pages, and one pass
             # over every attribute name cannot tell it from the sign-in link.

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -207,6 +207,18 @@
               ! released || fail "--probe must not release DNS"
             )
 
+            # The page a probe downloads used to outlive the run: probe_portal is
+            # called in a command substitution, so the body_file it created there
+            # never reached the parent's cleanup and nothing ever removed it.
+            (
+              reset
+              rm -f "$TMPDIR"/tmp.*
+              rc=$(run --probe)
+              [ "$rc" -eq 1 ] || fail "a clean network must exit 1 from --probe (exit $rc)"
+              leaked="$(find "$TMPDIR" -maxdepth 1 -name 'tmp.*' -print -quit)"
+              [ -z "$leaked" ] || fail "the probe body must not outlive the run ($leaked)"
+            )
+
             # The URL is the whole of stdout: every diagnostic goes to stderr.
             (
               reset

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -696,6 +696,34 @@
                 fail "the hijacked address must still be the portal URL"
             )
 
+            # RFC 6585's status for exactly this: a proxy portal that intercepts
+            # HTTP without touching DNS, so the canary resolves to its real
+            # public address and the status is the only tell. No arm matched it,
+            # so all three canaries fell through and the run printed the gateway
+            # as an unconfirmed guess while the body it had just fetched carried
+            # the sign-in link.
+            (
+              reset
+              export FF_STATUS=511 FF_BODY='<html><a href="http://portal.lan/login">Sign in</a></html>'
+              export AP_STATUS=511 GS_STATUS=511
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a 511 is a portal by definition (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/login" ] ||
+                fail "the 511 body's sign-in link must be the portal URL"
+            )
+
+            # A 511 is never clean, however its body happens to read: only a 200
+            # can clear a canary by carrying what that canary was told to expect.
+            (
+              reset
+              export FF_STATUS=511 FF_BODY=success
+              export AP_STATUS=000 GS_STATUS=000
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a 511 whose body reads clean is still a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "a 511 with no link must fall back to the answering address"
+            )
+
             # A 30x with no Location is no answer at all: the canary falls through
             # to the hijack check rather than counting as a detection.
             (

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -46,6 +46,12 @@
           # allowed to look like a failing `set`.
           tailscaleStub = pkgs.writeShellScriptBin "tailscale" ''
             if [ "$*" = "debug prefs" ]; then
+              # TS_PREFS_FAIL is the read half of TS_FAIL_STATE: tailscaled
+              # answering is not guaranteed either, and a reader that treated a
+              # failed read as an answer decided the run silently.
+              if [ -n "''${TS_PREFS_FAIL-}" ]; then
+                exit 1
+              fi
               printf '{"CorpDNS":%s,"WantRunning":%s}\n' \
                 "''${TS_CORP_DNS-true}" "''${TS_WANT_RUNNING-true}"
               exit 0
@@ -490,6 +496,57 @@
                 fail "a refused up must not report DNS it just handed back as released"
               grep -qxF 'nmcli general reload dns-full' "$work/log" ||
                 fail "a restored resolver still needs the NetworkManager reload"
+            )
+
+            # The run state was read straight into a comparison, so a failed read
+            # became an empty string, compared unequal to false, and skipped the
+            # restart the snapshot had asked for without a word.
+            (
+              reset
+              mkdir -p "$(dirname "$state")"
+              printf 'true\ttrue\n' >"$state"
+              rc=$(TS_PREFS_FAIL=1 run --restore)
+              [ "$rc" -eq 4 ] || fail "an unreadable prefs read must exit 4 (exit $rc)"
+              restored || fail "an unreadable prefs read must not keep DNS from Tailscale"
+              [ -s "$state" ] || fail "an incomplete restore must keep the snapshot"
+              ! grep -qxF 'tailscale up' "$work/log" ||
+                fail "an unknown run state must not be guessed at"
+              grep -q 'whether the node needs starting is unknown' "$work/err" ||
+                fail "an unreadable prefs read must say so"
+            )
+
+            # save_prefs ran with errexit suspended, because `if ! save_prefs` is
+            # its only caller, and ended in an assignment, so mkdir, mktemp, the
+            # write and the mv could all fail while the function still reported
+            # success and the run released DNS with nothing recorded. Both shapes
+            # reach it: the directory that cannot be created, and the one that
+            # exists and cannot be written.
+            (
+              reset
+              runtime="$work/denied-create"
+              mkdir -p "$runtime"
+              chmod 500 "$runtime"
+              rc=$(XDG_RUNTIME_DIR="$runtime" run --no-open)
+              chmod 700 "$runtime"
+              [ "$rc" -eq 4 ] || fail "a state directory that cannot be created must exit 4 (exit $rc)"
+              ! released || fail "a run that cannot record the prefs must not release DNS"
+              # The script's own prefix, because mkdir's stderr says "cannot
+              # create directory" too and matching that passed with no guard.
+              grep -q '^captive-portal: cannot create' "$work/err" ||
+                fail "the run must say the state directory could not be created"
+            )
+
+            (
+              reset
+              runtime="$work/denied-write"
+              mkdir -p "$runtime/captive-portal"
+              chmod 500 "$runtime/captive-portal"
+              rc=$(XDG_RUNTIME_DIR="$runtime" run --no-open)
+              chmod 700 "$runtime/captive-portal"
+              [ "$rc" -eq 4 ] || fail "a state directory that cannot be written must exit 4 (exit $rc)"
+              ! released || fail "a run that cannot record the prefs must not release DNS"
+              grep -q '^captive-portal: cannot write' "$work/err" ||
+                fail "the run must say the snapshot could not be written"
             )
 
             # Absence of a snapshot is not evidence the node was ever up: the

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -118,6 +118,7 @@
             url=""
             noproxy=""
             maxsize=""
+            resolve=""
             while [ "$#" -gt 0 ]; do
               case "$1" in
               -o)
@@ -130,6 +131,10 @@
                 ;;
               --max-filesize)
                 maxsize="$2"
+                shift 2
+                ;;
+              --resolve)
+                resolve="$2"
                 shift 2
                 ;;
               http://*)
@@ -155,6 +160,23 @@
               echo "curl stub: the probe must bound the body with --max-filesize" >&2
               exit 1
             fi
+            # And the flag the whole classification rests on. This stub answers
+            # from the URL alone, so deleting --resolve would leave every
+            # scenario green while production sent each canary through the
+            # system resolver instead of the address dig just got from the
+            # access point: $answer would stop describing what curl reached, and
+            # the hijack arm and both sinkhole guards would stop meaning
+            # anything. The host is checked too, not just the shape, so a
+            # triplet pointing at the wrong host is caught along with a missing one.
+            expected_host="''${url#http://}"
+            expected_host="''${expected_host%%/*}"
+            case "$resolve" in
+            "$expected_host:80:"*) ;;
+            *)
+              echo "curl stub: the probe must pin $expected_host with --resolve, got '$resolve'" >&2
+              exit 1
+              ;;
+            esac
             case "$url" in
             *success.txt)
               status="''${FF_STATUS-200}"

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -539,6 +539,20 @@
                 fail "a stylesheet href must not beat the form target, got '$(cat "$work/out")'"
             )
 
+            # HTML requires a literal & in an attribute value to be written
+            # &amp;, and a WISPr redirect carries several parameters, so the raw
+            # value was opened with amp; glued to every one after the first and
+            # the sign-in could not complete.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><head><meta http-equiv="refresh" content="0; url=http://1.1.1.1:3990/login?res=notyet&amp;uamip=192.168.1.1&amp;uamport=3990"></head><body><p>Padded past the bound the clean test applies, so this page is judged as the interception page it stands for.</p></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a WISPr refresh is a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://1.1.1.1:3990/login?res=notyet&uamip=192.168.1.1&uamport=3990" ] ||
+                fail "the sign-in URL must be entity-decoded, got '$(cat "$work/out")'"
+            )
+
             # The mirror image. Reaching the hijack check is not the same as
             # being a hijack: a canary that never answered, from an address that
             # is nobody's LAN, has to end in the gateway guess instead. 127.0.0.1

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -274,6 +274,22 @@
               )
             done
 
+            # --down is read only on a login run, so the other two accepted a
+            # flag naming a state change and made none: exit 0 with the node
+            # still up and nothing saying the flag was dropped. Both orders,
+            # since --down can precede the subcommand.
+            for combo in "--probe --down" "--down --probe" "--restore --down" "--down --restore"; do
+              (
+                reset
+                # shellcheck disable=SC2086  # the pair is the input under test
+                rc=$(run $combo)
+                [ "$rc" -eq 2 ] || fail "'$combo' must be rejected as usage (exit $rc)"
+                ! grep -qxF 'tailscale down' "$work/log" ||
+                  fail "'$combo' must not stop the node"
+                ! restored || fail "'$combo' must not touch DNS"
+              )
+            done
+
             # Repeating one is a slip, not a conflict, and must still run.
             (
               reset

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -108,10 +108,15 @@
           curlStub = pkgs.writeShellScriptBin "curl" ''
             out=""
             url=""
+            noproxy=""
             while [ "$#" -gt 0 ]; do
               case "$1" in
               -o)
                 out="$2"
+                shift 2
+                ;;
+              --noproxy)
+                noproxy="$2"
                 shift 2
                 ;;
               http://*)
@@ -121,6 +126,15 @@
               *) shift ;;
               esac
             done
+            # --resolve is what makes a status attributable to the address the
+            # access point's resolver returned, and an inherited http_proxy
+            # silently sends the request somewhere else instead. Nothing this
+            # stub can answer would reveal that, so the contract is asserted
+            # here: every scenario fails the moment the probe stops pinning it.
+            if [ "$noproxy" != "*" ]; then
+              echo "curl stub: the probe must pass --noproxy '*'" >&2
+              exit 1
+            fi
             case "$url" in
             *success.txt)
               status="''${FF_STATUS-200}"

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -704,7 +704,8 @@
             # sinkholed resolver or a filtering proxy in front of it can point
             # it at this machine as readily as at itself. The scheme check above
             # let all four of these through before the host was also checked.
-            for loopback in 'http://127.0.0.1/' 'http://0.0.0.0:8080/' 'http://localhost/admin' 'http://[::1]/'; do
+            for loopback in 'http://127.0.0.1/' 'http://0.0.0.0:8080/' 'http://localhost/admin' 'http://[::1]/' \
+              'http://x@127.0.0.1/' 'http://a@b@127.0.0.1/'; do
               (
                 reset
                 export FF_STATUS=302 FF_REDIRECT="$loopback"
@@ -727,6 +728,18 @@
               [ "$rc" -eq 0 ] || fail "an intercepted canary must still exit 0 (exit $rc)"
               [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
                 fail "a form target naming this machine must fall back to the answering address, got '$(cat "$work/out")'"
+            )
+
+            # Userinfo is part of the authority on this site too, and a form
+            # target is at least as free to carry one as a Location is.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><body><form action="http://a@localhost/pwn"></form></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "an intercepted canary must still exit 0 (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "a form target naming this machine through userinfo must fall back to the answering address, got '$(cat "$work/out")'"
             )
 
             # Login mode on a network that turns out to be clean: the release is

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -264,6 +264,20 @@
               [ ! -e "$state" ] || fail "a completed restore must consume the snapshot"
             )
 
+            # The gateway fallback is the lowest-confidence outcome and must
+            # report itself as one: probe_portal's own inconclusive return has
+            # to reach the caller as status 3 rather than 2, which is usage.
+            (
+              reset
+              export DIG_FIREFOX="" DIG_APPLE="" DIG_GSTATIC=""
+              rc=$(run --probe)
+              [ "$rc" -eq 3 ] || fail "a gateway guess must exit 3, not the usage status (exit $rc)"
+              [ "$(cat "$work/out")" = "http://192.168.1.1" ] ||
+                fail "the gateway guess must be printed as a URL"
+              grep -q 'no portal confirmed' "$work/err" ||
+                fail "a guess must not be worded like a detection"
+            )
+
             # An on-link default route has no via, and reading the third field
             # produced http://wifi0 as the portal URL.
             (

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -278,6 +278,43 @@
                 fail "a guess must not be worded like a detection"
             )
 
+            # A guess is printed, not launched: opening the user's own router
+            # unasked is worse than showing the address. The guess runs first and
+            # the confirmed detection second, so the wait for the detection's
+            # xdg-open is also the settle time the guess had to produce one; the
+            # script backgrounds that call, so nothing can be asserted the
+            # instant it exits.
+            (
+              reset
+              guess_log="$work/log-guess"
+              open_log="$work/log-open"
+              : >"$guess_log"
+              : >"$open_log"
+
+              CP_LOG="$guess_log" DIG_FIREFOX="" DIG_APPLE="" DIG_GSTATIC="" \
+                "$portal" >"$work/out" 2>"$work/err" && rc=0 || rc=$?
+              [ "$rc" -eq 3 ] || fail "the gateway guess must exit 3 in login mode (exit $rc)"
+              grep -q 'was not opened' "$work/err" ||
+                fail "the guess must say it was not opened"
+
+              rm -f "$state"
+              CP_LOG="$open_log" AP_STATUS=200 \
+                AP_BODY='<html><a href="http://portal.lan/login">x</a></html>' \
+                "$portal" >"$work/out" 2>"$work/err" && rc=0 || rc=$?
+              [ "$rc" -eq 0 ] || fail "a confirmed portal must exit 0 in login mode (exit $rc)"
+              waited=0
+              until grep -q '^xdg-open ' "$open_log"; do
+                waited=$((waited + 1))
+                [ "$waited" -le 100 ] || fail "a confirmed portal must be opened in a browser"
+                sleep 0.1
+              done
+              grep -qxF 'xdg-open http://portal.lan/login' "$open_log" ||
+                fail "the browser must be handed the portal URL"
+
+              ! grep -q '^xdg-open ' "$guess_log" ||
+                fail "a gateway guess must not be opened in a browser"
+            )
+
             # An on-link default route has no via, and reading the third field
             # produced http://wifi0 as the portal URL.
             (

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -629,6 +629,19 @@
                 fail "a stylesheet href must not beat a relative form target, got '$(cat "$work/out")'"
             )
 
+            # The extension filter only catches an asset URL that carries one.
+            # A preconnect hint has no path at all, which the two commonest
+            # <link> shapes both routinely omit.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><head><link rel="preconnect" href="https://fonts.gstatic.com"></head><body><form action="/login"></form></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "an intercepted canary must still exit 0 (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "a preconnect link must not beat a relative form target, got '$(cat "$work/out")'"
+            )
+
             # HTML requires a literal & in an attribute value to be written
             # &amp;, and a WISPr redirect carries several parameters, so the raw
             # value was opened with amp; glued to every one after the first and

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -810,9 +810,24 @@
               [ "$rc" -eq 4 ] || fail "a refused release must exit 4 (exit $rc)"
               grep -q 'operator' "$work/err" ||
                 fail "a refused release must name the operator pref"
+              # Both callers reach this on any nonzero exit, and a stopped
+              # tailscaled is the commoner one, so the wall is offered as the
+              # explanation rather than asserted as the fact.
+              grep -q 'tailscaled did not apply the change' "$work/err" ||
+                fail "a failed change must not be reported as a refusal outright"
               [ ! -e "$state" ] ||
                 fail "a release that changed nothing must not leave a snapshot to replay"
               [ ! -s "$work/out" ] || fail "a refused release must print no URL"
+            )
+
+            # id -un is root inside sudo, so the advice named the one user that
+            # never needs the pref.
+            (
+              reset
+              rc=$(SUDO_USER=someone TS_FAIL_STATE=set run --no-open)
+              [ "$rc" -eq 4 ] || fail "a refused release under sudo must exit 4 (exit $rc)"
+              grep -q 'operator to someone' "$work/err" ||
+                fail "under sudo the advice must name the invoking user"
             )
 
             # The mirror image: --restore is refused, DNS stays released, and the

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -642,6 +642,20 @@
                 fail "a preconnect link must not beat a relative form target, got '$(cat "$work/out")'"
             )
 
+            # sed works a line at a time, so this is the one shape the strip
+            # above cannot catch by itself: a <link> element whose attributes
+            # wrap onto a second line, which hand-written portal markup does
+            # as often as not.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY=$'<html><head><link rel="preconnect"\n      href="https://fonts.gstatic.com"></head><body><form action="/login"></form></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "an intercepted canary must still exit 0 (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "a link element wrapped across lines must not beat a relative form target, got '$(cat "$work/out")'"
+            )
+
             # HTML requires a literal & in an attribute value to be written
             # &amp;, and a WISPr redirect carries several parameters, so the raw
             # value was opened with amp; glued to every one after the first and
@@ -718,7 +732,7 @@
             # it at this machine as readily as at itself. The scheme check above
             # let all four of these through before the host was also checked.
             for loopback in 'http://127.0.0.1/' 'http://0.0.0.0:8080/' 'http://localhost/admin' 'http://[::1]/' \
-              'http://x@127.0.0.1/' 'http://a@b@127.0.0.1/'; do
+              'http://x@127.0.0.1/' 'http://a@b@127.0.0.1/' 'http://LOCALHOST/' 'http://[::]/'; do
               (
                 reset
                 export FF_STATUS=302 FF_REDIRECT="$loopback"

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -158,6 +158,7 @@
             noproxy=""
             maxsize=""
             resolve=""
+            nul=""
             while [ "$#" -gt 0 ]; do
               case "$1" in
               -o)
@@ -222,6 +223,7 @@
               body="''${FF_BODY-success}"
               redirect="''${FF_REDIRECT-}"
               abort="''${FF_ABORT-}"
+              nul="''${FF_NUL-}"
               ;;
             *hotspot-detect.html)
               status="''${AP_STATUS-200}"
@@ -250,7 +252,13 @@
               exit 28
             fi
             [ "$status" = 000 ] && exit 7
-            printf '%s' "$body" >"$out"
+            # Bash variables cannot carry NUL, so this knob writes one directly
+            # into the response file to exercise the production tr before grep.
+            if [ -n "$nul" ]; then
+              printf '%s\0' "$body" >"$out"
+            else
+              printf '%s' "$body" >"$out"
+            fi
             printf '%s %s' "$status" "$redirect"
           '';
 
@@ -727,6 +735,62 @@
                 fail "nothing a network chose the scheme of may be handed to xdg-open"
             )
 
+            # A NUL in the body must not make GNU grep switch to binary mode and
+            # lose an otherwise valid sign-in target.
+            (
+              reset
+              export FF_STATUS=200 FF_NUL=1
+              export FF_BODY='<html><form action="http://portal.lan/login"></form></html>'
+              export AP_STATUS=000 GS_STATUS=000
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a NUL-bearing portal body must still classify the portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/login" ] ||
+                fail "a NUL-bearing portal body must preserve the extracted URL"
+            )
+
+            # Control bytes in an extracted target must not reach stdout, the
+            # diagnostics, or the browser command. The URL remains usable only
+            # up to the first control byte after extraction filters it out.
+            (
+              reset
+              control_log="$work/log-control"
+              : >"$control_log"
+              export FF_STATUS=200
+              export FF_BODY=$'<html><form action="http://portal.lan/login\033[2K"></form></html>'
+              export AP_STATUS=000 GS_STATUS=000
+              CP_LOG="$control_log" "$portal" >"$work/out" 2>"$work/err" && rc=0 || rc=$?
+              [ "$rc" -eq 0 ] || fail "a control-bearing extracted target must still classify the portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/login" ] ||
+                fail "control bytes must not reach an extracted portal URL"
+              ! grep -q $'\033' "$work/out" || fail "stdout must not contain control bytes"
+              ! grep -q $'\033' "$work/err" || fail "diagnostics must not contain control bytes"
+              waited=0
+              until grep -q '^xdg-open ' "$control_log"; do
+                waited=$((waited + 1))
+                [ "$waited" -le 100 ] || fail "a confirmed extracted target must be opened in a browser"
+                sleep 0.1
+              done
+              grep -qxF 'xdg-open http://portal.lan/login' "$control_log" ||
+                fail "the browser must receive the control-free extracted URL"
+              ! grep -q $'\033' "$control_log" || fail "the browser command must not contain control bytes"
+            )
+
+            # The same bytes in Location invalidate the redirect rather than
+            # reaching xdg-open through the http(s) scheme arm.
+            (
+              reset
+              export FF_STATUS=302 FF_REDIRECT=$'http://portal.lan/login\033[2K'
+              export AP_STATUS=000 GS_STATUS=000
+              rc=$(run)
+              [ "$rc" -eq 3 ] || fail "a control-bearing redirect must not confirm a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://192.168.1.1" ] ||
+                fail "a control-bearing redirect must fall back to the gateway guess"
+              ! grep -q $'\033' "$work/out" || fail "stdout must not contain redirect control bytes"
+              ! grep -q $'\033' "$work/err" || fail "diagnostics must not contain redirect control bytes"
+              ! grep -q '^xdg-open ' "$work/log" ||
+                fail "a control-bearing redirect must not reach xdg-open"
+            )
+
             # Location is as network-chosen as the canary's DNS answer, and a
             # sinkholed resolver or a filtering proxy in front of it can point
             # it at this machine as readily as at itself. The scheme check above
@@ -817,8 +881,10 @@
             (
               reset
               guess_log="$work/log-guess"
+              noopen_log="$work/log-noopen"
               open_log="$work/log-open"
               : >"$guess_log"
+              : >"$noopen_log"
               : >"$open_log"
 
               CP_LOG="$guess_log" DIG_FIREFOX="" DIG_APPLE="" DIG_GSTATIC="" \
@@ -826,6 +892,14 @@
               [ "$rc" -eq 3 ] || fail "the gateway guess must exit 3 in login mode (exit $rc)"
               grep -q 'was not opened' "$work/err" ||
                 fail "the guess must say it was not opened"
+
+              rm -f "$state"
+              CP_LOG="$noopen_log" AP_STATUS=200 \
+                AP_BODY='<html><a href="http://portal.lan/login">x</a></html>' \
+                "$portal" --no-open >"$work/out" 2>"$work/err" && rc=0 || rc=$?
+              [ "$rc" -eq 0 ] || fail "--no-open must not change portal detection (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/login" ] ||
+                fail "--no-open must still print the portal URL"
 
               rm -f "$state"
               CP_LOG="$open_log" AP_STATUS=200 \
@@ -843,6 +917,8 @@
 
               ! grep -q '^xdg-open ' "$guess_log" ||
                 fail "a gateway guess must not be opened in a browser"
+              ! grep -q '^xdg-open ' "$noopen_log" ||
+                fail "--no-open must not launch a browser"
             )
 
             # An on-link default route has no via, and reading the third field

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -614,6 +614,21 @@
                 fail "a stylesheet href must not beat the form target, got '$(cat "$work/out")'"
             )
 
+            # A relative action is at least as common as an absolute one, and
+            # then tier 1 finds nothing: the stylesheet reaches tier 3 with no
+            # form target left to beat it. The answering address is at least
+            # the host serving the page, the same fallback a page with no
+            # usable link at all already gets.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><head><link rel="stylesheet" href="http://cdn.example.com/style.css"></head><body><form action="/login"></form></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "an intercepted canary must still exit 0 (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "a stylesheet href must not beat a relative form target, got '$(cat "$work/out")'"
+            )
+
             # HTML requires a literal & in an attribute value to be written
             # &amp;, and a WISPr redirect carries several parameters, so the raw
             # value was opened with amp; glued to every one after the first and

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -30,7 +30,9 @@
       checks."packages/captive-portal-runtime" =
         let
           # Answers `debug prefs` from the environment and records every state
-          # change, so a scenario can assert on what the run did to DNS.
+          # change, so a scenario can assert on what the run did to DNS. TS_SET_RC
+          # is the refusal tailscaled returns to a caller that is neither root nor
+          # its operator user, which `debug prefs` still answers for.
           tailscaleStub = pkgs.writeShellScriptBin "tailscale" ''
             if [ "$*" = "debug prefs" ]; then
               printf '{"CorpDNS":%s,"WantRunning":%s}\n' \
@@ -38,6 +40,7 @@
               exit 0
             fi
             printf 'tailscale %s\n' "$*" >>"$CP_LOG"
+            exit "''${TS_SET_RC-0}"
           '';
 
           nmcliStub = pkgs.writeShellScriptBin "nmcli" ''
@@ -372,6 +375,33 @@
               rc=$(run --restore)
               [ "$rc" -eq 0 ] || fail "--restore must succeed for a saved false (exit $rc)"
               ! restored || fail "a saved CorpDNS false must not be turned on"
+            )
+
+            # Nothing declared an operator user for tailscaled, so the release is
+            # refused. `debug prefs` answers anyway, so the run had already
+            # written a snapshot of a state it then failed to leave.
+            (
+              reset
+              rc=$(TS_SET_RC=1 run --no-open)
+              [ "$rc" -eq 4 ] || fail "a refused release must exit 4 (exit $rc)"
+              grep -q 'operator' "$work/err" ||
+                fail "a refused release must name the operator pref"
+              [ ! -e "$state" ] ||
+                fail "a release that changed nothing must not leave a snapshot to replay"
+              [ ! -s "$work/out" ] || fail "a refused release must print no URL"
+            )
+
+            # The mirror image: --restore is refused, DNS stays released, and the
+            # snapshot is the only record of what to put back.
+            (
+              reset
+              mkdir -p "$(dirname "$state")"
+              printf 'true\ttrue\n' >"$state"
+              rc=$(TS_SET_RC=1 run --restore)
+              [ "$rc" -eq 4 ] || fail "a refused restore must exit 4 (exit $rc)"
+              [ -s "$state" ] || fail "a refused restore must keep the snapshot for a retry"
+              grep -q 'captive-portal --restore' "$work/err" ||
+                fail "a refused restore must say how to retry"
             )
 
             # A docked laptop holds two links, and only one can be behind the

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -45,6 +45,18 @@
           # user, and it is per-subcommand because a failing `up` must not be
           # allowed to look like a failing `set`.
           tailscaleStub = pkgs.writeShellScriptBin "tailscale" ''
+            # TS_PREFS_STATE, when set, makes `debug prefs` answer from what
+            # up/down/set did earlier in the same run rather than from a static
+            # env var. Without it no scenario can express the transition --down
+            # depends on: stop the node, find the network clean, start it again,
+            # all inside one invocation. Scenarios that leave it unset behave
+            # exactly as before.
+            prefs="''${TS_PREFS_STATE-}"
+            corp="''${TS_CORP_DNS-true}"
+            want="''${TS_WANT_RUNNING-true}"
+            if [ -n "$prefs" ] && [ -s "$prefs" ]; then
+              read -r corp want <"$prefs"
+            fi
             if [ "$*" = "debug prefs" ]; then
               # TS_PREFS_FAIL is the read half of TS_FAIL_STATE: tailscaled
               # answering is not guaranteed either, and a reader that treated a
@@ -52,14 +64,22 @@
               if [ -n "''${TS_PREFS_FAIL-}" ]; then
                 exit 1
               fi
-              printf '{"CorpDNS":%s,"WantRunning":%s}\n' \
-                "''${TS_CORP_DNS-true}" "''${TS_WANT_RUNNING-true}"
+              printf '{"CorpDNS":%s,"WantRunning":%s}\n' "$corp" "$want"
               exit 0
             fi
             printf 'tailscale %s\n' "$*" >>"$CP_LOG"
             case " ''${TS_FAIL_STATE-} " in
             *" $1 "*) exit 1 ;;
             esac
+            case "$*" in
+            "down") want=false ;;
+            "up") want=true ;;
+            "set --accept-dns=false") corp=false ;;
+            "set --accept-dns=true") corp=true ;;
+            esac
+            if [ -n "$prefs" ]; then
+              printf '%s %s\n' "$corp" "$want" >"$prefs"
+            fi
           '';
 
           # NM_FAIL is a status rather than a flag because the guard's wording
@@ -255,7 +275,7 @@
             }
 
             reset() {
-              rm -f "$state" "$work/log"
+              rm -f "$state" "$work/log" "$work/prefs"
               : >"$work/log"
             }
 
@@ -953,16 +973,25 @@
               [ ! -e "$state" ] || fail "a completed restore must consume the snapshot"
             )
 
-            # --down on a network that turns out clean. Stopping the node is the
-            # whole of what --down changes: adding an accept-dns release on top
-            # would be a second undo for --restore to get wrong.
+            # --down on a network that turns out clean, which is the one run
+            # that stops the node and has to start it again inside the same
+            # invocation. TS_PREFS_STATE is what makes that expressible: the
+            # `debug prefs` read in apply_saved_prefs sees what `tailscale down`
+            # did a moment earlier rather than a static env var, which is what a
+            # real tailscaled would answer. Without it the `up` was skipped and
+            # nothing noticed, so breaking that branch left the node stopped and
+            # the run still reported exit 1.
             (
               reset
-              rc=$(run --no-open --down)
+              rc=$(TS_PREFS_STATE="$work/prefs" run --no-open --down)
               [ "$rc" -eq 1 ] || fail "--down on a clean network must exit 1 (exit $rc)"
               grep -qxF 'tailscale down' "$work/log" ||
                 fail "--down must stop the node rather than release DNS"
               ! released || fail "--down must not also set accept-dns=false"
+              grep -qxF 'tailscale up' "$work/log" ||
+                fail "a clean network must start the node --down stopped"
+              restored || fail "the release must be undone alongside the restart"
+              [ ! -e "$state" ] || fail "a completed restore must consume the snapshot"
             )
 
             # A portal that redirects rather than serving its page inline. Neither

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -24,6 +24,13 @@
   between releasing DNS and probing for the portal. One scenario asserts the
   message it prints instead, so the guard has a test that names it rather than
   only an environment that happens to exercise it.
+
+  Two branches stay out of reach here. The builder is uid 1000 and /run is not
+  writable, so neither the SUDO_UID fallback for the state directory nor the
+  chown that hands the snapshot back to the invoking user can run: both need a
+  root process and a /run/user/<uid> that logind made. What is asserted is the
+  precedence between them, that an explicit XDG_RUNTIME_DIR still outranks
+  SUDO_UID, which is the half a regression would reach every ordinary run.
 */
 {
   perSystem =
@@ -355,6 +362,19 @@
               rc=$(TS_CORP_DNS=false run --restore)
               [ "$rc" -eq 0 ] || fail "--restore must succeed after a retry (exit $rc)"
               restored || fail "--restore after a retry must hand DNS back"
+            )
+
+            # SUDO_UID names the state directory only because the sudo env reset
+            # took XDG_RUNTIME_DIR away with it. A runtime directory the caller
+            # set is the caller's answer and has to outrank it, or a `sudo -E`
+            # run would write where the session that exported it never looks.
+            (
+              reset
+              export SUDO_UID=12345 SUDO_GID=12345
+              export AP_STATUS=200 AP_BODY='<html><a href="http://portal.lan/">x</a></html>'
+              rc=$(run --no-open)
+              [ "$rc" -eq 0 ] || fail "SUDO_UID must not change a detected portal (exit $rc)"
+              [ -s "$state" ] || fail "an explicit XDG_RUNTIME_DIR must outrank SUDO_UID"
             )
 
             # A snapshot truncated by a failed `tailscale debug prefs` used to

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -322,6 +322,35 @@
                 fail "the form target must beat the DTD and the CDN, got '$(cat "$work/out")'"
             )
 
+            # The same hole on the other two attribute names: unanchored,
+            # `data-href=` and `?href=` both match, and grep -o emits in
+            # positional order, so whatever sits ahead of the form wins.
+            for decoy in \
+              '<div data-href="http://ads.example/x"></div>' \
+              '<a href="/login?href=http://tracker.example/beacon">go</a>'; do
+              (
+                reset
+                export FF_STATUS=200
+                export FF_BODY="<html><body>$decoy<form action=\"http://portal.lan/auth\"></form><p>Padded past the bound the clean test applies, so this page is judged as the interception page it stands for.</p></body></html>"
+                rc=$(run --probe)
+                [ "$rc" -eq 0 ] || fail "a page carrying a decoy is still a portal (exit $rc)"
+                [ "$(cat "$work/out")" = "http://portal.lan/auth" ] ||
+                  fail "a decoy must not beat the form target, got '$(cat "$work/out")'"
+              )
+            done
+
+            # formaction is a real submit-button attribute, and anchoring the
+            # names would drop it, its `action` being preceded by `m`.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><body><button formaction="http://portal.lan/submit">Go</button><p>Padded past the bound the clean test applies, so this page is judged as the interception page it stands for.</p></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a formaction page is still a portal (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/submit" ] ||
+                fail "formaction must still name the portal, got '$(cat "$work/out")'"
+            )
+
             # A portal page most often parks the address that was originally
             # asked for in a query parameter, and an unanchored `url=` matched
             # that as readily as a meta refresh: the canary's own URL was printed

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -371,6 +371,31 @@
               )
             done
 
+            # Location is whatever an untrusted network put there, and it reaches
+            # xdg-open. curl hands back a file:// target verbatim, so the run
+            # printed it as the portal and opened it.
+            (
+              reset
+              export FF_STATUS=302 FF_REDIRECT='file:///etc/shadow'
+              export AP_STATUS=000 GS_STATUS=000
+              rc=$(run --probe)
+              [ "$rc" -eq 3 ] || fail "a non-http redirect target is no answer (exit $rc)"
+              [ "$(cat "$work/out")" = "http://192.168.1.1" ] ||
+                fail "a file:// Location must never be printed as the portal, got '$(cat "$work/out")'"
+            )
+
+            # And the same target must not reach the browser in login mode, which
+            # is the path that opens a confirmed detection.
+            (
+              reset
+              export FF_STATUS=302 FF_REDIRECT='file:///etc/shadow'
+              export AP_STATUS=000 GS_STATUS=000
+              rc=$(run)
+              [ "$rc" -eq 3 ] || fail "a non-http redirect must not confirm a portal (exit $rc)"
+              ! grep -q 'xdg-open' "$work/log" ||
+                fail "nothing a network chose the scheme of may be handed to xdg-open"
+            )
+
             # Login mode on a network that turns out to be clean: the release is
             # undone before the run exits, and the snapshot is consumed.
             (

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -315,6 +315,22 @@
                 fail "with no usable link the canary's own address must be the URL"
             )
 
+            # The marker turning up somewhere is not the canary answering as
+            # specified. Login pages carry `success:` from a jQuery or
+            # hand-rolled AJAX callback, and the unbounded match cleared the
+            # canary on that, so the run reported no portal and handed DNS back
+            # on a network that had one, which is the state this helper exists
+            # to prevent.
+            (
+              reset
+              export FF_STATUS=200
+              export FF_BODY='<html><head><script>$.ajax({url:"/auth",success: function (r) { location.reload(); }});</script></head><body><p>Please sign in to continue. This page is served by the gateway in place of the resource that was asked for, and it runs well past the bound the clean test applies.</p></body></html>'
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a marker inside an interception page must not clear the canary (exit $rc)"
+              [ "$(cat "$work/out")" = "http://203.0.113.10" ] ||
+                fail "the answering address must be the portal URL, got '$(cat "$work/out")'"
+            )
+
             # A canary that answered correctly from a private address. The
             # hijack check used to run anyway and overrule the payload that had
             # just proved there was no interception.

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -19,9 +19,11 @@
   fails to resolve.
 
   /etc/resolv.conf does not exist in the sandbox, which is also what a portal
-  that hands out no lease produces. The login scenarios below therefore cover the
-  unguarded `grep '^nameserver' /etc/resolv.conf` that used to abort the run
-  between releasing DNS and probing for the portal.
+  that hands out no lease produces, so every scenario reaching show_resolvers
+  crosses the `grep '^nameserver' /etc/resolv.conf` that used to abort the run
+  between releasing DNS and probing for the portal. One scenario asserts the
+  message it prints instead, so the guard has a test that names it rather than
+  only an environment that happens to exercise it.
 */
 {
   perSystem =
@@ -30,9 +32,11 @@
       checks."packages/captive-portal-runtime" =
         let
           # Answers `debug prefs` from the environment and records every state
-          # change, so a scenario can assert on what the run did to DNS. TS_SET_RC
-          # is the refusal tailscaled returns to a caller that is neither root nor
-          # its operator user, which `debug prefs` still answers for.
+          # change, so a scenario can assert on what the run did to DNS.
+          # TS_FAIL_STATE names the subcommands that refuse, which is what
+          # tailscaled returns to a caller that is neither root nor its operator
+          # user, and it is per-subcommand because a failing `up` must not be
+          # allowed to look like a failing `set`.
           tailscaleStub = pkgs.writeShellScriptBin "tailscale" ''
             if [ "$*" = "debug prefs" ]; then
               printf '{"CorpDNS":%s,"WantRunning":%s}\n' \
@@ -40,7 +44,9 @@
               exit 0
             fi
             printf 'tailscale %s\n' "$*" >>"$CP_LOG"
-            exit "''${TS_SET_RC-0}"
+            case " ''${TS_FAIL_STATE-} " in
+            *" $1 "*) exit 1 ;;
+            esac
           '';
 
           nmcliStub = pkgs.writeShellScriptBin "nmcli" ''
@@ -382,7 +388,7 @@
             # written a snapshot of a state it then failed to leave.
             (
               reset
-              rc=$(TS_SET_RC=1 run --no-open)
+              rc=$(TS_FAIL_STATE=set run --no-open)
               [ "$rc" -eq 4 ] || fail "a refused release must exit 4 (exit $rc)"
               grep -q 'operator' "$work/err" ||
                 fail "a refused release must name the operator pref"
@@ -397,11 +403,91 @@
               reset
               mkdir -p "$(dirname "$state")"
               printf 'true\ttrue\n' >"$state"
-              rc=$(TS_SET_RC=1 run --restore)
+              rc=$(TS_FAIL_STATE=set run --restore)
               [ "$rc" -eq 4 ] || fail "a refused restore must exit 4 (exit $rc)"
               [ -s "$state" ] || fail "a refused restore must keep the snapshot for a retry"
               grep -q 'captive-portal --restore' "$work/err" ||
                 fail "a refused restore must say how to retry"
+            )
+
+            # `tailscale up` used to run first and gate the DNS restore, so a node
+            # that would not come back up kept its resolvers off for no reason.
+            (
+              reset
+              mkdir -p "$(dirname "$state")"
+              printf 'true\ttrue\n' >"$state"
+              rc=$(TS_WANT_RUNNING=false TS_FAIL_STATE=up run --restore)
+              [ "$rc" -eq 4 ] || fail "a refused up must still exit 4 (exit $rc)"
+              restored || fail "a refused up must not keep DNS from Tailscale"
+              [ -s "$state" ] || fail "an incomplete restore must keep the snapshot"
+            )
+
+            # Absence of a snapshot is not evidence the node was ever up: the
+            # WantRunning default started a node the user had stopped on purpose.
+            (
+              reset
+              rc=$(TS_WANT_RUNNING=false run --restore)
+              [ "$rc" -eq 0 ] || fail "--restore without a snapshot must succeed (exit $rc)"
+              restored || fail "--restore without a snapshot must still hand DNS back"
+              ! grep -qxF 'tailscale up' "$work/log" ||
+                fail "--restore must not start a node no snapshot says was running"
+            )
+
+            # The --down half of the retry contract: the second run must not
+            # record the WantRunning it just set, or --restore leaves the node down.
+            (
+              reset
+              export AP_STATUS=200 AP_BODY='<html><a href="http://portal.lan/">x</a></html>'
+              rc=$(run --no-open --down)
+              [ "$rc" -eq 0 ] || fail "a detected portal must exit 0 under --down (exit $rc)"
+              grep -qxF 'tailscale down' "$work/log" || fail "--down must stop Tailscale"
+
+              rc=$(TS_WANT_RUNNING=false run --no-open --down)
+              [ "$rc" -eq 0 ] || fail "a retry under --down must still report the portal (exit $rc)"
+              [ "$(cat "$state")" = "$(printf 'true\ttrue')" ] ||
+                fail "a retry must not record the WantRunning the first run set"
+
+              : >"$work/log"
+              rc=$(TS_WANT_RUNNING=false run --restore)
+              [ "$rc" -eq 0 ] || fail "--restore after --down must succeed (exit $rc)"
+              grep -qxF 'tailscale up' "$work/log" ||
+                fail "--restore must start the node --down stopped"
+            )
+
+            # A portal that redirects rather than serving its page inline. Neither
+            # 30x path had a scenario, so the branch that reads Location was free
+            # to break silently.
+            (
+              reset
+              export FF_STATUS=302 FF_REDIRECT=http://portal.lan/welcome
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a 302 to the portal must exit 0 (exit $rc)"
+              [ "$(cat "$work/out")" = "http://portal.lan/welcome" ] ||
+                fail "the redirect target must be the portal URL"
+            )
+
+            # A 30x with no Location is no answer at all: the canary falls through
+            # to the hijack check rather than counting as a detection.
+            (
+              reset
+              export DIG_FIREFOX=192.168.1.99
+              export FF_STATUS=302 FF_REDIRECT=""
+              export AP_STATUS=000 GS_STATUS=000
+              rc=$(run --probe)
+              [ "$rc" -eq 0 ] || fail "a private answer behind a bare 30x is a hijack (exit $rc)"
+              [ "$(cat "$work/out")" = "http://192.168.1.99" ] ||
+                fail "the hijacked address must be the portal URL"
+            )
+
+            # /etc/resolv.conf does not exist in the sandbox, which is also what a
+            # portal that hands out no lease produces. The unguarded grep aborted
+            # the run there; the message is what proves the guard is still in place.
+            (
+              reset
+              rc=$(run --restore)
+              [ "$rc" -eq 0 ] || fail "--restore must survive a missing resolv.conf (exit $rc)"
+              grep -q 'carries no nameserver line' "$work/err" ||
+                fail "a resolv.conf with no nameserver must be reported, not fatal"
             )
 
             # A docked laptop holds two links, and only one can be behind the

--- a/modules/packages/captive-portal-check.nix
+++ b/modules/packages/captive-portal-check.nix
@@ -466,6 +466,13 @@
               rc=$(run --restore)
               [ "$rc" -eq 0 ] || fail "--restore must succeed for a saved false (exit $rc)"
               ! restored || fail "a saved CorpDNS false must not be turned on"
+              # The branch was pinned and the message was not, so it drifted:
+              # this run reported DNS as handed back on the one path that
+              # deliberately does not hand it back.
+              ! grep -q 'DNS returned to Tailscale' "$work/err" ||
+                fail "a saved CorpDNS false must not be reported as DNS handed back"
+              grep -q 'so it was left off' "$work/err" ||
+                fail "a saved CorpDNS false must say DNS was left off"
             )
 
             # Nothing declared an operator user for tailscaled, so the release is

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -20,7 +20,19 @@ stop_tailscale=0
 dns_released=0
 prefs_snapshot_created=0
 
-state_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/captive-portal"
+# sudo-rs enforces env_reset with no opt-out and modules/hosts/common/sudo.nix
+# keeps only SSH_AUTH_SOCK, so XDG_RUNTIME_DIR is gone under sudo. Falling back
+# to root's own /run/user/0 there put a `sudo captive-portal` snapshot somewhere
+# a later plain --restore never looked, and that run then treated a released host
+# as one that had never been touched. SUDO_UID survives the reset, so both sides
+# name one directory. It is trusted only where logind has already made that
+# directory: inventing a runtime root for a user with no session is not a job
+# this script should take on, and a user with no session has no browser either.
+runtime_dir="${XDG_RUNTIME_DIR:-}"
+if [ -z "$runtime_dir" ] && [ -n "${SUDO_UID:-}" ] && [ -d "/run/user/$SUDO_UID" ]; then
+  runtime_dir="/run/user/$SUDO_UID"
+fi
+state_dir="${runtime_dir:-/run/user/$(id -u)}/captive-portal"
 state_file="$state_dir/tailscale-prefs"
 
 body_file=""
@@ -247,6 +259,17 @@ probe_portal() {
   return 3
 }
 
+# Root wrote the snapshot into the invoking user's runtime directory, so it has
+# to change hands with it: a plain --restore can read a root-owned snapshot but
+# not unlink it, and rm -f reports that EACCES rather than swallowing it.
+hand_state_to_invoker() {
+  if [ "$(id -u)" -ne 0 ] || [ -z "${SUDO_UID:-}" ]; then
+    return 0
+  fi
+  chown "$SUDO_UID:${SUDO_GID:-$SUDO_UID}" "$state_dir" "$state_file" ||
+    note "the snapshot stays owned by root; run the restore under sudo too: sudo captive-portal --restore"
+}
+
 # The snapshot must survive a retry: a second login run after a failed sign-in
 # would otherwise record the already-released prefs as the originals, and
 # --restore would then replay --accept-dns=false as if that were the user's
@@ -268,6 +291,7 @@ save_prefs() {
   tmp="$(mktemp "$state_file.XXXXXX")"
   printf '%s\n' "$prefs" >"$tmp"
   mv "$tmp" "$state_file"
+  hand_state_to_invoker
   prefs_snapshot_created=1
 }
 

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -359,15 +359,21 @@ probe_portal() {
         [ "$(wc -c <"$body_file")" -le 256 ] && grep -qF "$expect" "$body_file"; then
         host_clean=1
       else
-        # A submit target outranks any other link on the page. One pass over all
-        # four attribute names cannot tell a stylesheet or preconnect hint in
-        # <head> from the sign-in link, and grep -o emits in positional order, so
-        # a CDN <link href> ahead of the form won. Finding nothing in either tier
-        # is the good outcome: the caller falls back to the address that answered
-        # the hijacked lookup, which is at least the host serving the page.
+        # One pass over every attribute name cannot tell a stylesheet or
+        # preconnect hint in <head> from the sign-in link, and grep -o emits in
+        # positional order, so a CDN <link href> ahead of the real target won.
+        # Intent decides instead of position: a submit target first, then a meta
+        # refresh, which is how a WISPr gateway redirects and which since the
+        # anchoring in a5a475b9 is the only place `url=` can appear, and a plain
+        # href last. Finding nothing in any tier is the good outcome: the caller
+        # falls back to the address that answered the hijacked lookup, which is
+        # at least the host serving the page.
         found="$(extract_url 'formaction|action')"
         if [ -z "$found" ]; then
-          found="$(extract_url 'href|url')"
+          found="$(extract_url 'url')"
+        fi
+        if [ -z "$found" ]; then
+          found="$(extract_url 'href')"
         fi
         printf '%s\n' "${found:-http://$answer}"
         return 0

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -73,6 +73,8 @@ Usage:
   captive-portal --restore
       Return DNS to Tailscale after signing in.
 
+--probe and --restore name the run's whole purpose, so they cannot be combined.
+
 Options:
   --device DEV  Device to inspect (default: first connected wifi/ethernet).
   --no-open     Print the portal URL instead of launching a browser.
@@ -112,12 +114,19 @@ while [ "$#" -gt 0 ]; do
     esac
     shift 2
     ;;
-  --probe)
-    mode=probe
-    shift
-    ;;
-  --restore)
-    mode=restore
+  --probe | --restore)
+    # mode was last-wins, so `--probe --restore` ran restore: it set
+    # --accept-dns=true, could start the node, and unlinked the snapshot, on an
+    # invocation that named the subcommand documented as changing nothing. Same
+    # shape as `--device --probe` above, and the same answer: refuse the input
+    # rather than pick one of the two silently. A repeat of the same one is not
+    # a conflict.
+    requested="${1#--}"
+    if [ "$mode" != login ] && [ "$mode" != "$requested" ]; then
+      echo "captive-portal: --probe and --restore cannot be combined" >&2
+      exit 2
+    fi
+    mode="$requested"
     shift
     ;;
   --no-open)

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -224,11 +224,17 @@ is_private_v4() {
 # one absolute link some portal pages carry beside a relative form. The pattern
 # needs the leading dot optional and the trailing slash relaxed, or
 # `http://w3.org/TR/...` and `http://www.w3.org` walk past it.
+#
+# HTML requires a literal `&` in an attribute value to be written `&amp;`, and a
+# WISPr redirect carries several parameters, so the raw value would be opened
+# with `amp;` glued to every parameter after the first and the sign-in would
+# never complete.
 extract_url() {
   grep -oiE '(^|[;[:space:]])('"$1"')=["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
     grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
     grep -viE '^https?://([^/]*\.)?w3\.org([/:?]|$)' |
-    head -1 || true
+    head -1 |
+    sed 's/&amp;/\&/g' || true
 }
 
 # A portal that hijacks DNS answers public names with an address it controls, and

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -18,6 +18,7 @@ device=""
 open_browser=1
 stop_tailscale=0
 dns_released=0
+prefs_snapshot_created=0
 
 state_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/captive-portal"
 state_file="$state_dir/tailscale-prefs"
@@ -70,7 +71,12 @@ Exit status:
   1  no portal: this network answers the probes normally
   2  invalid usage
   3  the probes were inconclusive; a gateway guess is printed, never opened
-  4  the network could not be inspected, or Tailscale prefs could not be read
+  4  the network could not be inspected, or Tailscale state could not be read
+     or changed
+
+Changing DNS needs write access to tailscaled, which answers only root and the
+Unix user named by its operator pref. --probe reads the access point's resolver
+directly and needs neither.
 EOF
 }
 
@@ -262,6 +268,24 @@ save_prefs() {
   tmp="$(mktemp "$state_file.XXXXXX")"
   printf '%s\n' "$prefs" >"$tmp"
   mv "$tmp" "$state_file"
+  prefs_snapshot_created=1
+}
+
+# tailscaled answers `debug prefs` for anyone but takes a state change only from
+# root and from the Unix user named by its operator pref, so reading the prefs
+# proves nothing about being allowed to change them. Every caller below acts on
+# the refusal itself rather than second-guessing that rule.
+denied() {
+  note "tailscaled refused the change: it accepts one only from root or its operator user"
+  note "run this under sudo, or set programs.tailscale.extended.operator to $(id -un)"
+}
+
+drop_dns() {
+  if [ "$stop_tailscale" -eq 1 ]; then
+    tailscale down
+  else
+    tailscale set --accept-dns=false
+  fi
 }
 
 release_dns() {
@@ -269,10 +293,15 @@ release_dns() {
     exit 4
   fi
   dns_released=1
-  if [ "$stop_tailscale" -eq 1 ]; then
-    tailscale down
-  else
-    tailscale set --accept-dns=false
+  if ! drop_dns; then
+    # Nothing was released, so the reminders must not fire and the snapshot this
+    # run took must not outlive it and be replayed as a state the host never left.
+    dns_released=0
+    denied
+    if [ "$prefs_snapshot_created" -eq 1 ]; then
+      rm -f "$state_file"
+    fi
+    exit 4
   fi
   # dnsmasq holds the tailnet upstreams and any cached SERVFAIL until NM re-applies DNS.
   nmcli general reload dns-full
@@ -294,6 +323,18 @@ show_resolvers() {
   fi
 }
 
+apply_saved_prefs() {
+  local corp_dns="$1" want_running="$2"
+  # `tailscale up` resets every pref it is not passed, so reach for it only when
+  # --down stopped a node that had been running.
+  if [ "$want_running" = "true" ] && [ "$(tailscale debug prefs | jq -r '.WantRunning')" = "false" ]; then
+    tailscale up || return 1
+  fi
+  if [ "$corp_dns" = "true" ]; then
+    tailscale set --accept-dns=true || return 1
+  fi
+}
+
 restore_dns() {
   local corp_dns=true want_running=true saved_corp="" saved_want=""
   # An unreadable or truncated state file must not abort the run and must not
@@ -302,13 +343,12 @@ restore_dns() {
     case "$saved_corp" in true | false) corp_dns="$saved_corp" ;; esac
     case "$saved_want" in true | false) want_running="$saved_want" ;; esac
   fi
-  # `tailscale up` resets every pref it is not passed, so reach for it only when
-  # --down stopped a node that had been running.
-  if [ "$want_running" = "true" ] && [ "$(tailscale debug prefs | jq -r '.WantRunning')" = "false" ]; then
-    tailscale up
-  fi
-  if [ "$corp_dns" = "true" ]; then
-    tailscale set --accept-dns=true
+  if ! apply_saved_prefs "$corp_dns" "$want_running"; then
+    denied
+    # The snapshot is what a later run replays, so a refusal keeps it: dropping
+    # it here would turn a retryable failure into a permanently released host.
+    note "DNS is still released; rerun once that is fixed: captive-portal --restore"
+    exit 4
   fi
   rm -f "$state_file"
   nmcli general reload dns-full

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -245,11 +245,15 @@ probe_portal() {
       # 204 is body-less by definition, so there is nothing left to match.
       host_clean=1
       ;;
-    200)
+    200 | 511)
       # generate_204 carries no expected string because the status is the whole
       # answer: a 200 there is already the portal serving its page inline,
       # which is how an intercepting proxy replies when it does not redirect.
-      if [ -n "$expect" ] && grep -qF "$expect" "$body_file"; then
+      # 511 is RFC 6585's status for this and reaches the same branch, because a
+      # proxy portal that leaves DNS alone answers on the canary's real public
+      # address and the status is then the only tell. It is never clean, however
+      # its body reads, so only a 200 can clear a canary.
+      if [ "$status" = 200 ] && [ -n "$expect" ] && grep -qF "$expect" "$body_file"; then
         host_clean=1
       else
         # The first absolute URL in a page is usually not the sign-in target. An

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -600,6 +600,13 @@ apply_saved_prefs() {
 
 restore_dns() {
   local corp_dns=true want_running=false saved_corp="" saved_want="" rc=0 dns_outcome=""
+  # save_prefs refuses to write through a symlinked state_dir; this half reads
+  # and unlinks through the same path, and under sudo that read and that rm run
+  # as root against a name the invoking user owns.
+  if [ -L "$state_dir" ]; then
+    note "cannot use $state_dir: it is a symlink; no snapshot will be read or removed through it"
+    exit 4
+  fi
   # An unreadable or truncated state file must not abort the run and must not
   # decide that DNS stays off, so CorpDNS falls back to restoring Tailscale DNS.
   # WantRunning gets no such fallback: with no snapshot there is no evidence the

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -456,8 +456,16 @@ save_prefs() {
 # proves nothing about being allowed to change them. Every caller below acts on
 # the refusal itself rather than second-guessing that rule.
 denied() {
-  note "tailscaled refused the change: it accepts one only from root or its operator user"
-  note "run this under sudo, or set programs.tailscale.extended.operator to $(id -un)"
+  # Both callers reach this on any nonzero exit, and the commonest one is not a
+  # refusal at all: with tailscaled stopped, `tailscale set` fails with `failed
+  # to connect to local tailscaled`, and stating the operator wall as fact sent
+  # the user to change a pref that was already right. tailscale's own error is
+  # not redirected, so it is on screen directly above these lines.
+  note "tailscaled did not apply the change; its own error is above"
+  # id -un is root inside sudo, so the workaround used to advise setting the
+  # operator to root, which is the one user that never needs it.
+  note "if it refused, it takes a change only from root or its operator user: run"
+  note "this under sudo, or set programs.tailscale.extended.operator to ${SUDO_USER:-$(id -un)}"
 }
 
 drop_dns() {

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -252,12 +252,21 @@ is_loopback_host() {
 # never a sign-in target in any tier, so it is filtered here rather than only
 # where tier 3 reads it.
 #
+# A `<link>` element is metadata, never a submit target or a refresh, so its
+# href is stripped before any tier reads the body rather than guessed at by
+# extension: a preconnect hint carries no path at all, and a stylesheet behind
+# a font-service query string carries no dot before its extension, so neither
+# is caught by the filter above. It stays in place for an `<a href>` or
+# `<form action>` pointing at an asset directly, which the strip below does
+# not touch.
+#
 # HTML requires a literal `&` in an attribute value to be written `&amp;`, and a
 # WISPr redirect carries several parameters, so the raw value would be opened
 # with `amp;` glued to every parameter after the first and the sign-in would
 # never complete.
 extract_url() {
-  grep -oiE '(^|[;[:space:]])('"$1"')=["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
+  sed 's/<link[^>]*>//gI' "$body_file" |
+    grep -oiE '(^|[;[:space:]])('"$1"')=["'"'"']?https?://[^"'"'"'<>[:space:]]+' |
     grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
     grep -viE '^https?://([^/]*\.)?w3\.org([/:?]|$)' |
     grep -viE '\.(css|js|mjs|png|jpe?g|gif|svg|ico|woff2?|ttf|eot)([?#]|$)' |

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -225,8 +225,11 @@ is_private_v4() {
 is_loopback_host() {
   local authority="${1#*//}"
   authority="${authority%%/*}"
-  case "${authority##*@}" in
-  127.* | 0.0.0.0 | 0.0.0.0[:?#]* | localhost | localhost[:?#]* | \[::1\]*) return 0 ;;
+  authority="${authority##*@}"
+  # Host names are case-insensitive, so LOCALHOST names this machine as surely
+  # as localhost does, and [::] reaches it the same way 0.0.0.0 does.
+  case "${authority,,}" in
+  127.* | 0.0.0.0 | 0.0.0.0[:?#]* | localhost | localhost[:?#]* | \[::1\]* | \[::\]*) return 0 ;;
   *) return 1 ;;
   esac
 }

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -293,9 +293,16 @@ probe_portal() {
         # Finding nothing is the good outcome then: the caller falls back to the
         # address that answered the hijacked lookup, which is at least the host
         # serving the page.
-        found="$(grep -oiE '(href|action|url)=["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
+        # `url=` is anchored on `;` or whitespace so it still catches a meta
+        # refresh's `content="0; url=..."` and no longer catches `?url=` or
+        # `&url=`, which is where a portal page most often parks the address that
+        # was originally asked for: the canary's own URL was printed as the
+        # portal, and on a proxy portal that is a public host. The w3.org
+        # pattern needs the leading dot optional and the trailing slash relaxed,
+        # or `http://w3.org/TR/...` and `http://www.w3.org` walk past it.
+        found="$(grep -oiE '((href|action)=|[;[:space:]]url=)["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
           grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
-          grep -viE '^https?://[^/]*\.w3\.org/' | head -1 || true)"
+          grep -viE '^https?://([^/]*\.)?w3\.org([/:?]|$)' | head -1 || true)"
         printf '%s\n' "${found:-http://$answer}"
         return 0
       fi

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -268,7 +268,8 @@ is_loopback_host() {
 # with `amp;` glued to every parameter after the first and the sign-in would
 # never complete.
 extract_url() {
-  sed 's/<link[^>]*>//gI' "$body_file" |
+  tr '\n' ' ' <"$body_file" |
+    sed 's/<link[^>]*>//gI' |
     grep -oiE '(^|[;[:space:]])('"$1"')=["'"'"']?https?://[^"'"'"'<>[:space:]]+' |
     grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
     grep -viE '^https?://([^/]*\.)?w3\.org([/:?]|$)' |

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -427,6 +427,14 @@ save_prefs() {
     note "cannot create $state_dir; leaving DNS untouched"
     return 1
   fi
+  # Under sudo, state_dir sits inside a tree the invoking user owns (23f44cd),
+  # and mkdir -p above is a silent no-op if it is already a symlink to a real
+  # directory. mktemp and mv would then write through it, and chown in
+  # hand_state_to_invoker follows it too, handing that target's ownership away.
+  if [ -L "$state_dir" ]; then
+    note "cannot use $state_dir: it is a symlink; leaving DNS untouched"
+    return 1
+  fi
   if [ -s "$state_file" ]; then
     return 0
   fi

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -423,7 +423,7 @@ apply_saved_prefs() {
 }
 
 restore_dns() {
-  local corp_dns=true want_running=false saved_corp="" saved_want="" rc=0
+  local corp_dns=true want_running=false saved_corp="" saved_want="" rc=0 dns_outcome=""
   # An unreadable or truncated state file must not abort the run and must not
   # decide that DNS stays off, so CorpDNS falls back to restoring Tailscale DNS.
   # WantRunning gets no such fallback: with no snapshot there is no evidence the
@@ -440,16 +440,26 @@ restore_dns() {
     note "DNS is still released; rerun once that is fixed: captive-portal --restore"
     exit 4
   fi
-  # DNS is back from here on, whatever became of the run state, so the reload it
-  # needs still has to run and the interrupt reminder has to stand down.
+  # The DNS half is settled from here on, whether that meant handing it back or
+  # leaving it as the snapshot found it, so the reload it needs still has to run
+  # and the interrupt reminder has to stand down.
   reload_nm_dns
   dns_released=0
+  # apply_saved_prefs skips the DNS write for a saved false, correctly, since
+  # that was the host's state. Reporting it as handed back anyway told the user
+  # the release was undone on the one run where it deliberately was not, and this
+  # is the line they read to decide exactly that.
+  if [ "$corp_dns" = "true" ]; then
+    dns_outcome="DNS returned to Tailscale"
+  else
+    dns_outcome="the snapshot recorded Tailscale DNS as already off, so it was left off"
+  fi
   if [ "$rc" -ne 0 ]; then
     # Not the operator wall: that gate had already passed the DNS write above,
     # and apply_saved_prefs has already named which half of the run state failed.
     # The snapshot stays because it is the only record that this node was up.
-    note "DNS returned to Tailscale, but the node's run state was not restored"
-    note "start it with 'tailscale up', or rerun once that is fixed: captive-portal --restore"
+    note "$dns_outcome"
+    note "the node's run state was not restored; start it with 'tailscale up', or rerun: captive-portal --restore"
     exit 4
   fi
   # save_prefs keeps the first snapshot of a session, so one left behind here is
@@ -460,7 +470,7 @@ restore_dns() {
   if ! rm -f "$state_file"; then
     note "could not remove $state_file; delete it, or the next run will replay it"
   fi
-  note "DNS returned to Tailscale"
+  note "$dns_outcome"
   show_resolvers
 }
 

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -73,7 +73,8 @@ Usage:
   captive-portal --restore
       Return DNS to Tailscale after signing in.
 
---probe and --restore name the run's whole purpose, so they cannot be combined.
+--probe and --restore name the run's whole purpose, so they cannot be combined,
+and --down belongs to a login run, which is the only one that stops anything.
 
 Options:
   --device DEV  Device to inspect (default: first connected wifi/ethernet).
@@ -148,6 +149,16 @@ while [ "$#" -gt 0 ]; do
     ;;
   esac
 done
+
+# --down is read only by drop_dns, which only a login run reaches, so the other
+# two subcommands accepted a flag naming a state change and then made none: the
+# run reported success with the node still up and nothing on screen to say the
+# flag had been dropped. Same answer as --probe with --restore. The check sits
+# after the loop because --down can precede the subcommand.
+if [ "$stop_tailscale" -eq 1 ] && [ "$mode" != login ]; then
+  echo "captive-portal: --down applies to a login run, not --$mode" >&2
+  exit 2
+fi
 
 # Portals live on the wireless hop, so a docked laptop holding both links must
 # not have the choice decided by nmcli's listing order. Sorting the wifi-first

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -288,6 +288,15 @@ drop_dns() {
   fi
 }
 
+# dnsmasq holds the tailnet upstreams and any cached SERVFAIL until NM re-applies
+# DNS. A reload that fails leaves stale resolvers behind rather than a wrong
+# Tailscale state, so it is reported and the run carries on.
+reload_nm_dns() {
+  if ! nmcli general reload dns-full; then
+    note "NetworkManager did not reload DNS; run: nmcli general reload dns-full"
+  fi
+}
+
 release_dns() {
   if ! save_prefs; then
     exit 4
@@ -303,8 +312,7 @@ release_dns() {
     fi
     exit 4
   fi
-  # dnsmasq holds the tailnet upstreams and any cached SERVFAIL until NM re-applies DNS.
-  nmcli general reload dns-full
+  reload_nm_dns
 }
 
 # /etc/resolv.conf legitimately carries no nameserver before a portal hands out
@@ -325,20 +333,26 @@ show_resolvers() {
 
 apply_saved_prefs() {
   local corp_dns="$1" want_running="$2"
-  # `tailscale up` resets every pref it is not passed, so reach for it only when
-  # --down stopped a node that had been running.
-  if [ "$want_running" = "true" ] && [ "$(tailscale debug prefs | jq -r '.WantRunning')" = "false" ]; then
-    tailscale up || return 1
-  fi
+  # DNS is what the run took away, so it goes back first. Ordering the run state
+  # ahead of it let a refused `up` keep the resolvers off a host that could have
+  # had them back.
   if [ "$corp_dns" = "true" ]; then
     tailscale set --accept-dns=true || return 1
+  fi
+  # A flagless `tailscale up` on a node that is still logged in edits WantRunning
+  # alone, so it cannot clobber the prefs this two-field snapshot does not carry.
+  # It runs only when the snapshot says --down stopped a node that had been up.
+  if [ "$want_running" = "true" ] && [ "$(tailscale debug prefs | jq -r '.WantRunning')" = "false" ]; then
+    tailscale up || return 1
   fi
 }
 
 restore_dns() {
-  local corp_dns=true want_running=true saved_corp="" saved_want=""
+  local corp_dns=true want_running=false saved_corp="" saved_want=""
   # An unreadable or truncated state file must not abort the run and must not
-  # decide that DNS stays off: both fields fall back to restoring Tailscale.
+  # decide that DNS stays off, so CorpDNS falls back to restoring Tailscale DNS.
+  # WantRunning gets no such fallback: with no snapshot there is no evidence the
+  # node was ever up, and starting one the user stopped is not a restore.
   if [ -s "$state_file" ] && read -r saved_corp saved_want <"$state_file"; then
     case "$saved_corp" in true | false) corp_dns="$saved_corp" ;; esac
     case "$saved_want" in true | false) want_running="$saved_want" ;; esac
@@ -351,7 +365,7 @@ restore_dns() {
     exit 4
   fi
   rm -f "$state_file"
-  nmcli general reload dns-full
+  reload_nm_dns
   dns_released=0
   note "DNS returned to Tailscale"
   show_resolvers

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -158,8 +158,9 @@ is_private_v4() {
 
 # A portal that hijacks DNS answers public names with an address it controls, and
 # one that intercepts HTTP replaces the probe payload or 302s away from it. Both
-# reveal the sign-in URL. Exit 0 prints the portal URL, 1 means the network came
-# back clean, 2 means every probe was inconclusive and prints a gateway guess.
+# reveal the sign-in URL. The return values are the script's own exit statuses:
+# 0 prints the portal URL, 1 means the network came back clean, 3 means every
+# probe was inconclusive and prints a gateway guess when there is one.
 probe_portal() {
   local resolver="$1" gateway="$2"
   local hosts urls expects i host url expect answer status redirect found
@@ -235,7 +236,7 @@ probe_portal() {
   if [ -n "$gateway" ]; then
     printf 'http://%s\n' "$gateway"
   fi
-  return 2
+  return 3
 }
 
 # The snapshot must survive a retry: a second login run after a failed sign-in
@@ -365,7 +366,7 @@ case "$probe_status" in
   fi
   exit 1
   ;;
-2)
+3)
   if [ -z "$portal" ]; then
     note "probes inconclusive and no gateway to fall back on"
     # Nothing was found and nothing more will be tried, so the release must not

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -331,6 +331,9 @@ show_resolvers() {
   fi
 }
 
+# The two halves fail for unrelated reasons and need unrelated remedies, so they
+# report separately: 1 is the DNS write, which is the call the operator pref
+# gates, and 2 is the run state, which is only ever reached once DNS is back.
 apply_saved_prefs() {
   local corp_dns="$1" want_running="$2"
   # DNS is what the run took away, so it goes back first. Ordering the run state
@@ -340,15 +343,18 @@ apply_saved_prefs() {
     tailscale set --accept-dns=true || return 1
   fi
   # A flagless `tailscale up` on a node that is still logged in edits WantRunning
-  # alone, so it cannot clobber the prefs this two-field snapshot does not carry.
-  # It runs only when the snapshot says --down stopped a node that had been up.
+  # alone, so it cannot clobber the prefs this two-field snapshot does not carry:
+  # checkForAccidentalSettingReverts in cmd/tailscale/cli/up.go returns simpleUp
+  # when no flag is set, skipping the pref diff that produces `flag --ssh is not
+  # specified but it is set in prefs`. It runs only when the snapshot says --down
+  # stopped a node that had been up.
   if [ "$want_running" = "true" ] && [ "$(tailscale debug prefs | jq -r '.WantRunning')" = "false" ]; then
-    tailscale up || return 1
+    tailscale up || return 2
   fi
 }
 
 restore_dns() {
-  local corp_dns=true want_running=false saved_corp="" saved_want=""
+  local corp_dns=true want_running=false saved_corp="" saved_want="" rc=0
   # An unreadable or truncated state file must not abort the run and must not
   # decide that DNS stays off, so CorpDNS falls back to restoring Tailscale DNS.
   # WantRunning gets no such fallback: with no snapshot there is no evidence the
@@ -357,16 +363,26 @@ restore_dns() {
     case "$saved_corp" in true | false) corp_dns="$saved_corp" ;; esac
     case "$saved_want" in true | false) want_running="$saved_want" ;; esac
   fi
-  if ! apply_saved_prefs "$corp_dns" "$want_running"; then
+  apply_saved_prefs "$corp_dns" "$want_running" || rc=$?
+  if [ "$rc" -eq 1 ]; then
     denied
     # The snapshot is what a later run replays, so a refusal keeps it: dropping
     # it here would turn a retryable failure into a permanently released host.
     note "DNS is still released; rerun once that is fixed: captive-portal --restore"
     exit 4
   fi
-  rm -f "$state_file"
+  # DNS is back from here on, whatever became of the run state, so the reload it
+  # needs still has to run and the interrupt reminder has to stand down.
   reload_nm_dns
   dns_released=0
+  if [ "$rc" -ne 0 ]; then
+    # Not the operator wall: that gate had already passed the DNS write above.
+    # The snapshot stays because it is the only record that this node was up.
+    note "DNS returned to Tailscale, but 'tailscale up' failed and the node is still stopped"
+    note "start it by hand, or rerun once that is fixed: captive-portal --restore"
+    exit 4
+  fi
+  rm -f "$state_file"
   note "DNS returned to Tailscale"
   show_resolvers
 }

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -649,12 +649,6 @@ fi
 
 note "device $device, access-point resolver $resolver, gateway ${gateway:-unknown}"
 
-if [ "$mode" = login ]; then
-  release_dns
-  note "system resolvers now:"
-  show_resolvers
-fi
-
 portal=""
 probe_status=0
 # The scratch file is created here rather than in probe_portal because the
@@ -663,16 +657,22 @@ probe_status=0
 # it, so a body_file created inside was invisible to cleanup and every run left
 # the page it had fetched behind. Created in the shell that owns the trap, the
 # sweep already written above covers it on every exit and on a signal.
+#
+# It is created before the release rather than after, so mktemp's own 1, which
+# this script documents as "no portal", cannot reach a point where DNS has
+# already been handed back to the local resolver. Nothing between here and the
+# probe needs the release, so there is nothing to undo on this path.
 if ! body_file="$(mktemp)"; then
-  # Unguarded, mktemp's own 1 came back as this script's "no portal", from a
-  # point login mode has already released DNS: errexit killed the run with
-  # mktemp's error the only thing on screen, no reminder, and no restore.
   note "could not create a scratch file for the probe payload"
-  if [ "$mode" = login ]; then
-    restore_dns
-  fi
   exit 4
 fi
+
+if [ "$mode" = login ]; then
+  release_dns
+  note "system resolvers now:"
+  show_resolvers
+fi
+
 portal="$(probe_portal "$resolver" "$gateway")" || probe_status=$?
 
 # Every exit from here on is one of the documented statuses, and each one that

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -229,7 +229,12 @@ probe_portal() {
     # http://000. A transfer that failed is not an answer, so whatever it managed
     # to print is dropped and status stays 000, which no arm below matches and
     # which falls through to the hijack check the way a silent drop does.
-    if write_out="$(curl -sS -m 6 -o "$body_file" -w '%{http_code} %{redirect_url}' \
+    # --noproxy '*' because --resolve is the whole basis of the classification
+    # here: it is what makes a status and a body attributable to the address the
+    # access point's resolver handed back. An inherited http_proxy sends the
+    # request to the proxy instead, --resolve never applies, and every canary is
+    # then graded on what the proxy answered while dig stays honest.
+    if write_out="$(curl -sS -m 6 --noproxy '*' -o "$body_file" -w '%{http_code} %{redirect_url}' \
       --resolve "$host:80:$answer" "$url" 2>/dev/null)"; then
       read -r status redirect <<<"$write_out"
     fi

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -227,7 +227,8 @@ is_loopback_host() {
   authority="${authority%%/*}"
   authority="${authority##*@}"
   # Host names are case-insensitive, so LOCALHOST names this machine as surely
-  # as localhost does, and [::] reaches it the same way 0.0.0.0 does.
+  # as localhost does, and [::], the IPv6 unspecified address, reaches it the
+  # same way 0.0.0.0 does.
   case "${authority,,}" in
   127.* | 0.0.0.0 | 0.0.0.0[:?#]* | localhost | localhost[:?#]* | \[::1\]* | \[::\]*) return 0 ;;
   *) return 1 ;;
@@ -262,6 +263,13 @@ is_loopback_host() {
 # is caught by the filter above. It stays in place for an `<a href>` or
 # `<form action>` pointing at an asset directly, which the strip below does
 # not touch.
+#
+# sed works a line at a time, and a hand-written portal page wraps a tag's
+# attributes across lines as often as not, so the body is flattened first: a
+# `<link>` split over two lines would otherwise survive the strip, and a
+# `(^|[;[:space:]])`-anchored attribute at the start of one of those lines now
+# matches the same way through the whitespace a former newline became, rather
+# than through a line start that only sometimes existed.
 #
 # HTML requires a literal `&` in an attribute value to be written `&amp;`, and a
 # WISPr redirect carries several parameters, so the raw value would be opened
@@ -453,6 +461,13 @@ probe_portal() {
 # Root wrote the snapshot into the invoking user's runtime directory, so it has
 # to change hands with it: a plain --restore can read a root-owned snapshot but
 # not unlink it, and rm -f reports that EACCES rather than swallowing it.
+#
+# -h matters once this has run before: it leaves state_dir owned by SUDO_UID,
+# so a second sudo run's mv onto state_file, followed by this chown, is a
+# window a plain chown would follow straight through a symlink dropped there
+# in between, handing a root-owned target's ownership away the way the guard
+# on state_dir itself already stops mkdir -p and this chown from doing to it.
+# -h is inert for the ordinary directory and file this otherwise sees.
 hand_state_to_invoker() {
   if [ "$(id -u)" -ne 0 ] || [ -z "${SUDO_UID:-}" ]; then
     return 0

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -302,14 +302,18 @@ probe_portal() {
         # Finding nothing is the good outcome then: the caller falls back to the
         # address that answered the hijacked lookup, which is at least the host
         # serving the page.
-        # `url=` is anchored on `;` or whitespace so it still catches a meta
-        # refresh's `content="0; url=..."` and no longer catches `?url=` or
-        # `&url=`, which is where a portal page most often parks the address that
-        # was originally asked for: the canary's own URL was printed as the
-        # portal, and on a proxy portal that is a public host. The w3.org
-        # pattern needs the leading dot optional and the trailing slash relaxed,
-        # or `http://w3.org/TR/...` and `http://www.w3.org` walk past it.
-        found="$(grep -oiE '((href|action)=|[;[:space:]]url=)["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
+        # Every attribute name is anchored on line start, `;`, or whitespace, so
+        # each is the whole attribute rather than the tail of a longer one or a
+        # fragment of a query string: unanchored, `data-href=` and `?href=` both
+        # matched, and since grep -o emits in positional order a tracker URL
+        # ahead of the form won. The anchor still admits `<form action=`,
+        # `<a href=`, an attribute at the start of a wrapped line, and a meta
+        # refresh's `content="0; url=..."` with or without the space.
+        # `formaction` is named because anchoring would otherwise drop it, its
+        # `action` being preceded by `m`. The w3.org pattern needs the leading
+        # dot optional and the trailing slash relaxed, or `http://w3.org/TR/...`
+        # and `http://www.w3.org` walk past it.
+        found="$(grep -oiE '(^|[;[:space:]])(formaction|href|action|url)=["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
           grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
           grep -viE '^https?://([^/]*\.)?w3\.org([/:?]|$)' | head -1 || true)"
         printf '%s\n' "${found:-http://$answer}"

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -252,7 +252,19 @@ probe_portal() {
       if [ -n "$expect" ] && grep -qF "$expect" "$body_file"; then
         host_clean=1
       else
-        found="$(grep -oiE 'https?://[^"'"'"'<>[:space:]]+' "$body_file" | head -1 || true)"
+        # The first absolute URL in a page is usually not the sign-in target. An
+        # intercepted page served as XHTML opens with the w3.org DTD in its
+        # DOCTYPE, and a CDN script tag sits above the form on plenty of others,
+        # so matching anywhere in the body opened w3.org or googleapis while the
+        # form went unseen. Only what a link, form or meta refresh points at
+        # counts, and w3.org is dropped even there, because a "Valid XHTML"
+        # badge is the one href some portal pages carry besides a relative form.
+        # Finding nothing is the good outcome then: the caller falls back to the
+        # address that answered the hijacked lookup, which is at least the host
+        # serving the page.
+        found="$(grep -oiE '(href|action|url)=["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
+          grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
+          grep -viE '^https?://[^/]*\.w3\.org/' | head -1 || true)"
         printf '%s\n' "${found:-http://$answer}"
         return 0
       fi

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -453,7 +453,7 @@ hand_state_to_invoker() {
   if [ "$(id -u)" -ne 0 ] || [ -z "${SUDO_UID:-}" ]; then
     return 0
   fi
-  chown "$SUDO_UID:${SUDO_GID:-$SUDO_UID}" "$state_dir" "$state_file" ||
+  chown -h "$SUDO_UID:${SUDO_GID:-$SUDO_UID}" "$state_dir" "$state_file" ||
     note "the snapshot stays owned by root; run the restore under sudo too: sudo captive-portal --restore"
 }
 

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -238,6 +238,18 @@ probe_portal() {
       grep -E '^[0-9]+(\.[0-9]+){3}$' | tail -1 || true)"
     [ -n "$answer" ] || continue
 
+    # A resolver that sinkholes a blocklisted canary answers 127.0.0.1 or
+    # 0.0.0.0, and curl --resolve sends both to this machine. Pi-hole's default
+    # NULL blocking, AdGuard Home's default and a bare dnsmasq `address=/host/`
+    # all use 0.0.0.0, and the probe hosts sit on telemetry blocklists, so this
+    # is an ordinary network rather than a hostile one. Dropping the canary
+    # before the request is the only place that covers it: with anything
+    # listening on port 80 here the 200 arm grades the user's own page and hands
+    # its links to xdg-open, and it returns before is_private_v4 is consulted.
+    case "$answer" in
+    127.* | 0.0.0.0) continue ;;
+    esac
+
     host_clean=0
     status=000
     redirect=""

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -173,9 +173,14 @@ device_gateway() {
     grep -E '^[0-9]+(\.[0-9]+){3}$' || true
 }
 
+# Loopback is deliberately absent: 127.0.0.0/8 is this machine, not somewhere a
+# portal can sit. A resolver that sinkholes blocklisted names to 127.0.0.1, which
+# is what dnsmasq `address=/host/127.0.0.1` and OpenWrt's simple-adblock do,
+# answers a canary that way, and counting it as a hijack pointed the sign-in
+# instructions and xdg-open at the user's own machine.
 is_private_v4() {
   case "$1" in
-  10.* | 192.168.* | 127.*) return 0 ;;
+  10.* | 192.168.*) return 0 ;;
   172.1[6-9].* | 172.2[0-9].* | 172.3[01].*) return 0 ;;
   # A portal answers from whatever space it sits in: 169.254.0.0/16 when it
   # never issued a lease, and 100.64.0.0/10 on carrier and guest networks.

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -215,9 +215,18 @@ is_private_v4() {
 # canary's DNS answer is, so both need the exclusion the sinkholed-canary
 # guard already applies to $answer: 127.0.0.0/8 and 0.0.0.0 are this machine,
 # not somewhere a portal can sit, and neither is localhost or ::1.
+#
+# Userinfo is part of the authority, so a bare scheme strip left it in place:
+# `http://x@127.0.0.1/` matched no arm and named this machine as surely as the
+# plain form does. The path is stripped first so the trailing character
+# classes below only ever see a bare host or host:port, and `##*@` takes the
+# last `@` rather than the first, matching how a URL parser splits userinfo
+# from host on an authority that carries more than one.
 is_loopback_host() {
-  case "${1#*//}" in
-  127.* | 0.0.0.0 | 0.0.0.0[:/?#]* | localhost | localhost[:/?#]* | \[::1\]*) return 0 ;;
+  local authority="${1#*//}"
+  authority="${authority%%/*}"
+  case "${authority##*@}" in
+  127.* | 0.0.0.0 | 0.0.0.0[:?#]* | localhost | localhost[:?#]* | \[::1\]*) return 0 ;;
   *) return 1 ;;
   esac
 }

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -1,13 +1,15 @@
 # shellcheck shell=bash
 # Reach a captive portal from a host that resolves through Tailscale.
 #
-# With --accept-dns=true tailscaled registers a resolvconf entry that supersedes
-# NetworkManager's, so the dnsmasq at 127.0.0.1 is shadowed and every query goes
-# to the tailnet's global resolvers. A portal drops those upstreams
+# With --accept-dns=true tailscaled takes resolution away from whichever local
+# resolver the host runs: it registers a resolvconf entry that supersedes
+# NetworkManager's dnsmasq at 127.0.0.1, or hands its configuration to
+# systemd-resolved where that owns /etc/resolv.conf instead. Either way every
+# query goes to the tailnet's global resolvers. A portal drops those upstreams
 # until you authenticate and answers only on its own DHCP-advertised resolver, so
 # the DNS hijack that produces the sign-in page never runs and nothing surfaces
-# the portal. This releases DNS back to dnsmasq, finds the portal through the
-# access point's own resolver, and opens it.
+# the portal. This releases DNS back to the local resolver, finds the portal
+# through the access point's own resolver, and opens it.
 
 set -euo pipefail
 

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -210,6 +210,27 @@ is_private_v4() {
   esac
 }
 
+# Pull the first absolute URL the named attributes point at out of $body_file.
+#
+# The names are anchored on line start, `;`, or whitespace, so each is the whole
+# attribute rather than the tail of a longer one or a fragment of a query
+# string: unanchored, `data-href=` and `?href=` matched, and a tracker URL ahead
+# of the form won. The anchor still admits `<form action=`, `<a href=`, an
+# attribute at the start of a wrapped line, and a meta refresh's
+# `content="0; url=..."` with or without the space. `formaction` has to be named
+# wherever it is wanted, its `action` being preceded by `m`.
+#
+# w3.org is dropped even from a real href, because a "Valid XHTML" badge is the
+# one absolute link some portal pages carry beside a relative form. The pattern
+# needs the leading dot optional and the trailing slash relaxed, or
+# `http://w3.org/TR/...` and `http://www.w3.org` walk past it.
+extract_url() {
+  grep -oiE '(^|[;[:space:]])('"$1"')=["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
+    grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
+    grep -viE '^https?://([^/]*\.)?w3\.org([/:?]|$)' |
+    head -1 || true
+}
+
 # A portal that hijacks DNS answers public names with an address it controls, and
 # one that intercepts HTTP replaces the probe payload or 302s away from it. Both
 # reveal the sign-in URL. The return values are the script's own exit statuses:
@@ -324,30 +345,16 @@ probe_portal() {
         [ "$(wc -c <"$body_file")" -le 256 ] && grep -qF "$expect" "$body_file"; then
         host_clean=1
       else
-        # The first absolute URL in a page is usually not the sign-in target. An
-        # intercepted page served as XHTML opens with the w3.org DTD in its
-        # DOCTYPE, and a CDN script tag sits above the form on plenty of others,
-        # so matching anywhere in the body opened w3.org or googleapis while the
-        # form went unseen. Only what a link, form or meta refresh points at
-        # counts, and w3.org is dropped even there, because a "Valid XHTML"
-        # badge is the one href some portal pages carry besides a relative form.
-        # Finding nothing is the good outcome then: the caller falls back to the
-        # address that answered the hijacked lookup, which is at least the host
-        # serving the page.
-        # Every attribute name is anchored on line start, `;`, or whitespace, so
-        # each is the whole attribute rather than the tail of a longer one or a
-        # fragment of a query string: unanchored, `data-href=` and `?href=` both
-        # matched, and since grep -o emits in positional order a tracker URL
-        # ahead of the form won. The anchor still admits `<form action=`,
-        # `<a href=`, an attribute at the start of a wrapped line, and a meta
-        # refresh's `content="0; url=..."` with or without the space.
-        # `formaction` is named because anchoring would otherwise drop it, its
-        # `action` being preceded by `m`. The w3.org pattern needs the leading
-        # dot optional and the trailing slash relaxed, or `http://w3.org/TR/...`
-        # and `http://www.w3.org` walk past it.
-        found="$(grep -oiE '(^|[;[:space:]])(formaction|href|action|url)=["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
-          grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
-          grep -viE '^https?://([^/]*\.)?w3\.org([/:?]|$)' | head -1 || true)"
+        # A submit target outranks any other link on the page. One pass over all
+        # four attribute names cannot tell a stylesheet or preconnect hint in
+        # <head> from the sign-in link, and grep -o emits in positional order, so
+        # a CDN <link href> ahead of the form won. Finding nothing in either tier
+        # is the good outcome: the caller falls back to the address that answered
+        # the hijacked lookup, which is at least the host serving the page.
+        found="$(extract_url 'formaction|action')"
+        if [ -z "$found" ]; then
+          found="$(extract_url 'href|url')"
+        fi
         printf '%s\n' "${found:-http://$answer}"
         return 0
       fi

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -274,8 +274,15 @@ hand_state_to_invoker() {
 # --restore would then replay --accept-dns=false as if that were the user's
 # state. The first snapshot of a session wins until --restore consumes it.
 save_prefs() {
-  local prefs tmp
-  mkdir -p "$state_dir"
+  local prefs tmp=""
+  # Every step is checked because `if ! save_prefs` is the only call site, and
+  # that suspends errexit for the whole body: an unchecked failure fell through
+  # to the trailing assignment and reported success, so the run went on to
+  # release DNS with nothing recorded to put back.
+  if ! mkdir -p "$state_dir"; then
+    note "cannot create $state_dir; leaving DNS untouched"
+    return 1
+  fi
   if [ -s "$state_file" ]; then
     return 0
   fi
@@ -287,9 +294,15 @@ save_prefs() {
   fi
   # Write through a temporary so a failed read never leaves a truncated file
   # that --restore would later parse as "DNS was already off".
-  tmp="$(mktemp "$state_file.XXXXXX")"
-  printf '%s\n' "$prefs" >"$tmp"
-  mv "$tmp" "$state_file"
+  if ! tmp="$(mktemp "$state_file.XXXXXX")" ||
+    ! printf '%s\n' "$prefs" >"$tmp" ||
+    ! mv "$tmp" "$state_file"; then
+    if [ -n "$tmp" ]; then
+      rm -f "$tmp"
+    fi
+    note "cannot write $state_file; leaving DNS untouched"
+    return 1
+  fi
   hand_state_to_invoker
   prefs_snapshot_created=1
 }
@@ -357,8 +370,17 @@ show_resolvers() {
 # The two halves fail for unrelated reasons and need unrelated remedies, so they
 # report separately: 1 is the DNS write, which is the call the operator pref
 # gates, and 2 is the run state, which is only ever reached once DNS is back.
+
+# `debug prefs` answering is no promise the field is there, and jq's -e turns an
+# absent or non-boolean one into a nonzero status rather than an empty string.
+read_want_running() {
+  tailscale debug prefs |
+    jq -er 'if (.WantRunning | type) == "boolean" then (.WantRunning | tostring)
+            else error("WantRunning missing") end'
+}
+
 apply_saved_prefs() {
-  local corp_dns="$1" want_running="$2"
+  local corp_dns="$1" want_running="$2" live_running=""
   # DNS is what the run took away, so it goes back first. Ordering the run state
   # ahead of it let a refused `up` keep the resolvers off a host that could have
   # had them back.
@@ -371,8 +393,18 @@ apply_saved_prefs() {
   # when no flag is set, skipping the pref diff that produces `flag --ssh is not
   # specified but it is set in prefs`. It runs only when the snapshot says --down
   # stopped a node that had been up.
-  if [ "$want_running" = "true" ] && [ "$(tailscale debug prefs | jq -r '.WantRunning')" = "false" ]; then
-    tailscale up || return 2
+  if [ "$want_running" = "true" ]; then
+    # A failed read used to land here as an empty string, compare unequal to
+    # false, and skip the restart the snapshot had just asked for without saying
+    # anything. Not knowing the run state is a reason to stop, not to guess.
+    if ! live_running="$(read_want_running)"; then
+      note "cannot read Tailscale prefs, so whether the node needs starting is unknown"
+      return 2
+    fi
+    if [ "$live_running" = "false" ] && ! tailscale up; then
+      note "tailscaled refused 'tailscale up'"
+      return 2
+    fi
   fi
 }
 
@@ -399,10 +431,11 @@ restore_dns() {
   reload_nm_dns
   dns_released=0
   if [ "$rc" -ne 0 ]; then
-    # Not the operator wall: that gate had already passed the DNS write above.
+    # Not the operator wall: that gate had already passed the DNS write above,
+    # and apply_saved_prefs has already named which half of the run state failed.
     # The snapshot stays because it is the only record that this node was up.
-    note "DNS returned to Tailscale, but 'tailscale up' failed and the node is still stopped"
-    note "start it by hand, or rerun once that is fixed: captive-portal --restore"
+    note "DNS returned to Tailscale, but the node's run state was not restored"
+    note "start it with 'tailscale up', or rerun once that is fixed: captive-portal --restore"
     exit 4
   fi
   rm -f "$state_file"

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -180,7 +180,8 @@ is_private_v4() {
 # one that intercepts HTTP replaces the probe payload or 302s away from it. Both
 # reveal the sign-in URL. The return values are the script's own exit statuses:
 # 0 prints the portal URL, 1 means the network came back clean, 3 means every
-# probe was inconclusive and prints a gateway guess when there is one.
+# probe was inconclusive and prints a gateway guess when there is one. Each
+# payload lands in $body_file, which the caller owns; see the call site.
 probe_portal() {
   local resolver="$1" gateway="$2"
   local hosts urls expects i host url expect answer status redirect found
@@ -193,8 +194,6 @@ probe_portal() {
     http://connectivity-check.gstatic.com/generate_204
   )
   expects=(success Success "")
-
-  body_file="$(mktemp)"
 
   for i in "${!hosts[@]}"; do
     host="${hosts[$i]}"
@@ -450,6 +449,13 @@ fi
 
 portal=""
 probe_status=0
+# The scratch file is created here rather than in probe_portal because the
+# function only ever runs inside a command substitution: bash does not fire the
+# parent's EXIT trap in that subshell, and an assignment made there cannot escape
+# it, so a body_file created inside was invisible to cleanup and every run left
+# the page it had fetched behind. Created in the shell that owns the trap, the
+# sweep already written above covers it on every exit and on a signal.
+body_file="$(mktemp)"
 portal="$(probe_portal "$resolver" "$gateway")" || probe_status=$?
 
 # Every exit from here on is one of the documented statuses, and each one that

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -22,6 +22,7 @@ state_file="$state_dir/tailscale-prefs"
 
 body_file=""
 
+# shellcheck disable=SC2329  # invoked through the traps below
 cleanup() {
   if [ -n "$body_file" ]; then
     rm -f "$body_file"
@@ -32,11 +33,13 @@ trap cleanup EXIT
 # Probing three canaries takes up to ~24s, so a Ctrl-C inside that window is
 # likely. Bash's default disposition would drop the user back to the shell with
 # Tailscale DNS still off and nothing on screen saying so.
+# shellcheck disable=SC2329  # invoked through the INT and TERM traps below
 on_signal() {
   trap - INT TERM
   cleanup
   if [ "$dns_released" -eq 1 ]; then
-    printf '\ncaptive-portal: interrupted with DNS still released; run: captive-portal --restore\n' >&2
+    printf '\n' >&2
+    note "interrupted with DNS still released; run: captive-portal --restore"
   fi
   kill -s "$1" "$$"
 }
@@ -57,17 +60,34 @@ Options:
   --device DEV  Device to inspect (default: first connected wifi/ethernet).
   --no-open     Print the portal URL instead of launching a browser.
   --down        Stop Tailscale entirely rather than only releasing DNS.
+
+Only the portal URL goes to stdout; everything else is written to stderr.
+
+Exit status:
+  0  a portal was found and its URL was printed
+  1  no portal: this network answers the probes normally
+  2  invalid usage
+  3  the probes were inconclusive; a gateway guess is printed when one exists
+  4  the network could not be inspected, or Tailscale prefs could not be read
 EOF
+}
+
+note() {
+  printf 'captive-portal: %s\n' "$*" >&2
 }
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
   --device)
     device="${2:-}"
-    [ -n "$device" ] || {
-      echo "captive-portal: --device needs a value" >&2
+    # `--device --probe` used to consume the flag as a device name and then run
+    # in login mode, releasing real DNS for a request that asked to change none.
+    case "$device" in
+    "" | -*)
+      echo "captive-portal: --device needs a device name, got '${device:-}'" >&2
       exit 2
-    }
+      ;;
+    esac
     shift 2
     ;;
   --probe)
@@ -231,7 +251,7 @@ save_prefs() {
   if ! prefs="$(tailscale debug prefs |
     jq -er '[.CorpDNS, .WantRunning] |
       if all(type == "boolean") then @tsv else error("CorpDNS/WantRunning missing") end')"; then
-    echo "captive-portal: cannot read Tailscale prefs; leaving DNS untouched" >&2
+    note "cannot read Tailscale prefs; leaving DNS untouched"
     return 1
   fi
   # Write through a temporary so a failed read never leaves a truncated file
@@ -242,7 +262,9 @@ save_prefs() {
 }
 
 release_dns() {
-  save_prefs
+  if ! save_prefs; then
+    exit 4
+  fi
   dns_released=1
   if [ "$stop_tailscale" -eq 1 ]; then
     tailscale down
@@ -260,12 +282,12 @@ show_resolvers() {
   local lines
   lines="$(grep '^nameserver' /etc/resolv.conf || true)"
   if [ -z "$lines" ]; then
-    echo "captive-portal: /etc/resolv.conf carries no nameserver line" >&2
+    note "/etc/resolv.conf carries no nameserver line"
     return 0
   fi
   printf '%s\n' "$lines" >&2
   if ! printf '%s\n' "$lines" | grep -qvE '^nameserver[[:space:]]+127\.'; then
-    echo "captive-portal: that is a local stub; its upstream is the active connection's DNS" >&2
+    note "that is a local stub; its upstream is the active connection's DNS"
   fi
 }
 
@@ -288,7 +310,7 @@ restore_dns() {
   rm -f "$state_file"
   nmcli general reload dns-full
   dns_released=0
-  echo "captive-portal: DNS returned to Tailscale"
+  note "DNS returned to Tailscale"
   show_resolvers
 }
 
@@ -303,29 +325,29 @@ if [ -z "$device" ]; then
   device="$(printf '%s\n' "$candidates" | head -1 | cut -d: -f2)"
 fi
 if [ -z "$device" ]; then
-  echo "captive-portal: no connected wifi or ethernet device" >&2
-  exit 1
+  note "no connected wifi or ethernet device"
+  exit 4
 fi
 
 # Only one of several connected devices can be behind the portal, and nothing
 # here can tell which, so name the ones that were passed over.
 others="$(printf '%s\n' "$candidates" | tail -n +2 | cut -d: -f2 | paste -sd' ' - || true)"
 if [ -n "$others" ]; then
-  echo "captive-portal: also connected: $others; pass --device to inspect one of those" >&2
+  note "also connected: $others; pass --device to inspect one of those"
 fi
 
 resolver="$(device_dns "$device" | head -1)"
 gateway="$(device_gateway "$device")"
 if [ -z "$resolver" ]; then
-  echo "captive-portal: $device has no DHCP-provided resolver; is the lease up?" >&2
-  exit 1
+  note "$device has no DHCP-provided resolver; is the lease up?"
+  exit 4
 fi
 
-echo "captive-portal: device $device, access-point resolver $resolver, gateway ${gateway:-unknown}"
+note "device $device, access-point resolver $resolver, gateway ${gateway:-unknown}"
 
 if [ "$mode" = login ]; then
   release_dns
-  echo "captive-portal: system resolvers now:"
+  note "system resolvers now:"
   show_resolvers
 fi
 
@@ -333,27 +355,40 @@ portal=""
 probe_status=0
 portal="$(probe_portal "$resolver" "$gateway")" || probe_status=$?
 
+# Every exit from here on is one of the documented statuses, and each one that
+# leaves login mode has to decide what happens to the DNS release.
 case "$probe_status" in
 1)
-  echo "captive-portal: no portal detected; this network answers probes normally"
+  note "no portal detected; this network answers probes normally"
   if [ "$mode" = login ]; then
     restore_dns
   fi
-  exit 0
+  exit 1
   ;;
 2)
   if [ -z "$portal" ]; then
-    echo "captive-portal: probes inconclusive and no gateway to fall back on" >&2
-    exit 1
+    note "probes inconclusive and no gateway to fall back on"
+    # Nothing was found and nothing more will be tried, so the release must not
+    # outlive the run the way it did when this path exited on the spot.
+    if [ "$mode" = login ]; then
+      restore_dns
+    fi
+    exit 3
   fi
-  echo "captive-portal: probes inconclusive; falling back to the gateway"
+  # This is the gateway, not a portal anything confirmed: on a network that
+  # merely blocks the canaries it is the user's own router. Say so rather than
+  # reusing the wording of a detection.
+  note "probes inconclusive; no portal confirmed. Trying this network's gateway, which may just be your router:"
   ;;
 esac
 
-echo "captive-portal: portal at $portal"
+if [ "$probe_status" -eq 0 ]; then
+  note "portal at $portal"
+fi
+printf '%s\n' "$portal"
 
 if [ "$mode" = probe ]; then
-  exit 0
+  exit "$probe_status"
 fi
 
 if [ "$open_browser" -eq 1 ]; then
@@ -362,7 +397,7 @@ if [ "$open_browser" -eq 1 ]; then
   xdg-open "$portal" >/dev/null 2>&1 &
 fi
 
-cat <<EOF
+cat >&2 <<EOF
 
 Sign in at the page above, then run:
 
@@ -371,3 +406,5 @@ Sign in at the page above, then run:
 If the page does not load, open it in a private window: portals reject cached
 HSTS upgrades and stale cookies from an earlier session.
 EOF
+
+exit "$probe_status"

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -329,8 +329,16 @@ probe_portal() {
       esac
       ;;
     204)
-      # 204 is body-less by definition, so there is nothing left to match.
-      host_clean=1
+      # 204 is the whole answer for generate_204, which is why that canary is the
+      # one carrying no expected string. A canary that was told to expect a
+      # payload has served none of it here, so it clears nothing: a filter that
+      # answers a blocklisted or intercepted name with an empty 204, which
+      # AdGuard Home's HTTP filtering and proxies that suppress connectivity
+      # checks both do, would otherwise read as a clean network. Same rule as the
+      # arm below, where only the marker a canary was told to expect clears it.
+      if [ -z "$expect" ]; then
+        host_clean=1
+      fi
       ;;
     200 | 511)
       # generate_204 carries no expected string because the status is the whole

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -272,7 +272,15 @@ probe_portal() {
       # proxy portal that leaves DNS alone answers on the canary's real public
       # address and the status is then the only tell. It is never clean, however
       # its body reads, so only a 200 can clear a canary.
-      if [ "$status" = 200 ] && [ -n "$expect" ] && grep -qF "$expect" "$body_file"; then
+      # The size bound is what makes the marker mean "this canary answered as
+      # specified" rather than "the word turns up somewhere". The genuine
+      # payloads are 8 and 69 bytes; an interception page is kilobytes, and
+      # login pages routinely carry `success:` from a jQuery or hand-rolled AJAX
+      # callback, which cleared the canary and had the run hand DNS back on a
+      # network that did have a portal. Bounding beats pinning the exact
+      # document, which Apple can change out from under this.
+      if [ "$status" = 200 ] && [ -n "$expect" ] &&
+        [ "$(wc -c <"$body_file")" -le 256 ] && grep -qF "$expect" "$body_file"; then
         host_clean=1
       else
         # The first absolute URL in a page is usually not the sign-in target. An

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -386,8 +386,12 @@ release_dns() {
     # run took must not outlive it and be replayed as a state the host never left.
     dns_released=0
     denied
-    if [ "$prefs_snapshot_created" -eq 1 ]; then
-      rm -f "$state_file"
+    # Guarded for the same reason as the unlink in restore_dns: a bare rm that
+    # fails exits 1, which this script documents as "no portal", and errexit
+    # would end the run there rather than at the exit 4 below, reporting a
+    # tailscaled refusal as a clean network.
+    if [ "$prefs_snapshot_created" -eq 1 ] && ! rm -f "$state_file"; then
+      note "could not remove $state_file; delete it, or the next run will replay it"
     fi
     exit 4
   fi

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -559,7 +559,16 @@ probe_status=0
 # it, so a body_file created inside was invisible to cleanup and every run left
 # the page it had fetched behind. Created in the shell that owns the trap, the
 # sweep already written above covers it on every exit and on a signal.
-body_file="$(mktemp)"
+if ! body_file="$(mktemp)"; then
+  # Unguarded, mktemp's own 1 came back as this script's "no portal", from a
+  # point login mode has already released DNS: errexit killed the run with
+  # mktemp's error the only thing on screen, no reminder, and no restore.
+  note "could not create a scratch file for the probe payload"
+  if [ "$mode" = login ]; then
+    restore_dns
+  fi
+  exit 4
+fi
 portal="$(probe_portal "$resolver" "$gateway")" || probe_status=$?
 
 # Every exit from here on is one of the documented statuses, and each one that

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -210,6 +210,17 @@ is_private_v4() {
   esac
 }
 
+# Location and an extracted link are chosen by the network the same way the
+# canary's DNS answer is, so both need the exclusion the sinkholed-canary
+# guard already applies to $answer: 127.0.0.0/8 and 0.0.0.0 are this machine,
+# not somewhere a portal can sit, and neither is localhost or ::1.
+is_loopback_host() {
+  case "${1#*//}" in
+  127.* | 0.0.0.0 | 0.0.0.0[:/?#]* | localhost | localhost[:/?#]* | \[::1\]*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
 # Pull the first absolute URL the named attributes point at out of $body_file.
 #
 # The names are anchored on line start, `;`, or whitespace, so each is the whole
@@ -323,8 +334,10 @@ probe_portal() {
       # falls through to the hijack check below.
       case "$redirect" in
       http://* | https://*)
-        printf '%s\n' "$redirect"
-        return 0
+        if ! is_loopback_host "$redirect"; then
+          printf '%s\n' "$redirect"
+          return 0
+        fi
         ;;
       esac
       ;;
@@ -374,6 +387,11 @@ probe_portal() {
         fi
         if [ -z "$found" ]; then
           found="$(extract_url 'href')"
+        fi
+        # An extracted link is as network-chosen as Location; the same guard
+        # applies, falling back the same way finding nothing already does.
+        if [ -n "$found" ] && is_loopback_host "$found"; then
+          found=""
         fi
         printf '%s\n' "${found:-http://$answer}"
         return 0

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -20,11 +20,21 @@ dns_released=0
 state_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/captive-portal"
 state_file="$state_dir/tailscale-prefs"
 
+body_file=""
+
+cleanup() {
+  if [ -n "$body_file" ]; then
+    rm -f "$body_file"
+  fi
+}
+trap cleanup EXIT
+
 # Probing three canaries takes up to ~24s, so a Ctrl-C inside that window is
 # likely. Bash's default disposition would drop the user back to the shell with
 # Tailscale DNS still off and nothing on screen saying so.
 on_signal() {
   trap - INT TERM
+  cleanup
   if [ "$dns_released" -eq 1 ]; then
     printf '\ncaptive-portal: interrupted with DNS still released; run: captive-portal --restore\n' >&2
   fi
@@ -88,9 +98,15 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-pick_device() {
+# Portals live on the wireless hop, so a docked laptop holding both links must
+# not have the choice decided by nmcli's listing order. Sorting the wifi-first
+# key makes the pick reproducible, and the caller reports the runners-up.
+candidate_devices() {
   nmcli -t -f DEVICE,TYPE,STATE device status |
-    awk -F: '$3 == "connected" && ($2 == "wifi" || $2 == "ethernet") { print $1; exit }'
+    awk -F: '$3 == "connected" && ($2 == "wifi" || $2 == "ethernet") {
+      print ($2 == "wifi" ? 0 : 1) ":" $1
+    }' |
+    sort
 }
 
 device_dns() {
@@ -99,14 +115,23 @@ device_dns() {
     grep -E '^[0-9]+(\.[0-9]+){3}$' || true
 }
 
+# An on-link default route ("default dev wlan0 scope link", which tethered and
+# point-to-point links produce) carries no via, and $3 is then the device name:
+# taking it verbatim yielded a portal URL of http://wlan0.
 device_gateway() {
-  ip -4 route show default dev "$1" | awk '{ print $3; exit }'
+  ip -4 route show default dev "$1" |
+    awk '{ for (i = 1; i < NF; i++) if ($i == "via") { print $(i + 1); exit } }' |
+    grep -E '^[0-9]+(\.[0-9]+){3}$' || true
 }
 
 is_private_v4() {
   case "$1" in
   10.* | 192.168.* | 127.*) return 0 ;;
   172.1[6-9].* | 172.2[0-9].* | 172.3[01].*) return 0 ;;
+  # A portal answers from whatever space it sits in: 169.254.0.0/16 when it
+  # never issued a lease, and 100.64.0.0/10 on carrier and guest networks.
+  169.254.*) return 0 ;;
+  100.6[4-9].* | 100.[7-9][0-9].* | 100.1[01][0-9].* | 100.12[0-7].*) return 0 ;;
   *) return 1 ;;
   esac
 }
@@ -117,8 +142,8 @@ is_private_v4() {
 # back clean, 2 means every probe was inconclusive and prints a gateway guess.
 probe_portal() {
   local resolver="$1" gateway="$2"
-  local hosts urls expects i host url expect answer status redirect body found
-  local clean=0
+  local hosts urls expects i host url expect answer status redirect found
+  local clean=0 host_clean=0
 
   hosts=(detectportal.firefox.com captive.apple.com connectivity-check.gstatic.com)
   urls=(
@@ -127,6 +152,8 @@ probe_portal() {
     http://connectivity-check.gstatic.com/generate_204
   )
   expects=(success Success "")
+
+  body_file="$(mktemp)"
 
   for i in "${!hosts[@]}"; do
     host="${hosts[$i]}"
@@ -137,33 +164,45 @@ probe_portal() {
       grep -E '^[0-9]+(\.[0-9]+){3}$' | tail -1 || true)"
     [ -n "$answer" ] || continue
 
-    body="$(mktemp)"
+    host_clean=0
     status=000
     redirect=""
     read -r status redirect <<<"$(
-      curl -sS -m 6 -o "$body" -w '%{http_code} %{redirect_url}' \
+      curl -sS -m 6 -o "$body_file" -w '%{http_code} %{redirect_url}' \
         --resolve "$host:80:$answer" "$url" 2>/dev/null || echo '000 '
     )"
 
     case "$status" in
     30*)
-      [ -n "$redirect" ] && {
+      if [ -n "$redirect" ]; then
         printf '%s\n' "$redirect"
-        rm -f "$body"
-        return 0
-      }
-      ;;
-    200 | 204)
-      if [ -n "$expect" ] && ! grep -qF "$expect" "$body"; then
-        found="$(grep -oiE 'https?://[^"'"'"'<>[:space:]]+' "$body" | head -1 || true)"
-        printf '%s\n' "${found:-http://$answer}"
-        rm -f "$body"
         return 0
       fi
-      clean=1
+      ;;
+    204)
+      # 204 is body-less by definition, so there is nothing left to match.
+      host_clean=1
+      ;;
+    200)
+      # generate_204 carries no expected string because the status is the whole
+      # answer: a 200 there is already the portal serving its page inline,
+      # which is how an intercepting proxy replies when it does not redirect.
+      if [ -n "$expect" ] && grep -qF "$expect" "$body_file"; then
+        host_clean=1
+      else
+        found="$(grep -oiE 'https?://[^"'"'"'<>[:space:]]+' "$body_file" | head -1 || true)"
+        printf '%s\n' "${found:-http://$answer}"
+        return 0
+      fi
       ;;
     esac
-    rm -f "$body"
+
+    if [ "$host_clean" -eq 1 ]; then
+      # This canary answered as specified, so the address it resolved to is not
+      # a hijack however private it looks, and the check below must not run.
+      clean=1
+      continue
+    fi
 
     # The probe host answered with an address on this LAN: a DNS hijack.
     if is_private_v4 "$answer"; then
@@ -258,10 +297,21 @@ if [ "$mode" = restore ]; then
   exit 0
 fi
 
-[ -n "$device" ] || device="$(pick_device)"
+candidates=""
+if [ -z "$device" ]; then
+  candidates="$(candidate_devices)"
+  device="$(printf '%s\n' "$candidates" | head -1 | cut -d: -f2)"
+fi
 if [ -z "$device" ]; then
   echo "captive-portal: no connected wifi or ethernet device" >&2
   exit 1
+fi
+
+# Only one of several connected devices can be behind the portal, and nothing
+# here can tell which, so name the ones that were passed over.
+others="$(printf '%s\n' "$candidates" | tail -n +2 | cut -d: -f2 | paste -sd' ' - || true)"
+if [ -n "$others" ]; then
+  echo "captive-portal: also connected: $others; pass --device to inspect one of those" >&2
 fi
 
 resolver="$(device_dns "$device" | head -1)"

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -15,9 +15,23 @@ mode=login
 device=""
 open_browser=1
 stop_tailscale=0
+dns_released=0
 
 state_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/captive-portal"
 state_file="$state_dir/tailscale-prefs"
+
+# Probing three canaries takes up to ~24s, so a Ctrl-C inside that window is
+# likely. Bash's default disposition would drop the user back to the shell with
+# Tailscale DNS still off and nothing on screen saying so.
+on_signal() {
+  trap - INT TERM
+  if [ "$dns_released" -eq 1 ]; then
+    printf '\ncaptive-portal: interrupted with DNS still released; run: captive-portal --restore\n' >&2
+  fi
+  kill -s "$1" "$$"
+}
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
 
 usage() {
   cat <<'EOF'
@@ -165,13 +179,32 @@ probe_portal() {
   return 2
 }
 
+# The snapshot must survive a retry: a second login run after a failed sign-in
+# would otherwise record the already-released prefs as the originals, and
+# --restore would then replay --accept-dns=false as if that were the user's
+# state. The first snapshot of a session wins until --restore consumes it.
 save_prefs() {
+  local prefs tmp
   mkdir -p "$state_dir"
-  tailscale debug prefs | jq -r '[.CorpDNS, .WantRunning] | @tsv' >"$state_file"
+  if [ -s "$state_file" ]; then
+    return 0
+  fi
+  if ! prefs="$(tailscale debug prefs |
+    jq -er '[.CorpDNS, .WantRunning] |
+      if all(type == "boolean") then @tsv else error("CorpDNS/WantRunning missing") end')"; then
+    echo "captive-portal: cannot read Tailscale prefs; leaving DNS untouched" >&2
+    return 1
+  fi
+  # Write through a temporary so a failed read never leaves a truncated file
+  # that --restore would later parse as "DNS was already off".
+  tmp="$(mktemp "$state_file.XXXXXX")"
+  printf '%s\n' "$prefs" >"$tmp"
+  mv "$tmp" "$state_file"
 }
 
 release_dns() {
   save_prefs
+  dns_released=1
   if [ "$stop_tailscale" -eq 1 ]; then
     tailscale down
   else
@@ -181,10 +214,29 @@ release_dns() {
   nmcli general reload dns-full
 }
 
+# /etc/resolv.conf legitimately carries no nameserver before a portal hands out
+# a lease, and on a systemd-resolved host it only ever carries the 127.0.0.53
+# stub, so neither case may abort the run or masquerade as the whole story.
+show_resolvers() {
+  local lines
+  lines="$(grep '^nameserver' /etc/resolv.conf || true)"
+  if [ -z "$lines" ]; then
+    echo "captive-portal: /etc/resolv.conf carries no nameserver line" >&2
+    return 0
+  fi
+  printf '%s\n' "$lines" >&2
+  if ! printf '%s\n' "$lines" | grep -qvE '^nameserver[[:space:]]+127\.'; then
+    echo "captive-portal: that is a local stub; its upstream is the active connection's DNS" >&2
+  fi
+}
+
 restore_dns() {
-  local corp_dns=true want_running=true
-  if [ -f "$state_file" ]; then
-    read -r corp_dns want_running <"$state_file"
+  local corp_dns=true want_running=true saved_corp="" saved_want=""
+  # An unreadable or truncated state file must not abort the run and must not
+  # decide that DNS stays off: both fields fall back to restoring Tailscale.
+  if [ -s "$state_file" ] && read -r saved_corp saved_want <"$state_file"; then
+    case "$saved_corp" in true | false) corp_dns="$saved_corp" ;; esac
+    case "$saved_want" in true | false) want_running="$saved_want" ;; esac
   fi
   # `tailscale up` resets every pref it is not passed, so reach for it only when
   # --down stopped a node that had been running.
@@ -196,8 +248,9 @@ restore_dns() {
   fi
   rm -f "$state_file"
   nmcli general reload dns-full
+  dns_released=0
   echo "captive-portal: DNS returned to Tailscale"
-  grep '^nameserver' /etc/resolv.conf
+  show_resolvers
 }
 
 if [ "$mode" = restore ]; then
@@ -223,7 +276,7 @@ echo "captive-portal: device $device, access-point resolver $resolver, gateway $
 if [ "$mode" = login ]; then
   release_dns
   echo "captive-portal: system resolvers now:"
-  grep '^nameserver' /etc/resolv.conf
+  show_resolvers
 fi
 
 portal=""

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -236,6 +236,12 @@ is_loopback_host() {
 # needs the leading dot optional and the trailing slash relaxed, or
 # `http://w3.org/TR/...` and `http://www.w3.org` walk past it.
 #
+# A relative form action is at least as common as an absolute one, and then
+# tier 1 and tier 2 find nothing and tier 3 takes the first absolute href on
+# the page: a stylesheet or script sitting ahead of the form in `<head>` is
+# never a sign-in target in any tier, so it is filtered here rather than only
+# where tier 3 reads it.
+#
 # HTML requires a literal `&` in an attribute value to be written `&amp;`, and a
 # WISPr redirect carries several parameters, so the raw value would be opened
 # with `amp;` glued to every parameter after the first and the sign-in would
@@ -244,6 +250,7 @@ extract_url() {
   grep -oiE '(^|[;[:space:]])('"$1"')=["'"'"']?https?://[^"'"'"'<>[:space:]]+' "$body_file" |
     grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
     grep -viE '^https?://([^/]*\.)?w3\.org([/:?]|$)' |
+    grep -viE '\.(css|js|mjs|png|jpe?g|gif|svg|ico|woff2?|ttf|eot)([?#]|$)' |
     head -1 |
     sed 's/&amp;/\&/g' || true
 }

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -264,6 +264,11 @@ is_loopback_host() {
 # `<form action>` pointing at an asset directly, which the strip below does
 # not touch.
 #
+# The body is untrusted input and the extracted target is printed raw and passed
+# to xdg-open, so control bytes cannot be allowed into either path. NUL also has
+# to be mapped before grep sees it: GNU grep switches to binary mode and drops
+# its -o output when a NUL remains in the stream.
+#
 # sed works a line at a time, and a hand-written portal page wraps a tag's
 # attributes across lines as often as not, so the body is flattened first: a
 # `<link>` split over two lines would otherwise survive the strip, and a
@@ -276,10 +281,10 @@ is_loopback_host() {
 # with `amp;` glued to every parameter after the first and the sign-in would
 # never complete.
 extract_url() {
-  tr '\n' ' ' <"$body_file" |
+  tr '\n\000' '  ' <"$body_file" |
     sed 's/<link[^>]*>//gI' |
-    grep -oiE '(^|[;[:space:]])('"$1"')=["'"'"']?https?://[^"'"'"'<>[:space:]]+' |
-    grep -oiE 'https?://[^"'"'"'<>[:space:]]+' |
+    grep -oiE '(^|[;[:space:]])('"$1"')=["'"'"']?https?://[^"'"'"'<>[:space:][:cntrl:]]+' |
+    grep -oiE 'https?://[^"'"'"'<>[:space:][:cntrl:]]+' |
     grep -viE '^https?://([^/]*\.)?w3\.org([/:?]|$)' |
     grep -viE '\.(css|js|mjs|png|jpe?g|gif|svg|ico|woff2?|ttf|eot)([?#]|$)' |
     head -1 |
@@ -370,7 +375,10 @@ probe_portal() {
       # does any scheme with a desktop handler. Only the two the body-extraction
       # path already restricts itself to count; anything else is no answer and
       # falls through to the hijack check below.
+      # A Location header can carry terminal control bytes just like a page
+      # attribute, so reject the whole target before the http(s) arm sees it.
       case "$redirect" in
+      *[[:cntrl:]]*) ;;
       http://* | https://*)
         if ! is_loopback_host "$redirect"; then
           printf '%s\n' "$redirect"

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -69,7 +69,7 @@ Exit status:
   0  a portal was found and its URL was printed
   1  no portal: this network answers the probes normally
   2  invalid usage
-  3  the probes were inconclusive; a gateway guess is printed when one exists
+  3  the probes were inconclusive; a gateway guess is printed, never opened
   4  the network could not be inspected, or Tailscale prefs could not be read
 EOF
 }
@@ -381,7 +381,7 @@ case "$probe_status" in
   # This is the gateway, not a portal anything confirmed: on a network that
   # merely blocks the canaries it is the user's own router. Say so rather than
   # reusing the wording of a detection.
-  note "probes inconclusive; no portal confirmed. Trying this network's gateway, which may just be your router:"
+  note "probes inconclusive; no portal confirmed. This network's gateway, which may just be your router:"
   ;;
 esac
 
@@ -394,13 +394,16 @@ if [ "$mode" = probe ]; then
   exit "$probe_status"
 fi
 
-if [ "$open_browser" -eq 1 ]; then
+# Only a confirmed detection earns a browser. The gateway guess is as likely to
+# be the user's own router, and opening that unasked is worse than printing it.
+if [ "$open_browser" -eq 1 ] && [ "$probe_status" -eq 0 ]; then
   # LibreWolf ships network.captive-portal-service.enabled=false, so it never
   # raises a sign-in bar on its own; open the URL directly instead.
   xdg-open "$portal" >/dev/null 2>&1 &
 fi
 
-cat >&2 <<EOF
+if [ "$probe_status" -eq 0 ]; then
+  cat >&2 <<'EOF'
 
 Sign in at the page above, then run:
 
@@ -409,5 +412,15 @@ Sign in at the page above, then run:
 If the page does not load, open it in a private window: portals reject cached
 HSTS upgrades and stale cookies from an earlier session.
 EOF
+else
+  cat >&2 <<'EOF'
+
+Nothing was confirmed as a portal, so the address above was not opened. Try it
+by hand if you want, in a private window: portals reject cached HSTS upgrades
+and stale cookies from an earlier session. DNS stays released until you run:
+
+  captive-portal --restore
+EOF
+fi
 
 exit "$probe_status"

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -239,7 +239,16 @@ probe_portal() {
     # access point's resolver handed back. An inherited http_proxy sends the
     # request to the proxy instead, --resolve never applies, and every canary is
     # then graded on what the proxy answered while dig stays honest.
-    if write_out="$(curl -sS -m 6 --noproxy '*' -o "$body_file" -w '%{http_code} %{redirect_url}' \
+    # --max-filesize because -m caps time and not bytes, and this body is the one
+    # value from the network with no ceiling otherwise: /tmp is disk-backed here
+    # (modules/hosts/common/tmp.nix), so a hostile portal could fill the root
+    # filesystem with whatever it pushes in six seconds across three canaries,
+    # and wc and grep then read all of it. curl exits 63 on the cap, verified
+    # against 8.21.0 both with a Content-Length and mid-transfer without one, so
+    # this composes with the classification: the guard below fails, status stays
+    # 000, and the canary falls through like any other failed transfer.
+    if write_out="$(curl -sS -m 6 --max-filesize 1048576 --noproxy '*' -o "$body_file" \
+      -w '%{http_code} %{redirect_url}' \
       --resolve "$host:80:$answer" "$url" 2>/dev/null)"; then
       read -r status redirect <<<"$write_out"
     fi

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -20,6 +20,7 @@ stop_tailscale=0
 dns_released=0
 prefs_snapshot_created=0
 nmcli_status=0
+dns_status=0
 
 # sudo-rs enforces env_reset with no opt-out and modules/hosts/common/sudo.nix
 # keeps only SSH_AUTH_SOCK, so XDG_RUNTIME_DIR is gone under sudo. Falling back
@@ -150,8 +151,15 @@ candidate_devices() {
     sort
 }
 
+# nmcli runs on its own because the trailing `|| true` has to stay: grep exits 1
+# on a device that simply has no DNS, which is not a failure. That `|| true`
+# swallowed the whole pipeline though, and pipefail would hand back grep's 1
+# ahead of nmcli's own status anyway, so "no device by that name" (exit 10)
+# arrived at the caller as "no resolver".
 device_dns() {
-  nmcli -t -f IP4.DNS device show "$1" |
+  local raw
+  raw="$(nmcli -t -f IP4.DNS device show "$1")" || return "$?"
+  printf '%s\n' "$raw" |
     sed 's/^IP4\.DNS\[[0-9]*\]:*//' |
     grep -E '^[0-9]+(\.[0-9]+){3}$' || true
 }
@@ -503,10 +511,19 @@ if [ -n "$others" ]; then
   note "also connected: $others; pass --device to inspect one of those"
 fi
 
-resolver="$(device_dns "$device" | head -1)"
+resolver="$(device_dns "$device" | head -1)" || dns_status=$?
 gateway="$(device_gateway "$device")"
 if [ -z "$resolver" ]; then
-  note "$device has no DHCP-provided resolver; is the lease up?"
+  # --device is checked for shape and never for existence, and the hosts do not
+  # agree on what the wireless NIC is called (modules/tpnix/networking.nix pins
+  # wifi0 where system76 keeps wlan0), so a name from the wrong host is the typo
+  # the flag invites. Sending that to check a DHCP lease names an interface that
+  # is not there.
+  case "$dns_status" in
+  0) note "$device has no DHCP-provided resolver; is the lease up?" ;;
+  10) note "nmcli knows no device named $device; pick one from: nmcli -t -f DEVICE device status" ;;
+  *) note "nmcli could not read the DNS of $device (exit $dns_status)" ;;
+  esac
   exit 4
 fi
 

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -246,10 +246,19 @@ probe_portal() {
 
     case "$status" in
     30*)
-      if [ -n "$redirect" ]; then
+      # This value is whatever an untrusted network put in Location, and it ends
+      # up at xdg-open. curl builds %{redirect_url} through FOLLOW_FAKE, which
+      # skips the protocol check it applies when -L actually follows the hop, so
+      # `Location: file:///home/user/.ssh/id_ed25519` arrives here intact, as
+      # does any scheme with a desktop handler. Only the two the body-extraction
+      # path already restricts itself to count; anything else is no answer and
+      # falls through to the hijack check below.
+      case "$redirect" in
+      http://* | https://*)
         printf '%s\n' "$redirect"
         return 0
-      fi
+        ;;
+      esac
       ;;
     204)
       # 204 is body-less by definition, so there is nothing left to match.

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -185,7 +185,7 @@ is_private_v4() {
 # payload lands in $body_file, which the caller owns; see the call site.
 probe_portal() {
   local resolver="$1" gateway="$2"
-  local hosts urls expects i host url expect answer status redirect found
+  local hosts urls expects i host url expect answer status redirect found write_out
   local clean=0 host_clean=0
 
   hosts=(detectportal.firefox.com captive.apple.com connectivity-check.gstatic.com)
@@ -208,10 +208,23 @@ probe_portal() {
     host_clean=0
     status=000
     redirect=""
-    read -r status redirect <<<"$(
-      curl -sS -m 6 -o "$body_file" -w '%{http_code} %{redirect_url}' \
-        --resolve "$host:80:$answer" "$url" 2>/dev/null || echo '000 '
-    )"
+    # curl truncates -o for any transfer that completes, empty body included, but
+    # writes nothing at all when one dies before the first body byte. Clearing it
+    # here keeps a canary from being classified against the page the last one
+    # fetched, without resting that on curl's file handling.
+    : >"$body_file"
+    # curl writes its -w line and only then exits nonzero, and that line carries
+    # no terminator, so `|| echo '000 '` used to concatenate onto it rather than
+    # replace it: `read` took curl's own http_code as the status and the
+    # fallback's text as the redirect. A 302 whose body never arrived was
+    # reported as a portal at http://<target>000, and one with no Location at
+    # http://000. A transfer that failed is not an answer, so whatever it managed
+    # to print is dropped and status stays 000, which no arm below matches and
+    # which falls through to the hijack check the way a silent drop does.
+    if write_out="$(curl -sS -m 6 -o "$body_file" -w '%{http_code} %{redirect_url}' \
+      --resolve "$host:80:$answer" "$url" 2>/dev/null)"; then
+      read -r status redirect <<<"$write_out"
+    fi
 
     case "$status" in
     30*)

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -87,7 +87,8 @@ Exit status:
   0  a portal was found and its URL was printed
   1  no portal: this network answers the probes normally
   2  invalid usage
-  3  the probes were inconclusive; a gateway guess is printed, never opened
+  3  the probes were inconclusive; a gateway guess is printed if there is one,
+     and never opened
   4  the network could not be inspected, or Tailscale state could not be read
      or changed
 

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -19,6 +19,7 @@ open_browser=1
 stop_tailscale=0
 dns_released=0
 prefs_snapshot_created=0
+nmcli_status=0
 
 # sudo-rs enforces env_reset with no opt-out and modules/hosts/common/sudo.nix
 # keeps only SSH_AUTH_SOCK, so XDG_RUNTIME_DIR is gone under sudo. Falling back
@@ -438,7 +439,14 @@ restore_dns() {
     note "start it with 'tailscale up', or rerun once that is fixed: captive-portal --restore"
     exit 4
   fi
-  rm -f "$state_file"
+  # save_prefs keeps the first snapshot of a session, so one left behind here is
+  # replayed by the next run as prefs the host may no longer hold. The restore
+  # itself succeeded, so this is reported the way a failed reload is: unguarded,
+  # it crashed the run with rm's status 1, which for this script means "no
+  # portal", after the restore it is reporting had already worked.
+  if ! rm -f "$state_file"; then
+    note "could not remove $state_file; delete it, or the next run will replay it"
+  fi
   note "DNS returned to Tailscale"
   show_resolvers
 }
@@ -450,11 +458,18 @@ fi
 
 candidates=""
 if [ -z "$device" ]; then
-  candidates="$(candidate_devices)"
+  candidates="$(candidate_devices)" || nmcli_status=$?
   device="$(printf '%s\n' "$candidates" | head -1 | cut -d: -f2)"
 fi
 if [ -z "$device" ]; then
-  note "no connected wifi or ethernet device"
+  # nmcli's exit codes are not this script's. Unguarded, and under pipefail, the
+  # assignment above ended the run with nmcli's own 8 and printed nothing at
+  # all, past a status table that stops at 4 and past this guard.
+  case "$nmcli_status" in
+  0) note "no connected wifi or ethernet device" ;;
+  8) note "NetworkManager is not running, so nmcli could not list devices" ;;
+  *) note "nmcli could not list devices (exit $nmcli_status)" ;;
+  esac
   exit 4
 fi
 

--- a/packages/captive-portal/captive-portal.sh
+++ b/packages/captive-portal/captive-portal.sh
@@ -1,0 +1,270 @@
+# shellcheck shell=bash
+# Reach a captive portal from a host that resolves through Tailscale.
+#
+# With --accept-dns=true tailscaled registers a resolvconf entry that supersedes
+# NetworkManager's, so the dnsmasq at 127.0.0.1 is shadowed and every query goes
+# to the tailnet's global resolvers. A portal drops those upstreams
+# until you authenticate and answers only on its own DHCP-advertised resolver, so
+# the DNS hijack that produces the sign-in page never runs and nothing surfaces
+# the portal. This releases DNS back to dnsmasq, finds the portal through the
+# access point's own resolver, and opens it.
+
+set -euo pipefail
+
+mode=login
+device=""
+open_browser=1
+stop_tailscale=0
+
+state_dir="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/captive-portal"
+state_file="$state_dir/tailscale-prefs"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  captive-portal [--device DEV] [--no-open] [--down]
+      Release DNS to the local network, locate the portal, and open it.
+  captive-portal --probe [--device DEV]
+      Report portal state and URL without touching DNS.
+  captive-portal --restore
+      Return DNS to Tailscale after signing in.
+
+Options:
+  --device DEV  Device to inspect (default: first connected wifi/ethernet).
+  --no-open     Print the portal URL instead of launching a browser.
+  --down        Stop Tailscale entirely rather than only releasing DNS.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --device)
+    device="${2:-}"
+    [ -n "$device" ] || {
+      echo "captive-portal: --device needs a value" >&2
+      exit 2
+    }
+    shift 2
+    ;;
+  --probe)
+    mode=probe
+    shift
+    ;;
+  --restore)
+    mode=restore
+    shift
+    ;;
+  --no-open)
+    open_browser=0
+    shift
+    ;;
+  --down)
+    stop_tailscale=1
+    shift
+    ;;
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  *)
+    echo "captive-portal: unknown argument: $1" >&2
+    usage >&2
+    exit 2
+    ;;
+  esac
+done
+
+pick_device() {
+  nmcli -t -f DEVICE,TYPE,STATE device status |
+    awk -F: '$3 == "connected" && ($2 == "wifi" || $2 == "ethernet") { print $1; exit }'
+}
+
+device_dns() {
+  nmcli -t -f IP4.DNS device show "$1" |
+    sed 's/^IP4\.DNS\[[0-9]*\]:*//' |
+    grep -E '^[0-9]+(\.[0-9]+){3}$' || true
+}
+
+device_gateway() {
+  ip -4 route show default dev "$1" | awk '{ print $3; exit }'
+}
+
+is_private_v4() {
+  case "$1" in
+  10.* | 192.168.* | 127.*) return 0 ;;
+  172.1[6-9].* | 172.2[0-9].* | 172.3[01].*) return 0 ;;
+  *) return 1 ;;
+  esac
+}
+
+# A portal that hijacks DNS answers public names with an address it controls, and
+# one that intercepts HTTP replaces the probe payload or 302s away from it. Both
+# reveal the sign-in URL. Exit 0 prints the portal URL, 1 means the network came
+# back clean, 2 means every probe was inconclusive and prints a gateway guess.
+probe_portal() {
+  local resolver="$1" gateway="$2"
+  local hosts urls expects i host url expect answer status redirect body found
+  local clean=0
+
+  hosts=(detectportal.firefox.com captive.apple.com connectivity-check.gstatic.com)
+  urls=(
+    http://detectportal.firefox.com/success.txt
+    http://captive.apple.com/hotspot-detect.html
+    http://connectivity-check.gstatic.com/generate_204
+  )
+  expects=(success Success "")
+
+  for i in "${!hosts[@]}"; do
+    host="${hosts[$i]}"
+    url="${urls[$i]}"
+    expect="${expects[$i]}"
+
+    answer="$(dig +short +time=2 +tries=1 "@$resolver" A "$host" |
+      grep -E '^[0-9]+(\.[0-9]+){3}$' | tail -1 || true)"
+    [ -n "$answer" ] || continue
+
+    body="$(mktemp)"
+    status=000
+    redirect=""
+    read -r status redirect <<<"$(
+      curl -sS -m 6 -o "$body" -w '%{http_code} %{redirect_url}' \
+        --resolve "$host:80:$answer" "$url" 2>/dev/null || echo '000 '
+    )"
+
+    case "$status" in
+    30*)
+      [ -n "$redirect" ] && {
+        printf '%s\n' "$redirect"
+        rm -f "$body"
+        return 0
+      }
+      ;;
+    200 | 204)
+      if [ -n "$expect" ] && ! grep -qF "$expect" "$body"; then
+        found="$(grep -oiE 'https?://[^"'"'"'<>[:space:]]+' "$body" | head -1 || true)"
+        printf '%s\n' "${found:-http://$answer}"
+        rm -f "$body"
+        return 0
+      fi
+      clean=1
+      ;;
+    esac
+    rm -f "$body"
+
+    # The probe host answered with an address on this LAN: a DNS hijack.
+    if is_private_v4 "$answer"; then
+      printf 'http://%s\n' "$answer"
+      return 0
+    fi
+  done
+
+  [ "$clean" -eq 1 ] && return 1
+  if [ -n "$gateway" ]; then
+    printf 'http://%s\n' "$gateway"
+  fi
+  return 2
+}
+
+save_prefs() {
+  mkdir -p "$state_dir"
+  tailscale debug prefs | jq -r '[.CorpDNS, .WantRunning] | @tsv' >"$state_file"
+}
+
+release_dns() {
+  save_prefs
+  if [ "$stop_tailscale" -eq 1 ]; then
+    tailscale down
+  else
+    tailscale set --accept-dns=false
+  fi
+  # dnsmasq holds the tailnet upstreams and any cached SERVFAIL until NM re-applies DNS.
+  nmcli general reload dns-full
+}
+
+restore_dns() {
+  local corp_dns=true want_running=true
+  if [ -f "$state_file" ]; then
+    read -r corp_dns want_running <"$state_file"
+  fi
+  # `tailscale up` resets every pref it is not passed, so reach for it only when
+  # --down stopped a node that had been running.
+  if [ "$want_running" = "true" ] && [ "$(tailscale debug prefs | jq -r '.WantRunning')" = "false" ]; then
+    tailscale up
+  fi
+  if [ "$corp_dns" = "true" ]; then
+    tailscale set --accept-dns=true
+  fi
+  rm -f "$state_file"
+  nmcli general reload dns-full
+  echo "captive-portal: DNS returned to Tailscale"
+  grep '^nameserver' /etc/resolv.conf
+}
+
+if [ "$mode" = restore ]; then
+  restore_dns
+  exit 0
+fi
+
+[ -n "$device" ] || device="$(pick_device)"
+if [ -z "$device" ]; then
+  echo "captive-portal: no connected wifi or ethernet device" >&2
+  exit 1
+fi
+
+resolver="$(device_dns "$device" | head -1)"
+gateway="$(device_gateway "$device")"
+if [ -z "$resolver" ]; then
+  echo "captive-portal: $device has no DHCP-provided resolver; is the lease up?" >&2
+  exit 1
+fi
+
+echo "captive-portal: device $device, access-point resolver $resolver, gateway ${gateway:-unknown}"
+
+if [ "$mode" = login ]; then
+  release_dns
+  echo "captive-portal: system resolvers now:"
+  grep '^nameserver' /etc/resolv.conf
+fi
+
+portal=""
+probe_status=0
+portal="$(probe_portal "$resolver" "$gateway")" || probe_status=$?
+
+case "$probe_status" in
+1)
+  echo "captive-portal: no portal detected; this network answers probes normally"
+  if [ "$mode" = login ]; then
+    restore_dns
+  fi
+  exit 0
+  ;;
+2)
+  if [ -z "$portal" ]; then
+    echo "captive-portal: probes inconclusive and no gateway to fall back on" >&2
+    exit 1
+  fi
+  echo "captive-portal: probes inconclusive; falling back to the gateway"
+  ;;
+esac
+
+echo "captive-portal: portal at $portal"
+
+if [ "$mode" = probe ]; then
+  exit 0
+fi
+
+if [ "$open_browser" -eq 1 ]; then
+  # LibreWolf ships network.captive-portal-service.enabled=false, so it never
+  # raises a sign-in bar on its own; open the URL directly instead.
+  xdg-open "$portal" >/dev/null 2>&1 &
+fi
+
+cat <<EOF
+
+Sign in at the page above, then run:
+
+  captive-portal --restore
+
+If the page does not load, open it in a private window: portals reject cached
+HSTS upgrades and stale cookies from an earlier session.
+EOF

--- a/packages/captive-portal/default.nix
+++ b/packages/captive-portal/default.nix
@@ -40,7 +40,7 @@ writeShellApplication {
   meta = {
     description = "Sign in to a captive portal on a host whose DNS is claimed by Tailscale";
     homepage = "https://github.com/Bad3r/nixos";
-    license = lib.licenses.mit;
+    license = lib.licenses.agpl3Only;
     platforms = lib.platforms.linux;
   };
 }

--- a/packages/captive-portal/default.nix
+++ b/packages/captive-portal/default.nix
@@ -1,4 +1,5 @@
 {
+  lib,
   writeShellApplication,
   coreutils,
   curl,
@@ -31,4 +32,15 @@ writeShellApplication {
   ];
 
   text = builtins.readFile ./captive-portal.sh;
+
+  # mainProgram is not set here: writeTextFile derives it from the /bin/<name>
+  # destination, and `nix eval ... .meta.mainProgram` already answers
+  # captive-portal. platforms is linux rather than dnsleak's all, because this
+  # one drives NetworkManager and iproute2.
+  meta = {
+    description = "Sign in to a captive portal on a host whose DNS is claimed by Tailscale";
+    homepage = "https://github.com/Bad3r/nixos";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux;
+  };
 }

--- a/packages/captive-portal/default.nix
+++ b/packages/captive-portal/default.nix
@@ -1,0 +1,34 @@
+{
+  writeShellApplication,
+  coreutils,
+  curl,
+  dnsutils,
+  gawk,
+  gnugrep,
+  gnused,
+  iproute2,
+  jq,
+  networkmanager,
+  tailscale,
+  xdg-utils,
+}:
+
+writeShellApplication {
+  name = "captive-portal";
+
+  runtimeInputs = [
+    coreutils
+    curl
+    dnsutils
+    gawk
+    gnugrep
+    gnused
+    iproute2
+    jq
+    networkmanager
+    tailscale
+    xdg-utils
+  ];
+
+  text = builtins.readFile ./captive-portal.sh;
+}


### PR DESCRIPTION
## Summary

Connecting to a captive-portal SSID (observed on `AC-WIFI`) leaves tpnix with no usable DNS and no reachable sign-in
page. tailscaled registers a resolvconf entry that supersedes NetworkManager's, so `/etc/resolv.conf` carries only
`100.100.100.100` and the dnsmasq at `127.0.0.1` from `modules/hosts/common/private-dns-hosts.nix` is shadowed.
`resolvconf -l` lists NetworkManager's `nameserver 127.0.0.1` while `/etc/resolv.conf` does not.

With MagicDNS and split DNS both disabled tailnet-wide, the coordination server pushes global resolvers `194.242.2.2`
and `1.1.1.1`, so `100.100.100.100` forwards every query to the public internet. A portal drops those upstreams before
authentication, so lookups time out rather than being hijacked. The portal's DNS hijack is what produces the sign-in
redirect, so nothing surfaces the portal and NetworkManager's connectivity check settles on `limited` instead of
`portal`.

This adds a `captive-portal` helper that releases DNS back to dnsmasq, locates the portal by querying the access point's
resolver directly with `dig`, opens it, and restores the saved Tailscale state afterwards.

- `packages/captive-portal/` with the script and its `writeShellApplication` wrapper.
- `modules/apps/captive-portal.nix` and `modules/custom-overlays/captive-portal.nix` following the `dnsleak` pattern.
- Enabled at the common baseline in `modules/hosts/common/apps-enable.nix`.
- `programs.tailscale.extended.operator` in `modules/apps/tailscale.nix`, so tailscaled takes a state change from the
  owner rather than root alone. It reaches the daemon through `services.tailscale.extraSetFlags`, which nixpkgs replays
  from a root oneshot on every boot, and an assertion rejects a name no host account carries.
- `modules/packages/captive-portal-check.nix`, a runtime check that drives the packaged script against stubbed `dig`,
  `curl`, `nmcli`, `ip`, `tailscale` and `xdg-open`. Nothing else executes this script: a host build lints it with
  shellcheck and stops there.
- A "Sign in to a captive portal" section in `docs/networking/README.md` covering the resolver chain, the helper, a
  manual fallback, and two host-specific traps.

Details worth review:

- A portal counts as confirmed on a redirect, a page served in place of the expected payload, RFC 6585's `511`, or a
  canary resolving to an address on this LAN. The first three also catch a proxy that intercepts HTTP and leaves DNS
  alone. The sign-in URL comes from what a link, form or meta refresh points at, falling back to the address the canary
  resolved to, because the first absolute URL in a page is as often a DOCTYPE's w3.org DTD or a CDN script tag. Link
  metadata is stripped before extraction, wrapped attributes are flattened, and control bytes are excluded from
  extracted targets, while a `Location` target containing one is rejected before it reaches diagnostics or `xdg-open`.
- `--restore` starts the node only when the snapshot recorded one that was running. With no snapshot there is no
  evidence the node was ever up, and starting one the user stopped is not a restore. The call is a flagless
  `tailscale up`, which `checkForAccidentalSettingReverts` in `cmd/tailscale/cli/up.go` short-circuits to a
  WantRunning-only edit when no flag is set, so it cannot clear this node's `RunSSH`.
- DNS goes back before the run state, and the two halves report separately. A refused `tailscale set --accept-dns=true`
  is the operator wall and names it; a refused `tailscale up` happens after DNS is already back, so it reports the
  stopped node instead and still runs the NetworkManager reload. Both keep the snapshot, so `--restore` stays
  retryable.
- Under `sudo` the snapshot is keyed off `SUDO_UID`, because `sudo-rs` enforces `env_reset` with no opt-out and
  `modules/hosts/common/sudo.nix` keeps only `SSH_AUTH_SOCK`, so `XDG_RUNTIME_DIR` is gone and root's own
  `/run/user/0` would hide the snapshot from a later plain `--restore`. Root still inherits no `DISPLAY`, Wayland
  socket or session bus, so the browser half is documented rather than fixed: pass `--no-open` and open the URL, which
  prints either way.
- That same SUDO_UID-keyed directory sits inside a tree the invoking user owns for the run's whole life, so
  `save_prefs` and `restore_dns` both refuse to use it if it is a symlink: `mkdir -p` is a silent no-op against one
  that already resolves to a directory, `hand_state_to_invoker` uses `chown -h` for the snapshot entries, and a plain
  `read` and `rm -f` would follow a symlink on the restore side. The guards prevent root from handing a root-owned
  target's ownership to the invoking user, or reading and unlinking a file the invoking user named. No privilege
  boundary crosses on hosts where sudo is wheel-wide, so this is hardening rather than a fix for an active escalation
  here.
- LibreWolf is the default browser and ships `network.captive-portal-service.enabled` false, so it never raises a
  sign-in bar; the helper opens the portal URL directly.

## Test plan

- [x] `nix fmt` reports 0 changed.
- [x] `nix build --impure --expr '(import <nixpkgs> {}).callPackage ./packages/captive-portal { }'` succeeds, which also
      runs shellcheck through `writeShellApplication`.
- [x] `nix build path:.#checks.x86_64-linux."packages/captive-portal-runtime"` exits 0. Scenarios cover classification
      (DNS hijack, inline portal page, 30x with and without a `Location`, RFC 6585's 511, a sign-in target read from a
      link rather than from a DOCTYPE or a CDN tag, one address per arm of `is_private_v4` plus the public address that
      must not match any), every path that released DNS giving it back, the refused-release and refused-restore
      mirrors, the snapshot's retry contract, `--down`, and the failures that used to pass for success: a transfer that
      died after the response line, a scratch file that cannot be created and one that outlived the run, a snapshot
      that cannot be written or unlinked or is reached through a symlinked state directory, an unreadable
      `tailscale debug prefs`, nmcli failing to list devices, a `--device` name nmcli does not know, wrapped link
      attributes, loopback aliases, raw NUL and ESC-bearing portal targets, control-bearing redirects, and `--no-open`
      browser suppression. Existing scenarios were confirmed non-vacuous by mutating the fix back out and watching the
      named assertion fail. The new cases directly assert the raw-NUL extraction, control-free output and browser
      argument, redirect fallback, and `--no-open` suppression contracts.
- [x] `nix eval path:.#nixosConfigurations.tpnix.config.environment.systemPackages` finds `captive-portal` exactly once,
      proving module discovery, overlay, and host closure wiring.
- [x] `nix flake check --accept-flake-config --no-build path:.` exits 0.
- [x] `pre-commit` hooks pass, including shellcheck, statix, deadnix, treefmt, and typos.
- [x] End-to-end run on an open network: `/etc/resolv.conf` moved `100.100.100.100` to `127.0.0.1` and back, the network
      was classified as having no portal, and `CorpDNS`, `WantRunning`, and `RunSSH` were unchanged afterwards.
- [ ] Not yet exercised against a live portal; the portal-found branch is covered only by the probe classifier.
- [ ] The `sudo` halves of the state-directory choice are not covered by the runtime check: the builder is uid 1000 and
      cannot create `/run/user`, so neither the `SUDO_UID` fallback nor the chown that hands the snapshot back can run
      there. The check asserts the precedence an ordinary run does cross, and its header records what it cannot reach.

Note: `nix flake check --no-build` first fails with a `did not exist in the store during evaluation` error, on
`browsers/firefoxpwa-module-eval` and `hm-apps/rclone-protondrive-otp`. That is `--no-build` refusing those checks' IFD
fixtures, unrelated to this change; building them directly succeeds and the full check then exits 0.