### PR TITLE
fix(browsers): make managed extensions user-removable

### DIFF
--- a/modules/browsers/_chromium-policies.nix
+++ b/modules/browsers/_chromium-policies.nix
@@ -1,6 +1,6 @@
 /*
   Internal: shared managed-policy payloads for Chromium-family browsers
-  Description: Extension force-install list and default-search-provider
+  Description: User-removable extension list and default-search-provider
   policy shared verbatim by google-chrome and ungoogled-chromium so the
   two browsers stay symmetric. Imported via a relative path; the leading
   underscore keeps this file out of module auto-discovery.
@@ -9,12 +9,12 @@
   managedExtensionSettings = {
     # uBlock Origin Lite
     "ddkjiahejlhfcafbddmgiahcphecmpfh" = {
-      installation_mode = "force_installed";
+      installation_mode = "normal_installed";
       update_url = "https://clients2.google.com/service/update2/crx";
     };
     # 1Password - Password Manager
     "aeblfdkhhhdcdjpifhhbdiojplfjncoa" = {
-      installation_mode = "force_installed";
+      installation_mode = "normal_installed";
       update_url = "https://clients2.google.com/service/update2/crx";
     };
   };

--- a/modules/browsers/_chromium-policies.nix
+++ b/modules/browsers/_chromium-policies.nix
@@ -1,9 +1,15 @@
 /*
   Internal: shared managed-policy payloads for Chromium-family browsers
-  Description: User-removable extension list and default-search-provider
+  Description: User-disableable extension list and default-search-provider
   policy shared verbatim by google-chrome and ungoogled-chromium so the
   two browsers stay symmetric. Imported via a relative path; the leading
   underscore keeps this file out of module auto-discovery.
+
+  `StandardManagementPolicyProvider::MustRemainInstalled` covers
+  INSTALLATION_RECOMMENDED (`normal_installed`) as well as INSTALLATION_FORCED,
+  so chrome://extensions still refuses uninstall; the only permission
+  `normal_installed` adds back is Disable. Gecko behaves the same way, see
+  modules/browsers/_gecko-extension-data.nix.
 */
 {
   managedExtensionSettings = {

--- a/modules/browsers/_gecko-extension-data.nix
+++ b/modules/browsers/_gecko-extension-data.nix
@@ -104,6 +104,8 @@ let
   # are silently inert in private windows. Setting the key at all also removes
   # the per-addon "Run in Private Windows" toggle from about:addons, so keep the
   # list to add-ons whose absence in a private window is itself the hazard.
+  # Both the regular-browser policy in _gecko-extensions.nix and the PWA runtime
+  # policy below derive from this list, so every id here must belong in both.
   privateBrowsingExtensionIds = [
     onePassword
     ublockOrigin
@@ -126,9 +128,7 @@ let
   # scoped to Home Manager profiles, and PWA profile ULIDs are generated at
   # runtime, so per-profile seeding is not reliable.
   firefoxpwaRuntimePolicies = {
-    ExtensionSettings = {
-      "${ublockOrigin}" = mkPrivateBrowsingPolicy ublockOrigin;
-      "${onePassword}" = mkPrivateBrowsingPolicy onePassword;
+    ExtensionSettings = lib.genAttrs privateBrowsingExtensionIds mkPrivateBrowsingPolicy // {
       "${tridactyl}" = mkNormalInstalledPolicy tridactyl;
       "${tabReloader}" = mkNormalInstalledPolicy tabReloader;
     };

--- a/modules/browsers/_gecko-extension-data.nix
+++ b/modules/browsers/_gecko-extension-data.nix
@@ -24,7 +24,6 @@ let
     "${lib.stringAsChars sanitizeChar (lib.toLower extension)}-browser-action";
 
   ublockOrigin = "uBlock0@raymondhill.net";
-  ublockOriginInstallUrl = mkAmoInstallUrl ublockOrigin;
   onePassword = "{d634138d-c276-4fc8-924b-40a0ea21d284}";
 
   arabicDictionary = "ar@dictionaries.addons.mozilla.org";
@@ -42,8 +41,8 @@ let
   wappalyzer = "wappalyzer@crunchlabz.com";
   webArchives = "{d07ccf11-c0cd-4938-a265-2a4d6ad01189}";
 
-  # PWAsForFirefox management extension. Force-installed on the regular gecko
-  # browsers, like uBlock, so PWAs can be installed and managed from the browser.
+  # PWAsForFirefox management extension. Installed on the regular gecko browsers
+  # so PWAs can be installed and managed from the browser, but user-removable.
   # The native connector is wired in modules/browsers/{firefox,librewolf}/home.nix.
   firefoxpwaExt = "firefoxpwa@filips.si";
 
@@ -96,27 +95,18 @@ let
   };
 
   # Enterprise policy applied to the firefoxpwa runtime (every PWA profile) by
-  # modules/custom-overlays/firefoxpwa.nix. uBlock and 1Password are
-  # force-installed so the ad blocker and password manager are always present in
-  # PWAs; 1Password reaches its desktop app through the native-messaging host the
-  # firefox module already drops in ~/.mozilla/native-messaging-hosts, which the
-  # runtime reads (XRE_USER_NATIVE_MANIFESTS is the hardcoded legacy path).
-  # Tridactyl and Tab Reloader are normal_installed: present but user-removable.
+  # modules/custom-overlays/firefoxpwa.nix. The declared add-ons are installed
+  # as user-removable defaults; 1Password reaches its desktop app through the
+  # native-messaging host the firefox module already drops in
+  # ~/.mozilla/native-messaging-hosts, which the runtime reads
+  # (XRE_USER_NATIVE_MANIFESTS is the hardcoded legacy path).
   # uBlock here keeps default settings: the medium-mode extensionStorage below is
   # scoped to Home Manager profiles, and PWA profile ULIDs are generated at
   # runtime, so per-profile seeding is not reliable.
   firefoxpwaRuntimePolicies = {
     ExtensionSettings = {
-      "${ublockOrigin}" = {
-        installation_mode = "force_installed";
-        install_url = ublockOriginInstallUrl;
-        private_browsing = true;
-      };
-      "${onePassword}" = {
-        installation_mode = "force_installed";
-        install_url = mkAmoInstallUrl onePassword;
-        private_browsing = true;
-      };
+      "${ublockOrigin}" = mkNormalInstalledPolicy ublockOrigin;
+      "${onePassword}" = mkNormalInstalledPolicy onePassword;
       "${tridactyl}" = mkNormalInstalledPolicy tridactyl;
       "${tabReloader}" = mkNormalInstalledPolicy tabReloader;
     };
@@ -129,7 +119,6 @@ in
   inherit
     toWidgetId
     ublockOrigin
-    ublockOriginInstallUrl
     onePassword
     cookieAutoDelete
     darkreader

--- a/modules/browsers/_gecko-extension-data.nix
+++ b/modules/browsers/_gecko-extension-data.nix
@@ -42,7 +42,7 @@ let
   webArchives = "{d07ccf11-c0cd-4938-a265-2a4d6ad01189}";
 
   # PWAsForFirefox management extension. Installed on the regular gecko browsers
-  # so PWAs can be installed and managed from the browser, but user-removable.
+  # so PWAs can be installed and managed from the browser, but user-disableable.
   # The native connector is wired in modules/browsers/{firefox,librewolf}/home.nix.
   firefoxpwaExt = "firefoxpwa@filips.si";
 
@@ -66,7 +66,7 @@ let
       throw "firefoxpwa management-extension pin is stale: pinned for connector ${firefoxpwaExtensionPin.packageVersion} but pkgs.firefoxpwa is ${version}. Refresh modules/browsers/_firefoxpwa-extension-pin.json with scripts/update-firefoxpwa-extension.py (or run the update-firefoxpwa-extension workflow).";
 
   # Tab Reloader (page auto refresh). Installed only into the firefoxpwa runtime
-  # profiles via firefoxpwaRuntimePolicies (normal_installed, user-removable),
+  # profiles via firefoxpwaRuntimePolicies (normal_installed, user-disableable),
   # never the regular browsers; periodic reloads keep authenticated PWA sessions
   # alive past idle timeouts.
   tabReloader = "jid0-bnmfwWw2w2w4e4edvcdDbnMhdVg@jetpack";
@@ -84,19 +84,41 @@ let
     svgGobbler
     tabStash
     tridactyl
+    ublockOrigin
     violentmonkey
     wappalyzer
     webArchives
   ];
 
+  # Gecko disallows `uninstall-extension:<id>` for normal_installed just as it
+  # does for force_installed, so about:addons keeps Remove greyed out; the only
+  # permission normal_installed adds back is Disable. Dropping an add-on from
+  # the policy set is the only way to make it truly removable.
   mkNormalInstalledPolicy = extension: {
     installation_mode = "normal_installed";
     install_url = mkAmoInstallUrl extension;
   };
 
+  # Firefox grants private-window access to a non-privileged add-on only when
+  # policy asks for it, so without this the ad blocker and the password manager
+  # are silently inert in private windows. Setting the key at all also removes
+  # the per-addon "Run in Private Windows" toggle from about:addons, so keep the
+  # list to add-ons whose absence in a private window is itself the hazard.
+  privateBrowsingExtensionIds = [
+    onePassword
+    ublockOrigin
+  ];
+
+  mkPrivateBrowsingPolicy =
+    extension:
+    mkNormalInstalledPolicy extension
+    // {
+      private_browsing = true;
+    };
+
   # Enterprise policy applied to the firefoxpwa runtime (every PWA profile) by
   # modules/custom-overlays/firefoxpwa.nix. The declared add-ons are installed
-  # as user-removable defaults; 1Password reaches its desktop app through the
+  # as user-disableable defaults; 1Password reaches its desktop app through the
   # native-messaging host the firefox module already drops in
   # ~/.mozilla/native-messaging-hosts, which the runtime reads
   # (XRE_USER_NATIVE_MANIFESTS is the hardcoded legacy path).
@@ -105,8 +127,8 @@ let
   # runtime, so per-profile seeding is not reliable.
   firefoxpwaRuntimePolicies = {
     ExtensionSettings = {
-      "${ublockOrigin}" = mkNormalInstalledPolicy ublockOrigin;
-      "${onePassword}" = mkNormalInstalledPolicy onePassword;
+      "${ublockOrigin}" = mkPrivateBrowsingPolicy ublockOrigin;
+      "${onePassword}" = mkPrivateBrowsingPolicy onePassword;
       "${tridactyl}" = mkNormalInstalledPolicy tridactyl;
       "${tabReloader}" = mkNormalInstalledPolicy tabReloader;
     };
@@ -135,7 +157,9 @@ in
     firefoxpwaExt
     mkFirefoxpwaInstallUrl
     policyExtensionIds
+    privateBrowsingExtensionIds
     mkNormalInstalledPolicy
+    mkPrivateBrowsingPolicy
     firefoxpwaRuntimePolicies
     ;
 }

--- a/modules/browsers/_gecko-extensions.nix
+++ b/modules/browsers/_gecko-extensions.nix
@@ -8,8 +8,8 @@
   lib,
   pkgs,
   # Whether the host enables programs.firefoxpwa.extended. Gates the firefoxpwa
-  # management extension so it is only force-installed where the native
-  # connector and CLI also exist (see firefox.nix/librewolf.nix).
+  # management extension so it is only installed where the native connector and
+  # CLI also exist (see firefox.nix/librewolf.nix).
   firefoxpwaEnabled ? false,
   firefoxpwaPackage ? null,
 }:
@@ -18,7 +18,6 @@ let
   inherit (geckoExtensionData)
     toWidgetId
     ublockOrigin
-    ublockOriginInstallUrl
     onePassword
     cookieAutoDelete
     darkreader
@@ -352,21 +351,13 @@ let
 
   extensionSettings =
     (lib.genAttrs policyExtensionIds mkNormalInstalledPolicy)
-    // {
-      "${ublockOrigin}" = {
-        installation_mode = "force_installed";
-        install_url = ublockOriginInstallUrl;
-        private_browsing = true;
-      };
-      "${onePassword}".private_browsing = true;
-    }
     # The firefoxpwa management extension is only useful when the host enables
     # firefoxpwa: the native connector and `firefoxpwa` CLI are gated on the same
-    # option. Force-installing it on an opt-out host would leave a non-removable
+    # option. Keep it user-removable so an opt-out host cannot leave a mandatory
     # add-on stuck in a "connector not installed" state.
     // lib.optionalAttrs firefoxpwaEnabled {
       "${firefoxpwaExt}" = {
-        installation_mode = "force_installed";
+        installation_mode = "normal_installed";
         install_url = mkFirefoxpwaInstallUrl (
           firefoxpwaPackage.version
             or (throw "firefoxpwaPackage.version is required when firefoxpwaEnabled is true")

--- a/modules/browsers/_gecko-extensions.nix
+++ b/modules/browsers/_gecko-extensions.nix
@@ -34,7 +34,9 @@ let
     firefoxpwaExt
     mkFirefoxpwaInstallUrl
     policyExtensionIds
+    privateBrowsingExtensionIds
     mkNormalInstalledPolicy
+    mkPrivateBrowsingPolicy
     ;
 
   stylixEnabled = config.stylix.enable or false;
@@ -351,9 +353,13 @@ let
 
   extensionSettings =
     (lib.genAttrs policyExtensionIds mkNormalInstalledPolicy)
+    # Whole-attrset override, not a nested `.private_browsing` assignment: `//`
+    # is shallow, so the nested form would drop installation_mode/install_url
+    # and leave these two add-ons uninstalled.
+    // (lib.genAttrs privateBrowsingExtensionIds mkPrivateBrowsingPolicy)
     # The firefoxpwa management extension is only useful when the host enables
     # firefoxpwa: the native connector and `firefoxpwa` CLI are gated on the same
-    # option. Keep it user-removable so an opt-out host cannot leave a mandatory
+    # option. Keep it user-disableable so an opt-out host cannot leave a mandatory
     # add-on stuck in a "connector not installed" state.
     // lib.optionalAttrs firefoxpwaEnabled {
       "${firefoxpwaExt}" = {

--- a/modules/browsers/_gecko-extensions.nix
+++ b/modules/browsers/_gecko-extensions.nix
@@ -359,8 +359,9 @@ let
     // (lib.genAttrs privateBrowsingExtensionIds mkPrivateBrowsingPolicy)
     # The firefoxpwa management extension is only useful when the host enables
     # firefoxpwa: the native connector and `firefoxpwa` CLI are gated on the same
-    # option. Keep it user-disableable so an opt-out host cannot leave a mandatory
-    # add-on stuck in a "connector not installed" state.
+    # option, so an opt-out host gets no policy entry at all and cannot end up
+    # with a policy-installed add-on stuck in a "connector not installed" state.
+    # normal_installed still blocks uninstall here; it only adds Disable back.
     // lib.optionalAttrs firefoxpwaEnabled {
       "${firefoxpwaExt}" = {
         installation_mode = "normal_installed";

--- a/modules/browsers/_gecko-prefs.nix
+++ b/modules/browsers/_gecko-prefs.nix
@@ -44,6 +44,12 @@ in
       # Keep Arabic out of automatic translation prompts.
       "browser.translations.neverTranslateLanguages" = "ar";
 
+      # Home Manager drops `extensions.packages` XPIs straight into
+      # <profile>/extensions, which XPIDatabase treats as a foreignInstall at
+      # SCOPE_PROFILE; the default 15 masks that scope and would install them
+      # disabled with no diagnostic. Policy-installed add-ons never take that
+      # path and are unaffected either way.
+      "extensions.autoDisableScopes" = 0;
       "extensions.pictureinpicture.enable_picture_in_picture_overrides" = true;
       "extensions.webcompat.perform_injections" = true;
 

--- a/modules/browsers/_gecko-prefs.nix
+++ b/modules/browsers/_gecko-prefs.nix
@@ -44,9 +44,6 @@ in
       # Keep Arabic out of automatic translation prompts.
       "browser.translations.neverTranslateLanguages" = "ar";
 
-      # Pre-enable extensions delivered through the Nix scope (default 15 would
-      # leave system-scope XPIs installed-but-disabled on first launch).
-      "extensions.autoDisableScopes" = 0;
       "extensions.pictureinpicture.enable_picture_in_picture_overrides" = true;
       "extensions.webcompat.perform_injections" = true;
 

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -9,9 +9,9 @@
   Notes:
     * The companion extension and native-messaging connector are wired into the
       gecko browsers in modules/browsers/{firefox,librewolf}/home.nix.
-    * Extensions for the isolated PWA runtime profiles are installed (per-add-on
-      force_installed or user-removable normal_installed) through a policy file
-      injected by modules/custom-overlays/firefoxpwa.nix.
+    * Extensions for the isolated PWA runtime profiles are installed as
+      user-removable defaults through a policy file injected by
+      modules/custom-overlays/firefoxpwa.nix.
 */
 _:
 let

--- a/modules/browsers/firefoxpwa/apps.nix
+++ b/modules/browsers/firefoxpwa/apps.nix
@@ -10,7 +10,7 @@
     * The companion extension and native-messaging connector are wired into the
       gecko browsers in modules/browsers/{firefox,librewolf}/home.nix.
     * Extensions for the isolated PWA runtime profiles are installed as
-      user-removable defaults through a policy file injected by
+      user-disableable defaults through a policy file injected by
       modules/custom-overlays/firefoxpwa.nix.
 */
 _:

--- a/modules/browsers/ungoogled-chromium/apps.nix
+++ b/modules/browsers/ungoogled-chromium/apps.nix
@@ -87,7 +87,15 @@ let
           type = lib.types.bool;
           default = false;
           description = ''
-            Whether to load the Chromium Web Store extension.
+            Whether to load the Chromium Web Store extension. ungoogled-chromium
+            strips the Web Store install API, so this loader is the only
+            one-click in-browser installer; it also carries the
+            `--extension-mime-request-handling=always-prompt-for-install` flag
+            that CRX downloads need. With it off, an extension the user removes
+            from the `normal_installed` managed policy in
+            `modules/browsers/_chromium-policies.nix` is recovered by enabling
+            this option or by dropping the CRX onto `chrome://extensions` with
+            Developer Mode on.
           '';
         };
 

--- a/modules/browsers/ungoogled-chromium/apps.nix
+++ b/modules/browsers/ungoogled-chromium/apps.nix
@@ -88,14 +88,14 @@ let
           default = false;
           description = ''
             Whether to load the Chromium Web Store extension. ungoogled-chromium
-            strips the Web Store install API, so this loader is the only
-            one-click in-browser installer; it also carries the
-            `--extension-mime-request-handling=always-prompt-for-install` flag
-            that CRX downloads need. With it off, an extension the user removes
-            from the `normal_installed` managed policy in
-            `modules/browsers/_chromium-policies.nix` is recovered by enabling
-            this option or by dropping the CRX onto `chrome://extensions` with
-            Developer Mode on.
+            strips the Web Store install API, so this loader and the
+            `--extension-mime-request-handling=always-prompt-for-install` flag it
+            carries are the only in-browser route for installing extensions
+            beyond the managed policy set. The policy extensions in
+            `modules/browsers/_chromium-policies.nix` do not depend on it:
+            `normal_installed` blocks uninstall exactly as `force_installed`
+            does, so those are disable and re-enable only, from
+            `chrome://extensions`.
           '';
         };
 

--- a/modules/browsers/ungoogled-chromium/apps.nix
+++ b/modules/browsers/ungoogled-chromium/apps.nix
@@ -85,9 +85,9 @@ let
 
         enableWebStoreExtension = lib.mkOption {
           type = lib.types.bool;
-          default = true;
+          default = false;
           description = ''
-            Whether to load the Chromium Web Store extension by default.
+            Whether to load the Chromium Web Store extension.
           '';
         };
 

--- a/modules/browsers/ungoogled-chromium/home.nix
+++ b/modules/browsers/ungoogled-chromium/home.nix
@@ -6,7 +6,7 @@
   Repository: https://github.com/ungoogled-software/ungoogled-chromium
 
   Summary:
-    * Reuses the wrapped package so the default Chromium Web Store extension is available in HM-managed profiles too.
+    * Reuses the wrapped package so an explicitly enabled Chromium Web Store extension is available in HM-managed profiles too.
 */
 
 _: {

--- a/modules/custom-overlays/firefoxpwa.nix
+++ b/modules/custom-overlays/firefoxpwa.nix
@@ -10,7 +10,9 @@
 
   This overlay injects that policy file into the unwrapped package. The policy
   installs uBlock Origin, 1Password, Tridactyl, and the Tab Reloader keep-alive
-  extension as user-removable defaults in every PWA profile.
+  extension as user-disableable defaults in every PWA profile. uBlock and
+  1Password additionally carry `private_browsing = true` so they stay active in
+  private windows.
   nixpkgs builds `firefoxpwa = wrapFirefox firefoxpwa-unwrapped { }`, so
   overriding only the unwrapped package lets the package-set fixpoint rebuild the
   wrapped `firefoxpwa` around the patched runtime, with no manual re-wrap. The

--- a/modules/custom-overlays/firefoxpwa.nix
+++ b/modules/custom-overlays/firefoxpwa.nix
@@ -9,8 +9,8 @@
   `wrapFirefox` uses for normal Firefox).
 
   This overlay injects that policy file into the unwrapped package. The policy
-  force-installs uBlock Origin and 1Password into every PWA profile, and adds
-  Tridactyl and the Tab Reloader keep-alive extension as user-removable installs.
+  installs uBlock Origin, 1Password, Tridactyl, and the Tab Reloader keep-alive
+  extension as user-removable defaults in every PWA profile.
   nixpkgs builds `firefoxpwa = wrapFirefox firefoxpwa-unwrapped { }`, so
   overriding only the unwrapped package lets the package-set fixpoint rebuild the
   wrapped `firefoxpwa` around the patched runtime, with no manual re-wrap. The

--- a/scripts/update-firefoxpwa-extension.py
+++ b/scripts/update-firefoxpwa-extension.py
@@ -8,7 +8,7 @@ is not in the nixpkgs `firefoxpwa` output and is absent from upstream GitHub
 release assets), and AMO download URLs require a per-version opaque file id that
 cannot be derived from the version string. This script resolves that id from the
 AMO API and writes it to `modules/browsers/_firefoxpwa-extension-pin.json`, which the
-gecko extension policy reads to force-install the extension.
+gecko extension policy reads to install the extension.
 
 The connector (native messaging host) and extension stay protocol-compatible as
 long as they share a major version: the upstream `checkNativeStatus` treats a


### PR DESCRIPTION
## Summary

- Change Gecko and Chromium managed browser extensions from `force_installed` to `normal_installed`. On both engines
  this makes them user-disableable, not user-removable: Gecko's `Policies.sys.mjs` calls
  `disallowFeature("uninstall-extension:<id>")` for both modes, and Chromium's
  `StandardManagementPolicyProvider::MustRemainInstalled` covers `INSTALLATION_RECOMMENDED` as well as
  `INSTALLATION_FORCED`. The only permission `normal_installed` adds back is Disable.
- Keep uBlock Origin in the Gecko policy. It was never in `policyExtensionIds`, so demoting the bespoke
  `force_installed` block dropped it from `ExtensionSettings` entirely and left fresh Firefox/LibreWolf profiles with no
  ad blocker but a live toolbar pin, `3rdparty` `adminSettings`, and `extensionStorage` seed.
- Keep `private_browsing = true` on uBlock Origin and 1Password, in the regular browsers and in the firefoxpwa runtime
  policy. The key is orthogonal to removability: `Extension.sys.mjs` `_setupStartupPermissions` grants
  `internal:privateBrowsingAllowed` only when policy sets it, so without it private windows run unblocked and without
  autofill. Both consumers derive from `privateBrowsingExtensionIds` through `mkPrivateBrowsingPolicy`, which returns the
  whole attrset; the nested `"${id}".private_browsing = true` form is a shallow `//` merge that silently drops
  `installation_mode`.
- Keep `extensions.autoDisableScopes = 0`. It does not affect policy-installed add-ons, but it still guards the live
  `extensions.packages` path: home-manager links those XPIs at `<profilesPath>/<profile>/extensions`, a SCOPE_PROFILE
  foreign install that the default 15 masks, so the first non-empty profile package list would install add-ons disabled
  with no diagnostic.
- Make the ungoogled-Chromium Web Store loader opt-in by default, and scope its option description to what it actually
  governs: installing extensions outside the managed policy set, together with the
  `--extension-mime-request-handling=always-prompt-for-install` flag it carries.
- Update Firefox PWA and firefoxpwa-pin documentation to match the new installation modes.

## Test plan

- `nix run path:.#formatter.x86_64-linux -- --fail-on-change` over all changed Nix files and
  `scripts/update-firefoxpwa-extension.py`.
- `nix flake check path:. --accept-flake-config --no-build --offline` (exit 0).
- `nix eval path:.#nixosConfigurations.system76.config.home-manager.users.vx.programs.firefox.policies.ExtensionSettings`
  confirms 19 entries with `uBlock0@raymondhill.net` and `{d634138d-c276-4fc8-924b-40a0ea21d284}` at
  `normal_installed` + `private_browsing = true`, `tridactyl.vim@cmcaine.co.uk` and `firefoxpwa@filips.si` at
  `normal_installed` without the key.
- `nix eval` of `firefoxpwaRuntimePolicies.ExtensionSettings` confirms the same split for the PWA runtime, and is
  unchanged across the refactor that made it derive from `privateBrowsingExtensionIds`.
- `nix eval` of `profiles.primary.settings."extensions.autoDisableScopes"` returns 0.
- Gecko behavior verified against the local Mozilla source mirror at `/data/git/mozilla-firefox-firefox`
  (`Policies.sys.mjs`, `XPIDatabase.sys.mjs` `permissions()` and the `isDetectedInstall && foreignInstall` branch,
  `Extension.sys.mjs` `_setupStartupPermissions`) and the policy schema mirrors at `/data/git/mozilla-policy-templates`
  and `/data/git/mozilla-enterprise-admin-reference`.
- Chromium behavior verified against `extensions/browser/standard_management_policy_provider.cc`
  (`MustRemainInstalled`, `IDS_EXTENSION_CANT_UNINSTALL_POLICY_REQUIRED`).
- Home Manager delivery path verified against `/data/git/nix-community-home-manager`
  (`modules/programs/firefox/mkFirefoxModule.nix`, the `<profilesPath>/<profile>/extensions` buildEnv link).
- Commit and push hooks passed: deadnix, nix-parse, statix, treefmt, typos, apps-catalog-sync, flake-checker, gitleaks,
  and managed-files-drift.