### PR TITLE
docs(csec): add cybersecurity reference documentation

### DIFF
--- a/docs/csec/framework-tracker.md
+++ b/docs/csec/framework-tracker.md
@@ -23,16 +23,17 @@ reproducible when a framework changes.
 
 ## Tracking fields
 
-These values apply to the `Status` column of the element tables below. The
-`Review status` column in the framework inventory is separate and records
-whether that framework version is still current: `Active` when the recorded
-source version is the current published one, `Superseded` when a newer version
-exists, and `Withdrawn` when the framework is no longer maintained.
+These values apply to the `Status` column of the element tables below.
 
 - `Not started`: no evidence or mapping has been recorded.
 - `In progress`: evidence collection, practice, or mapping is underway.
 - `Demonstrated`: evidence is linked and the element has been reviewed.
 - `Needs review`: the source, evidence, or mapping needs to be revisited.
+
+The `Review status` column in the framework inventory is separate and records
+whether that framework version is still current: `Active` when the recorded
+source version is the current published one, `Superseded` when a newer version
+exists, and `Withdrawn` when the framework is no longer maintained.
 
 For each element, add evidence or a mapping such as a report, lab, work
 sample, process, tool, certification, related competency area, or work role.

--- a/docs/csec/framework-tracker.md
+++ b/docs/csec/framework-tracker.md
@@ -41,6 +41,11 @@ overall proficiency.
 
 ## Initial NICE Framework elements
 
+The tables below record elements from the NICE Framework Components version
+named in the inventory above. Give each additional framework its own element
+section rather than adding rows here, because statement ID forms such as `K`,
+`S`, and `T` are not unique across frameworks.
+
 ### Knowledge
 
 | ID      | Statement                                                          | Status      | Evidence or mapping | Last reviewed |

--- a/docs/csec/framework-tracker.md
+++ b/docs/csec/framework-tracker.md
@@ -1,0 +1,72 @@
+# Cybersecurity Framework Tracker
+
+Use this document to identify cybersecurity workforce framework elements, map
+them to evidence, and track follow-up work. The initial inventory is from the
+[NICE Workforce Framework for Cybersecurity](https://www.nist.gov/itl/applied-cybersecurity/nice/nice-framework-resource-center/getting-started).
+NICE uses Task, Knowledge, and Skill (TKS) statements as the building blocks
+for work roles and competency areas.
+
+NICE Framework Components are maintained separately from the framework
+structure. Check the [NICE Framework current versions](https://www.nist.gov/itl/applied-cybersecurity/nice/nice-framework-resource-center/nice-framework-current-versions)
+page before adding or revising entries, and record the component version and
+review date in the table below.
+
+## Framework inventory
+
+| Framework                                  | Scope                                 | Source version | Review status | Last reviewed |
+| ------------------------------------------ | ------------------------------------- | -------------- | ------------- | ------------- |
+| NICE Workforce Framework for Cybersecurity | Task, Knowledge, and Skill statements | 2.2.0          | Active        | 2026-08-09    |
+
+Additional frameworks can be added as separate rows. Keep the source,
+version, and review date with each framework so that mappings remain
+reproducible when a framework changes.
+
+## Tracking fields
+
+- `Not started`: no evidence or mapping has been recorded.
+- `In progress`: evidence collection, practice, or mapping is underway.
+- `Demonstrated`: evidence is linked and the element has been reviewed.
+- `Needs review`: the source, evidence, or mapping needs to be revisited.
+
+For each element, add evidence or a mapping such as a report, lab, work
+sample, process, tool, certification, related competency area, or work role.
+The status field tracks the state of the evidence record, not a claim of
+overall proficiency.
+
+## Initial NICE Framework elements
+
+### Knowledge
+
+| ID      | Statement                                                          | Status      | Evidence or mapping | Last reviewed |
+| ------- | ------------------------------------------------------------------ | ----------- | ------------------- | ------------- |
+| `K0678` | Knowledge of privacy laws and regulations                          | Not started | -                   | -             |
+| `K0680` | Knowledge of cybersecurity principles and practices                | Not started | -                   | -             |
+| `K0682` | Knowledge of cybersecurity threats                                 | Not started | -                   | -             |
+| `K0685` | Knowledge of access control principles and practices               | Not started | -                   | -             |
+| `K0686` | Knowledge of authentication and authorization tools and techniques | Not started | -                   | -             |
+| `K0723` | Knowledge of vulnerability data sources                            | Not started | -                   | -             |
+| `K0724` | Knowledge of incident response principles and practices            | Not started | -                   | -             |
+
+### Skills
+
+| ID      | Statement                                      | Status      | Evidence or mapping | Last reviewed |
+| ------- | ---------------------------------------------- | ----------- | ------------------- | ------------- |
+| `S0505` | Skill in performing intrusion data analysis    | Not started | -                   | -             |
+| `S0612` | Skill in performing digital forensics analysis | Not started | -                   | -             |
+| `S0718` | Skill in identifying cybersecurity threats     | Not started | -                   | -             |
+| `S0904` | Skill in correlating data from multiple tools  | Not started | -                   | -             |
+| `S0911` | Skill in performing data queries               | Not started | -                   | -             |
+
+### Tasks
+
+| ID      | Statement                                                  | Status      | Evidence or mapping | Last reviewed |
+| ------- | ---------------------------------------------------------- | ----------- | ------------------- | ------------- |
+| `T0510` | Coordinate incident response functions                     | Not started | -                   | -             |
+| `T0513` | Perform operational testing                                | Not started | -                   | -             |
+| `T1010` | Communicate enterprise information technology architecture | Not started | -                   | -             |
+
+## References
+
+- [NICE Framework: Current Versions](https://www.nist.gov/itl/applied-cybersecurity/nice/nice-framework-resource-center/nice-framework-current-versions)
+- [Getting Started with the NICE Framework](https://www.nist.gov/itl/applied-cybersecurity/nice/nice-framework-resource-center/getting-started)
+- [NIST SP 800-181 Rev. 1: Workforce Framework for Cybersecurity](https://csrc.nist.gov/pubs/sp/800/181/r1/final)

--- a/docs/csec/framework-tracker.md
+++ b/docs/csec/framework-tracker.md
@@ -1,4 +1,4 @@
-# Cybersecurity Framework Tracker
+# Track cybersecurity framework evidence
 
 Use this document to identify cybersecurity workforce framework elements, map
 them to evidence, and track follow-up work. The initial inventory is from the

--- a/docs/csec/framework-tracker.md
+++ b/docs/csec/framework-tracker.md
@@ -81,3 +81,4 @@ section rather than adding rows here, because statement ID forms such as `K`,
 - [NICE Framework: Current Versions](https://www.nist.gov/itl/applied-cybersecurity/nice/nice-framework-resource-center/nice-framework-current-versions)
 - [Getting Started with the NICE Framework](https://www.nist.gov/itl/applied-cybersecurity/nice/nice-framework-resource-center/getting-started)
 - [NIST SP 800-181 Rev. 1: Workforce Framework for Cybersecurity](https://csrc.nist.gov/pubs/sp/800/181/r1/final)
+- [NICE Framework Components v2.2.0 element data (JSON)](https://csrc.nist.gov/csrc/media/Projects/cprt/documents/nice/v2-2-0_nf_components.json)

--- a/docs/csec/framework-tracker.md
+++ b/docs/csec/framework-tracker.md
@@ -25,7 +25,9 @@ reproducible when a framework changes.
 
 These values apply to the `Status` column of the element tables below. The
 `Review status` column in the framework inventory is separate and records
-whether that framework version is still current.
+whether that framework version is still current: `Active` when the recorded
+source version is the current published one, `Superseded` when a newer version
+exists, and `Withdrawn` when the framework is no longer maintained.
 
 - `Not started`: no evidence or mapping has been recorded.
 - `In progress`: evidence collection, practice, or mapping is underway.

--- a/docs/csec/framework-tracker.md
+++ b/docs/csec/framework-tracker.md
@@ -23,6 +23,10 @@ reproducible when a framework changes.
 
 ## Tracking fields
 
+These values apply to the `Status` column of the element tables below. The
+`Review status` column in the framework inventory is separate and records
+whether that framework version is still current.
+
 - `Not started`: no evidence or mapping has been recorded.
 - `In progress`: evidence collection, practice, or mapping is underway.
 - `Demonstrated`: evidence is linked and the element has been reviewed.

--- a/docs/csec/glossary.md
+++ b/docs/csec/glossary.md
@@ -3,7 +3,8 @@
 This glossary defines acronyms and concepts used in the repository's
 cybersecurity and software engineering documentation. Keep entries in
 alphabetical order by term and use the same fields for each entry: definition,
-example, security note, and references.
+example, security note, and references. Add every new entry to the `Contents`
+list below, which is maintained by hand.
 
 ## Contents
 

--- a/docs/csec/glossary.md
+++ b/docs/csec/glossary.md
@@ -124,7 +124,7 @@ static, behavioral, and provenance evidence.
 
 ### References
 
-- [NIST SP 800-168, Approximate Matching: Definition and Terminology](https://csrc.nist.gov/files/pubs/sp/800/168/final/docs/sp800_168_draft.pdf)
+- [NIST SP 800-168, Approximate Matching: Definition and Terminology](https://csrc.nist.gov/pubs/sp/800/168/final)
 - [Carnegie Mellon Software Engineering Institute: Fuzzy Hashing Techniques in Applied Malware Analysis](https://insights.sei.cmu.edu/blog/fuzzy-hashing-techniques-in-applied-malware-analysis/)
 
 ## Linked data

--- a/docs/csec/glossary.md
+++ b/docs/csec/glossary.md
@@ -5,6 +5,193 @@ cybersecurity and software engineering documentation. Keep entries in
 alphabetical order by term and use the same fields for each entry: definition,
 example, security note, and references.
 
+## Contents
+
+- [Baseline deviation](#baseline-deviation)
+- [DIKW pyramid](#dikw-pyramid)
+- [Dwell time](#dwell-time)
+- [Fuzzy hashing](#fuzzy-hashing)
+- [Linked data](#linked-data)
+- [OODA loop](#ooda-loop)
+- [Pyramid of pain](#pyramid-of-pain)
+- [Threat hunting](#threat-hunting)
+- [TOFU (trust on first use)](#tofu-trust-on-first-use)
+
+## Baseline deviation
+
+### Definition
+
+A baseline deviation is an observed difference between expected activity and
+actual user, host, network, or application behavior. In threat hunting,
+observations of baseline deviations are used to develop hypotheses that guide
+further investigation.
+
+### Example
+
+A privileged account authenticating from a new host outside its normal hours is
+a baseline deviation.
+
+### Security note
+
+A baseline deviation is an investigative signal, not proof of compromise.
+Validate it against approved changes, known administrative activity, and the
+exercise scope before classifying it as malicious.
+
+### References
+
+- [NIST CSRC glossary: Behavioral Anomaly Detection](https://csrc.nist.gov/glossary/term/behavioral_anomaly_detection)
+- [CISA Red Team Shares Key Findings to Improve Monitoring and Hardening of Networks](https://www.cisa.gov/news-events/cybersecurity-advisories/aa23-059a)
+
+## DIKW pyramid
+
+### Definition
+
+The DIKW pyramid is a conceptual hierarchy describing how raw data can be
+organized into information, interpreted as knowledge, and applied with
+judgment as wisdom. The layers are commonly summarized as data, information,
+knowledge, and wisdom.
+
+### Example
+
+Individual authentication events are data. Grouping them by account, source,
+and time produces information about login patterns. Recognizing an unusual
+sequence as possible credential abuse produces knowledge, while choosing a
+proportionate containment action based on business impact and available
+evidence applies that knowledge as wisdom.
+
+### Security note
+
+The DIKW pyramid is a reasoning aid, not a mandatory or strictly linear
+process. Accurate conclusions still depend on data quality, context, and
+analyst judgment, and more abstract layers do not automatically make a
+conclusion more reliable.
+
+### References
+
+- [The wisdom hierarchy: representations of the DIKW hierarchy](https://doi.org/10.1177/0165551506070706)
+
+## Dwell time
+
+Dwell time is the time elapsed between an adversary's breach of the corporate environment and the breach's detection.
+
+## Fuzzy hashing
+
+### Definition
+
+Fuzzy hashing is a similarity-preserving technique that produces a digest
+designed to estimate how similar two inputs are, even when they are not
+byte-for-byte identical. Unlike cryptographic hashes, which are designed so
+small input changes produce unrelated digests, fuzzy hashes provide a
+similarity score for approximate matching.
+
+### Example
+
+An analyst computes a fuzzy hash for a suspicious executable and compares it
+with a reference set. A high similarity score can prioritize a sample for
+investigation even when its cryptographic hash differs because of a small
+change.
+
+### Security note
+
+A fuzzy-hash similarity score is a triage signal, not proof that files are
+identical, share authorship, or are malicious. Scores and detection limits
+vary by algorithm, file type, input size, and threshold, and an adversary may
+be able to manipulate the input to evade similarity matching. Use
+cryptographic hashes for exact integrity checks and combine fuzzy matches with
+static, behavioral, and provenance evidence.
+
+### References
+
+- [NIST SP 800-168, Approximate Matching: Definition and Terminology](https://csrc.nist.gov/files/pubs/sp/800/168/final/docs/sp800_168_draft.pdf)
+- [Carnegie Mellon Software Engineering Institute: Fuzzy Hashing Techniques in Applied Malware Analysis](https://insights.sei.cmu.edu/blog/fuzzy-hashing-techniques-in-applied-malware-analysis/)
+
+## Linked data
+
+### Definition
+
+Linked data is structured, machine-readable data in which identifiable entities
+are connected by explicit relationships, allowing information from different
+sources to be combined and analyzed as a graph.
+
+### Example
+
+A security investigation links a user, workstation, authentication event, and
+destination domain to trace a suspicious login across related records instead
+of reviewing each record in isolation.
+
+### Security note
+
+Entity-resolution errors can create false links or hide real ones. Verify
+identifiers, timestamps, and source provenance before treating a graph
+relationship as evidence.
+
+### References
+
+- [W3C: Linked Data](https://www.w3.org/DesignIssues/LinkedData.html)
+
+## OODA loop
+
+### Definition
+
+The OODA loop is an iterative decision-making cycle of Observe, Orient,
+Decide, and Act. It describes how a person or team gathers observations,
+interprets them in context, selects a response, and acts before reassessing
+the resulting situation.
+
+### Example
+
+A security operations team observes a suspicious PowerShell alert and collects
+the process, user, host, and network context. The team orients by comparing the
+activity with the host's role, known changes, and threat intelligence, decides
+to isolate the host while preserving evidence, and acts by applying the
+containment control. The resulting telemetry starts the next loop.
+
+### Security note
+
+A fast loop without sound orientation can accelerate an incorrect response.
+Challenge assumptions, preserve relevant evidence, and confirm that
+containment or recovery actions are authorized before acting.
+
+### References
+
+- [NIST CSRC glossary: OODA](https://csrc.nist.gov/glossary/term/ooda)
+
+## Pyramid of pain
+
+### Definition
+
+The Pyramid of Pain is a threat-hunting model that ranks adversary indicators
+by how difficult and costly they are for an attacker to change after
+detection. From lower to higher levels, it commonly considers hash values, IP
+addresses, domain names, network and host artifacts, tools, and tactics,
+techniques, and procedures (TTPs).
+
+### Example
+
+A hunt based only on a malware hash may miss a rebuilt sample, while a hunt for
+the associated behavior, such as an encoded PowerShell download followed by a
+scheduled-task persistence change, can remain useful after the file changes.
+
+### Security note
+
+Lower-level indicators are useful for fast triage but are often easy to change.
+Higher-level behavior is usually more durable but less unique, so validate it
+with context, baselines, and multiple data sources before treating it as
+malicious.
+
+### References
+
+- [A Framework for Cyber Threat Hunting Part 1: The Pyramid of Pain](https://www.threathunting.net/files/A%20Framework%20for%20Cyber%20Threat%20Hunting%20Part%201_%20The%20Pyramid%20of%20Pain%20_%20Sqrrl.pdf)
+
+## Threat hunting
+
+### Definition
+
+Threat hunting is the human-driven activity of proactively and iteratively
+searching through the organization's environment (network, endpoints, and
+applications) for signs of compromise to shorten the dwell time and minimize
+the breach impact for the organization.
+
 ## TOFU (trust on first use)
 
 ### Definition

--- a/docs/csec/glossary.md
+++ b/docs/csec/glossary.md
@@ -269,5 +269,5 @@ before accepting a replacement key.
 ### References
 
 - [RFC 4253, section 8: Diffie-Hellman key exchange](https://datatracker.ietf.org/doc/html/rfc4253#section-8)
-- [OpenSSH `ssh(1)` manual, host-key checking](https://man.openbsd.org/ssh#HOST_KEY_AUTHENTICATION)
+- [OpenSSH `ssh(1)` manual, verifying host keys](https://man.openbsd.org/ssh#VERIFYING_HOST_KEYS)
 - [OpenSSH `ssh_config(5)` manual, `StrictHostKeyChecking`](https://man.openbsd.org/ssh_config#StrictHostKeyChecking)

--- a/docs/csec/glossary.md
+++ b/docs/csec/glossary.md
@@ -268,6 +268,6 @@ before accepting a replacement key.
 
 ### References
 
-- [RFC 4253, section 8: Diffie-Hellman key exchange](https://datatracker.ietf.org/doc/html/rfc4253#section-8)
+- [RFC 4251, section 4.1: Host Keys](https://datatracker.ietf.org/doc/html/rfc4251#section-4.1)
 - [OpenSSH `ssh(1)` manual, verifying host keys](https://man.openbsd.org/ssh#VERIFYING_HOST_KEYS)
 - [OpenSSH `ssh_config(5)` manual, `StrictHostKeyChecking`](https://man.openbsd.org/ssh_config#StrictHostKeyChecking)

--- a/docs/csec/glossary.md
+++ b/docs/csec/glossary.md
@@ -72,7 +72,28 @@ conclusion more reliable.
 
 ## Dwell time
 
-Dwell time is the time elapsed between an adversary's breach of the corporate environment and the breach's detection.
+### Definition
+
+Dwell time is the interval between an adversary's initial compromise of an
+environment and the detection of that compromise.
+
+### Example
+
+An intrusion that begins with a phishing-delivered implant on 2026-03-01 and is
+detected by an endpoint alert on 2026-04-12 has a dwell time of 42 days.
+
+### Security note
+
+Dwell time is measured from the earliest compromise that forensic evidence can
+establish, not from the first alert. Log retention bounds how far back that
+reconstruction reaches, so an intrusion that outlives the retention window is
+reported with a dwell time biased low. Record the evidence window alongside the
+figure, and treat published cross-organization medians as context rather than a
+target.
+
+### References
+
+- [M-Trends 2026](https://cloud.google.com/blog/topics/threat-intelligence/m-trends-2026/)
 
 ## Fuzzy hashing
 
@@ -191,6 +212,25 @@ Threat hunting is the human-driven activity of proactively and iteratively
 searching through the organization's environment (network, endpoints, and
 applications) for signs of compromise to shorten the dwell time and minimize
 the breach impact for the organization.
+
+### Example
+
+An analyst hypothesizes that an adversary is using scheduled tasks for
+persistence, queries endpoint telemetry for task creations that launch encoded
+interpreters, and reviews the results against the host baseline instead of
+waiting for an alert to fire.
+
+### Security note
+
+A hunt that finds nothing is not evidence of a clean environment. It bounds only
+what the queried telemetry could have shown, so record the hypothesis, the data
+sources searched, and their retention window to keep a negative result
+interpretable later. Promote a confirmed hunt finding into a durable detection
+rather than leaving it as a one-off investigation.
+
+### References
+
+- [NIST SP 800-53 Rev. 5, control RA-10: Threat Hunting](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final)
 
 ## TOFU (trust on first use)
 

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -157,7 +157,7 @@ malware-detonation environment:
 
 - [`Sandboxie-Plus`](https://github.com/sandboxie-plus/Sandboxie/releases)
   provides Windows application isolation.
-- [`bubblewrap`](https://github.com/containers/bubblewrap/releases/tag/0.11.2)
+- [`bubblewrap`](https://github.com/containers/bubblewrap/releases/tag/v0.11.2)
   provides unprivileged Linux namespace isolation.
 - [`Firejail`](https://github.com/netblue30/firejail/releases/tag/0.9.80)
   provides Linux namespace and seccomp-based application confinement. It is a

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -232,6 +232,11 @@ vendor-review questions rather than controls you configure:
   concurrent analysis or any other service on the hypervisor. Reach the host's
   own management interface only through a separate restricted administrative
   path.
+- Expose submission and result interfaces to analysts, and to an orchestrator
+  such as Assemblyline, only on a separate inbound path that terminates on the
+  detonation host and reaches no guest. Without it the segment rule above leaves
+  the web UI and API of a self-hosted deployment unreachable, and the operator
+  recovers access by routing production into the detonation segment.
 - Default-deny guest egress. Provide internet access only through a simulated
   or brokered path that is logged and rate-limited.
 - Never domain-join an analysis guest.
@@ -257,10 +262,12 @@ vendor-review questions rather than controls you configure:
   the host append-only credentials to the collector, and allow the host no
   access to the collector beyond appending, so it cannot rewrite or delete what
   it already sent.
-- Keep the gold images and snapshots that those reverts and rebuilds depend on
-  outside the detonation host's write path, and verify them by hash before use.
-  A sample that reaches the host can otherwise poison the baseline it is
-  restored from.
+- Keep the gold images that those reverts and rebuilds restore from outside the
+  detonation host's write path, serve them read-only, and verify them by hash
+  before use. Revert by discarding the guest's writable overlay and recreating
+  it from that image rather than from a snapshot the host can write, because a
+  sample that reaches the host can otherwise poison the baseline it is restored
+  from.
 
 ## Choose a deployment path
 
@@ -270,11 +277,11 @@ of these paths.
 - Use CAPE with KVM and disposable Windows guests for a self-hosted Cuckoo-style
   analysis service.
 - Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
-  scoring, enrichment, and analyst queue management. Run it off the detonation
-  host, which is dedicated to analysis, and treat it as the only component that
-  crosses the isolation boundary: it submits into the detonation segment and
-  serves analysts outside it, so allow no inbound path from the guests or the
-  detonation host back to it.
+  scoring, enrichment, and analyst queue management. Run it on a separate host,
+  because the detonation host is dedicated to analysis, and treat it as the only
+  component that crosses the isolation boundary: it submits into the detonation
+  segment and serves analysts outside it, so allow no inbound path from the
+  guests or the detonation host back to it.
 - Use DRAKVUF when agentless virtual-machine introspection is more important
   than deployment simplicity.
 - Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -23,7 +23,7 @@ commercial terms, and API limits.
 | CAPE                                 | Self-hosted VM detonation              | Active rolling development through August 2026; no formal GitHub releases                             | Current Cuckoo-style Windows analysis            |
 | DRAKVUF                              | Agentless VMI                          | Active engine and automated builds through August 2026                                                | Stealthier, agentless behavioral analysis        |
 | Assemblyline 4                       | Triage and orchestration               | Stable 4.7.4.stable6 and active 4.7.5 development line                                                | SOC-scale file triage around analysis services   |
-| PANDA                                | Whole-system research                  | Active QEMU record/replay and plugin platform                                                         | Custom instrumentation and replay research       |
+| PANDA                                | Whole-system research                  | Active QEMU record/replay and plugin platform; tagged releases through June 2026                      | Custom instrumentation and replay research       |
 | ANY.RUN                              | Hosted interactive sandbox             | Active commercial SaaS with free public-oriented and paid private plans                               | Fast analyst-driven investigation                |
 | Joe Sandbox Cloud                    | Hosted deep-analysis service           | Active commercial SaaS; Cloud upgraded to v44 Smoke Quartz in 2026-01                                 | Managed cross-platform analysis and rich reports |
 | Sandboxie-Plus, bubblewrap, Firejail | Local application or process isolation | Active projects, but not malware detonation platforms                                                 | Additional local containment                     |
@@ -53,10 +53,10 @@ CAPE does not publish normal GitHub Release objects. Its [tags page](https://git
 reports that there are no releases. Treat the repository as a rolling
 development stream:
 
-- Pin a reviewed commit instead of tracking `master` directly, because there is
-  no release tag to pin.
 - Review changes before updating because there is no formal upstream release
   boundary to provide that review point.
+- The baseline requirement to pin a reviewed commit or release resolves to a
+  commit here, since there is no release tag to pin.
 
 The guest, network, and versioning controls that CAPE shares with the other
 self-hosted options are listed under [Apply containment requirements to every detonation option](#apply-containment-requirements-to-every-detonation-option).
@@ -105,7 +105,9 @@ development line.
 platform built on QEMU. Its record/replay model and plugin architecture make it
 valuable for deterministic experiments, custom instrumentation, reverse
 engineering research, and studies that need visibility unavailable in a normal
-detonation workflow.
+detonation workflow. The currency recorded in the table above comes from its
+[release index](https://github.com/panda-re/panda/releases), where `v1.8.85` was
+tagged on 2026-06-09.
 
 PANDA is not a turnkey malware-analysis service. Use it beside CAPE or DRAKVUF
 when research instrumentation is required, rather than replacing the
@@ -210,9 +212,9 @@ hypervisor, guest, and network belong to the vendor, so these are contract and
 vendor-review questions rather than controls you configure:
 
 - Place detonation hosts on a dedicated network segment with no route to
-  production or backup networks, and give the guests no route off that segment.
-  Reach the host's own management interface only through a separate restricted
-  administrative path.
+  production or backup networks. Give the guests no route off that segment
+  except the brokered egress path below. Reach the host's own management
+  interface only through a separate restricted administrative path.
 - Default-deny guest egress. Provide internet access only through a simulated
   or brokered path that is logged and rate-limited.
 - Never domain-join an analysis guest.

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -225,23 +225,27 @@ hypervisor, guest, and network belong to the vendor, so these are contract and
 vendor-review questions rather than controls you configure:
 
 - Place detonation hosts on a dedicated network segment with no route to
-  production or backup networks. Give the guests no route off that segment
-  except the brokered egress path below, and isolate them from each other and
-  from every host interface on that segment except the analysis framework's own
-  control and result channel on its approved ports and the brokered-egress
-  listener on its approved ports at the broker's segment-side interface, so a
-  self-propagating sample
-  cannot reach a concurrent analysis or any other service on either host. Reach
-  the management interfaces of the detonation and broker hosts only through a
-  separate restricted administrative path, never from the detonation segment.
+  production or backup networks.
+- Give the guests no route off that segment except the brokered egress path
+  below.
+- Isolate the guests from each other so a self-propagating sample cannot reach
+  a concurrent analysis.
+- Block every host interface on that segment from the guests except two: the
+  analysis framework's own control and result channel on its approved ports,
+  and the brokered-egress listener on its approved ports at the broker's
+  segment-side interface. No other service on either host is reachable from a
+  guest.
+- Reach the management interfaces of the detonation and broker hosts only
+  through a separate restricted administrative path, never from the
+  detonation segment.
 - Expose submission and result interfaces to analysts, and to an orchestrator
   such as Assemblyline, only on a separate inbound path that terminates on the
   detonation host and reaches no guest. Allow connections inbound only on it, so
   the host accepts on that path and never initiates over it, matching the
   direction constraint the Assemblyline placement below states. Without it the
-  segment rule above leaves
-  the web UI and API of a self-hosted deployment unreachable, and the operator
-  recovers access by routing production into the detonation segment.
+  segment rules above leave the web UI and API of a self-hosted deployment
+  unreachable, and the operator recovers access by routing production into
+  the detonation segment.
 - Treat every Assemblyline deployment node as an analyst-and-orchestrator
   security boundary. Dedicate each node to that role, keep its management and
   maintenance on a restricted administrative path apart from the detonation
@@ -284,13 +288,11 @@ vendor-review questions rather than controls you configure:
   access limited to the package-update service and repository-signature
   verification, so maintenance does not require guest egress or a
   production-network route.
-- Rebuild the detonation host from known-good media when an escape is suspected
-  or its off-host logs or another incident signal indicates host-level
-  compromise. Rebuild the broker host from known-good media when an escape is
-  suspected or its off-host logs or another incident signal indicates host-level
-  compromise. Rebuild an Assemblyline deployment node from known-good media when
-  its off-host logs or another incident signal indicates host-level compromise.
-  A guest snapshot revert does not restore a host the sample reached.
+- Rebuild any boundary host from known-good media when its off-host logs or
+  another incident signal indicates host-level compromise. Rebuild the
+  detonation host and the broker host additionally when an escape is
+  suspected, because both sit on the guest-reachable path. A guest snapshot
+  revert does not restore a host the sample reached.
 - Ship hypervisor and host logs off the detonation host, egress-broker logs off
   the broker host, and Assemblyline deployment-node logs off their nodes as they
   are written. Review all of them for host-level compromise. A compromised
@@ -301,9 +303,13 @@ vendor-review questions rather than controls you configure:
   no shipping host access to the collector beyond appending, so it cannot rewrite
   or delete what it already sent.
 - On the restricted administrative path, the broker host reaches only the log
-  collector and the approved update mirror stated above. Give it no route to the
-  hypervisor console, the orchestration API, or the gold-image store, because it
-  is the one self-hosted component every sample may reach.
+  collector and the approved update mirror stated above. Give it no route to
+  the hypervisor console, the orchestration API, or the gold-image store,
+  because it is the one self-hosted component every sample may reach. Bound
+  the detonation host and each Assemblyline deployment node the same way:
+  neither reaches another boundary host's management interface on that path,
+  and the detonation host's only further reach is the read-only gold-image
+  access already granted above.
 - Keep guest gold images outside the detonation host's write path, and keep
   known-good rebuild media outside the write path of the detonation host, broker
   host, or Assemblyline deployment node it rebuilds.
@@ -312,10 +318,14 @@ vendor-review questions rather than controls you configure:
   segment. Deliver rebuild media and its manifest for any of those systems only
   through a separate recovery procedure, not a runtime route of the system being
   rebuilt.
-- Pair every gold image and rebuild medium with an authenticated manifest from a
-  separately administered recovery authority that binds the exact media version
-  to a cryptographic digest, rather than a locally recorded hash, and verify the
-  relevant media against that manifest for every restore or rebuild.
+- Pair every gold image and rebuild medium with an authenticated manifest from
+  a separately administered recovery authority that binds the exact media
+  version to a cryptographic digest, rather than a locally recorded hash.
+  Before trusting any digest in it, verify the manifest's signature against
+  the recovery-verification trust anchor granted above; only then verify the
+  relevant media against that manifest, for every restore or rebuild. A store
+  that serves the image and its manifest together can otherwise ship a
+  matched, poisoned pair.
 - Revert by discarding the guest's writable overlay and recreating it from the
   gold image rather than from a snapshot the host can write, because a sample
   that reaches the host can otherwise poison the baseline it is restored from.
@@ -323,7 +333,10 @@ vendor-review questions rather than controls you configure:
 ## Choose a deployment path
 
 Meet the containment requirements above before detonating a live sample on any
-of these paths.
+of these paths. For a self-hosted path they are not host-local settings: they
+add dedicated hosts, network paths, and administered services well beyond the
+detonation host itself. Budget for that infrastructure before choosing a
+self-hosted path over a hosted one, which shifts it to the vendor instead.
 
 - Use CAPE with KVM and disposable Windows guests for a self-hosted Cuckoo-style
   analysis service.

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -211,6 +211,9 @@ Apply these to every detonation option above, self-hosted or hosted:
   hypervisor, monitor, guest artifacts, and interaction timing to suppress their
   behavior, so record which evasion checks the platform applied alongside the
   verdict. See [MITRE ATT&CK T1497](https://attack.mitre.org/techniques/T1497/).
+
+Apply these to the hosted options as well:
+
 - Confirm task visibility before uploading to a hosted service. The ANY.RUN and
   Joe Sandbox sections above record which tiers expose samples and results.
 - Treat any upload to a hosted service as disclosure to the vendor, including on
@@ -224,9 +227,11 @@ vendor-review questions rather than controls you configure:
 - Place detonation hosts on a dedicated network segment with no route to
   production or backup networks. Give the guests no route off that segment
   except the brokered egress path below, and isolate them from each other and
-  from the host's interfaces on that segment so a self-propagating sample cannot
-  reach a concurrent analysis or the hypervisor. Reach the host's own management
-  interface only through a separate restricted administrative path.
+  from every host interface on that segment except the analysis framework's own
+  control and result channel, so a self-propagating sample cannot reach a
+  concurrent analysis or any other service on the hypervisor. Reach the host's
+  own management interface only through a separate restricted administrative
+  path.
 - Default-deny guest egress. Provide internet access only through a simulated
   or brokered path that is logged and rate-limited.
 - Never domain-join an analysis guest.
@@ -247,11 +252,11 @@ vendor-review questions rather than controls you configure:
 - Ship hypervisor, host, and egress-broker logs off the detonation host as they
   are written, and review them for host-level compromise. A sample that reaches
   the host can edit any log it can still write to, so nothing held on the host
-  can raise the suspicion the rebuild above depends on. Give the host
-  append-only credentials to the collector and place the collector where the
-  detonation host cannot reach it to rewrite or delete what it already sent,
-  otherwise shipping moves the logs without moving them out of the sample's
-  reach.
+  can raise the suspicion the rebuild above depends on. Carry that shipping on
+  the restricted administrative path rather than the detonation segment, give
+  the host append-only credentials to the collector, and allow the host no
+  access to the collector beyond appending, so it cannot rewrite or delete what
+  it already sent.
 - Keep the gold images and snapshots that those reverts and rebuilds depend on
   outside the detonation host's write path, and verify them by hash before use.
   A sample that reaches the host can otherwise poison the baseline it is

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -59,7 +59,7 @@ development stream:
   boundary to provide that review point.
 
 The guest, network, and versioning controls that CAPE shares with the other
-self-hosted options are listed under [Apply containment requirements to every option](#apply-containment-requirements-to-every-option).
+self-hosted options are listed under [Apply containment requirements to every detonation option](#apply-containment-requirements-to-every-detonation-option).
 
 The [CAPE installation documentation](https://capev2.readthedocs.io/en/latest/)
 uses a Linux host with KVM and Windows analysis guests as its reference model.
@@ -177,7 +177,7 @@ malware-detonation environment:
   provides Linux namespace and seccomp-based application confinement. It is a
   local process-isolation helper, not a hypervisor boundary.
 
-## Apply containment requirements to every option
+## Apply containment requirements to every detonation option
 
 > **Warning:** A sandbox result is not evidence that the host is safe. Treat
 > every sample as hostile and design for an escape attempt, network abuse, data
@@ -197,6 +197,9 @@ Apply these to every detonation option above, self-hosted or hosted:
   reproducible.
 - Confirm task visibility before uploading to a hosted service. The ANY.RUN and
   Joe Sandbox sections above record which tiers expose samples and results.
+- Treat any upload to a hosted service as disclosure to the vendor, including on
+  a private tier. Check retention, deletion, and data-residency terms against
+  the sample's classification before submitting an internal artifact.
 
 Apply these to the self-hosted options as well. On a hosted service the
 hypervisor, guest, and network belong to the vendor, so these are contract and
@@ -215,6 +218,10 @@ vendor-review questions rather than controls you configure:
   monitor, and analysis policy as one tested unit.
 - Reset every guest to a known-good snapshot after each analysis, and treat the
   guest disk as tainted until the revert completes.
+- Dedicate the hypervisor host to analysis. Run no other workload on it, and
+  patch it as a security boundary rather than on a general server schedule.
+- Rebuild the host from known-good media when an escape is suspected. A guest
+  snapshot revert does not restore a host the sample reached.
 
 ## Choose a deployment path
 

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -25,7 +25,7 @@ commercial terms, and API limits.
 | Assemblyline 4                       | Triage and orchestration               | Stable 4.7.4.stable6 and active 4.7.5 development line                                                | SOC-scale file triage around analysis services   |
 | PANDA                                | Whole-system research                  | Active QEMU record/replay and plugin platform                                                         | Custom instrumentation and replay research       |
 | ANY.RUN                              | Hosted interactive sandbox             | Active commercial SaaS with free public-oriented and paid private plans                               | Fast analyst-driven investigation                |
-| Joe Sandbox Cloud                    | Hosted deep-analysis service           | Active commercial SaaS, with Cloud v44.0.0 documented in 2026                                         | Managed cross-platform analysis and rich reports |
+| Joe Sandbox Cloud                    | Hosted deep-analysis service           | Active commercial SaaS; Cloud upgraded to v44 Smoke Quartz in 2026-01                                 | Managed cross-platform analysis and rich reports |
 | Sandboxie-Plus, bubblewrap, Firejail | Local application or process isolation | Active projects, but not malware detonation platforms                                                 | Additional local containment                     |
 
 ## Retire the original Cuckoo from new deployments
@@ -58,8 +58,8 @@ development stream:
 - Review changes before updating because there is no formal upstream release
   boundary to provide that review point.
 
-The guest, network, and versioning controls that CAPE shares with every other
-option are listed under [Apply containment requirements to every option](#apply-containment-requirements-to-every-option).
+The guest, network, and versioning controls that CAPE shares with the other
+self-hosted options are listed under [Apply containment requirements to every option](#apply-containment-requirements-to-every-option).
 
 The [CAPE installation documentation](https://capev2.readthedocs.io/en/latest/)
 uses a Linux host with KVM and Windows analysis guests as its reference model.
@@ -93,7 +93,11 @@ volumes.
 Assemblyline's [deployment documentation](https://cybercentrecanada.github.io/assemblyline4_docs/installation/deployment/)
 treats Cuckoo and CAPE as external sandbox infrastructure. The practical
 architecture is therefore Assemblyline for intake and triage, with CAPE or
-another detonation backend for dynamic execution.
+another detonation backend for dynamic execution. The version line recorded in
+the table above comes from the
+[Assemblyline release index](https://github.com/CybercentreCanada/assemblyline/releases),
+where the `stable` tags carry the supported line and the `dev` tags carry the
+development line.
 
 ## Use PANDA for research instrumentation
 
@@ -142,7 +146,11 @@ and Linux. Its current feature set includes live interaction, hypervisor-based
 inspection, execution graphs, network analysis, behavior and YARA signatures,
 configuration extraction, PCAP, screenshots, memory dumps, ATT&CK context, and
 structured report exports. See the [Joe Sandbox technology overview](https://www.joesecurity.org/index.php/joe-sandbox-technology)
-and the [Cloud product page](https://joesecurity.org/joe-sandbox-cloud).
+and the [Cloud product page](https://joesecurity.org/joe-sandbox-cloud). The
+release line recorded in the table above is
+[Joe Sandbox v44 Smoke Quartz](https://www.joesecurity.org/blog/4986670706879863609),
+published 2026-01-19, which states that the Cloud Basic, Pro, and OEM servers
+were upgraded to it.
 
 The free [Cloud Basic](https://www.joesecurity.org/joe-sandbox-cloud#subscriptions)
 tier is intended for evaluation, has limited analysis capacity and output, and
@@ -176,47 +184,55 @@ malware-detonation environment:
 > destruction, and credential theft.
 
 These requirements are prerequisites for detonating live samples, not follow-up
-work. Apply them to every detonation option above, self-hosted or hosted. The
-local isolation tools in the previous section are out of scope because they are
-not detonation platforms:
+work. The local isolation tools in the previous section are out of scope because
+they are not detonation platforms.
+
+Apply these to every detonation option above, self-hosted or hosted:
+
+- Never expose production credentials, tokens, SSH agents, or mounted shares to
+  an analysis environment.
+- Keep samples and results encrypted or password-protected at rest, and move
+  them only through the analysis pipeline.
+- Record the analysis platform version with each report so results stay
+  reproducible.
+- Confirm task visibility before uploading to a hosted service. The ANY.RUN and
+  Joe Sandbox sections above record which tiers expose samples and results.
+
+Apply these to the self-hosted options as well. On a hosted service the
+hypervisor, guest, and network belong to the vendor, so these are contract and
+vendor-review questions rather than controls you configure:
 
 - Place detonation hosts on a dedicated network segment with no route to
   production, management, or backup networks.
 - Default-deny guest egress. Provide internet access only through a simulated
   or brokered path that is logged and rate-limited.
-- Never domain-join an analysis guest, and never expose production credentials,
-  tokens, SSH agents, or mounted shares to it.
+- Never domain-join an analysis guest.
 - Disable shared folders, clipboard sharing, and drag-and-drop between guest and
   host.
 - Restrict hypervisor console and orchestration API access to the analysis
   team, separately from the analyst path used to read results.
 - Pin a reviewed commit or release and version the host software, guest image,
-  monitor, and analysis policy as one tested unit. Record that version with each
-  report so results stay reproducible.
+  monitor, and analysis policy as one tested unit.
 - Reset every guest to a known-good snapshot after each analysis, and treat the
   guest disk as tainted until the revert completes.
-- Keep samples and results encrypted or password-protected at rest, and move
-  them only through the analysis pipeline.
-- Confirm task visibility before uploading to a hosted service. The ANY.RUN and
-  Joe Sandbox sections above record which tiers expose samples and results.
 
 ## Choose a deployment path
 
 Meet the containment requirements above before detonating a live sample on any
 of these paths.
 
-1. Use CAPE with KVM and disposable Windows guests for a self-hosted Cuckoo-style
-   analysis service.
-2. Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
-   scoring, enrichment, and analyst queue management.
-3. Use DRAKVUF when agentless virtual-machine introspection is more important
-   than deployment simplicity.
-4. Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,
-   and rapid onboarding outweigh self-hosting and data-residency requirements.
-5. Use PANDA when deterministic replay or custom whole-system instrumentation is
-   the primary research requirement.
-6. Use bubblewrap, Firejail, or Sandboxie-Plus only as an additional isolation
-   layer for local tools and applications.
+- Use CAPE with KVM and disposable Windows guests for a self-hosted Cuckoo-style
+  analysis service.
+- Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
+  scoring, enrichment, and analyst queue management.
+- Use DRAKVUF when agentless virtual-machine introspection is more important
+  than deployment simplicity.
+- Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,
+  and rapid onboarding outweigh self-hosting and data-residency requirements.
+- Use PANDA when deterministic replay or custom whole-system instrumentation is
+  the primary research requirement.
+- Use bubblewrap, Firejail, or Sandboxie-Plus only as an additional isolation
+  layer for local tools and applications.
 
 ## References
 

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -35,6 +35,12 @@ archived by its owner on 2021-04-26 and is read-only. Its README states that
 the Cuckoo 2.x line is unmaintained, and the [2.0.6 release](https://github.com/cuckoosandbox/cuckoo/releases/tag/2.0.6)
 is from 2018.
 
+The [Cuckoo3 rewrite](https://github.com/cert-ee/cuckoo3) is the successor line
+listed in the table above. Its `main` branch last advanced on 2025-12-18, and
+the only newer commits sit on unmerged dependabot branches, so confirm both its
+activity and its production-readiness statement before treating it as a
+migration target.
+
 ## Use CAPE for a self-hosted Cuckoo-style platform
 
 [`CAPEv2`](https://github.com/kevoreilly/CAPEv2) is the strongest current
@@ -170,7 +176,9 @@ malware-detonation environment:
 > destruction, and credential theft.
 
 These requirements are prerequisites for detonating live samples, not follow-up
-work. Apply them to every option above, self-hosted or hosted:
+work. Apply them to every detonation option above, self-hosted or hosted. The
+local isolation tools in the previous section are out of scope because they are
+not detonation platforms:
 
 - Place detonation hosts on a dedicated network segment with no route to
   production, management, or backup networks.

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -149,7 +149,7 @@ analysis, phishing and email workflows, or commercial integrations matter more
 than owning the sandbox infrastructure. It remains a hosted commercial
 alternative, not an open-source replacement for CAPE or DRAKVUF.
 
-## local isolation tools
+## Add local isolation as a supplementary layer
 
 These projects are useful as additional containment layers for ordinary
 applications and local analysis helpers, but they do not provide a full

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -256,9 +256,7 @@ vendor-review questions rather than controls you configure:
   or brokered path that is logged and rate-limited. Run that broker on the
   segment boundary rather than on the detonation host, which carries no other
   workload, so the guests reach it as the one permitted route off the segment
-  and not through a detonation-host interface. Dedicate the broker host to its
-  brokered-egress role, because it is the only self-hosted component every
-  sample is permitted to reach.
+  and not through a detonation-host interface.
 - Keep production credentials, tokens, SSH agents, and mounted shares belonging
   to systems outside the analysis environment off the detonation and broker
   hosts and every Assemblyline deployment node. Give each only role-required
@@ -290,31 +288,32 @@ vendor-review questions rather than controls you configure:
   compromise. A guest snapshot revert does not restore a host the sample
   reached.
 - Ship hypervisor and host logs off the detonation host, egress-broker logs off
-  whichever host runs the broker, and Assemblyline deployment-node logs off
-  their nodes as they are written. Review all of them for host-level compromise.
-  A compromised boundary host can edit any log it can still write to, so nothing
-  held on that host can raise the suspicion the rebuild above depends on. Carry
-  that shipping on the restricted administrative path rather than the detonation
-  segment, give each shipping host its own append-only credentials to the
-  collector, and allow no shipping host access to the collector beyond
-  appending, so it cannot rewrite or delete what it already sent. Reach only the
-  collector and approved update mirror from the broker host on that path: give
-  it no route to the hypervisor console, the orchestration API, or the gold-image
-  store, because it is the one self-hosted component every sample may reach.
-- Keep guest gold images outside the detonation host's write path. Keep
+  the broker host, and Assemblyline deployment-node logs off their nodes as they
+  are written. Review all of them for host-level compromise. A compromised
+  boundary host can edit any log it can still write to, so nothing held on that
+  host can raise the suspicion the rebuild above depends on. Carry that shipping
+  on the restricted administrative path rather than the detonation segment, give
+  each shipping host its own append-only credentials to the collector, and allow
+  no shipping host access to the collector beyond appending, so it cannot rewrite
+  or delete what it already sent. Reach only the collector and approved update
+  mirror from the broker host on that path: give it no route to the hypervisor
+  console, the orchestration API, or the gold-image store, because it is the one
+  self-hosted component every sample may reach.
+- Keep guest gold images outside the detonation host's write path, and keep
   known-good rebuild media outside the write path of the detonation host, broker
-  host, or Assemblyline deployment node it rebuilds. Serve a gold image and its
-  authenticated manifest read-only to the detonation host over the restricted
-  administrative path rather than the detonation segment. Pair every gold image
-  and rebuild medium with an authenticated manifest from a separately
-  administered recovery authority that binds the exact media version to a
-  cryptographic digest, rather than a locally recorded hash. For every restore
-  or rebuild, verify the relevant media against that manifest. Deliver rebuild
-  media and its manifest for any of those systems only through a separate
-  recovery procedure, not a runtime route of the system being rebuilt. Revert by
-  discarding the guest's writable overlay and recreating it from that image
-  rather than from a snapshot the host can write, because a sample that reaches
-  the host can otherwise poison the baseline it is restored from.
+  host, or Assemblyline deployment node it rebuilds.
+- Serve a gold image and its authenticated manifest read-only to the detonation
+  host over the restricted administrative path rather than the detonation
+  segment. Deliver rebuild media and its manifest for any of those systems only
+  through a separate recovery procedure, not a runtime route of the system being
+  rebuilt.
+- Pair every gold image and rebuild medium with an authenticated manifest from a
+  separately administered recovery authority that binds the exact media version
+  to a cryptographic digest, rather than a locally recorded hash, and verify the
+  relevant media against that manifest for every restore or rebuild.
+- Revert by discarding the guest's writable overlay and recreating it from the
+  gold image rather than from a snapshot the host can write, because a sample
+  that reaches the host can otherwise poison the baseline it is restored from.
 
 ## Choose a deployment path
 
@@ -325,15 +324,14 @@ of these paths.
   analysis service.
 - Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
   scoring, enrichment, and analyst queue management. Run it on a separate host,
-  because the detonation host is dedicated to analysis, and treat it as the only
-  service that submits into the detonation segment from outside: it serves
-  analysts outside the segment, so allow no inbound path from the guests or the
-  detonation host back to it. Make Assemblyline the analyst-facing surface in
-  this deployment and restrict the detonation host's own submission and result
-  interfaces on the inbound path above to Assemblyline and the operators who
-  administer the deployment, so analysts reach results only through Assemblyline
-  and the composition adds no second analyst crossing. The egress broker remains
-  the guests' only outbound crossing.
+  because the detonation host is dedicated to analysis, and make it the
+  analyst-facing surface of the deployment. Analysts reach results only through
+  Assemblyline, and the detonation host's own submission and result interfaces
+  on the designated inbound path stay restricted to Assemblyline and the
+  operators who administer the deployment. The Assemblyline containment
+  requirement above governs the rest of its boundary: it submits to the
+  detonation host on that inbound path without attaching to the detonation
+  segment. The egress broker remains the guests' only outbound crossing.
 - Use DRAKVUF when agentless virtual-machine introspection is more important
   than deployment simplicity.
 - Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -35,6 +35,8 @@ archived by its owner on 2021-04-26 and is read-only. Its README states that
 the Cuckoo 2.x line is unmaintained, and the [2.0.6 release](https://github.com/cuckoosandbox/cuckoo/releases/tag/2.0.6)
 is from 2018.
 
+## Treat Cuckoo3 as evaluation-only
+
 The [Cuckoo3 rewrite](https://github.com/cert-ee/cuckoo3) is the successor line
 listed in the table above. Its `main` branch last advanced on 2025-12-18, and
 the only newer commits sit on unmerged dependabot branches. Its
@@ -99,8 +101,8 @@ architecture is therefore Assemblyline for intake and triage, with CAPE or
 another detonation backend for dynamic execution. The version line recorded in
 the table above comes from the
 [Assemblyline release index](https://github.com/CybercentreCanada/assemblyline/releases),
-where the `stable` tags carry the supported line and the `dev` tags carry the
-development line.
+where `v4.7.4.stable6` was published on 2026-07-16 as the latest `stable` tag
+and the `dev` tags carry the development line.
 
 ## Use PANDA for research instrumentation
 
@@ -242,6 +244,10 @@ vendor-review questions rather than controls you configure:
   patch it as a security boundary rather than on a general server schedule.
 - Rebuild the host from known-good media when an escape is suspected. A guest
   snapshot revert does not restore a host the sample reached.
+- Ship hypervisor, host, and egress-broker logs off the detonation host as they
+  are written, and review them for host-level compromise. A sample that reaches
+  the host can edit any log it can still write to, so nothing held on the host
+  can raise the suspicion the rebuild above depends on.
 - Keep the gold images and snapshots that those reverts and rebuilds depend on
   outside the detonation host's write path, and verify them by hash before use.
   A sample that reaches the host can otherwise poison the baseline it is

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -235,7 +235,10 @@ vendor-review questions rather than controls you configure:
   path.
 - Expose submission and result interfaces to analysts, and to an orchestrator
   such as Assemblyline, only on a separate inbound path that terminates on the
-  detonation host and reaches no guest. Without it the segment rule above leaves
+  detonation host and reaches no guest. Allow connections inbound only on it, so
+  the host accepts on that path and never initiates over it, matching the
+  direction constraint the Assemblyline placement below states. Without it the
+  segment rule above leaves
   the web UI and API of a self-hosted deployment unreachable, and the operator
   recovers access by routing production into the detonation segment.
 - Default-deny guest egress. Provide internet access only through a simulated
@@ -248,9 +251,10 @@ vendor-review questions rather than controls you configure:
   from known-good media when an escape is suspected, because it is the only
   self-hosted component every sample is permitted to reach.
 - Keep production credentials, tokens, SSH agents, and mounted shares off the
-  detonation and broker hosts. Both carry only what their own analysis role
-  needs, such as the framework's own service credentials, the append-only
-  collector credential, and the read-only gold-image mount.
+  detonation and broker hosts. Each carries only what its own role needs: the
+  detonation host the analysis framework's service credentials, its append-only
+  collector credential, and the read-only gold-image mount; the broker host its
+  own append-only collector credential and nothing else.
 - Never domain-join an analysis guest.
 - Disable shared folders, clipboard sharing, and drag-and-drop between guest and
   host.
@@ -274,7 +278,9 @@ vendor-review questions rather than controls you configure:
   path rather than the detonation segment, give each shipping host its own
   append-only credentials to the collector, and allow neither host any access to
   the collector beyond appending, so it cannot rewrite or delete what it already
-  sent.
+  sent. Reach only the collector from the broker host on that path: give it no
+  route to the hypervisor console, the orchestration API, or the gold-image
+  store, because it is the one self-hosted component every sample may reach.
 - Keep the gold images that those reverts and rebuilds restore from outside the
   detonation host's write path, serve them read-only to the host over the
   restricted administrative path rather than the detonation segment, and verify
@@ -295,10 +301,11 @@ of these paths.
   because the detonation host is dedicated to analysis, and treat it as the only
   service that submits into the detonation segment from outside: it serves
   analysts outside the segment, so allow no inbound path from the guests or the
-  detonation host back to it. Analysts still reach the detonation host's own
-  submission and result interfaces on the inbound path required above, not
-  through Assemblyline, and the egress broker remains the guests' only outbound
-  crossing.
+  detonation host back to it. Make Assemblyline the analyst-facing surface in
+  this deployment and restrict the detonation host's own submission and result
+  interfaces on the inbound path above to Assemblyline and the analysis team, so
+  the composition adds no second analyst crossing. The egress broker remains the
+  guests' only outbound crossing.
 - Use DRAKVUF when agentless virtual-machine introspection is more important
   than deployment simplicity.
 - Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -245,7 +245,10 @@ vendor-review questions rather than controls you configure:
   direction constraint the Assemblyline placement below states. Without it the
   segment rules above leave the web UI and API of a self-hosted deployment
   unreachable, and the operator recovers access by routing production into
-  the detonation segment.
+  the detonation segment. Treat each system that directly retrieves or processes
+  result data from the detonation host on this path as a result-consumer security
+  boundary. Apply the credential, logging, recovery-media, and recovery controls
+  below to it.
 - Treat every Assemblyline deployment node as an analyst-and-orchestrator
   security boundary. Dedicate each node to that role, keep its management and
   maintenance on a restricted administrative path apart from the detonation
@@ -265,11 +268,11 @@ vendor-review questions rather than controls you configure:
   path that cannot route to or through production or backup networks.
 - Keep production credentials, tokens, SSH agents, and mounted shares belonging
   to systems outside the analysis environment off the detonation and broker
-  hosts and every Assemblyline deployment node. Give each only role-required
-  credentials and public trust anchors for update and recovery verification. The
-  detonation host alone receives read-only guest gold-image access; the broker
-  has no runtime access to it. Scope Assemblyline credentials to the analyst,
-  submission, or result-retrieval function each node provides.
+  hosts and every result consumer. Give each only role-required credentials and
+  public trust anchors for update and recovery verification. The detonation host
+  alone receives read-only guest gold-image access; the broker has no runtime
+  access to it. Scope each result consumer's credentials to the analyst,
+  submission, or result-retrieval function it provides.
 - Never domain-join an analysis guest.
 - Disable shared folders, clipboard sharing, and drag-and-drop between guest and
   host.
@@ -288,57 +291,64 @@ vendor-review questions rather than controls you configure:
   access limited to the package-update service and repository-signature
   verification, so maintenance does not require guest egress or a
   production-network route.
-- Rebuild any boundary host from known-good media when its off-host logs or
-  another incident signal indicates host-level compromise. Rebuild the
-  detonation host and the broker host additionally when an escape is
-  suspected, because both sit on the guest-reachable path. On that same signal,
-  isolate the designated submission-and-result path. Before reconnecting the
-  recovered detonation host to it, rebuild every Assemblyline deployment node
-  that retrieved or processed result data from that detonation host since its
-  last known-good rebuild. A compromised detonation host can return
-  attacker-controlled result data over an Assemblyline-initiated connection even
-  though it cannot initiate a new connection. A guest snapshot revert does not
-  restore a host the sample reached.
 - Ship hypervisor and host logs off the detonation host, egress-broker logs off
-  the broker host, and Assemblyline deployment-node logs off their nodes as they
-  are written. Record on the append-only collector which detonation host
-  supplied result data to each Assemblyline deployment node. If that record
-  cannot identify every node exposed after a suspected escape, rebuild every
-  Assemblyline deployment node before reconnecting the recovered detonation host.
-  Configure the collector to alert on boundary-host signals that indicate
-  host-level compromise, and require acknowledgement and escalation within 15
-  minutes. Use those signals to trigger the rebuild requirement above. A
-  compromised boundary host can edit any log it can still write to, so nothing
-  held on that host can raise the suspicion the rebuild above depends on. Carry
-  that shipping on the restricted administrative path rather than the detonation
-  segment, give each shipping host its own append-only credentials to the
-  collector, and allow no shipping host access to the collector beyond appending,
-  so it cannot rewrite or delete what it already sent.
+  the broker host, and result-consumer logs off each result consumer as they are
+  written. A compromised boundary system can edit any log it can still write, so
+  nothing held on that system can raise the suspicion the recovery policy depends
+  on.
+- Carry that shipping on the restricted administrative path rather than the
+  detonation segment. Give each shipping system its own append-only credentials
+  to the collector, and allow no shipping system access to the collector beyond
+  appending, so it cannot rewrite or delete what it already sent.
+- Configure the collector to alert on boundary-host and result-consumer signals
+  that indicate host-level compromise, and require acknowledgement and escalation
+  within 15 minutes. Use those signals to trigger the rebuild requirements below.
+- Record on the append-only collector which detonation host supplied result data
+  to each result consumer.
+- Rebuild any boundary host or result consumer from known-good media when its
+  off-host logs or another incident signal indicates host-level compromise.
+  Rebuild the detonation host and the broker host additionally when an escape is
+  suspected, because both sit on the guest-reachable path. A guest snapshot
+  revert does not restore a host the sample reached.
+- Whenever a detonation-host compromise is indicated or an escape is suspected,
+  isolate the designated submission-and-result path. Before reconnecting the
+  recovered detonation host to it, rebuild every result consumer that retrieved
+  or processed result data directly from that detonation host over the designated
+  inbound path since its last known-good rebuild. If the collector record cannot
+  identify every result consumer exposed after either condition, rebuild every
+  result consumer before reconnecting the recovered detonation host. A compromised
+  detonation host can return attacker-controlled result data in response to a
+  result-consumer-initiated connection even though it cannot initiate a new
+  connection.
 - On the restricted administrative path, the broker host reaches only the log
   collector and the approved update mirror stated above. Give it no route to
   the hypervisor console, the orchestration API, or the gold-image store,
-  because it is the one self-hosted component every sample may reach. Bound
-  the detonation host and each Assemblyline deployment node the same way:
+  because it is the one self-hosted component every sample may reach. Apply the
+  same restriction to the detonation host and each result consumer:
   neither reaches another boundary host's management interface on that path,
   and the detonation host's only further reach is the read-only gold-image
   access already granted above.
 - Keep guest gold images outside the detonation host's write path, and keep
-  known-good rebuild media outside the write path of the detonation host, broker
-  host, or Assemblyline deployment node it rebuilds.
+  known-good rebuild media outside the write path of the boundary host or result
+  consumer being rebuilt.
 - Serve a gold image and its authenticated manifest read-only to the detonation
   host over the restricted administrative path rather than the detonation
-  segment. Deliver rebuild media and its manifest for any of those systems only
-  through a separate recovery procedure, not a runtime route of the system being
-  rebuilt.
+  segment. Deliver rebuild media and its manifest for every boundary host and
+  result consumer only through a separate recovery procedure, not a runtime route
+  of the system being rebuilt.
 - Pair every gold image and rebuild medium with an authenticated manifest from
   a separately administered recovery authority that binds the exact media
   identity, version, and cryptographic digest, rather than a locally recorded
-  hash. Keep each medium's expected approved release with the pinned tested unit,
-  outside the delivery store's control. For every restore or rebuild, verify the
-  manifest's signature against the recovery-verification trust anchor granted
-  above, require its signed media identity and version to match that expected
-  release, and only then verify the relevant media against its digest. Reject a
-  validly signed manifest for any older or otherwise unexpected release.
+  hash. The recovery authority maintains each medium's expected approved release
+  as protected recovery configuration for the pinned tested unit. Keep that record
+  outside the delivery store's control and outside the write path of every system
+  it restores or rebuilds. For every restore or rebuild, the separate recovery
+  procedure uses the recovery authority's protected trust anchor and
+  expected-release record to verify the manifest's signature, require its signed
+  media identity and version to match that expected release, and only then verify
+  the relevant media against its digest. Reject and stop if either protected
+  recovery record is unavailable, the signature fails, or the release is older or
+  otherwise unexpected.
 - Revert by discarding the guest's writable overlay and recreating it from the
   gold image rather than from a snapshot the host can write, because a sample
   that reaches the host can otherwise poison the baseline it is restored from.

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -196,9 +196,8 @@ they are not detonation platforms.
 
 Apply these to every detonation option above, self-hosted or hosted:
 
-- Never expose production credentials, tokens, SSH agents, or mounted shares to
-  an analysis guest. The detonation host itself carries only the append-only
-  collector credential and the read-only gold-image mount required below.
+- Never expose credentials, tokens, SSH agents, or mounted shares belonging to
+  any system outside the analysis environment to an analysis guest.
 - Keep every copy of a sample or result that you hold encrypted or
   password-protected at rest, and move it only through the analysis pipeline.
   Store samples in a password-protected archive or under a defanged extension so
@@ -229,8 +228,9 @@ vendor-review questions rather than controls you configure:
   production or backup networks. Give the guests no route off that segment
   except the brokered egress path below, and isolate them from each other and
   from every host interface on that segment except the analysis framework's own
-  control and result channel, so a self-propagating sample cannot reach a
-  concurrent analysis or any other service on the hypervisor. Reach the host's
+  control and result channel and the egress broker's segment-side interface, so
+  a self-propagating sample cannot reach a concurrent analysis or any other
+  service on the hypervisor. Reach the host's
   own management interface only through a separate restricted administrative
   path.
 - Expose submission and result interfaces to analysts, and to an orchestrator
@@ -242,7 +242,15 @@ vendor-review questions rather than controls you configure:
   or brokered path that is logged and rate-limited. Run that broker on the
   segment boundary rather than on the detonation host, which carries no other
   workload, so the guests reach it as the one permitted route off the segment
-  and not through a host interface.
+  and not through a detonation-host interface. Hold the broker host to the same
+  requirements as the detonation host, dedicated, patched as a security
+  boundary, logs shipped off-host under append-only credentials, and rebuilt
+  from known-good media when an escape is suspected, because it is the only
+  self-hosted component every sample is permitted to reach.
+- Keep production credentials, tokens, SSH agents, and mounted shares off the
+  detonation and broker hosts. Both carry only what their own analysis role
+  needs, such as the framework's own service credentials, the append-only
+  collector credential, and the read-only gold-image mount.
 - Never domain-join an analysis guest.
 - Disable shared folders, clipboard sharing, and drag-and-drop between guest and
   host.
@@ -260,13 +268,13 @@ vendor-review questions rather than controls you configure:
   snapshot revert does not restore a host the sample reached.
 - Ship hypervisor and host logs off the detonation host, and egress-broker logs
   off whichever host runs the broker, as they are written, and review them for
-  host-level compromise. A sample that reaches
-  the host can edit any log it can still write to, so nothing held on the host
-  can raise the suspicion the rebuild above depends on. Carry that shipping on
-  the restricted administrative path rather than the detonation segment, give
-  the host append-only credentials to the collector, and allow the host no
-  access to the collector beyond appending, so it cannot rewrite or delete what
-  it already sent.
+  host-level compromise. A sample that reaches either host can edit any log it
+  can still write to, so nothing held on that host can raise the suspicion the
+  rebuild above depends on. Carry that shipping on the restricted administrative
+  path rather than the detonation segment, give each shipping host its own
+  append-only credentials to the collector, and allow neither host any access to
+  the collector beyond appending, so it cannot rewrite or delete what it already
+  sent.
 - Keep the gold images that those reverts and rebuilds restore from outside the
   detonation host's write path, serve them read-only to the host over the
   restricted administrative path rather than the detonation segment, and verify

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -245,18 +245,18 @@ vendor-review questions rather than controls you configure:
   security boundary. Dedicate each node to that role, keep its management and
   maintenance on a restricted administrative path apart from the detonation
   segment, and patch it through the approved update mirror on that path with
-  host-initiated access limited to the package-update service. Ship each node's
-  logs off-host as they are written using its own append-only collector
-  credentials. Its only connection toward the detonation deployment is the
-  designated inbound submission and result path above, which terminates on the
-  detonation host and reaches no guest. It must not attach to the detonation
-  segment or accept guest-originated or detonation-host-initiated new
-  connections.
+  host-initiated access limited to the package-update service. Its only
+  connection toward the detonation deployment is the designated inbound
+  submission and result path above, which terminates on the detonation host and
+  reaches no guest. It must not attach to the detonation segment or accept
+  guest-originated or detonation-host-initiated new connections.
 - Default-deny guest egress. Provide internet access only through a simulated
   or brokered path that is logged and rate-limited. Run that broker on the
   segment boundary rather than on the detonation host, which carries no other
   workload, so the guests reach it as the one permitted route off the segment
-  and not through a detonation-host interface.
+  and not through a detonation-host interface. Allow only guest-initiated flows
+  and their stateful replies across the broker, and accept no unsolicited inbound
+  connection on its untrusted-side interface.
 - Keep production credentials, tokens, SSH agents, and mounted shares belonging
   to systems outside the analysis environment off the detonation and broker
   hosts and every Assemblyline deployment node. Give each only role-required
@@ -282,11 +282,12 @@ vendor-review questions rather than controls you configure:
   access limited to the package-update service and repository-signature
   verification, so maintenance does not require guest egress or a
   production-network route.
-- Rebuild the detonation host or broker host from known-good media when an
-  escape is suspected. Rebuild an Assemblyline deployment node from known-good
-  media when its off-host logs or another incident signal indicates host-level
-  compromise. A guest snapshot revert does not restore a host the sample
-  reached.
+- Rebuild the detonation host from known-good media when an escape is suspected.
+  Rebuild the broker host from known-good media when an escape is suspected or
+  its off-host logs or another incident signal indicates host-level compromise.
+  Rebuild an Assemblyline deployment node from known-good media when its
+  off-host logs or another incident signal indicates host-level compromise. A
+  guest snapshot revert does not restore a host the sample reached.
 - Ship hypervisor and host logs off the detonation host, egress-broker logs off
   the broker host, and Assemblyline deployment-node logs off their nodes as they
   are written. Review all of them for host-level compromise. A compromised

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -157,26 +157,11 @@ malware-detonation environment:
 
 - [`Sandboxie-Plus`](https://github.com/sandboxie-plus/Sandboxie/releases)
   provides Windows application isolation.
-- [`bubblewrap`](https://github.com/containers/bubblewrap/releases/tag/v0.11.2)
+- [`bubblewrap`](https://github.com/containers/bubblewrap/releases)
   provides unprivileged Linux namespace isolation.
-- [`Firejail`](https://github.com/netblue30/firejail/releases/tag/0.9.80)
+- [`Firejail`](https://github.com/netblue30/firejail/releases)
   provides Linux namespace and seccomp-based application confinement. It is a
   local process-isolation helper, not a hypervisor boundary.
-
-## Choose a deployment path
-
-1. Use CAPE with KVM and disposable Windows guests for a self-hosted Cuckoo-style
-   analysis service.
-2. Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
-   scoring, enrichment, and analyst queue management.
-3. Use DRAKVUF when agentless virtual-machine introspection is more important
-   than deployment simplicity.
-4. Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,
-   and rapid onboarding outweigh self-hosting and data-residency requirements.
-5. Use PANDA when deterministic replay or custom whole-system instrumentation is
-   the primary research requirement.
-6. Use bubblewrap, Firejail, or Sandboxie-Plus only as an additional isolation
-   layer for local tools and applications.
 
 ## Apply containment requirements to every option
 
@@ -184,7 +169,8 @@ malware-detonation environment:
 > every sample as hostile and design for an escape attempt, network abuse, data
 > destruction, and credential theft.
 
-Apply these requirements to every option above, self-hosted or hosted:
+These requirements are prerequisites for detonating live samples, not follow-up
+work. Apply them to every option above, self-hosted or hosted:
 
 - Place detonation hosts on a dedicated network segment with no route to
   production, management, or backup networks.
@@ -205,6 +191,24 @@ Apply these requirements to every option above, self-hosted or hosted:
   them only through the analysis pipeline.
 - Confirm task visibility before uploading to a hosted service. The ANY.RUN and
   Joe Sandbox sections above record which tiers expose samples and results.
+
+## Choose a deployment path
+
+Meet the containment requirements above before detonating a live sample on any
+of these paths.
+
+1. Use CAPE with KVM and disposable Windows guests for a self-hosted Cuckoo-style
+   analysis service.
+2. Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
+   scoring, enrichment, and analyst queue management.
+3. Use DRAKVUF when agentless virtual-machine introspection is more important
+   than deployment simplicity.
+4. Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,
+   and rapid onboarding outweigh self-hosting and data-residency requirements.
+5. Use PANDA when deterministic replay or custom whole-system instrumentation is
+   the primary research requirement.
+6. Use bubblewrap, Firejail, or Sandboxie-Plus only as an additional isolation
+   layer for local tools and applications.
 
 ## References
 

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -228,8 +228,9 @@ vendor-review questions rather than controls you configure:
   production or backup networks. Give the guests no route off that segment
   except the brokered egress path below, and isolate them from each other and
   from every host interface on that segment except the analysis framework's own
-  control and result channel and the brokered-egress listener on its approved
-  ports at the broker's segment-side interface, so a self-propagating sample
+  control and result channel on its approved ports and the brokered-egress
+  listener on its approved ports at the broker's segment-side interface, so a
+  self-propagating sample
   cannot reach a concurrent analysis or any other service on either host. Reach
   the management interfaces of the detonation and broker hosts only through a
   separate restricted administrative path, never from the detonation segment.
@@ -256,7 +257,8 @@ vendor-review questions rather than controls you configure:
   workload, so the guests reach it as the one permitted route off the segment
   and not through a detonation-host interface. Allow only guest-initiated flows
   and their stateful replies across the broker, and accept no unsolicited inbound
-  connection on its untrusted-side interface.
+  connection on its untrusted-side interface. Give that interface an internet
+  path that cannot route to or through production or backup networks.
 - Keep production credentials, tokens, SSH agents, and mounted shares belonging
   to systems outside the analysis environment off the detonation and broker
   hosts and every Assemblyline deployment node. Give each only role-required
@@ -282,12 +284,13 @@ vendor-review questions rather than controls you configure:
   access limited to the package-update service and repository-signature
   verification, so maintenance does not require guest egress or a
   production-network route.
-- Rebuild the detonation host from known-good media when an escape is suspected.
-  Rebuild the broker host from known-good media when an escape is suspected or
+- Rebuild the detonation host from known-good media when an escape is suspected
+  or its off-host logs or another incident signal indicates host-level
+  compromise. Rebuild the broker host from known-good media when an escape is
+  suspected or its off-host logs or another incident signal indicates host-level
+  compromise. Rebuild an Assemblyline deployment node from known-good media when
   its off-host logs or another incident signal indicates host-level compromise.
-  Rebuild an Assemblyline deployment node from known-good media when its
-  off-host logs or another incident signal indicates host-level compromise. A
-  guest snapshot revert does not restore a host the sample reached.
+  A guest snapshot revert does not restore a host the sample reached.
 - Ship hypervisor and host logs off the detonation host, egress-broker logs off
   the broker host, and Assemblyline deployment-node logs off their nodes as they
   are written. Review all of them for host-level compromise. A compromised
@@ -296,10 +299,11 @@ vendor-review questions rather than controls you configure:
   on the restricted administrative path rather than the detonation segment, give
   each shipping host its own append-only credentials to the collector, and allow
   no shipping host access to the collector beyond appending, so it cannot rewrite
-  or delete what it already sent. Reach only the collector and approved update
-  mirror from the broker host on that path: give it no route to the hypervisor
-  console, the orchestration API, or the gold-image store, because it is the one
-  self-hosted component every sample may reach.
+  or delete what it already sent.
+- On the restricted administrative path, the broker host reaches only the log
+  collector and the approved update mirror stated above. Give it no route to the
+  hypervisor console, the orchestration API, or the gold-image store, because it
+  is the one self-hosted component every sample may reach.
 - Keep guest gold images outside the detonation host's write path, and keep
   known-good rebuild media outside the write path of the detonation host, broker
   host, or Assemblyline deployment node it rebuilds.

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -247,18 +247,18 @@ vendor-review questions rather than controls you configure:
   segment, and patch it through the approved update mirror on that path with
   host-initiated access limited to the package-update service. Ship each node's
   logs off-host as they are written using its own append-only collector
-  credentials. Its only detonation-segment connection is the designated
-  submission and result control path: it must not accept guest-originated or
-  detonation-host-initiated connections.
+  credentials. Its only connection toward the detonation deployment is the
+  designated inbound submission and result path above, which terminates on the
+  detonation host and reaches no guest. It must not attach to the detonation
+  segment or accept guest-originated or detonation-host-initiated new
+  connections.
 - Default-deny guest egress. Provide internet access only through a simulated
   or brokered path that is logged and rate-limited. Run that broker on the
   segment boundary rather than on the detonation host, which carries no other
   workload, so the guests reach it as the one permitted route off the segment
-  and not through a detonation-host interface. Hold the broker host to the same
-  requirements as the detonation host, dedicated, patched as a security
-  boundary, logs shipped off-host under append-only credentials, and rebuilt
-  from known-good media when an escape is suspected, because it is the only
-  self-hosted component every sample is permitted to reach.
+  and not through a detonation-host interface. Dedicate the broker host to its
+  brokered-egress role, because it is the only self-hosted component every
+  sample is permitted to reach.
 - Keep production credentials, tokens, SSH agents, and mounted shares belonging
   to systems outside the analysis environment off the detonation and broker
   hosts and every Assemblyline deployment node. Give each only role-required
@@ -277,39 +277,44 @@ vendor-review questions rather than controls you configure:
   as well as after it, and treat the guest disk as tainted until the revert
   completes. A run that ends before its post-analysis revert must not leave a
   tainted guest available to the next submission.
-- Dedicate the hypervisor host to analysis. Run no other workload on it, and
-  patch it and the broker host as security boundaries rather than on a general
-  server schedule. Fetch their updates only from an approved mirror on the
-  restricted administrative path, with host-initiated access limited to the
-  package-update service and repository-signature verification, so maintenance
-  does not require guest egress or a production-network route.
-- Rebuild the host from known-good media when an escape is suspected. A guest
-  snapshot revert does not restore a host the sample reached.
-- Ship hypervisor and host logs off the detonation host, and egress-broker logs
-  off whichever host runs the broker, as they are written, and review them for
-  host-level compromise. A sample that reaches either host can edit any log it
-  can still write to, so nothing held on that host can raise the suspicion the
-  rebuild above depends on. Carry that shipping on the restricted administrative
-  path rather than the detonation segment, give each shipping host its own
-  append-only credentials to the collector, and allow neither host any access to
-  the collector beyond appending, so it cannot rewrite or delete what it already
-  sent. Reach only the collector and approved update mirror from the broker host
-  on that path: give it no route to the hypervisor console, the orchestration
-  API, or the gold-image store, because it is the one self-hosted component
-  every sample may reach.
+- Dedicate the hypervisor host to analysis and the broker host to brokered
+  egress. Run no other workload on either, and patch both as security boundaries
+  rather than on a general server schedule. Fetch their updates only from an
+  approved mirror on the restricted administrative path, with host-initiated
+  access limited to the package-update service and repository-signature
+  verification, so maintenance does not require guest egress or a
+  production-network route.
+- Rebuild the detonation host or broker host from known-good media when an
+  escape is suspected. Rebuild an Assemblyline deployment node from known-good
+  media when its off-host logs or another incident signal indicates host-level
+  compromise. A guest snapshot revert does not restore a host the sample
+  reached.
+- Ship hypervisor and host logs off the detonation host, egress-broker logs off
+  whichever host runs the broker, and Assemblyline deployment-node logs off
+  their nodes as they are written. Review all of them for host-level compromise.
+  A compromised boundary host can edit any log it can still write to, so nothing
+  held on that host can raise the suspicion the rebuild above depends on. Carry
+  that shipping on the restricted administrative path rather than the detonation
+  segment, give each shipping host its own append-only credentials to the
+  collector, and allow no shipping host access to the collector beyond
+  appending, so it cannot rewrite or delete what it already sent. Reach only the
+  collector and approved update mirror from the broker host on that path: give
+  it no route to the hypervisor console, the orchestration API, or the gold-image
+  store, because it is the one self-hosted component every sample may reach.
 - Keep guest gold images outside the detonation host's write path. Keep
   known-good rebuild media outside the write path of the detonation host, broker
-  host, or Assemblyline deployment node it rebuilds. Serve a gold image
-  read-only to the detonation host over the restricted administrative path
-  rather than the detonation segment. For every restore or rebuild, verify the
-  exact media version against an authenticated manifest from a separately
-  administered recovery authority that binds it to a cryptographic digest,
-  rather than a locally recorded hash. Deliver rebuild media for any of those
-  systems only through a separate recovery procedure, not a runtime route of
-  the system being rebuilt. Revert by discarding the guest's writable overlay
-  and recreating it from that image rather than from a snapshot the host can
-  write, because a sample that reaches the host can otherwise poison the
-  baseline it is restored from.
+  host, or Assemblyline deployment node it rebuilds. Serve a gold image and its
+  authenticated manifest read-only to the detonation host over the restricted
+  administrative path rather than the detonation segment. Pair every gold image
+  and rebuild medium with an authenticated manifest from a separately
+  administered recovery authority that binds the exact media version to a
+  cryptographic digest, rather than a locally recorded hash. For every restore
+  or rebuild, verify the relevant media against that manifest. Deliver rebuild
+  media and its manifest for any of those systems only through a separate
+  recovery procedure, not a runtime route of the system being rebuilt. Revert by
+  discarding the guest's writable overlay and recreating it from that image
+  rather than from a snapshot the host can write, because a sample that reaches
+  the host can otherwise poison the baseline it is restored from.
 
 ## Choose a deployment path
 
@@ -325,9 +330,10 @@ of these paths.
   analysts outside the segment, so allow no inbound path from the guests or the
   detonation host back to it. Make Assemblyline the analyst-facing surface in
   this deployment and restrict the detonation host's own submission and result
-  interfaces on the inbound path above to Assemblyline and the analysis team, so
-  the composition adds no second analyst crossing. The egress broker remains the
-  guests' only outbound crossing.
+  interfaces on the inbound path above to Assemblyline and the operators who
+  administer the deployment, so analysts reach results only through Assemblyline
+  and the composition adds no second analyst crossing. The egress broker remains
+  the guests' only outbound crossing.
 - Use DRAKVUF when agentless virtual-machine introspection is more important
   than deployment simplicity.
 - Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -195,6 +195,10 @@ Apply these to every detonation option above, self-hosted or hosted:
   them only through the analysis pipeline.
 - Record the analysis platform version with each report so results stay
   reproducible.
+- Treat a benign verdict as unproven rather than clean. Samples fingerprint the
+  hypervisor, monitor, guest artifacts, and interaction timing to suppress their
+  behavior, so record which evasion checks the platform applied alongside the
+  verdict. See [MITRE ATT&CK T1497](https://attack.mitre.org/techniques/T1497/).
 - Confirm task visibility before uploading to a hosted service. The ANY.RUN and
   Joe Sandbox sections above record which tiers expose samples and results.
 - Treat any upload to a hosted service as disclosure to the vendor, including on
@@ -206,7 +210,9 @@ hypervisor, guest, and network belong to the vendor, so these are contract and
 vendor-review questions rather than controls you configure:
 
 - Place detonation hosts on a dedicated network segment with no route to
-  production, management, or backup networks.
+  production or backup networks, and give the guests no route off that segment.
+  Reach the host's own management interface only through a separate restricted
+  administrative path.
 - Default-deny guest egress. Provide internet access only through a simulated
   or brokered path that is logged and rate-limited.
 - Never domain-join an analysis guest.
@@ -235,7 +241,8 @@ of these paths.
 - Use DRAKVUF when agentless virtual-machine introspection is more important
   than deployment simplicity.
 - Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,
-  and rapid onboarding outweigh self-hosting and data-residency requirements.
+  and rapid onboarding outweigh self-hosting, and the vendor's retention and
+  data-residency terms are acceptable for the sample's classification.
 - Use PANDA when deterministic replay or custom whole-system instrumentation is
   the primary research requirement.
 - Use bubblewrap, Firejail, or Sandboxie-Plus only as an additional isolation

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -228,11 +228,11 @@ vendor-review questions rather than controls you configure:
   production or backup networks. Give the guests no route off that segment
   except the brokered egress path below, and isolate them from each other and
   from every host interface on that segment except the analysis framework's own
-  control and result channel and the egress broker's segment-side interface, so
-  a self-propagating sample cannot reach a concurrent analysis or any other
-  service on the hypervisor. Reach the host's
-  own management interface only through a separate restricted administrative
-  path.
+  control and result channel and the brokered-egress listener on its approved
+  ports at the broker's segment-side interface, so a self-propagating sample
+  cannot reach a concurrent analysis or any other service on either host. Reach
+  the management interfaces of the detonation and broker hosts only through a
+  separate restricted administrative path, never from the detonation segment.
 - Expose submission and result interfaces to analysts, and to an orchestrator
   such as Assemblyline, only on a separate inbound path that terminates on the
   detonation host and reaches no guest. Allow connections inbound only on it, so
@@ -241,6 +241,15 @@ vendor-review questions rather than controls you configure:
   segment rule above leaves
   the web UI and API of a self-hosted deployment unreachable, and the operator
   recovers access by routing production into the detonation segment.
+- Treat every Assemblyline deployment node as an analyst-and-orchestrator
+  security boundary. Dedicate each node to that role, keep its management and
+  maintenance on a restricted administrative path apart from the detonation
+  segment, and patch it through the approved update mirror on that path with
+  host-initiated access limited to the package-update service. Ship each node's
+  logs off-host as they are written using its own append-only collector
+  credentials. Its only detonation-segment connection is the designated
+  submission and result control path: it must not accept guest-originated or
+  detonation-host-initiated connections.
 - Default-deny guest egress. Provide internet access only through a simulated
   or brokered path that is logged and rate-limited. Run that broker on the
   segment boundary rather than on the detonation host, which carries no other
@@ -250,11 +259,13 @@ vendor-review questions rather than controls you configure:
   boundary, logs shipped off-host under append-only credentials, and rebuilt
   from known-good media when an escape is suspected, because it is the only
   self-hosted component every sample is permitted to reach.
-- Keep production credentials, tokens, SSH agents, and mounted shares off the
-  detonation and broker hosts. Each carries only what its own role needs: the
-  detonation host the analysis framework's service credentials, its append-only
-  collector credential, and the read-only gold-image mount; the broker host its
-  own append-only collector credential and nothing else.
+- Keep production credentials, tokens, SSH agents, and mounted shares belonging
+  to systems outside the analysis environment off the detonation and broker
+  hosts and every Assemblyline deployment node. Give each only role-required
+  credentials and public trust anchors for update and recovery verification. The
+  detonation host alone receives read-only guest gold-image access; the broker
+  has no runtime access to it. Scope Assemblyline credentials to the analyst,
+  submission, or result-retrieval function each node provides.
 - Never domain-join an analysis guest.
 - Disable shared folders, clipboard sharing, and drag-and-drop between guest and
   host.
@@ -286,17 +297,19 @@ vendor-review questions rather than controls you configure:
   on that path: give it no route to the hypervisor console, the orchestration
   API, or the gold-image store, because it is the one self-hosted component
   every sample may reach.
-- Keep the gold images used for guest reverts and the known-good rebuild media
-  for both hosts outside each host's write path. Serve a gold image read-only to
-  the detonation host over the restricted administrative path rather than the
-  detonation segment. For every restore or rebuild, verify the exact media
-  version against an authenticated manifest from a separately administered
-  recovery authority that binds it to a cryptographic digest, rather than a
-  locally recorded hash. Deliver broker rebuild media only through a separate
-  recovery procedure, not a broker runtime route. Revert by discarding the
-  guest's writable overlay and recreating it from that image rather than from a
-  snapshot the host can write, because a sample that reaches the host can
-  otherwise poison the baseline it is restored from.
+- Keep guest gold images outside the detonation host's write path. Keep
+  known-good rebuild media outside the write path of the detonation host, broker
+  host, or Assemblyline deployment node it rebuilds. Serve a gold image
+  read-only to the detonation host over the restricted administrative path
+  rather than the detonation segment. For every restore or rebuild, verify the
+  exact media version against an authenticated manifest from a separately
+  administered recovery authority that binds it to a cryptographic digest,
+  rather than a locally recorded hash. Deliver rebuild media for any of those
+  systems only through a separate recovery procedure, not a runtime route of
+  the system being rebuilt. Revert by discarding the guest's writable overlay
+  and recreating it from that image rather than from a snapshot the host can
+  write, because a sample that reaches the host can otherwise poison the
+  baseline it is restored from.
 
 ## Choose a deployment path
 

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -1,0 +1,186 @@
+# Evaluate malware sandboxing options
+
+This page records the status of open-source and hosted malware sandboxing
+options reviewed on 2026-08. It focuses on file, URL, document, and email
+detonation for malware analysis. General-purpose process isolation tools are
+listed separately because they do not provide the same telemetry or containment
+boundary as a disposable virtual machine.
+
+The original Cuckoo 2 project is retired. `CAPE` is the closest active,
+self-hosted replacement for the Cuckoo workflow. `DRAKVUF` is the stronger
+option when agentless virtual-machine introspection matters. `Assemblyline`
+provides the triage and orchestration layer around a detonation backend.
+`ANY.RUN` and `Joe Sandbox` provide managed web-based alternatives with faster
+deployment, but they require careful review of sample privacy, data residency,
+commercial terms, and API limits.
+
+## Compare the current options
+
+| Tool                                 | Category                               | Status                                                                                                | Best fit                                         |
+| ------------------------------------ | -------------------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Original Cuckoo 2                    | Self-hosted VM detonation              | Archived and read-only; latest 2.0 release is from 2018                                               | Legacy maintenance only                          |
+| Cuckoo3                              | Self-hosted VM detonation              | Open-source revival, but still marked non-production-ready and apparently dormant since December 2025 | Evaluation and migration research                |
+| CAPE                                 | Self-hosted VM detonation              | Active rolling development through August 2026; no formal GitHub releases                             | Current Cuckoo-style Windows analysis            |
+| DRAKVUF                              | Agentless VMI                          | Active engine and automated builds through August 2026                                                | Stealthier, agentless behavioral analysis        |
+| Assemblyline 4                       | Triage and orchestration               | Stable 4.7.4.stable6 and active 4.7.5 development line                                                | SOC-scale file triage around analysis services   |
+| PANDA                                | Whole-system research                  | Active QEMU record/replay and plugin platform                                                         | Custom instrumentation and replay research       |
+| ANY.RUN                              | Hosted interactive sandbox             | Active commercial SaaS with free public-oriented and paid private plans                               | Fast analyst-driven investigation                |
+| Joe Sandbox Cloud                    | Hosted deep-analysis service           | Active commercial SaaS, with Cloud v44.0.0 documented in 2026                                         | Managed cross-platform analysis and rich reports |
+| Sandboxie-Plus, bubblewrap, Firejail | Local application or process isolation | Active projects, but not malware detonation platforms                                                 | Additional local containment                     |
+
+## Retire the original Cuckoo from new deployments
+
+The [original Cuckoo repository](https://github.com/cuckoosandbox/cuckoo) was
+archived by its owner on 2021-04-26 and is read-only. Its README states that
+the Cuckoo 2.x line is unmaintained, and the [2.0.6 release](https://github.com/cuckoosandbox/cuckoo/releases/tag/2.0.6)
+is from 2018.
+
+## Use CAPE for a self-hosted Cuckoo-style platform
+
+[`CAPEv2`](https://github.com/kevoreilly/CAPEv2) is the strongest current
+option for the workflow historically associated with Cuckoo. It extends the
+Cuckoo lineage with behavioral monitoring, API hooking, dropped-file
+collection, PCAP, screenshots, memory dumps, automated unpacking, YARA
+classification, and malware configuration extraction.
+
+CAPE does not publish normal GitHub Release objects. Its [tags page](https://github.com/kevoreilly/CAPEv2/tags)
+reports that there are no releases. Treat the repository as a rolling
+development stream:
+
+- Pin a reviewed commit instead of tracking `master` directly.
+- Version the host software, guest image, monitor, and analysis policy as one
+  tested unit.
+- Maintain disposable Windows guests and reset them after every analysis.
+- Keep the guest network, management network, and analyst access paths
+  separate.
+- Review changes before updating because there is no formal upstream release
+  boundary to provide that review point.
+
+The [CAPE installation documentation](https://capev2.readthedocs.io/en/latest/)
+uses a Linux host with KVM and Windows analysis guests as its reference model.
+This is a capable but operationally demanding deployment, not a single-package
+replacement for the old Cuckoo appliance pattern.
+
+## Use DRAKVUF for agentless virtual-machine introspection
+
+[`DRAKVUF`](https://github.com/tklengyel/drakvuf) takes a different approach
+from CAPE. It performs virtualization-based, agentless black-box analysis with
+virtual-machine introspection, so the guest does not require a conventional
+analysis agent. The project documents Intel VT-x/EPT requirements and supports
+Windows and Linux analysis scenarios.
+
+- [automated builds repository](https://github.com/tklengyel/drakvuf-builds/releases)
+- [DRAKVUF Sandbox frontend](https://github.com/CERT-Polska/drakvuf-sandbox/releases)
+
+DRAKVUF is a good fit when the priority is a lower-footprint, agentless view of
+guest behavior. It is less suitable than CAPE when the priority is an easy,
+well-known analyst workflow. Xen operations, compatible hardware, guest symbol
+handling, and frontend integration add significant engineering work.
+
+## Use Assemblyline to orchestrate analysis
+
+[`Assemblyline 4`](https://github.com/CybercentreCanada/assemblyline) is an
+open-source malware triage and orchestration platform rather than a direct
+Cuckoo replacement. It provides submission, queueing, scoring, service
+execution, result storage, web access, and API-driven workflows for large file
+volumes.
+
+Assemblyline's [deployment documentation](https://cybercentrecanada.github.io/assemblyline4_docs/installation/deployment/)
+treats Cuckoo and CAPE as external sandbox infrastructure. The practical
+architecture is therefore Assemblyline for intake and triage, with CAPE or
+another detonation backend for dynamic execution.
+
+## Use PANDA for research instrumentation
+
+[`PANDA`](https://github.com/panda-re/panda) is a whole-system dynamic-analysis
+platform built on QEMU. Its record/replay model and plugin architecture make it
+valuable for deterministic experiments, custom instrumentation, reverse
+engineering research, and studies that need visibility unavailable in a normal
+detonation workflow.
+
+PANDA is not a turnkey malware-analysis service. Use it beside CAPE or DRAKVUF
+when research instrumentation is required, rather than replacing the
+submission, reporting, and guest-lifecycle functions of an operational
+sandbox.
+
+## Use ANY.RUN for managed interactive analysis
+
+[`ANY.RUN`](https://any.run/) is a hosted interactive malware sandbox. It lets
+an analyst interact with a running analysis system, inspect behavior, and
+export results rather than waiting for a single automated verdict. The service
+currently advertises Windows 7, Windows 10, Windows 11, Linux, Android, and
+macOS analysis platforms, along with API, SDK, STIX, MISP, SIEM, TIP, and XDR
+integration.
+
+The [current plans page](https://any.run/plans/) lists a free Community plan
+with limited functionality and public-oriented analysis, a Hunter plan with
+private analysis and additional operating systems, and an Enterprise Suite
+with team controls, SSO, higher API capacity, and additional privacy features.
+The [privacy documentation](https://any.run/cybersecurity-blog/privacy/)
+explains that public tasks and link-shared tasks can expose the submitted
+sample and its results. Confirm the selected visibility before uploading an
+internal artifact.
+
+ANY.RUN is attractive when analysts need immediate live interaction, current
+browser and operating-system presets, threat-intelligence context, or an API
+without operating KVM, guest images, and snapshot infrastructure. It is a
+hosted commercial service, not an open-source or self-hosted Cuckoo successor.
+It also limits customization of the analysis environment compared with a
+self-hosted CAPE deployment.
+
+## Use Joe Sandbox Cloud for managed deep analysis
+
+[`Joe Sandbox Cloud`](https://www.joesandbox.com) is another hosted alternative
+for automated and analyst-driven malware analysis. Joe Security describes
+Cloud as a web service for analyzing files and URLs targeting Windows, macOS,
+and Linux. Its current feature set includes live interaction, hypervisor-based
+inspection, execution graphs, network analysis, behavior and YARA signatures,
+configuration extraction, PCAP, screenshots, memory dumps, ATT&CK context, and
+structured report exports. See the [Joe Sandbox technology overview](https://www.joesecurity.org/index.php/joe-sandbox-technology)
+and the [Cloud product page](https://joesecurity.org/joe-sandbox-cloud).
+
+The free [Cloud Basic](https://www.joesandbox.com)
+tier is intended for evaluation, has limited analysis capacity and output, and
+makes samples and results public. Paid Cloud Light, Cloud Pro, and Cloud
+Enterprise tiers provide private analysis, with higher tiers adding API,
+integration, team, or single-tenant capabilities.
+
+Joe Sandbox is a strong managed option when broad report output, cross-platform
+analysis, phishing and email workflows, or commercial integrations matter more
+than owning the sandbox infrastructure. It remains a hosted commercial
+alternative, not an open-source replacement for CAPE or DRAKVUF.
+
+## local isolation tools
+
+These projects are useful as additional containment layers for ordinary
+applications and local analysis helpers, but they do not provide a full
+malware-detonation environment:
+
+- [`Sandboxie-Plus`](https://github.com/sandboxie-plus/Sandboxie/releases)
+  provides Windows application isolation.
+- [`bubblewrap`](https://github.com/containers/bubblewrap/releases/tag/0.11.2)
+  provides unprivileged Linux namespace isolation.
+- [`Firejail`](https://github.com/netblue30/firejail/releases/tag/0.9.80)
+  provides Linux namespace and seccomp-based application confinement. It is a
+  local process-isolation helper, not a hypervisor boundary.
+
+## Choose a deployment path
+
+1. Use CAPE with KVM and disposable Windows guests for a self-hosted Cuckoo-style
+   analysis service.
+2. Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
+   scoring, enrichment, and analyst queue management.
+3. Use DRAKVUF when agentless virtual-machine introspection is more important
+   than deployment simplicity.
+4. Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,
+   and rapid onboarding outweigh self-hosting and data-residency requirements.
+5. Use PANDA when deterministic replay or custom whole-system instrumentation is
+   the primary research requirement.
+6. Use bubblewrap, Firejail, or Sandboxie-Plus only as an additional isolation
+   layer for local tools and applications.
+
+## Apply containment requirements to every option
+
+> **Warning:** A sandbox result is not evidence that the host is safe. Treat
+> every sample as hostile and design for an escape attempt, network abuse, data
+> destruction, and credential theft.

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -37,8 +37,10 @@ is from 2018.
 
 The [Cuckoo3 rewrite](https://github.com/cert-ee/cuckoo3) is the successor line
 listed in the table above. Its `main` branch last advanced on 2025-12-18, and
-the only newer commits sit on unmerged dependabot branches, so confirm both its
-activity and its production-readiness statement before treating it as a
+the only newer commits sit on unmerged dependabot branches. Its
+[README](https://github.com/cert-ee/cuckoo3/blob/main/README.md) carries the
+production-readiness statement recorded in the table above: "This is not a
+production ready solution just yet." Re-check both before treating it as a
 migration target.
 
 ## Use CAPE for a self-hosted Cuckoo-style platform
@@ -50,8 +52,9 @@ collection, PCAP, screenshots, memory dumps, automated unpacking, YARA
 classification, and malware configuration extraction.
 
 CAPE does not publish normal GitHub Release objects. Its [tags page](https://github.com/kevoreilly/CAPEv2/tags)
-reports that there are no releases. Treat the repository as a rolling
-development stream:
+reports that there are no releases, so the activity recorded in the table above
+comes from its [commit history](https://github.com/kevoreilly/CAPEv2/commits)
+instead. Treat the repository as a rolling development stream:
 
 - Review changes before updating because there is no formal upstream release
   boundary to provide that review point.
@@ -193,8 +196,10 @@ Apply these to every detonation option above, self-hosted or hosted:
 
 - Never expose production credentials, tokens, SSH agents, or mounted shares to
   an analysis environment.
-- Keep samples and results encrypted or password-protected at rest, and move
-  them only through the analysis pipeline.
+- Keep every copy of a sample or result that you hold encrypted or
+  password-protected at rest, and move it only through the analysis pipeline. On
+  a hosted service the vendor's copy is outside that control and is governed by
+  the disclosure requirement below instead.
 - Record the analysis platform version with each report so results stay
   reproducible.
 - Treat a benign verdict as unproven rather than clean. Samples fingerprint the

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -247,7 +247,11 @@ vendor-review questions rather than controls you configure:
 - Ship hypervisor, host, and egress-broker logs off the detonation host as they
   are written, and review them for host-level compromise. A sample that reaches
   the host can edit any log it can still write to, so nothing held on the host
-  can raise the suspicion the rebuild above depends on.
+  can raise the suspicion the rebuild above depends on. Give the host
+  append-only credentials to the collector and place the collector where the
+  detonation host cannot reach it to rewrite or delete what it already sent,
+  otherwise shipping moves the logs without moving them out of the sample's
+  reach.
 - Keep the gold images and snapshots that those reverts and rebuilds depend on
   outside the detonation host's write path, and verify them by hash before use.
   A sample that reaches the host can otherwise poison the baseline it is
@@ -261,7 +265,11 @@ of these paths.
 - Use CAPE with KVM and disposable Windows guests for a self-hosted Cuckoo-style
   analysis service.
 - Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
-  scoring, enrichment, and analyst queue management.
+  scoring, enrichment, and analyst queue management. Run it off the detonation
+  host, which is dedicated to analysis, and treat it as the only component that
+  crosses the isolation boundary: it submits into the detonation segment and
+  serves analysts outside it, so allow no inbound path from the guests or the
+  detonation host back to it.
 - Use DRAKVUF when agentless virtual-machine introspection is more important
   than deployment simplicity.
 - Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -267,7 +267,11 @@ vendor-review questions rather than controls you configure:
   completes. A run that ends before its post-analysis revert must not leave a
   tainted guest available to the next submission.
 - Dedicate the hypervisor host to analysis. Run no other workload on it, and
-  patch it as a security boundary rather than on a general server schedule.
+  patch it and the broker host as security boundaries rather than on a general
+  server schedule. Fetch their updates only from an approved mirror on the
+  restricted administrative path, with host-initiated access limited to the
+  package-update service and repository-signature verification, so maintenance
+  does not require guest egress or a production-network route.
 - Rebuild the host from known-good media when an escape is suspected. A guest
   snapshot revert does not restore a host the sample reached.
 - Ship hypervisor and host logs off the detonation host, and egress-broker logs
@@ -278,16 +282,21 @@ vendor-review questions rather than controls you configure:
   path rather than the detonation segment, give each shipping host its own
   append-only credentials to the collector, and allow neither host any access to
   the collector beyond appending, so it cannot rewrite or delete what it already
-  sent. Reach only the collector from the broker host on that path: give it no
-  route to the hypervisor console, the orchestration API, or the gold-image
-  store, because it is the one self-hosted component every sample may reach.
-- Keep the gold images that those reverts and rebuilds restore from outside the
-  detonation host's write path, serve them read-only to the host over the
-  restricted administrative path rather than the detonation segment, and verify
-  them by hash before use. Revert by discarding the guest's writable overlay and recreating
-  it from that image rather than from a snapshot the host can write, because a
-  sample that reaches the host can otherwise poison the baseline it is restored
-  from.
+  sent. Reach only the collector and approved update mirror from the broker host
+  on that path: give it no route to the hypervisor console, the orchestration
+  API, or the gold-image store, because it is the one self-hosted component
+  every sample may reach.
+- Keep the gold images used for guest reverts and the known-good rebuild media
+  for both hosts outside each host's write path. Serve a gold image read-only to
+  the detonation host over the restricted administrative path rather than the
+  detonation segment. For every restore or rebuild, verify the exact media
+  version against an authenticated manifest from a separately administered
+  recovery authority that binds it to a cryptographic digest, rather than a
+  locally recorded hash. Deliver broker rebuild media only through a separate
+  recovery procedure, not a broker runtime route. Revert by discarding the
+  guest's writable overlay and recreating it from that image rather than from a
+  snapshot the host can write, because a sample that reaches the host can
+  otherwise poison the baseline it is restored from.
 
 ## Choose a deployment path
 

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -246,8 +246,8 @@ vendor-review questions rather than controls you configure:
   team, separately from the analyst path used to read results.
 - Pin a reviewed commit or release and version the host software, guest image,
   monitor, and analysis policy as one tested unit.
-- Reset every guest to a known-good snapshot immediately before each analysis as
-  well as after it, and treat the guest disk as tainted until the revert
+- Reset every guest to the read-only gold image immediately before each analysis
+  as well as after it, and treat the guest disk as tainted until the revert
   completes. A run that ends before its post-analysis revert must not leave a
   tainted guest available to the next submission.
 - Dedicate the hypervisor host to analysis. Run no other workload on it, and
@@ -263,8 +263,9 @@ vendor-review questions rather than controls you configure:
   access to the collector beyond appending, so it cannot rewrite or delete what
   it already sent.
 - Keep the gold images that those reverts and rebuilds restore from outside the
-  detonation host's write path, serve them read-only, and verify them by hash
-  before use. Revert by discarding the guest's writable overlay and recreating
+  detonation host's write path, serve them read-only to the host over the
+  restricted administrative path rather than the detonation segment, and verify
+  them by hash before use. Revert by discarding the guest's writable overlay and recreating
   it from that image rather than from a snapshot the host can write, because a
   sample that reaches the host can otherwise poison the baseline it is restored
   from.
@@ -279,9 +280,11 @@ of these paths.
 - Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
   scoring, enrichment, and analyst queue management. Run it on a separate host,
   because the detonation host is dedicated to analysis, and treat it as the only
-  component that crosses the isolation boundary: it submits into the detonation
+  service placed across the isolation boundary: it submits into the detonation
   segment and serves analysts outside it, so allow no inbound path from the
-  guests or the detonation host back to it.
+  guests or the detonation host back to it. Analysts still reach the detonation
+  host's own submission and result interfaces on the inbound path required
+  above, not through Assemblyline.
 - Use DRAKVUF when agentless virtual-machine introspection is more important
   than deployment simplicity.
 - Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -47,14 +47,13 @@ CAPE does not publish normal GitHub Release objects. Its [tags page](https://git
 reports that there are no releases. Treat the repository as a rolling
 development stream:
 
-- Pin a reviewed commit instead of tracking `master` directly.
-- Version the host software, guest image, monitor, and analysis policy as one
-  tested unit.
-- Maintain disposable Windows guests and reset them after every analysis.
-- Keep the guest network, management network, and analyst access paths
-  separate.
+- Pin a reviewed commit instead of tracking `master` directly, because there is
+  no release tag to pin.
 - Review changes before updating because there is no formal upstream release
   boundary to provide that review point.
+
+The guest, network, and versioning controls that CAPE shares with every other
+option are listed under [Apply containment requirements to every option](#apply-containment-requirements-to-every-option).
 
 The [CAPE installation documentation](https://capev2.readthedocs.io/en/latest/)
 uses a Linux host with KVM and Windows analysis guests as its reference model.
@@ -139,7 +138,7 @@ configuration extraction, PCAP, screenshots, memory dumps, ATT&CK context, and
 structured report exports. See the [Joe Sandbox technology overview](https://www.joesecurity.org/index.php/joe-sandbox-technology)
 and the [Cloud product page](https://joesecurity.org/joe-sandbox-cloud).
 
-The free [Cloud Basic](https://www.joesandbox.com)
+The free [Cloud Basic](https://www.joesecurity.org/joe-sandbox-cloud#subscriptions)
 tier is intended for evaluation, has limited analysis capacity and output, and
 makes samples and results public. Paid Cloud Light, Cloud Pro, and Cloud
 Enterprise tiers provide private analysis, with higher tiers adding API,
@@ -184,3 +183,31 @@ malware-detonation environment:
 > **Warning:** A sandbox result is not evidence that the host is safe. Treat
 > every sample as hostile and design for an escape attempt, network abuse, data
 > destruction, and credential theft.
+
+Apply these requirements to every option above, self-hosted or hosted:
+
+- Place detonation hosts on a dedicated network segment with no route to
+  production, management, or backup networks.
+- Default-deny guest egress. Provide internet access only through a simulated
+  or brokered path that is logged and rate-limited.
+- Never domain-join an analysis guest, and never expose production credentials,
+  tokens, SSH agents, or mounted shares to it.
+- Disable shared folders, clipboard sharing, and drag-and-drop between guest and
+  host.
+- Restrict hypervisor console and orchestration API access to the analysis
+  team, separately from the analyst path used to read results.
+- Pin a reviewed commit or release and version the host software, guest image,
+  monitor, and analysis policy as one tested unit. Record that version with each
+  report so results stay reproducible.
+- Reset every guest to a known-good snapshot after each analysis, and treat the
+  guest disk as tainted until the revert completes.
+- Keep samples and results encrypted or password-protected at rest, and move
+  them only through the analysis pipeline.
+- Confirm task visibility before uploading to a hosted service. The ANY.RUN and
+  Joe Sandbox sections above record which tiers expose samples and results.
+
+## References
+
+- [NIST SP 800-83 Rev. 1: Guide to Malware Incident Prevention and Handling for Desktops and Laptops](https://csrc.nist.gov/pubs/sp/800/83/r1/final)
+- [NIST SP 800-125: Guide to Security for Full Virtualization Technologies](https://csrc.nist.gov/pubs/sp/800/125/final)
+- [MITRE ATT&CK T1497: Virtualization/Sandbox Evasion](https://attack.mitre.org/techniques/T1497/)

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -197,9 +197,12 @@ Apply these to every detonation option above, self-hosted or hosted:
 - Never expose production credentials, tokens, SSH agents, or mounted shares to
   an analysis environment.
 - Keep every copy of a sample or result that you hold encrypted or
-  password-protected at rest, and move it only through the analysis pipeline. On
-  a hosted service the vendor's copy is outside that control and is governed by
-  the disclosure requirement below instead.
+  password-protected at rest, and move it only through the analysis pipeline.
+  Store samples in a password-protected archive or under a defanged extension so
+  an accidental open cannot execute them and an endpoint scan cannot quarantine
+  them; disk encryption alone prevents neither. On a hosted service the vendor's
+  copy is outside that control and is governed by the disclosure requirement
+  below instead.
 - Record the analysis platform version with each report so results stay
   reproducible.
 - Treat a benign verdict as unproven rather than clean. Samples fingerprint the
@@ -218,7 +221,9 @@ vendor-review questions rather than controls you configure:
 
 - Place detonation hosts on a dedicated network segment with no route to
   production or backup networks. Give the guests no route off that segment
-  except the brokered egress path below. Reach the host's own management
+  except the brokered egress path below, and isolate them from each other and
+  from the host's interfaces on that segment so a self-propagating sample cannot
+  reach a concurrent analysis or the hypervisor. Reach the host's own management
   interface only through a separate restricted administrative path.
 - Default-deny guest egress. Provide internet access only through a simulated
   or brokered path that is logged and rate-limited.
@@ -229,12 +234,18 @@ vendor-review questions rather than controls you configure:
   team, separately from the analyst path used to read results.
 - Pin a reviewed commit or release and version the host software, guest image,
   monitor, and analysis policy as one tested unit.
-- Reset every guest to a known-good snapshot after each analysis, and treat the
-  guest disk as tainted until the revert completes.
+- Reset every guest to a known-good snapshot immediately before each analysis as
+  well as after it, and treat the guest disk as tainted until the revert
+  completes. A run that ends before its post-analysis revert must not leave a
+  tainted guest available to the next submission.
 - Dedicate the hypervisor host to analysis. Run no other workload on it, and
   patch it as a security boundary rather than on a general server schedule.
 - Rebuild the host from known-good media when an escape is suspected. A guest
   snapshot revert does not restore a host the sample reached.
+- Keep the gold images and snapshots that those reverts and rebuilds depend on
+  outside the detonation host's write path, and verify them by hash before use.
+  A sample that reaches the host can otherwise poison the baseline it is
+  restored from.
 
 ## Choose a deployment path
 

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -197,7 +197,8 @@ they are not detonation platforms.
 Apply these to every detonation option above, self-hosted or hosted:
 
 - Never expose production credentials, tokens, SSH agents, or mounted shares to
-  an analysis environment.
+  an analysis guest. The detonation host itself carries only the append-only
+  collector credential and the read-only gold-image mount required below.
 - Keep every copy of a sample or result that you hold encrypted or
   password-protected at rest, and move it only through the analysis pipeline.
   Store samples in a password-protected archive or under a defanged extension so
@@ -238,7 +239,10 @@ vendor-review questions rather than controls you configure:
   the web UI and API of a self-hosted deployment unreachable, and the operator
   recovers access by routing production into the detonation segment.
 - Default-deny guest egress. Provide internet access only through a simulated
-  or brokered path that is logged and rate-limited.
+  or brokered path that is logged and rate-limited. Run that broker on the
+  segment boundary rather than on the detonation host, which carries no other
+  workload, so the guests reach it as the one permitted route off the segment
+  and not through a host interface.
 - Never domain-join an analysis guest.
 - Disable shared folders, clipboard sharing, and drag-and-drop between guest and
   host.
@@ -254,8 +258,9 @@ vendor-review questions rather than controls you configure:
   patch it as a security boundary rather than on a general server schedule.
 - Rebuild the host from known-good media when an escape is suspected. A guest
   snapshot revert does not restore a host the sample reached.
-- Ship hypervisor, host, and egress-broker logs off the detonation host as they
-  are written, and review them for host-level compromise. A sample that reaches
+- Ship hypervisor and host logs off the detonation host, and egress-broker logs
+  off whichever host runs the broker, as they are written, and review them for
+  host-level compromise. A sample that reaches
   the host can edit any log it can still write to, so nothing held on the host
   can raise the suspicion the rebuild above depends on. Carry that shipping on
   the restricted administrative path rather than the detonation segment, give
@@ -280,11 +285,12 @@ of these paths.
 - Put Assemblyline in front of CAPE when the workflow needs large-scale intake,
   scoring, enrichment, and analyst queue management. Run it on a separate host,
   because the detonation host is dedicated to analysis, and treat it as the only
-  service placed across the isolation boundary: it submits into the detonation
-  segment and serves analysts outside it, so allow no inbound path from the
-  guests or the detonation host back to it. Analysts still reach the detonation
-  host's own submission and result interfaces on the inbound path required
-  above, not through Assemblyline.
+  service that submits into the detonation segment from outside: it serves
+  analysts outside the segment, so allow no inbound path from the guests or the
+  detonation host back to it. Analysts still reach the detonation host's own
+  submission and result interfaces on the inbound path required above, not
+  through Assemblyline, and the egress broker remains the guests' only outbound
+  crossing.
 - Use DRAKVUF when agentless virtual-machine introspection is more important
   than deployment simplicity.
 - Use ANY.RUN or Joe Sandbox when a managed service, live analyst interaction,

--- a/docs/csec/sandboxing-tools-status.md
+++ b/docs/csec/sandboxing-tools-status.md
@@ -291,17 +291,29 @@ vendor-review questions rather than controls you configure:
 - Rebuild any boundary host from known-good media when its off-host logs or
   another incident signal indicates host-level compromise. Rebuild the
   detonation host and the broker host additionally when an escape is
-  suspected, because both sit on the guest-reachable path. A guest snapshot
-  revert does not restore a host the sample reached.
+  suspected, because both sit on the guest-reachable path. On that same signal,
+  isolate the designated submission-and-result path. Before reconnecting the
+  recovered detonation host to it, rebuild every Assemblyline deployment node
+  that retrieved or processed result data from that detonation host since its
+  last known-good rebuild. A compromised detonation host can return
+  attacker-controlled result data over an Assemblyline-initiated connection even
+  though it cannot initiate a new connection. A guest snapshot revert does not
+  restore a host the sample reached.
 - Ship hypervisor and host logs off the detonation host, egress-broker logs off
   the broker host, and Assemblyline deployment-node logs off their nodes as they
-  are written. Review all of them for host-level compromise. A compromised
-  boundary host can edit any log it can still write to, so nothing held on that
-  host can raise the suspicion the rebuild above depends on. Carry that shipping
-  on the restricted administrative path rather than the detonation segment, give
-  each shipping host its own append-only credentials to the collector, and allow
-  no shipping host access to the collector beyond appending, so it cannot rewrite
-  or delete what it already sent.
+  are written. Record on the append-only collector which detonation host
+  supplied result data to each Assemblyline deployment node. If that record
+  cannot identify every node exposed after a suspected escape, rebuild every
+  Assemblyline deployment node before reconnecting the recovered detonation host.
+  Configure the collector to alert on boundary-host signals that indicate
+  host-level compromise, and require acknowledgement and escalation within 15
+  minutes. Use those signals to trigger the rebuild requirement above. A
+  compromised boundary host can edit any log it can still write to, so nothing
+  held on that host can raise the suspicion the rebuild above depends on. Carry
+  that shipping on the restricted administrative path rather than the detonation
+  segment, give each shipping host its own append-only credentials to the
+  collector, and allow no shipping host access to the collector beyond appending,
+  so it cannot rewrite or delete what it already sent.
 - On the restricted administrative path, the broker host reaches only the log
   collector and the approved update mirror stated above. Give it no route to
   the hypervisor console, the orchestration API, or the gold-image store,
@@ -320,12 +332,13 @@ vendor-review questions rather than controls you configure:
   rebuilt.
 - Pair every gold image and rebuild medium with an authenticated manifest from
   a separately administered recovery authority that binds the exact media
-  version to a cryptographic digest, rather than a locally recorded hash.
-  Before trusting any digest in it, verify the manifest's signature against
-  the recovery-verification trust anchor granted above; only then verify the
-  relevant media against that manifest, for every restore or rebuild. A store
-  that serves the image and its manifest together can otherwise ship a
-  matched, poisoned pair.
+  identity, version, and cryptographic digest, rather than a locally recorded
+  hash. Keep each medium's expected approved release with the pinned tested unit,
+  outside the delivery store's control. For every restore or rebuild, verify the
+  manifest's signature against the recovery-verification trust anchor granted
+  above, require its signed media identity and version to match that expected
+  release, and only then verify the relevant media against its digest. Reject a
+  validly signed manifest for any older or otherwise unexpected release.
 - Revert by discarding the guest's writable overlay and recreating it from the
   gold image rather than from a snapshot the host can write, because a sample
   that reaches the host can otherwise poison the baseline it is restored from.

--- a/docs/index.md
+++ b/docs/index.md
@@ -155,8 +155,12 @@
 
 - [csec/toolkit.md](csec/toolkit.md)
   - Catalog of cybersecurity-relevant apps managed by this configuration covering recon, web testing, credential attacks, RE, forensics, and dual-use utilities.
+- [csec/sandboxing-tools-status.md](csec/sandboxing-tools-status.md)
+  - Current status and deployment guidance for open-source malware sandboxes, hosted analysis services, and local isolation tools.
 - [csec/glossary.md](csec/glossary.md)
   - Reference glossary for cybersecurity and software-engineering acronyms and concepts.
+- [csec/framework-tracker.md](csec/framework-tracker.md)
+  - Tracker for NICE Task, Knowledge, and Skill elements and future cybersecurity framework mappings.
 - [csec/additional-tools-reference.md](csec/additional-tools-reference.md)
   - Reference catalog of pentesting tools available via `nix run`/`nix shell` that complement the active toolkit, grouped by AD, recon, web testing, credential attacks, wireless, RE, forensics, stego, SAST, cloud, and pivoting.
 - [csec/additional-tools-runtime-status.md](csec/additional-tools-runtime-status.md)


### PR DESCRIPTION
## Summary

- Expand the cybersecurity glossary with investigation and threat-hunting concepts.
- Add a NICE Workforce Framework tracker for Task, Knowledge, and Skill evidence mapping.
- Add sandboxing options, containment requirements, and deployment guidance.
- Link the new reference pages from `docs/index.md`.

## Test plan

- `nix run --accept-flake-config 'path:.#formatter.x86_64-linux' -- --ci docs/csec/glossary.md docs/csec/framework-tracker.md docs/csec/sandboxing-tools-status.md docs/index.md`
- `nix develop --accept-flake-config path:. -c pre-commit run --files docs/csec/glossary.md docs/csec/framework-tracker.md docs/csec/sandboxing-tools-status.md docs/index.md --hook-stage manual`
- `lychee --no-progress docs/csec/glossary.md docs/csec/framework-tracker.md docs/csec/sandboxing-tools-status.md docs/index.md`
  - Run online rather than with `--offline`. Offline mode resolves local file links only and never requests the
    external references these pages cite, which is how a 404 shipped in the bubblewrap release link.
- `git diff --check main...HEAD`