### PR TITLE
fix(scripts): carry both ref OIDs in the current-pr payload

### DIFF
--- a/scripts/gh-cli/pr-comments-mgmt.sh
+++ b/scripts/gh-cli/pr-comments-mgmt.sh
@@ -251,7 +251,7 @@ usage_json() {
           "name": "current-pr",
           "usage": "current-pr",
           "description": [
-            "PR view as JSON. Fields: id, number, title, body, state, url, headRefName, baseRefName, author, isDraft, mergeable, mergeStateStatus, and labels flattened to a name array."
+            "PR view as JSON. Fields: id, number, title, body, state, url, headRefName, headRefOid, baseRefName, baseRefOid, author, isDraft, mergeable, mergeStateStatus, labels. Labels are flattened to a name array. The two OIDs bound a diff range without a second API call: baseRefOid is the base branch tip the PR is measured against, headRefOid the PR head, so `git diff --stat <baseRefOid>...<headRefOid>` needs no local checkout state."
           ]
         }
       ]
@@ -1933,7 +1933,7 @@ current_pr() {
 
   local data
   if ! data=$(_gh_run pr view "${PR_NUMBER}" --repo "${PR_OWNER_REPO}" --json \
-    id,number,title,body,state,url,headRefName,baseRefName,author,isDraft,mergeable,mergeStateStatus,labels); then
+    id,number,title,body,state,url,headRefName,headRefOid,baseRefName,baseRefOid,author,isDraft,mergeable,mergeStateStatus,labels); then
     err "current-pr: failed to view ${PR_OWNER_REPO}#${PR_NUMBER}"
     return 2
   fi

--- a/tests/pr-comments-mgmt/run.sh
+++ b/tests/pr-comments-mgmt/run.sh
@@ -163,6 +163,43 @@ format_dispatch_arms() {
   [[ ${found} == true ]] || fail "no OUTPUT_FORMAT dispatch in ${SUT}"
 }
 
+current_pr_view_fields() {
+  # The --json list `current_pr` hands gh, one field per line. Scoped to that
+  # function so another `pr view` cannot join the set. The list sits on the
+  # line after a `--json \` continuation, so both spellings are handled.
+  local line found=false continued=false fields=""
+  while IFS= read -r line; do
+    if [[ ${found} == false ]]; then
+      [[ ${line} == 'current_pr() {'* ]] && found=true
+      continue
+    fi
+    [[ ${line} == '}'* ]] && break
+    if [[ ${continued} == true ]]; then
+      [[ ${line} =~ ^[[:space:]]*([A-Za-z,]+) ]] && fields="${BASH_REMATCH[1]}"
+      break
+    elif [[ ${line} =~ --json[[:space:]]+\\$ ]]; then
+      continued=true
+    elif [[ ${line} =~ --json[[:space:]]+([A-Za-z,]+) ]]; then
+      fields="${BASH_REMATCH[1]}"
+      break
+    fi
+  done <"${SUT}"
+  [[ ${found} == true ]] || fail "no current_pr definition in ${SUT}"
+  [[ -n ${fields} ]] || fail "no --json field list in current_pr"
+  printf '%s\n' "${fields//,/$'\n'}"
+}
+
+current_pr_documented_fields() {
+  # The `Fields:` run out of current-pr's description, one field per line. It
+  # ends at the first period, so prose about those fields can follow.
+  local description
+  description="$("${SUT}" --help --json |
+    jq -r '.subcommandGroups[].subcommands[] | select(.name == "current-pr") | .description[0]')"
+  [[ ${description} =~ Fields:[[:space:]]*([^.]+) ]] ||
+    fail "current-pr's description carries no 'Fields:' list"
+  printf '%s\n' "${BASH_REMATCH[1]//,/$'\n'}" | tr -d ' '
+}
+
 flatten() {
   # Whitespace-normalized help text. The renderer rewraps every paragraph, so a
   # document string only survives into the text as a run of words.
@@ -280,6 +317,18 @@ test_every_documented_format_has_a_renderer() {
     fail "accepted --format values (${accepted}) differ from _format_array arms (${dispatched})"
 }
 
+test_current_pr_documents_its_payload() {
+  # `current-pr` is read for fields the caller then feeds to something else, so
+  # a field dropped from the gh call while the document still advertises it is
+  # a null the caller only discovers at use. The payload itself is past the API
+  # call, so this joins the two lists in the source instead.
+  local documented enforced
+  documented="$(current_pr_documented_fields | sort | tr '\n' ' ')"
+  enforced="$(current_pr_view_fields | sort | tr '\n' ' ')"
+  [[ ${documented} == "${enforced}" ]] ||
+    fail "documented current-pr fields (${documented}) differ from the gh --json list (${enforced})"
+}
+
 test_usage_error_goes_to_stderr() {
   # The output convention is diagnostics on stderr, payloads on stdout: a usage
   # error on stdout corrupts `list-threads --format=ids | ... resolve`. Needs
@@ -352,6 +401,7 @@ tests=(
   test_documented_subcommands_match_the_allowlist
   test_documented_choices_are_the_enforced_ones
   test_every_documented_format_has_a_renderer
+  test_current_pr_documents_its_payload
   test_json_flag_requires_help
   test_help_needs_no_gh
   test_help_tolerates_a_closed_reader

--- a/tests/pr-comments-mgmt/run.sh
+++ b/tests/pr-comments-mgmt/run.sh
@@ -175,8 +175,9 @@ current_pr_view_fields() {
     fi
     [[ ${line} == '}'* ]] && break
     if [[ ${continued} == true ]]; then
-      [[ ${line} =~ ^[[:space:]]*([A-Za-z,]+) ]] && fields="${BASH_REMATCH[1]}"
-      break
+      [[ ${line} =~ ^[[:space:]]*([A-Za-z,]+) ]] || break
+      fields+="${BASH_REMATCH[1]}"
+      [[ ${line} =~ \\$ ]] || break
     elif [[ ${line} =~ --json[[:space:]]+\\$ ]]; then
       continued=true
     elif [[ ${line} =~ --json[[:space:]]+([A-Za-z,]+) ]]; then


### PR DESCRIPTION
## Summary

`current-pr` named the two branches of a PR through `headRefName` and `baseRefName` but carried neither commit, so a
caller reading the payload to compute a diff range had nothing to anchor it and `git diff --stat <base>...<head>`
stopped before reporting any path. `gh pr view --json` already accepts `baseRefOid` and `headRefOid`, so both join the
field list; the range then resolves without a second API call or any local checkout state.

Nothing tied the documented field list to the one `current_pr` hands `gh`, which is how the two could disagree in the
first place. The `Fields:` run in the help document becomes machine-extractable (the list ends at a period, with the
labels-flattening note following as prose), and a new `test_current_pr_documents_its_payload` joins it against the
`--json` argument parsed out of the source, in the same idiom as the existing `SUBCOMMAND_FLAGS` and `OUTPUT_FORMAT`
drift checks.

## Test plan

- `bash tests/pr-comments-mgmt/run.sh` -> `12 passed`
- `nix build "path:.#checks.x86_64-linux.script-tests-pr-comments-mgmt" --no-link --accept-flake-config` -> `12 passed`
  inside the sandbox
- `nix run nixpkgs#shellcheck -- -x scripts/gh-cli/pr-comments-mgmt.sh tests/pr-comments-mgmt/run.sh` -> clean
- `nix fmt -- scripts/gh-cli/pr-comments-mgmt.sh tests/pr-comments-mgmt/run.sh` -> `0 changed`
- The new check is not vacuous. Three mutations each fail it:
  - `baseRefOid` dropped from the `gh` call while the document still claims it
  - `baseRefOid` dropped from the document while the call still requests it
  - the `Fields:` run removed entirely
- End to end against a live PR: `pr-comments-mgmt.sh --pr 458 current-pr` fed into
  `git diff --stat <baseRefOid>...<headRefOid>` reported both changed paths, which is the run that previously stopped
  early.