### PR TITLE
feat(system76): route Chromium VA-API at the Intel render node

### DIFF
--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -154,8 +154,9 @@ options.system76.gpu = {
       render-node flag is appended last and Chromium keeps the last occurrence of a
       repeated switch, so flags added here cannot displace it. One entry is one
       argument: entries containing whitespace are quoted, and an entry containing a
-      quote character, a line break, or a `$`/`@` expansion character cannot be
-      encoded and fails an assertion.
+      quote character, a line break, a `#` (pam_env truncates its conffile line
+      there), or a pam_env expansion (a braced `$`/`@` reference, or a literal
+      `$HOME` or `$USER`) cannot be encoded and fails an assertion.
     '';
     example = [ "--host-resolver-rules=MAP * 127.0.0.1" ];
   };
@@ -196,14 +197,16 @@ environment.sessionVariables = {
 
 # unquotableFlags is a helper from the module's `let` block, like quoteFlag: it
 # filters chromeExtraFlags ++ [ the derived flag ] for entries carrying a quote
-# character, a line break, or a $/@ pam_env expansion character.
+# character, a line break, a # (pam_env truncates its conffile line there), or a
+# pam_env expansion (a braced $/@ reference, or a literal $HOME/$USER).
 assertions = [
   {
     assertion = unquotableFlags == [ ];
     message =
       "system76.gpu: entries are quoted into CHROME_EXTRA_FLAGS, so neither "
       + "chromeExtraFlags nor the flag derived from videoDecodeDevice may contain "
-      + "a quote character, a line break, or a $/@ expansion character. "
+      + "a quote character, a line break, a #, or a pam_env expansion "
+      + "(a braced $/@ reference, or a literal $HOME or $USER). "
       + "Offending entries: "
       + lib.concatStringsSep ", " unquotableFlags;
   }

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -105,8 +105,8 @@ sudo system76-power charge-thresholds --profile full_charge   # 96-100%
 Shared NVIDIA wiring (driver selection, open-module toggle, container
 toolkit, VA-API routing, PRIME) lives in the parameterized
 `flake.nixosModules.nvidia-gpu` module (`modules/hardware/nvidia-gpu.nix`).
-The host file maps the `system76.gpu.mode` enum onto it and keeps the
-chassis-specific libva routing.
+The host file selects the `system76.gpu.mode` value and the module keeps the
+chassis-specific Intel VA-API routing consistent across both modes.
 
 ```nix
 # modules/system76/nvidia-gpu.nix
@@ -115,8 +115,17 @@ options.system76.gpu = {
     type = lib.types.enum [ "hybrid-sync" "nvidia-only" ];
     default = "hybrid-sync";
   };
+  # Xorg decimal PCI:bus@domain:device:function form. The domain may be omitted when 0.
   intelBusId = lib.mkOption { type = lib.types.str; default = "PCI:0:2:0"; };
   nvidiaBusId = lib.mkOption { type = lib.types.str; default = "PCI:1:0:0"; };
+  videoDecodeDevice = lib.mkOption {
+    type = lib.types.str;
+    # The module derives this by-path default from intelBusId:
+    # PCI:0:2:0 -> /dev/dri/by-path/pci-0000:00:02.0-render.
+    # An optional domain is accepted, for example PCI:2@1:3:4 -> pci-0001:02:03.4.
+    default = "/dev/dri/by-path/pci-0000:00:02.0-render";
+    example = "/dev/dri/renderD128";
+  };
 };
 
 gpu.nvidia = {
@@ -131,9 +140,16 @@ gpu.nvidia = {
   };
 };
 
-# nvidia-only branch: libva uses Intel Quick Sync through the stable iGPU render node.
-environment.sessionVariables.LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
-environment.sessionVariables.LIBVA_DRM_DEVICE = lib.mkDefault "/dev/dri/by-path/pci-0000:00:02.0-render";
+# Chromium matches its VA-API node to the GPU it renders on and rejects nvidia-drm
+# (crbug.com/1492880), so point it at the Intel node in either GPU mode. The browsers
+# read this variable directly; no per-package wiring is needed.
+# libva uses the same Intel Quick Sync node and iHD driver for every VA-API consumer.
+environment.sessionVariables = {
+  CHROME_EXTRA_FLAGS =
+    lib.mkDefault "--hardware-video-device-path=${config.system76.gpu.videoDecodeDevice}";
+  LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
+  LIBVA_DRM_DEVICE = lib.mkDefault config.system76.gpu.videoDecodeDevice;
+};
 ```
 
 ```nix

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -154,7 +154,7 @@ options.system76.gpu = {
       render-node flag is appended last and Chromium keeps the last occurrence of a
       repeated switch, so flags added here cannot displace it. One entry is one
       argument: entries containing whitespace are quoted, and an entry containing a
-      quote character cannot be encoded and fails an assertion.
+      quote character or a line break cannot be encoded and fails an assertion.
     '';
     example = [ "--host-resolver-rules=MAP * 127.0.0.1" ];
   };

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -144,8 +144,9 @@ options.system76.gpu = {
     type = lib.types.listOf lib.types.str;
     default = [ ];
     description = ''
-      Additional Chromium flags exported through `CHROME_EXTRA_FLAGS`. The required
-      render-node flag is prepended automatically.
+      Additional Chromium flags exported through `CHROME_EXTRA_FLAGS`. The derived
+      render-node flag is appended last and Chromium keeps the last occurrence of a
+      repeated switch, so flags added here cannot displace it.
     '';
   };
 };
@@ -163,14 +164,16 @@ gpu.nvidia = {
 };
 
 # Chromium matches its VA-API node to the GPU it renders on and rejects nvidia-drm
-# (crbug.com/1492880), so point it at the Intel node in either GPU mode. The browsers
-# read this variable directly; no per-package wiring is needed. Add Chromium flags
-# through system76.gpu.chromeExtraFlags; the render-node flag is always prepended.
+# (crbug.com/1492880), so point it at the Intel node in either GPU mode. The browser
+# binary reads this variable itself (AppendExtraArgumentsToCommandLine in
+# chrome/app/chrome_main_linux.cc), so no per-package wiring is needed. Add Chromium
+# flags through system76.gpu.chromeExtraFlags; the render-node flag is always appended
+# last, and Chromium keeps the last occurrence of a repeated switch.
 # libva uses the same Intel Quick Sync node and iHD driver for every VA-API consumer.
 environment.sessionVariables = {
   CHROME_EXTRA_FLAGS = lib.mkDefault (lib.concatStringsSep " " (
-    [ "--hardware-video-device-path=${config.system76.gpu.videoDecodeDevice}" ]
-    ++ config.system76.gpu.chromeExtraFlags
+    config.system76.gpu.chromeExtraFlags
+    ++ [ "--hardware-video-device-path=${config.system76.gpu.videoDecodeDevice}" ]
   ));
   LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
   LIBVA_DRM_DEVICE = lib.mkDefault config.system76.gpu.videoDecodeDevice;

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -122,6 +122,9 @@ options.system76.gpu = {
       Intel iGPU address in Xorg's decimal `PCI:bus@domain:device:function` form.
       Used for PRIME sync in `hybrid-sync` mode and as the source of the
       `videoDecodeDevice` default in both modes. The domain may be omitted when it is 0.
+      Fields are range-checked against their PCI widths (bus 0-255, device 0-31,
+      function 0-7, any domain); an out-of-range field fails evaluation naming this
+      option rather than aborting inside `lib.fixedWidthString`.
     '';
   };
   nvidiaBusId = lib.mkOption { type = lib.types.str; default = "PCI:1:0:0"; };

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -154,7 +154,8 @@ options.system76.gpu = {
       render-node flag is appended last and Chromium keeps the last occurrence of a
       repeated switch, so flags added here cannot displace it. One entry is one
       argument: entries containing whitespace are quoted, and an entry containing a
-      quote character or a line break cannot be encoded and fails an assertion.
+      quote character, a line break, or a `$`/`@` expansion character cannot be
+      encoded and fails an assertion.
     '';
     example = [ "--host-resolver-rules=MAP * 127.0.0.1" ];
   };

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -115,16 +115,27 @@ options.system76.gpu = {
     type = lib.types.enum [ "hybrid-sync" "nvidia-only" ];
     default = "hybrid-sync";
   };
-  # Xorg decimal PCI:bus@domain:device:function form. The domain may be omitted when 0.
-  intelBusId = lib.mkOption { type = lib.types.str; default = "PCI:0:2:0"; };
+  intelBusId = lib.mkOption {
+    type = lib.types.str;
+    default = "PCI:0:2:0";
+    description = ''
+      Intel iGPU address in Xorg's decimal `PCI:bus@domain:device:function` form.
+      Used for PRIME sync in `hybrid-sync` mode and as the source of the
+      `videoDecodeDevice` default in both modes. The domain may be omitted when it is 0.
+    '';
+  };
   nvidiaBusId = lib.mkOption { type = lib.types.str; default = "PCI:1:0:0"; };
   videoDecodeDevice = lib.mkOption {
     type = lib.types.str;
-    # Derived from intelBusId rather than hardcoded:
+    # Derived from intelBusId rather than hardcoded. For example:
     # PCI:0:2:0 -> /dev/dri/by-path/pci-0000:00:02.0-render.
-    # An optional domain is accepted, for example PCI:2@1:3:4 -> pci-0001:02:03.4.
-    default = "/dev/dri/by-path/pci-${domain}:${bus}:${device}.${function}-render";
+    # PCI:2@1:3:4 -> /dev/dri/by-path/pci-0001:02:03.4-render.
+    defaultText = lib.literalExpression ''"/dev/dri/by-path/pci-<intelBusId as a sysfs address>-render"'';
     example = "/dev/dri/renderD128";
+    description = ''
+      Intel render node offered to VA-API consumers. Override this when the
+      chassis uses a non-standard device path.
+    '';
   };
 };
 

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -193,6 +193,21 @@ environment.sessionVariables = {
   LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
   LIBVA_DRM_DEVICE = lib.mkDefault config.system76.gpu.videoDecodeDevice;
 };
+
+# unquotableFlags is a helper from the module's `let` block, like quoteFlag: it
+# filters chromeExtraFlags ++ [ the derived flag ] for entries carrying a quote
+# character, a line break, or a $/@ pam_env expansion character.
+assertions = [
+  {
+    assertion = unquotableFlags == [ ];
+    message =
+      "system76.gpu: entries are quoted into CHROME_EXTRA_FLAGS, so neither "
+      + "chromeExtraFlags nor the flag derived from videoDecodeDevice may contain "
+      + "a quote character, a line break, or a $/@ expansion character. "
+      + "Offending entries: "
+      + lib.concatStringsSep ", " unquotableFlags;
+  }
+];
 ```
 
 ```nix

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -179,7 +179,8 @@ gpu.nvidia = {
 # chrome/app/chrome_main_linux.cc), so no per-package wiring is needed. Add Chromium
 # flags through system76.gpu.chromeExtraFlags; the render-node flag is always appended
 # last, and Chromium keeps the last occurrence of a repeated switch. Chromium re-splits
-# the variable on whitespace, so quoteFlag single-quotes any entry that contains
+# the variable on whitespace, so quoteFlag, a helper from the module's `let` block like
+# intelBusFields and intelBusPadded above, single-quotes any entry that contains
 # whitespace to keep one list entry as one argument. The quote is single because
 # sessionVariables render into /etc/pam/environment as NAME DEFAULT="<value>", where a
 # double quote would close the value early.

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -120,10 +120,10 @@ options.system76.gpu = {
   nvidiaBusId = lib.mkOption { type = lib.types.str; default = "PCI:1:0:0"; };
   videoDecodeDevice = lib.mkOption {
     type = lib.types.str;
-    # The module derives this by-path default from intelBusId:
+    # Derived from intelBusId rather than hardcoded:
     # PCI:0:2:0 -> /dev/dri/by-path/pci-0000:00:02.0-render.
     # An optional domain is accepted, for example PCI:2@1:3:4 -> pci-0001:02:03.4.
-    default = "/dev/dri/by-path/pci-0000:00:02.0-render";
+    default = "/dev/dri/by-path/pci-${domain}:${bus}:${device}.${function}-render";
     example = "/dev/dri/renderD128";
   };
 };

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -130,11 +130,17 @@ options.system76.gpu = {
   nvidiaBusId = lib.mkOption { type = lib.types.str; default = "PCI:1:0:0"; };
   videoDecodeDevice = lib.mkOption {
     type = lib.types.str;
-    # Derived from intelBusId rather than hardcoded. For example:
+    # Derived from intelBusId rather than hardcoded, via the intelBusFields and
+    # intelBusPadded helpers at the top of the module. For example:
     # PCI:0:2:0 -> /dev/dri/by-path/pci-0000:00:02.0-render.
     # PCI:2@1:3:4 -> /dev/dri/by-path/pci-0001:02:03.4-render.
+    default =
+      "/dev/dri/by-path/pci-${intelBusPadded 4 intelBusFields.domain}:${intelBusPadded 2 intelBusFields.bus}"
+      + ":${intelBusPadded 2 intelBusFields.device}.${toString intelBusFields.function}-render";
     defaultText = lib.literalExpression ''"/dev/dri/by-path/pci-<intelBusId as a sysfs address>-render"'';
-    example = "/dev/dri/renderD128";
+    # Not a renderD path: renderD numbering follows driver probe order, so it can
+    # move between boots. Override with a by-path node.
+    example = "/dev/dri/by-path/pci-0000:00:02.0-render";
     description = ''
       Intel render node offered to VA-API consumers. Override this when the
       chassis uses a non-standard device path.
@@ -146,8 +152,11 @@ options.system76.gpu = {
     description = ''
       Additional Chromium flags exported through `CHROME_EXTRA_FLAGS`. The derived
       render-node flag is appended last and Chromium keeps the last occurrence of a
-      repeated switch, so flags added here cannot displace it.
+      repeated switch, so flags added here cannot displace it. One entry is one
+      argument: entries containing whitespace are quoted, and an entry containing a
+      quote character cannot be encoded and fails an assertion.
     '';
+    example = [ "--host-resolver-rules=MAP * 127.0.0.1" ];
   };
 };
 
@@ -168,10 +177,12 @@ gpu.nvidia = {
 # binary reads this variable itself (AppendExtraArgumentsToCommandLine in
 # chrome/app/chrome_main_linux.cc), so no per-package wiring is needed. Add Chromium
 # flags through system76.gpu.chromeExtraFlags; the render-node flag is always appended
-# last, and Chromium keeps the last occurrence of a repeated switch.
+# last, and Chromium keeps the last occurrence of a repeated switch. Chromium re-splits
+# the variable on whitespace, so quoteFlag quotes any entry that contains whitespace to
+# keep one list entry as one argument.
 # libva uses the same Intel Quick Sync node and iHD driver for every VA-API consumer.
 environment.sessionVariables = {
-  CHROME_EXTRA_FLAGS = lib.mkDefault (lib.concatStringsSep " " (
+  CHROME_EXTRA_FLAGS = lib.mkDefault (lib.concatMapStringsSep " " quoteFlag (
     config.system76.gpu.chromeExtraFlags
     ++ [ "--hardware-video-device-path=${config.system76.gpu.videoDecodeDevice}" ]
   ));

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -178,8 +178,10 @@ gpu.nvidia = {
 # chrome/app/chrome_main_linux.cc), so no per-package wiring is needed. Add Chromium
 # flags through system76.gpu.chromeExtraFlags; the render-node flag is always appended
 # last, and Chromium keeps the last occurrence of a repeated switch. Chromium re-splits
-# the variable on whitespace, so quoteFlag quotes any entry that contains whitespace to
-# keep one list entry as one argument.
+# the variable on whitespace, so quoteFlag single-quotes any entry that contains
+# whitespace to keep one list entry as one argument. The quote is single because
+# sessionVariables render into /etc/pam/environment as NAME DEFAULT="<value>", where a
+# double quote would close the value early.
 # libva uses the same Intel Quick Sync node and iHD driver for every VA-API consumer.
 environment.sessionVariables = {
   CHROME_EXTRA_FLAGS = lib.mkDefault (lib.concatMapStringsSep " " quoteFlag (

--- a/docs/system76/system76-configuration.md
+++ b/docs/system76/system76-configuration.md
@@ -137,6 +137,14 @@ options.system76.gpu = {
       chassis uses a non-standard device path.
     '';
   };
+  chromeExtraFlags = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = [ ];
+    description = ''
+      Additional Chromium flags exported through `CHROME_EXTRA_FLAGS`. The required
+      render-node flag is prepended automatically.
+    '';
+  };
 };
 
 gpu.nvidia = {
@@ -153,11 +161,14 @@ gpu.nvidia = {
 
 # Chromium matches its VA-API node to the GPU it renders on and rejects nvidia-drm
 # (crbug.com/1492880), so point it at the Intel node in either GPU mode. The browsers
-# read this variable directly; no per-package wiring is needed.
+# read this variable directly; no per-package wiring is needed. Add Chromium flags
+# through system76.gpu.chromeExtraFlags; the render-node flag is always prepended.
 # libva uses the same Intel Quick Sync node and iHD driver for every VA-API consumer.
 environment.sessionVariables = {
-  CHROME_EXTRA_FLAGS =
-    lib.mkDefault "--hardware-video-device-path=${config.system76.gpu.videoDecodeDevice}";
+  CHROME_EXTRA_FLAGS = lib.mkDefault (lib.concatStringsSep " " (
+    [ "--hardware-video-device-path=${config.system76.gpu.videoDecodeDevice}" ]
+    ++ config.system76.gpu.chromeExtraFlags
+  ));
   LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
   LIBVA_DRM_DEVICE = lib.mkDefault config.system76.gpu.videoDecodeDevice;
 };

--- a/modules/system76/nvidia-gpu-checks.nix
+++ b/modules/system76/nvidia-gpu-checks.nix
@@ -1,0 +1,83 @@
+# system76.gpu.intelBusId -> videoDecodeDevice (modules/system76/nvidia-gpu.nix) has
+# regressed twice within this PR on bus/domain bounds alone, with `nix flake check`
+# staying green each time, because no host overrides intelBusId away from its
+# default so no eval ever exercised a boundary value. This forces the boundary
+# table through the already-public option surface via extendModules, the same
+# technique modules/configurations/nixos.nix uses for its fleet-key check, so no
+# source hoist out of the host module's `let` is needed.
+{ config, lib, ... }:
+let
+  system76 =
+    config.flake.nixosConfigurations.system76
+      or (throw "modules/system76/nvidia-gpu-checks.nix: flake.nixosConfigurations.system76 is missing");
+
+  videoDecodeDeviceFor =
+    intelBusId:
+    builtins.tryEval
+      (system76.extendModules { modules = [ { system76.gpu.intelBusId = intelBusId; } ]; })
+      .config.system76.gpu.videoDecodeDevice;
+
+  # Golden values captured from the current, reviewed derivation: the domain-0
+  # default, an explicit non-zero domain, a domain widened past 0xffff, and the
+  # three PCI field maxima (bus 255, device 31, function 7).
+  acceptCases = {
+    "PCI:0:2:0" = "/dev/dri/by-path/pci-0000:00:02.0-render";
+    "PCI:2@1:3:4" = "/dev/dri/by-path/pci-0001:02:03.4-render";
+    "PCI:0@65536:2:0" = "/dev/dri/by-path/pci-10000:00:02.0-render";
+    "PCI:255:2:0" = "/dev/dri/by-path/pci-0000:ff:02.0-render";
+    "PCI:0:31:0" = "/dev/dri/by-path/pci-0000:00:1f.0-render";
+    "PCI:0:2:7" = "/dev/dri/by-path/pci-0000:00:02.7-render";
+  };
+
+  # One past the bus and device maxima, and past the regex's own function digit.
+  rejectCases = [
+    "PCI:256:2:0"
+    "PCI:0:32:0"
+    "PCI:0:2:9"
+  ];
+
+  acceptResults = lib.mapAttrs (_intelBusId: expected: {
+    inherit expected;
+    actual = videoDecodeDeviceFor _intelBusId;
+  }) acceptCases;
+
+  acceptFailures = lib.filterAttrs (
+    _intelBusId: r: !r.actual.success || r.actual.value != r.expected
+  ) acceptResults;
+
+  rejectFailures = builtins.filter (
+    intelBusId: (videoDecodeDeviceFor intelBusId).success
+  ) rejectCases;
+
+  acceptFailureLines = lib.mapAttrsToList (
+    intelBusId: r:
+    "  ${intelBusId}: expected ${r.expected}, got "
+    + (if r.actual.success then r.actual.value else "<eval failure>")
+  ) acceptFailures;
+
+  rejectFailureLines = map (
+    intelBusId: "  ${intelBusId}: expected to fail evaluation but succeeded"
+  ) rejectFailures;
+
+  failureLines = acceptFailureLines ++ rejectFailureLines;
+in
+{
+  perSystem =
+    { pkgs, ... }:
+    {
+      checks.system76-video-decode-device =
+        # throw, not a failing derivation: CI forces this check's drvPath with
+        # `nix eval` and never builds checks, so only an eval-time failure gates
+        # CI (same rationale as modules/hosts/common/checks.nix).
+        if failureLines != [ ] then
+          throw (
+            "system76-video-decode-device: system76.gpu.intelBusId -> videoDecodeDevice "
+            + "boundary table regressed:\n"
+            + lib.concatStringsSep "\n" failureLines
+          )
+        else
+          pkgs.runCommandLocal "system76-video-decode-device-ok" { } ''
+            echo "ok: system76.gpu.intelBusId -> videoDecodeDevice boundary table matches" > $out
+          '';
+    };
+}

--- a/modules/system76/nvidia-gpu-checks.nix
+++ b/modules/system76/nvidia-gpu-checks.nix
@@ -100,6 +100,47 @@ let
     + chromeExtraFlagsFor case.flags
   ) chromeFailures;
 
+  # This PR's central change is moving CHROME_EXTRA_FLAGS/LIBVA_DRM_DEVICE/
+  # LIBVA_DRIVER_NAME out of lib.mkIf (mode == "nvidia-only") so hybrid-sync gets
+  # the same Intel routing. Every case above reads through the unmodified host
+  # config, and modules/system76/hardware-config.nix pins that host to
+  # mode = "nvidia-only", so none of them would notice a future edit that
+  # re-wraps the block in that mkIf: hybrid-sync is the option's own default and
+  # is never otherwise evaluated here.
+  sessionVariablesForMode =
+    mode:
+    let
+      vars =
+        (system76.extendModules { modules = [ { system76.gpu.mode = lib.mkForce mode; } ]; })
+        .config.environment.sessionVariables;
+    in
+    {
+      inherit (vars) CHROME_EXTRA_FLAGS LIBVA_DRM_DEVICE LIBVA_DRIVER_NAME;
+    };
+
+  expectedSessionVariables = {
+    CHROME_EXTRA_FLAGS = defaultRenderFlag;
+    LIBVA_DRM_DEVICE = "/dev/dri/by-path/pci-0000:00:02.0-render";
+    LIBVA_DRIVER_NAME = "iHD";
+  };
+
+  modeFailureLines =
+    lib.concatMap
+      (
+        mode:
+        let
+          vars = sessionVariablesForMode mode;
+          mismatched = lib.filterAttrs (name: expected: vars.${name} != expected) expectedSessionVariables;
+        in
+        lib.mapAttrsToList (
+          name: expected: "  mode ${mode}: ${name} expected ${expected}, got ${vars.${name}}"
+        ) mismatched
+      )
+      [
+        "hybrid-sync"
+        "nvidia-only"
+      ];
+
   # The reject half of the encoder (does a bad entry fail the module's assertion)
   # is deliberately NOT tested here: it would require scanning config.assertions,
   # a ~2925-entry whole-system list, for this module's own entry, and there is no
@@ -136,7 +177,7 @@ let
     intelBusId: "  ${intelBusId}: expected to fail evaluation but succeeded"
   ) rejectFailures;
 
-  failureLines = acceptFailureLines ++ rejectFailureLines ++ chromeFailureLines;
+  failureLines = acceptFailureLines ++ rejectFailureLines ++ chromeFailureLines ++ modeFailureLines;
 in
 {
   perSystem =
@@ -149,12 +190,13 @@ in
         if failureLines != [ ] then
           throw (
             "system76-video-decode-device: system76.gpu derivation regressed "
-            + "(videoDecodeDevice boundary table and/or CHROME_EXTRA_FLAGS encoding):\n"
+            + "(videoDecodeDevice boundary table, CHROME_EXTRA_FLAGS encoding, "
+            + "and/or hybrid-sync/nvidia-only routing parity):\n"
             + lib.concatStringsSep "\n" failureLines
           )
         else
           pkgs.runCommandLocal "system76-video-decode-device-ok" { } ''
-            echo "ok: system76.gpu videoDecodeDevice boundary table and CHROME_EXTRA_FLAGS encoding match" > $out
+            echo "ok: system76.gpu videoDecodeDevice boundary table, CHROME_EXTRA_FLAGS encoding, and mode routing match" > $out
           '';
     };
 }

--- a/modules/system76/nvidia-gpu-checks.nix
+++ b/modules/system76/nvidia-gpu-checks.nix
@@ -1,10 +1,14 @@
-# system76.gpu.intelBusId -> videoDecodeDevice (modules/system76/nvidia-gpu.nix) has
-# regressed twice within this PR on bus/domain bounds alone, with `nix flake check`
-# staying green each time, because no host overrides intelBusId away from its
-# default so no eval ever exercised a boundary value. This forces the boundary
-# table through the already-public option surface via extendModules, the same
-# technique modules/configurations/nixos.nix uses for its fleet-key check, so no
-# source hoist out of the host module's `let` is needed.
+# The two new branches modules/system76/nvidia-gpu.nix added (the intelBusId ->
+# videoDecodeDevice bus/domain arithmetic, and the CHROME_EXTRA_FLAGS quote/append
+# encoder) have each regressed twice within this PR, both times with `nix flake
+# check` staying green: bus/domain bounds (2a28268d, then 5c3cad05 after review
+# found bus > 255 still aborted inside lib.fixedWidthString naming lib instead of
+# the option), and the encoder (dba4c22f double quote, 76a4c847 line break). No
+# host overrides intelBusId or chromeExtraFlags away from their defaults, so no
+# eval has ever exercised either branch beyond its default input. This forces both
+# through the already-public option surface via extendModules, the same technique
+# modules/configurations/nixos.nix uses for its fleet-key check, so no source
+# hoist out of the host module's `let` is needed.
 { config, lib, ... }:
 let
   system76 =
@@ -41,6 +45,50 @@ let
     "PCI:0:2:9"
   ];
 
+  # The CHROME_EXTRA_FLAGS encoder is the other new branch in nvidia-gpu.nix, and it
+  # has corrupted /etc/pam/environment twice in this PR (double quote in dba4c22f,
+  # then an embedded line break in 76a4c847). Reading the rendered variable back
+  # through the same extendModules handle pins the encoding and the append-last
+  # ordering (d6007d14) without forcing config.assertions, which is a whole-system
+  # list and would drag in unrelated modules' entries.
+  chromeExtraFlagsFor =
+    flags:
+    (system76.extendModules { modules = [ { system76.gpu.chromeExtraFlags = flags; } ]; })
+    .config.environment.sessionVariables.CHROME_EXTRA_FLAGS;
+
+  defaultRenderFlag = "--hardware-video-device-path=/dev/dri/by-path/pci-0000:00:02.0-render";
+
+  chromeFlagCases = [
+    {
+      flags = [ ];
+      expected = defaultRenderFlag;
+    }
+    {
+      flags = [ "--ozone-platform-hint=auto" ];
+      expected = "--ozone-platform-hint=auto ${defaultRenderFlag}";
+    }
+    {
+      flags = [ "--host-resolver-rules=MAP * 127.0.0.1" ];
+      expected = "'--host-resolver-rules=MAP * 127.0.0.1' ${defaultRenderFlag}";
+    }
+    {
+      # The derived flag must still win last-occurrence over a same-named
+      # user-supplied entry: the ordering d6007d14 fixed.
+      flags = [ "--hardware-video-device-path=/tmp/other" ];
+      expected = "--hardware-video-device-path=/tmp/other ${defaultRenderFlag}";
+    }
+  ];
+
+  chromeFailures = builtins.filter (
+    case: chromeExtraFlagsFor case.flags != case.expected
+  ) chromeFlagCases;
+
+  chromeFailureLines = map (
+    case:
+    "  chromeExtraFlags ${builtins.toJSON case.flags}: expected ${case.expected}, got "
+    + chromeExtraFlagsFor case.flags
+  ) chromeFailures;
+
   acceptFailures = lib.filterAttrs (
     intelBusId: expected: videoDecodeDeviceFor intelBusId != expected
   ) acceptCases;
@@ -58,7 +106,7 @@ let
     intelBusId: "  ${intelBusId}: expected to fail evaluation but succeeded"
   ) rejectFailures;
 
-  failureLines = acceptFailureLines ++ rejectFailureLines;
+  failureLines = acceptFailureLines ++ rejectFailureLines ++ chromeFailureLines;
 in
 {
   perSystem =
@@ -70,13 +118,13 @@ in
         # CI (same rationale as modules/hosts/common/checks.nix).
         if failureLines != [ ] then
           throw (
-            "system76-video-decode-device: system76.gpu.intelBusId -> videoDecodeDevice "
-            + "boundary table regressed:\n"
+            "system76-video-decode-device: system76.gpu derivation regressed "
+            + "(videoDecodeDevice boundary table and/or CHROME_EXTRA_FLAGS encoding):\n"
             + lib.concatStringsSep "\n" failureLines
           )
         else
           pkgs.runCommandLocal "system76-video-decode-device-ok" { } ''
-            echo "ok: system76.gpu.intelBusId -> videoDecodeDevice boundary table matches" > $out
+            echo "ok: system76.gpu videoDecodeDevice boundary table and CHROME_EXTRA_FLAGS encoding match" > $out
           '';
     };
 }

--- a/modules/system76/nvidia-gpu-checks.nix
+++ b/modules/system76/nvidia-gpu-checks.nix
@@ -90,14 +90,15 @@ let
     }
   ];
 
-  chromeFailures = builtins.filter (
-    case: chromeExtraFlagsFor case.flags != case.expected
-  ) chromeFlagCases;
+  # Reuse each extendModules result for comparison and failure formatting so a
+  # failing case is not evaluated a second time while constructing diagnostics.
+  chromeResults = map (case: case // { actual = chromeExtraFlagsFor case.flags; }) chromeFlagCases;
+
+  chromeFailures = builtins.filter (case: case.actual != case.expected) chromeResults;
 
   chromeFailureLines = map (
     case:
-    "  chromeExtraFlags ${builtins.toJSON case.flags}: expected ${case.expected}, got "
-    + chromeExtraFlagsFor case.flags
+    "  chromeExtraFlags ${builtins.toJSON case.flags}: expected ${case.expected}, got " + case.actual
   ) chromeFailures;
 
   # This PR's central change is moving CHROME_EXTRA_FLAGS/LIBVA_DRM_DEVICE/
@@ -114,9 +115,13 @@ let
         (system76.extendModules { modules = [ { system76.gpu.mode = lib.mkForce mode; } ]; })
         .config.environment.sessionVariables;
     in
-    {
-      inherit (vars) CHROME_EXTRA_FLAGS LIBVA_DRM_DEVICE LIBVA_DRIVER_NAME;
-    };
+    # Preserve the check's own diagnostic when a mode-specific edit removes one
+    # of these variables instead of failing on a raw missing-attribute error.
+    lib.genAttrs [
+      "CHROME_EXTRA_FLAGS"
+      "LIBVA_DRM_DEVICE"
+      "LIBVA_DRIVER_NAME"
+    ] (name: vars.${name} or "<unset>");
 
   expectedSessionVariables = {
     CHROME_EXTRA_FLAGS = defaultRenderFlag;
@@ -160,8 +165,11 @@ let
   # nvidia-gpu.nix's own eval-time assertion, which does fail loudly for a real
   # configuration; what is not safely re-verifiable from here is that the
   # assertion still fires, independent of re-reading the whole system's list.
+  # Reuse each extendModules result for comparison and failure formatting so a
+  # failing case is not evaluated a second time while constructing diagnostics.
+  acceptResults = lib.mapAttrs (intelBusId: _: videoDecodeDeviceFor intelBusId) acceptCases;
   acceptFailures = lib.filterAttrs (
-    intelBusId: expected: videoDecodeDeviceFor intelBusId != expected
+    intelBusId: expected: acceptResults.${intelBusId} != expected
   ) acceptCases;
 
   rejectFailures = builtins.filter (
@@ -169,8 +177,7 @@ let
   ) rejectCases;
 
   acceptFailureLines = lib.mapAttrsToList (
-    intelBusId: expected:
-    "  ${intelBusId}: expected ${expected}, got ${videoDecodeDeviceFor intelBusId}"
+    intelBusId: expected: "  ${intelBusId}: expected ${expected}, got ${acceptResults.${intelBusId}}"
   ) acceptFailures;
 
   rejectFailureLines = map (

--- a/modules/system76/nvidia-gpu-checks.nix
+++ b/modules/system76/nvidia-gpu-checks.nix
@@ -6,12 +6,20 @@
 # the option), and the encoder (dba4c22f double quote, 76a4c847 line break). No
 # host overrides intelBusId or chromeExtraFlags away from their defaults, so no
 # eval has ever exercised either branch beyond its default input. This forces both
-# through the already-public option surface via extendModules, the same technique
-# modules/configurations/nixos.nix uses for its fleet-key check, so no source
-# hoist out of the host module's `let` is needed. The accepted encoding
-# (config.environment.sessionVariables.CHROME_EXTRA_FLAGS) is covered below; see
-# the note before acceptFailures for why the rejected half (config.assertions)
-# is not.
+# through the already-public option surface via extendModules, so no source hoist
+# out of the host module's `let` is needed. This is not the technique
+# modules/configurations/nixos.nix uses for its fleet-key check: that one reads
+# nixos.config.services.openssh.publicKey off an already-constructed
+# nixosConfigurations entry and never calls extendModules, and
+# modules/hosts/common/checks.nix deliberately stays at flake.lib level to avoid
+# the infinite recursion that arises from reading a host module back from a
+# flake-level check. This file is safe from that specific recursion only because
+# it reads config.flake.nixosConfigurations, which this file does not itself
+# contribute to (contrast: hosts-common's hazard is a common module reading back
+# config.configurations.nixos.<host>.module, an option it also writes into). The
+# accepted encoding (config.environment.sessionVariables.CHROME_EXTRA_FLAGS) is
+# covered below; see the note before acceptFailures for why the rejected half
+# (config.assertions) is not.
 { config, lib, ... }:
 let
   system76 =

--- a/modules/system76/nvidia-gpu-checks.nix
+++ b/modules/system76/nvidia-gpu-checks.nix
@@ -13,9 +13,14 @@ let
 
   videoDecodeDeviceFor =
     intelBusId:
-    builtins.tryEval
-      (system76.extendModules { modules = [ { system76.gpu.intelBusId = intelBusId; } ]; })
-      .config.system76.gpu.videoDecodeDevice;
+    (system76.extendModules { modules = [ { system76.gpu.intelBusId = intelBusId; } ]; })
+    .config.system76.gpu.videoDecodeDevice;
+
+  # tryEval only where a failure is the expected outcome (the reject rows below):
+  # wrapping the accept rows in tryEval would also swallow an unrelated eval error
+  # anywhere in the system76 closure, reporting it as "<eval failure>" and making
+  # the reject rows pass vacuously instead of surfacing the real break.
+  videoDecodeDeviceTryFor = intelBusId: builtins.tryEval (videoDecodeDeviceFor intelBusId);
 
   # Golden values captured from the current, reviewed derivation: the domain-0
   # default, an explicit non-zero domain, a domain widened past 0xffff, and the
@@ -36,23 +41,17 @@ let
     "PCI:0:2:9"
   ];
 
-  acceptResults = lib.mapAttrs (_intelBusId: expected: {
-    inherit expected;
-    actual = videoDecodeDeviceFor _intelBusId;
-  }) acceptCases;
-
   acceptFailures = lib.filterAttrs (
-    _intelBusId: r: !r.actual.success || r.actual.value != r.expected
-  ) acceptResults;
+    intelBusId: expected: videoDecodeDeviceFor intelBusId != expected
+  ) acceptCases;
 
   rejectFailures = builtins.filter (
-    intelBusId: (videoDecodeDeviceFor intelBusId).success
+    intelBusId: (videoDecodeDeviceTryFor intelBusId).success
   ) rejectCases;
 
   acceptFailureLines = lib.mapAttrsToList (
-    intelBusId: r:
-    "  ${intelBusId}: expected ${r.expected}, got "
-    + (if r.actual.success then r.actual.value else "<eval failure>")
+    intelBusId: expected:
+    "  ${intelBusId}: expected ${expected}, got ${videoDecodeDeviceFor intelBusId}"
   ) acceptFailures;
 
   rejectFailureLines = map (

--- a/modules/system76/nvidia-gpu-checks.nix
+++ b/modules/system76/nvidia-gpu-checks.nix
@@ -8,7 +8,10 @@
 # eval has ever exercised either branch beyond its default input. This forces both
 # through the already-public option surface via extendModules, the same technique
 # modules/configurations/nixos.nix uses for its fleet-key check, so no source
-# hoist out of the host module's `let` is needed.
+# hoist out of the host module's `let` is needed. The accepted encoding
+# (config.environment.sessionVariables.CHROME_EXTRA_FLAGS) is covered below; see
+# the note before acceptFailures for why the rejected half (config.assertions)
+# is not.
 { config, lib, ... }:
 let
   system76 =
@@ -89,6 +92,25 @@ let
     + chromeExtraFlagsFor case.flags
   ) chromeFailures;
 
+  # The reject half of the encoder (does a bad entry fail the module's assertion)
+  # is deliberately NOT tested here: it would require scanning config.assertions,
+  # a ~2925-entry whole-system list, for this module's own entry, and there is no
+  # safe way to probe an arbitrary unrelated entry in that list. tryEval only
+  # catches AssertionError, i.e. throw/assert (lix/libexpr/primops.cc's
+  # prim_tryEval: `catch (AssertionError & e) { return false; }`), not EvalError
+  # classes like a missing attribute. At least one real entry in this repo's
+  # closure needs the latter: nixos/modules/tasks/filesystems.nix's fileSystems
+  # cycle check has `message = "... ${fileSystems'.cycle} ...";`, safe only once
+  # `assertion` is already known false, and forcing it in the untriggered case
+  # (as any prefix- or content-based scan over the full list must, to rule entries
+  # out) throws "attribute 'cycle' missing" uncaught by tryEval, reproduced
+  # empirically against this exact list. No operand order or per-entry tryEval
+  # wrapping avoids this: both `.assertion` and `.message` can be the unsafe
+  # field, and unsafe-when-forced is exactly the failure mode tryEval cannot
+  # catch. Quote, line-break, and expansion-character rejection remain covered by
+  # nvidia-gpu.nix's own eval-time assertion, which does fail loudly for a real
+  # configuration; what is not safely re-verifiable from here is that the
+  # assertion still fires, independent of re-reading the whole system's list.
   acceptFailures = lib.filterAttrs (
     intelBusId: expected: videoDecodeDeviceFor intelBusId != expected
   ) acceptCases;

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -45,21 +45,6 @@ _: {
             because renderD numbering follows driver probe order, not the PCI slot.
           '';
         };
-
-        videoDecodeElectronApps = lib.mkOption {
-          type = lib.types.listOf lib.types.str;
-          default = [
-            "discord"
-            "signal-desktop"
-          ];
-          example = [ "element-desktop" ];
-          description = ''
-            Electron packages wrapped so `videoDecodeDevice` reaches argv. Electron
-            honours no environment variable that injects Chromium switches, so unlike
-            the browsers it cannot pick the node up from `CHROME_EXTRA_FLAGS`. Naming
-            a package here is the only edit needed to cover it.
-          '';
-        };
       };
 
       config = lib.mkMerge [
@@ -100,37 +85,6 @@ _: {
           # iGPU node restores hardware decode. The browsers read this variable
           # themselves, which covers new ones without any per-package wiring.
           environment.sessionVariables.CHROME_EXTRA_FLAGS = lib.mkDefault videoDeviceFlag;
-
-          nixpkgs.overlays = [
-            (
-              final: prev:
-              lib.genAttrs cfg.videoDecodeElectronApps (
-                name:
-                let
-                  base = prev.${name};
-                in
-                # symlinkJoin keeps this a thin wrapper: overriding electron_* instead
-                # would rebuild every dependent from source and still miss the apps
-                # that vendor their own Electron.
-                final.symlinkJoin {
-                  name = "${name}-vaapi-device";
-                  # lib.getName drives the unfree predicate, so the wrapper has to
-                  # keep the wrapped package's pname or the allowlist stops matching.
-                  pname = lib.getName base;
-                  inherit (base) version;
-                  paths = [ base ];
-                  nativeBuildInputs = [ final.makeWrapper ];
-                  meta = base.meta or { };
-                  postBuild = ''
-                    for bin in "$out"/bin/*; do
-                      [ -e "$bin" ] || continue
-                      wrapProgram "$bin" --add-flags ${lib.escapeShellArg videoDeviceFlag}
-                    done
-                  '';
-                }
-              )
-            )
-          ];
         }
 
         (lib.mkIf (cfg.mode == "nvidia-only") {

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -42,8 +42,12 @@ _: {
       # a quoted whole token and trims the outer quotes, so quoting keeps one list
       # entry as exactly one argument. A quote character inside an entry has no
       # representation, hence the assertion below.
+      # The quote is single, not double: sessionVariables land in /etc/pam/environment
+      # as NAME DEFAULT="<value>", which the generator interpolates unescaped, so a
+      # double quote would close that value early and truncate the line. Chromium's
+      # tokenizer accepts either (set_quote_chars("\"'")), and ' is inert in that file.
       hasQuote = flag: builtins.match ".*[\"'].*" flag != null;
-      quoteFlag = flag: if builtins.match ".*[[:space:]].*" flag == null then flag else ''"${flag}"'';
+      quoteFlag = flag: if builtins.match ".*[[:space:]].*" flag == null then flag else "'${flag}'";
       unquotableFlags = lib.filter hasQuote (cfg.chromeExtraFlags ++ [ videoDeviceFlag ]);
     in
     {
@@ -125,8 +129,9 @@ _: {
           {
             assertion = unquotableFlags == [ ];
             message =
-              "system76.gpu.chromeExtraFlags: entries are quoted into CHROME_EXTRA_FLAGS, "
-              + "so none may contain a quote character. Offending entries: "
+              "system76.gpu: entries are quoted into CHROME_EXTRA_FLAGS, so neither "
+              + "chromeExtraFlags nor the flag derived from videoDecodeDevice may "
+              + "contain a quote character. Offending entries: "
               + lib.concatStringsSep ", " unquotableFlags;
           }
         ];

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -5,24 +5,38 @@ _: {
       cfg = config.system76.gpu;
       intelBusFields =
         let
-          matched = builtins.match "PCI:([0-9]{1,3})(@([0-9]{1,10}))?:([0-9]{1,2}):([0-9])" cfg.intelBusId;
+          matched = builtins.match "PCI:([0-9]{1,3})(@([0-9]{1,10}))?:([0-9]{1,2}):([0-7])" cfg.intelBusId;
+          fields =
+            if matched == null then
+              null
+            else
+              {
+                bus = lib.toIntBase10 (lib.elemAt matched 0);
+                domain = if lib.elemAt matched 2 == null then 0 else lib.toIntBase10 (lib.elemAt matched 2);
+                device = lib.toIntBase10 (lib.elemAt matched 3);
+                function = lib.toIntBase10 (lib.elemAt matched 4);
+              };
         in
-        if matched == null then
+        # Check ranges, not just digit counts: a field that parses but overflows its
+        # PCI width would otherwise abort inside lib.fixedWidthString, naming lib
+        # rather than the option that carries the bad value.
+        if fields == null || fields.bus > 255 || fields.device > 31 then
           throw (
             "system76.gpu.intelBusId: expected decimal PCI:bus[@domain]:device:function "
-            + "with bus 1-3 digits, optional domain 1-10 digits, device 1-2 digits, "
-            + "and function 1 digit, got '${cfg.intelBusId}'"
+            + "with bus 0-255, device 0-31, function 0-7, and an optional domain, "
+            + "got '${cfg.intelBusId}'"
           )
         else
-          {
-            bus = lib.elemAt matched 0;
-            domain = if lib.elemAt matched 2 == null then "0" else lib.elemAt matched 2;
-            device = lib.elemAt matched 3;
-            function = lib.elemAt matched 4;
-          };
-      intelBusHex = part: lib.toLower (lib.toHexString (lib.toIntBase10 part));
-      intelBusHexPadded = part: lib.fixedWidthString 2 "0" (intelBusHex part);
-      intelDomainHexPadded = part: lib.fixedWidthString 4 "0" (intelBusHex part);
+          fields;
+      # sysfs names a PCI device "%04x:%02x:%02x.%d". Those widths are minimums, so a
+      # domain above 0xffff widens its field instead of being rejected, and the
+      # function stays decimal.
+      intelBusPadded =
+        width: part:
+        let
+          hex = lib.toLower (lib.toHexString part);
+        in
+        if lib.stringLength hex >= width then hex else lib.fixedWidthString width "0" hex;
       videoDeviceFlag = "--hardware-video-device-path=${cfg.videoDecodeDevice}";
     in
     {
@@ -43,7 +57,9 @@ _: {
           description = ''
             PCI address for the Intel iGPU, in Xorg's decimal
             `PCI:bus@domain:device:function` form; the domain may be omitted when it
-            is 0. Used for PRIME sync when `mode = "hybrid-sync"`, and as the source
+            is 0. Fields are range-checked against their PCI widths: bus 0-255,
+            device 0-31, function 0-7, and any domain. Used for PRIME sync when
+            `mode = "hybrid-sync"`, and as the source
             of the `videoDecodeDevice` default in both modes. Unless
             `videoDecodeDevice` is overridden explicitly, an incorrect value can point
             the default Chromium and libva routing at the wrong render node and make
@@ -66,8 +82,8 @@ _: {
         videoDecodeDevice = lib.mkOption {
           type = lib.types.str;
           default =
-            "/dev/dri/by-path/pci-${intelDomainHexPadded intelBusFields.domain}:${intelBusHexPadded intelBusFields.bus}"
-            + ":${intelBusHexPadded intelBusFields.device}.${intelBusHex intelBusFields.function}-render";
+            "/dev/dri/by-path/pci-${intelBusPadded 4 intelBusFields.domain}:${intelBusPadded 2 intelBusFields.bus}"
+            + ":${intelBusPadded 2 intelBusFields.device}.${toString intelBusFields.function}-render";
           defaultText = lib.literalExpression ''"/dev/dri/by-path/pci-<intelBusId as a sysfs address>-render"'';
           example = "/dev/dri/renderD128";
           description = ''

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -3,6 +3,7 @@ _: {
     { config, lib, ... }:
     let
       cfg = config.system76.gpu;
+      videoDeviceFlag = "--hardware-video-device-path=${cfg.videoDecodeDevice}";
     in
     {
       options.system76.gpu = {
@@ -32,6 +33,31 @@ _: {
           description = ''
             PCI address for the NVIDIA dGPU when PRIME sync is enabled. Override if
             `lspci -nn | grep NVIDIA` reports a different slot.
+          '';
+        };
+
+        videoDecodeDevice = lib.mkOption {
+          type = lib.types.str;
+          default = "/dev/dri/by-path/pci-0000:00:02.0-render";
+          example = "/dev/dri/renderD128";
+          description = ''
+            Intel render node offered to VA-API consumers. The by-path form is stable
+            because renderD numbering follows driver probe order, not the PCI slot.
+          '';
+        };
+
+        videoDecodeElectronApps = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [
+            "discord"
+            "signal-desktop"
+          ];
+          example = [ "element-desktop" ];
+          description = ''
+            Electron packages wrapped so `videoDecodeDevice` reaches argv. Electron
+            honours no environment variable that injects Chromium switches, so unlike
+            the browsers it cannot pick the node up from `CHROME_EXTRA_FLAGS`. Naming
+            a package here is the only edit needed to cover it.
           '';
         };
       };
@@ -66,6 +92,45 @@ _: {
               inherit (cfg) intelBusId nvidiaBusId;
             };
           };
+
+          # Chromium picks a VA-API render node by matching whichever GPU it renders
+          # on, then rejects nvidia-drm outright (crbug.com/1492880). NVIDIA renders in
+          # both modes here, so the match lands on the dGPU, the pre-sandbox VA-API
+          # init finds nothing, and every Chromium app decodes in software. Naming the
+          # iGPU node restores hardware decode. The browsers read this variable
+          # themselves, which covers new ones without any per-package wiring.
+          environment.sessionVariables.CHROME_EXTRA_FLAGS = lib.mkDefault videoDeviceFlag;
+
+          nixpkgs.overlays = [
+            (
+              final: prev:
+              lib.genAttrs cfg.videoDecodeElectronApps (
+                name:
+                let
+                  base = prev.${name};
+                in
+                # symlinkJoin keeps this a thin wrapper: overriding electron_* instead
+                # would rebuild every dependent from source and still miss the apps
+                # that vendor their own Electron.
+                final.symlinkJoin {
+                  name = "${name}-vaapi-device";
+                  # lib.getName drives the unfree predicate, so the wrapper has to
+                  # keep the wrapped package's pname or the allowlist stops matching.
+                  pname = lib.getName base;
+                  inherit (base) version;
+                  paths = [ base ];
+                  nativeBuildInputs = [ final.makeWrapper ];
+                  meta = base.meta or { };
+                  postBuild = ''
+                    for bin in "$out"/bin/*; do
+                      [ -e "$bin" ] || continue
+                      wrapProgram "$bin" --add-flags ${lib.escapeShellArg videoDeviceFlag}
+                    done
+                  '';
+                }
+              )
+            )
+          ];
         }
 
         (lib.mkIf (cfg.mode == "nvidia-only") {
@@ -81,7 +146,7 @@ _: {
           # sessionVariables (PAM-initialised) so GUI apps launched outside a
           # shell inherit the iHD routing, not just terminal-spawned ones.
           environment.sessionVariables = {
-            LIBVA_DRM_DEVICE = lib.mkDefault "/dev/dri/by-path/pci-0000:00:02.0-render";
+            LIBVA_DRM_DEVICE = lib.mkDefault cfg.videoDecodeDevice;
             LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
           };
         })

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -89,9 +89,9 @@ _: {
           description = ''
             Intel render node offered to VA-API consumers. When omitted, the by-path
             default is derived from the decimal Xorg `PCI:bus@domain:device:function`
-            components (with domain 0 when omitted), converted to the hexadecimal sysfs
-            address. The by-path form is stable because renderD numbering follows driver
-            probe order, not the PCI slot.
+            components (with domain 0 when omitted), formatted as sysfs'
+            `%04x:%02x:%02x.%d` address. The by-path form is stable because renderD
+            numbering follows driver probe order, not the PCI slot.
           '';
         };
 
@@ -108,64 +108,62 @@ _: {
         };
       };
 
-      config = lib.mkMerge [
-        {
-          # Blacklist nouveau to avoid conflicts with proprietary NVIDIA driver.
-          # i915 is deliberately absent: internal HDA/SOF audio on this chassis can
-          # depend on Intel graphics-side plumbing even when NVIDIA renders X11, and
-          # the iGPU also backs the only VA-API decode target configured below.
-          boot.blacklistedKernelModules = [ "nouveau" ];
+      config = {
+        # Blacklist nouveau to avoid conflicts with proprietary NVIDIA driver.
+        # i915 is deliberately absent: internal HDA/SOF audio on this chassis can
+        # depend on Intel graphics-side plumbing even when NVIDIA renders X11, and
+        # the iGPU also backs the only VA-API decode target configured below.
+        boot.blacklistedKernelModules = [ "nouveau" ];
 
-          boot.kernelParams = [
-            "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
-            "nvidia.NVreg_EnableGpuFirmware=1"
-          ];
+        boot.kernelParams = [
+          "nvidia.NVreg_PreserveVideoMemoryAllocations=1"
+          "nvidia.NVreg_EnableGpuFirmware=1"
+        ];
 
-          gpu.nvidia = {
-            enable = true;
-            # GTX 1070 Max-Q is supported by the 580.xx legacy branch; newer production drivers ignore it.
-            package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
-            # Pascal predates the open kernel modules.
-            open = false;
-            # nvidia-vaapi-driver's VA-API -> NVDEC handoff faults under decode-context
-            # churn on this chassis: switching videos quickly or reloading stalled
-            # SMB/SFTP streams produces an Xid 31 MMU page fault on ENGINE NVDEC,
-            # hanging the dGPU and freezing the session (the dGPU drives the display
-            # in nvidia-only mode). Intel UHD 630 decodes H.264/HEVC/VP9 in hardware;
-            # AV1 falls back to software. mpv is unaffected because hwdec=auto uses
-            # FFmpeg NVCUVID (nvdec), never libva.
-            vaapi.backend = "intel-media";
-            prime = {
-              # PRIME sync keeps the internal panel on the iGPU while NVIDIA renders.
-              enable = cfg.mode == "hybrid-sync";
-              inherit (cfg) intelBusId nvidiaBusId;
-            };
+        gpu.nvidia = {
+          enable = true;
+          # GTX 1070 Max-Q is supported by the 580.xx legacy branch; newer production drivers ignore it.
+          package = config.boot.kernelPackages.nvidiaPackages.legacy_580;
+          # Pascal predates the open kernel modules.
+          open = false;
+          # nvidia-vaapi-driver's VA-API -> NVDEC handoff faults under decode-context
+          # churn on this chassis: switching videos quickly or reloading stalled
+          # SMB/SFTP streams produces an Xid 31 MMU page fault on ENGINE NVDEC,
+          # hanging the dGPU and freezing the session (the dGPU drives the display
+          # in nvidia-only mode). Intel UHD 630 decodes H.264/HEVC/VP9 in hardware;
+          # AV1 falls back to software. mpv is unaffected because hwdec=auto uses
+          # FFmpeg NVCUVID (nvdec), never libva.
+          vaapi.backend = "intel-media";
+          prime = {
+            # PRIME sync keeps the internal panel on the iGPU while NVIDIA renders.
+            enable = cfg.mode == "hybrid-sync";
+            inherit (cfg) intelBusId nvidiaBusId;
           };
+        };
 
-          # Chromium picks a VA-API render node by matching whichever GPU it renders
-          # on, then rejects nvidia-drm outright (crbug.com/1492880). NVIDIA renders in
-          # both modes here, so the match lands on the dGPU, the pre-sandbox VA-API
-          # init finds nothing, and every Chromium app decodes in software. Naming the
-          # iGPU node restores hardware decode. The browser binary reads this variable
-          # itself (AppendExtraArgumentsToCommandLine in chrome/app/chrome_main_linux.cc,
-          # not a launcher script), which covers new ones without per-package wiring.
-          # It appends onto the parsed command line, so it also outranks the wrapper
-          # --add-flags this repo bakes into its Chromium packages. Chromium keeps the
-          # last occurrence of a repeated switch, hence videoDeviceFlag goes last.
-          # Keep libva on the same Intel node and iHD driver in both modes so non-Chromium
-          # VA-API consumers do not fall back to render-node probe order.
-          # VDPAU_DRIVER is intentionally unset: VDPAU is legacy, and pointing it at
-          # nvidia would route back into the NVDEC path that faults above.
-          # sessionVariables is PAM-initialised, so GUI apps launched outside a shell
-          # inherit this routing too, not just terminal-spawned ones.
-          environment.sessionVariables = {
-            CHROME_EXTRA_FLAGS = lib.mkDefault (
-              lib.concatStringsSep " " (cfg.chromeExtraFlags ++ [ videoDeviceFlag ])
-            );
-            LIBVA_DRM_DEVICE = lib.mkDefault cfg.videoDecodeDevice;
-            LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
-          };
-        }
-      ];
+        # Chromium picks a VA-API render node by matching whichever GPU it renders
+        # on, then rejects nvidia-drm outright (crbug.com/1492880). NVIDIA renders in
+        # both modes here, so the match lands on the dGPU, the pre-sandbox VA-API
+        # init finds nothing, and every Chromium app decodes in software. Naming the
+        # iGPU node restores hardware decode. The browser binary reads this variable
+        # itself (AppendExtraArgumentsToCommandLine in chrome/app/chrome_main_linux.cc,
+        # not a launcher script), which covers new ones without per-package wiring.
+        # It appends onto the parsed command line, so it also outranks the wrapper
+        # --add-flags this repo bakes into its Chromium packages. Chromium keeps the
+        # last occurrence of a repeated switch, hence videoDeviceFlag goes last.
+        # Keep libva on the same Intel node and iHD driver in both modes so non-Chromium
+        # VA-API consumers do not fall back to render-node probe order.
+        # VDPAU_DRIVER is intentionally unset: VDPAU is legacy, and pointing it at
+        # nvidia would route back into the NVDEC path that faults above.
+        # sessionVariables is PAM-initialised, so GUI apps launched outside a shell
+        # inherit this routing too, not just terminal-spawned ones.
+        environment.sessionVariables = {
+          CHROME_EXTRA_FLAGS = lib.mkDefault (
+            lib.concatStringsSep " " (cfg.chromeExtraFlags ++ [ videoDeviceFlag ])
+          );
+          LIBVA_DRM_DEVICE = lib.mkDefault cfg.videoDecodeDevice;
+          LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
+        };
+      };
     };
 }

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -51,8 +51,14 @@ _: {
       # variable), so a raw line break inside a value has no representation either:
       # it would split one record into two and drop everything after it.
       hasLineBreak = flag: builtins.match ".*[\n\r].*" flag != null;
+      # pam_env(8) reads this file as its conffile and expands ${VAR} and @{PAM_ITEM}
+      # inside a DEFAULT= value with no escape for either character (man pam_env.conf);
+      # nixpkgs' own generator relies on this to make $HOME/$USER work in
+      # sessionVariables (nixos/modules/config/system-environment.nix's replaceEnvVars).
+      # An entry carrying $ or @ is rewritten before any browser sees it.
+      hasExpansion = flag: builtins.match ".*[$@].*" flag != null;
       quoteFlag = flag: if builtins.match ".*[[:space:]].*" flag == null then flag else "'${flag}'";
-      unquotableFlags = lib.filter (flag: hasQuote flag || hasLineBreak flag) (
+      unquotableFlags = lib.filter (flag: hasQuote flag || hasLineBreak flag || hasExpansion flag) (
         cfg.chromeExtraFlags ++ [ videoDeviceFlag ]
       );
     in
@@ -124,7 +130,8 @@ _: {
 
             One entry is one argument: entries containing whitespace are quoted, since
             Chromium re-splits the variable on whitespace. An entry containing a quote
-            character or a line break cannot be encoded and fails the assertion.
+            character, a line break, or a `$`/`@` expansion character cannot be encoded
+            and fails the assertion.
           '';
           example = [ "--host-resolver-rules=MAP * 127.0.0.1" ];
         };
@@ -136,8 +143,9 @@ _: {
             assertion = unquotableFlags == [ ];
             message =
               "system76.gpu: entries are quoted into CHROME_EXTRA_FLAGS, so neither "
-              + "chromeExtraFlags nor the flag derived from videoDecodeDevice may "
-              + "contain a quote character or a line break. Offending entries: "
+              + "chromeExtraFlags nor the flag derived from videoDecodeDevice may contain "
+              + "a quote character, a line break, or a $/@ expansion character. "
+              + "Offending entries: "
               + lib.concatStringsSep ", " unquotableFlags;
           }
         ];

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -78,6 +78,16 @@ _: {
             probe order, not the PCI slot.
           '';
         };
+
+        chromeExtraFlags = lib.mkOption {
+          type = lib.types.listOf lib.types.str;
+          default = [ ];
+          description = ''
+            Additional flags exported to Chromium browsers through
+            `CHROME_EXTRA_FLAGS`. The required render-node flag is prepended
+            automatically, so adding flags here cannot disable hardware video decode.
+          '';
+        };
       };
 
       config = lib.mkMerge [
@@ -120,7 +130,9 @@ _: {
           # Keep libva on the same Intel node and iHD driver in both modes so non-Chromium
           # VA-API consumers do not fall back to render-node probe order.
           environment.sessionVariables = {
-            CHROME_EXTRA_FLAGS = lib.mkDefault videoDeviceFlag;
+            CHROME_EXTRA_FLAGS = lib.mkDefault (
+              lib.concatStringsSep " " ([ videoDeviceFlag ] ++ cfg.chromeExtraFlags)
+            );
             LIBVA_DRM_DEVICE = lib.mkDefault cfg.videoDecodeDevice;
             LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
           };

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -51,16 +51,16 @@ _: {
       # variable), so a raw line break inside a value has no representation either:
       # it would split one record into two and drop everything after it.
       hasLineBreak = flag: builtins.match ".*[\n\r].*" flag != null;
-      # pam_env(8) reads this file as its conffile and expands ${VAR} and @{PAM_ITEM}
-      # inside a DEFAULT= value with no escape for either character (man pam_env.conf);
-      # nixpkgs' own generator relies on this to make $HOME/$USER work in
-      # sessionVariables (nixos/modules/config/system-environment.nix's replaceEnvVars).
-      # An entry carrying $ or @ is rewritten before any browser sees it.
+      # pam_env(8) expands ${VAR} and @{PAM_ITEM} inside DEFAULT= values, and
+      # nixpkgs rewrites literal $HOME/$USER for sessionVariables. Bare $ and @ remain
+      # literal, so only those braced forms and literals are rejected.
       hasExpansion = flag: builtins.match ".*([$@][{]|[$](HOME|USER)).*" flag != null;
       quoteFlag = flag: if builtins.match ".*[[:space:]].*" flag == null then flag else "'${flag}'";
+      # pam_env's conffile parser treats # as a comment, so a # inside an entry
+      # truncates that line and drops the derived flag appended after it.
+      hasComment = flag: builtins.match ".*#.*" flag != null;
       unquotableFlags = lib.filter (
-        flag:
-        hasQuote flag || hasLineBreak flag || hasExpansion flag || builtins.match ".*#.*" flag != null
+        flag: hasQuote flag || hasLineBreak flag || hasExpansion flag || hasComment flag
       ) (cfg.chromeExtraFlags ++ [ videoDeviceFlag ]);
     in
     {
@@ -131,8 +131,9 @@ _: {
 
             One entry is one argument: entries containing whitespace are quoted, since
             Chromium re-splits the variable on whitespace. An entry containing a quote
-            character, a line break, or a `$`/`@` expansion character cannot be encoded
-            and fails the assertion.
+            character, a line break, a `#` (pam_env truncates its conffile line at the
+            first one), or a pam_env expansion (a braced `$`/`@` reference, or a
+            literal `$HOME` or `$USER`) cannot be encoded and fails the assertion.
           '';
           example = [ "--host-resolver-rules=MAP * 127.0.0.1" ];
         };
@@ -145,7 +146,8 @@ _: {
             message =
               "system76.gpu: entries are quoted into CHROME_EXTRA_FLAGS, so neither "
               + "chromeExtraFlags nor the flag derived from videoDecodeDevice may contain "
-              + "a quote character, a line break, or a $/@ expansion character. "
+              + "a quote character, a line break, a #, or a pam_env expansion "
+              + "(a braced $/@ reference, or a literal $HOME or $USER). "
               + "Offending entries: "
               + lib.concatStringsSep ", " unquotableFlags;
           }

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -56,7 +56,7 @@ _: {
       # nixpkgs' own generator relies on this to make $HOME/$USER work in
       # sessionVariables (nixos/modules/config/system-environment.nix's replaceEnvVars).
       # An entry carrying $ or @ is rewritten before any browser sees it.
-      hasExpansion = flag: builtins.match ".*[$@].*" flag != null;
+      hasExpansion = flag: builtins.match ".*([$@][{]|[$](HOME|USER)).*" flag != null;
       quoteFlag = flag: if builtins.match ".*[[:space:]].*" flag == null then flag else "'${flag}'";
       unquotableFlags = lib.filter (
         flag:

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -3,6 +3,11 @@ _: {
     { config, lib, ... }:
     let
       cfg = config.system76.gpu;
+      intelBusParts = lib.splitString ":" (lib.removePrefix "PCI:" cfg.intelBusId);
+      intelBusDomainParts = lib.splitString "@" (lib.elemAt intelBusParts 0);
+      intelBusHex = part: lib.toLower (lib.toHexString (lib.toIntBase10 part));
+      intelBusHexPadded = part: lib.fixedWidthString 2 "0" (intelBusHex part);
+      intelDomainHexPadded = part: lib.fixedWidthString 4 "0" (intelBusHex part);
       videoDeviceFlag = "--hardware-video-device-path=${cfg.videoDecodeDevice}";
     in
     {
@@ -21,8 +26,10 @@ _: {
           default = "PCI:0:2:0";
           example = "PCI:0:2:0";
           description = ''
-            PCI address for the Intel iGPU when PRIME sync is enabled. Determine via
-            `lspci -nn | grep VGA` if the default does not match this chassis.
+            PCI address for the Intel iGPU when PRIME sync is enabled, in Xorg's
+            decimal `PCI:bus@domain:device:function` form. Determine the slot via
+            `lspci -nn | grep VGA` and convert its hexadecimal components if the
+            default does not match this chassis. The domain may be omitted when it is 0.
           '';
         };
 
@@ -38,11 +45,21 @@ _: {
 
         videoDecodeDevice = lib.mkOption {
           type = lib.types.str;
-          default = "/dev/dri/by-path/pci-0000:00:02.0-render";
+          default =
+            "/dev/dri/by-path/pci-${
+              intelDomainHexPadded (
+                if builtins.length intelBusDomainParts == 2 then lib.elemAt intelBusDomainParts 1 else "0"
+              )
+            }:${intelBusHexPadded (lib.elemAt intelBusDomainParts 0)}"
+            + ":${intelBusHexPadded (lib.elemAt intelBusParts 1)}.${intelBusHex (lib.elemAt intelBusParts 2)}-render";
+          defaultText = lib.literalExpression ''"/dev/dri/by-path/pci-<intelBusId as a sysfs address>-render"'';
           example = "/dev/dri/renderD128";
           description = ''
-            Intel render node offered to VA-API consumers. The by-path form is stable
-            because renderD numbering follows driver probe order, not the PCI slot.
+            Intel render node offered to VA-API consumers. When omitted, the by-path
+            default is derived from the decimal Xorg `PCI:bus@domain:device:function`
+            components (with domain 0 when omitted), converted to the hexadecimal sysfs
+            address. The by-path form is stable because renderD numbering follows driver
+            probe order, not the PCI slot.
           '';
         };
       };
@@ -84,26 +101,14 @@ _: {
           # init finds nothing, and every Chromium app decodes in software. Naming the
           # iGPU node restores hardware decode. The browsers read this variable
           # themselves, which covers new ones without any per-package wiring.
-          environment.sessionVariables.CHROME_EXTRA_FLAGS = lib.mkDefault videoDeviceFlag;
-        }
-
-        (lib.mkIf (cfg.mode == "nvidia-only") {
-          # Only the dGPU drives displays; PRIME stays disabled via gpu.nvidia.prime.
-
-          # Do not blacklist i915: internal HDA/SOF audio on this chassis can
-          # depend on Intel graphics-side plumbing even when NVIDIA renders X11.
-
-          # Route libva to the Intel render node by stable path so it never opens
-          # the NVIDIA DRM device (see the vaapi.backend note above).
-          # VDPAU_DRIVER is intentionally unset: VDPAU is legacy, and pointing it at
-          # nvidia would route back into NVDEC.
-          # sessionVariables (PAM-initialised) so GUI apps launched outside a
-          # shell inherit the iHD routing, not just terminal-spawned ones.
+          # Keep libva on the same Intel node and iHD driver in both modes so non-Chromium
+          # VA-API consumers do not fall back to render-node probe order.
           environment.sessionVariables = {
+            CHROME_EXTRA_FLAGS = lib.mkDefault videoDeviceFlag;
             LIBVA_DRM_DEVICE = lib.mkDefault cfg.videoDecodeDevice;
             LIBVA_DRIVER_NAME = lib.mkDefault "iHD";
           };
-        })
+        }
       ];
     };
 }

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -38,6 +38,13 @@ _: {
         in
         if lib.stringLength hex >= width then hex else lib.fixedWidthString width "0" hex;
       videoDeviceFlag = "--hardware-video-device-path=${cfg.videoDecodeDevice}";
+      # Chromium re-splits CHROME_EXTRA_FLAGS on whitespace, but its tokenizer honours
+      # a quoted whole token and trims the outer quotes, so quoting keeps one list
+      # entry as exactly one argument. A quote character inside an entry has no
+      # representation, hence the assertion below.
+      hasQuote = flag: builtins.match ".*[\"'].*" flag != null;
+      quoteFlag = flag: if builtins.match ".*[[:space:]].*" flag == null then flag else ''"${flag}"'';
+      unquotableFlags = lib.filter hasQuote (cfg.chromeExtraFlags ++ [ videoDeviceFlag ]);
     in
     {
       options.system76.gpu = {
@@ -85,7 +92,7 @@ _: {
             "/dev/dri/by-path/pci-${intelBusPadded 4 intelBusFields.domain}:${intelBusPadded 2 intelBusFields.bus}"
             + ":${intelBusPadded 2 intelBusFields.device}.${toString intelBusFields.function}-render";
           defaultText = lib.literalExpression ''"/dev/dri/by-path/pci-<intelBusId as a sysfs address>-render"'';
-          example = "/dev/dri/renderD128";
+          example = "/dev/dri/by-path/pci-0000:00:02.0-render";
           description = ''
             Intel render node offered to VA-API consumers. When omitted, the by-path
             default is derived from the decimal Xorg `PCI:bus@domain:device:function`
@@ -104,11 +111,26 @@ _: {
             Chromium keeps the last occurrence of a repeated switch, so flags added
             here cannot displace it. Change the render node through
             `videoDecodeDevice` instead.
+
+            One entry is one argument: entries containing whitespace are quoted, since
+            Chromium re-splits the variable on whitespace. An entry containing a quote
+            character cannot be encoded and fails the assertion.
           '';
+          example = [ "--host-resolver-rules=MAP * 127.0.0.1" ];
         };
       };
 
       config = {
+        assertions = [
+          {
+            assertion = unquotableFlags == [ ];
+            message =
+              "system76.gpu.chromeExtraFlags: entries are quoted into CHROME_EXTRA_FLAGS, "
+              + "so none may contain a quote character. Offending entries: "
+              + lib.concatStringsSep ", " unquotableFlags;
+          }
+        ];
+
         # Blacklist nouveau to avoid conflicts with proprietary NVIDIA driver.
         # i915 is deliberately absent: internal HDA/SOF audio on this chassis can
         # depend on Intel graphics-side plumbing even when NVIDIA renders X11, and
@@ -159,7 +181,7 @@ _: {
         # inherit this routing too, not just terminal-spawned ones.
         environment.sessionVariables = {
           CHROME_EXTRA_FLAGS = lib.mkDefault (
-            lib.concatStringsSep " " (cfg.chromeExtraFlags ++ [ videoDeviceFlag ])
+            lib.concatMapStringsSep " " quoteFlag (cfg.chromeExtraFlags ++ [ videoDeviceFlag ])
           );
           LIBVA_DRM_DEVICE = lib.mkDefault cfg.videoDecodeDevice;
           LIBVA_DRIVER_NAME = lib.mkDefault "iHD";

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -47,8 +47,14 @@ _: {
       # double quote would close that value early and truncate the line. Chromium's
       # tokenizer accepts either (set_quote_chars("\"'")), and ' is inert in that file.
       hasQuote = flag: builtins.match ".*[\"'].*" flag != null;
+      # /etc/pam/environment is line-oriented (one NAME DEFAULT="<value>" record per
+      # variable), so a raw line break inside a value has no representation either:
+      # it would split one record into two and drop everything after it.
+      hasLineBreak = flag: builtins.match ".*[\n\r].*" flag != null;
       quoteFlag = flag: if builtins.match ".*[[:space:]].*" flag == null then flag else "'${flag}'";
-      unquotableFlags = lib.filter hasQuote (cfg.chromeExtraFlags ++ [ videoDeviceFlag ]);
+      unquotableFlags = lib.filter (flag: hasQuote flag || hasLineBreak flag) (
+        cfg.chromeExtraFlags ++ [ videoDeviceFlag ]
+      );
     in
     {
       options.system76.gpu = {
@@ -118,7 +124,7 @@ _: {
 
             One entry is one argument: entries containing whitespace are quoted, since
             Chromium re-splits the variable on whitespace. An entry containing a quote
-            character cannot be encoded and fails the assertion.
+            character or a line break cannot be encoded and fails the assertion.
           '';
           example = [ "--host-resolver-rules=MAP * 127.0.0.1" ];
         };
@@ -131,7 +137,7 @@ _: {
             message =
               "system76.gpu: entries are quoted into CHROME_EXTRA_FLAGS, so neither "
               + "chromeExtraFlags nor the flag derived from videoDecodeDevice may "
-              + "contain a quote character. Offending entries: "
+              + "contain a quote character or a line break. Offending entries: "
               + lib.concatStringsSep ", " unquotableFlags;
           }
         ];

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -92,7 +92,10 @@ _: {
 
       config = lib.mkMerge [
         {
-          # Blacklist nouveau to avoid conflicts with proprietary NVIDIA driver
+          # Blacklist nouveau to avoid conflicts with proprietary NVIDIA driver.
+          # i915 is deliberately absent: internal HDA/SOF audio on this chassis can
+          # depend on Intel graphics-side plumbing even when NVIDIA renders X11, and
+          # the iGPU also backs the only VA-API decode target configured below.
           boot.blacklistedKernelModules = [ "nouveau" ];
 
           boot.kernelParams = [
@@ -129,6 +132,10 @@ _: {
           # themselves, which covers new ones without any per-package wiring.
           # Keep libva on the same Intel node and iHD driver in both modes so non-Chromium
           # VA-API consumers do not fall back to render-node probe order.
+          # VDPAU_DRIVER is intentionally unset: VDPAU is legacy, and pointing it at
+          # nvidia would route back into the NVDEC path that faults above.
+          # sessionVariables is PAM-initialised, so GUI apps launched outside a shell
+          # inherit this routing too, not just terminal-spawned ones.
           environment.sessionVariables = {
             CHROME_EXTRA_FLAGS = lib.mkDefault (
               lib.concatStringsSep " " ([ videoDeviceFlag ] ++ cfg.chromeExtraFlags)

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -3,8 +3,23 @@ _: {
     { config, lib, ... }:
     let
       cfg = config.system76.gpu;
-      intelBusParts = lib.splitString ":" (lib.removePrefix "PCI:" cfg.intelBusId);
-      intelBusDomainParts = lib.splitString "@" (lib.elemAt intelBusParts 0);
+      intelBusFields =
+        let
+          matched = builtins.match "PCI:([0-9]{1,3})(@([0-9]{1,10}))?:([0-9]{1,2}):([0-9])" cfg.intelBusId;
+        in
+        if matched == null then
+          throw (
+            "system76.gpu.intelBusId: expected decimal PCI:bus[@domain]:device:function "
+            + "with bus 1-3 digits, optional domain 1-10 digits, device 1-2 digits, "
+            + "and function 1 digit, got '${cfg.intelBusId}'"
+          )
+        else
+          {
+            bus = lib.elemAt matched 0;
+            domain = if lib.elemAt matched 2 == null then "0" else lib.elemAt matched 2;
+            device = lib.elemAt matched 3;
+            function = lib.elemAt matched 4;
+          };
       intelBusHex = part: lib.toLower (lib.toHexString (lib.toIntBase10 part));
       intelBusHexPadded = part: lib.fixedWidthString 2 "0" (intelBusHex part);
       intelDomainHexPadded = part: lib.fixedWidthString 4 "0" (intelBusHex part);
@@ -26,10 +41,15 @@ _: {
           default = "PCI:0:2:0";
           example = "PCI:0:2:0";
           description = ''
-            PCI address for the Intel iGPU when PRIME sync is enabled, in Xorg's
-            decimal `PCI:bus@domain:device:function` form. Determine the slot via
-            `lspci -nn | grep VGA` and convert its hexadecimal components if the
-            default does not match this chassis. The domain may be omitted when it is 0.
+            PCI address for the Intel iGPU, in Xorg's decimal
+            `PCI:bus@domain:device:function` form; the domain may be omitted when it
+            is 0. Used for PRIME sync when `mode = "hybrid-sync"`, and as the source
+            of the `videoDecodeDevice` default in both modes. Unless
+            `videoDecodeDevice` is overridden explicitly, an incorrect value can point
+            the default Chromium and libva routing at the wrong render node and make
+            hardware video decode fall back to software even with PRIME disabled.
+            Determine the slot via `lspci -nn | grep VGA` and convert its hexadecimal
+            components to decimal.
           '';
         };
 
@@ -46,12 +66,8 @@ _: {
         videoDecodeDevice = lib.mkOption {
           type = lib.types.str;
           default =
-            "/dev/dri/by-path/pci-${
-              intelDomainHexPadded (
-                if builtins.length intelBusDomainParts == 2 then lib.elemAt intelBusDomainParts 1 else "0"
-              )
-            }:${intelBusHexPadded (lib.elemAt intelBusDomainParts 0)}"
-            + ":${intelBusHexPadded (lib.elemAt intelBusParts 1)}.${intelBusHex (lib.elemAt intelBusParts 2)}-render";
+            "/dev/dri/by-path/pci-${intelDomainHexPadded intelBusFields.domain}:${intelBusHexPadded intelBusFields.bus}"
+            + ":${intelBusHexPadded intelBusFields.device}.${intelBusHex intelBusFields.function}-render";
           defaultText = lib.literalExpression ''"/dev/dri/by-path/pci-<intelBusId as a sysfs address>-render"'';
           example = "/dev/dri/renderD128";
           description = ''

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -58,9 +58,10 @@ _: {
       # An entry carrying $ or @ is rewritten before any browser sees it.
       hasExpansion = flag: builtins.match ".*[$@].*" flag != null;
       quoteFlag = flag: if builtins.match ".*[[:space:]].*" flag == null then flag else "'${flag}'";
-      unquotableFlags = lib.filter (flag: hasQuote flag || hasLineBreak flag || hasExpansion flag) (
-        cfg.chromeExtraFlags ++ [ videoDeviceFlag ]
-      );
+      unquotableFlags = lib.filter (
+        flag:
+        hasQuote flag || hasLineBreak flag || hasExpansion flag || builtins.match ".*#.*" flag != null
+      ) (cfg.chromeExtraFlags ++ [ videoDeviceFlag ]);
     in
     {
       options.system76.gpu = {

--- a/modules/system76/nvidia-gpu.nix
+++ b/modules/system76/nvidia-gpu.nix
@@ -100,8 +100,10 @@ _: {
           default = [ ];
           description = ''
             Additional flags exported to Chromium browsers through
-            `CHROME_EXTRA_FLAGS`. The required render-node flag is prepended
-            automatically, so adding flags here cannot disable hardware video decode.
+            `CHROME_EXTRA_FLAGS`. The derived render-node flag is appended last, and
+            Chromium keeps the last occurrence of a repeated switch, so flags added
+            here cannot displace it. Change the render node through
+            `videoDecodeDevice` instead.
           '';
         };
       };
@@ -144,8 +146,12 @@ _: {
           # on, then rejects nvidia-drm outright (crbug.com/1492880). NVIDIA renders in
           # both modes here, so the match lands on the dGPU, the pre-sandbox VA-API
           # init finds nothing, and every Chromium app decodes in software. Naming the
-          # iGPU node restores hardware decode. The browsers read this variable
-          # themselves, which covers new ones without any per-package wiring.
+          # iGPU node restores hardware decode. The browser binary reads this variable
+          # itself (AppendExtraArgumentsToCommandLine in chrome/app/chrome_main_linux.cc,
+          # not a launcher script), which covers new ones without per-package wiring.
+          # It appends onto the parsed command line, so it also outranks the wrapper
+          # --add-flags this repo bakes into its Chromium packages. Chromium keeps the
+          # last occurrence of a repeated switch, hence videoDeviceFlag goes last.
           # Keep libva on the same Intel node and iHD driver in both modes so non-Chromium
           # VA-API consumers do not fall back to render-node probe order.
           # VDPAU_DRIVER is intentionally unset: VDPAU is legacy, and pointing it at
@@ -154,7 +160,7 @@ _: {
           # inherit this routing too, not just terminal-spawned ones.
           environment.sessionVariables = {
             CHROME_EXTRA_FLAGS = lib.mkDefault (
-              lib.concatStringsSep " " ([ videoDeviceFlag ] ++ cfg.chromeExtraFlags)
+              lib.concatStringsSep " " (cfg.chromeExtraFlags ++ [ videoDeviceFlag ])
             );
             LIBVA_DRM_DEVICE = lib.mkDefault cfg.videoDecodeDevice;
             LIBVA_DRIVER_NAME = lib.mkDefault "iHD";


### PR DESCRIPTION
## Summary

Chromium selects its VA-API render node by matching whichever GPU it renders on, then rejects any device whose DRM driver reports `nvidia-drm` ([crbug.com/1492880](https://crbug.com/1492880)). NVIDIA renders in both `system76.gpu.mode` values on this chassis, so the match lands on the dGPU, `LoadDrmFD` skips it, `VADisplayStateSingleton::PreSandboxInitialization` finds no suitable node, and every Chromium browser falls back to software video decode.

Measured on `chrome://gpu` via CDP:

| Configuration | Hardware decode profiles |
| --- | --- |
| default | 0 |
| `--enable-features=AcceleratedVideoDecodeLinuxGL` only | 0 |
| `--hardware-video-device-path=<Intel node>` | **8** |

The 8 profiles are H.264 baseline/main/high, HEVC main and main 10, VP8, and VP9 profile0/profile2. The feature flag is not needed; the device path alone is sufficient.

The module declares `system76.gpu.videoDecodeDevice` as the single source for the Intel render node:

- Its default is derived from the Xorg decimal `system76.gpu.intelBusId`, including optional PCI domains and zero-padded decimal components, and formatted as sysfs' `%04x:%02x:%02x.%d` address. Fields are range-checked against their PCI widths (bus 0-255, device 0-31, function 0-7) so an out-of-range value fails evaluation naming the option instead of aborting inside `lib.fixedWidthString`. The domain is left uncapped because those sysfs widths are minimums and nixpkgs' own `busIDType` documents domains above `0xffff`. An explicit `videoDecodeDevice` path remains available for non-standard layouts. This boundary table is pinned by the new flake check `checks.system76-video-decode-device` (`modules/system76/nvidia-gpu-checks.nix`), which reads the derivation back through `nixosConfigurations.system76.extendModules` (not a precedent from `modules/configurations/nixos.nix`'s fleet-key check, which reads an already-constructed entry and never calls `extendModules`; safe here specifically because this file reads `config.flake.nixosConfigurations`, an option it does not itself contribute to, unlike the recursion hazard `modules/hosts/common/checks.nix` documents for reading a host module back from a flake-level check) so a future edit to the regex or the padding helper fails `nix flake check` by name instead of only a manual eval: the bus/domain arithmetic in this option had already regressed twice within this PR with no host ever exercising a boundary value. The domain-uncapped-past-`0xffff` claim was directly re-verified against this flake's pinned nixpkgs after review disputed it with an out-of-date `busIDType` regex: `hardware.nvidia.prime.intelBusId` accepts `PCI:0@65536:2:0` without a type error, matching the real `busIDType = lib.types.strMatching "([[:print:]]+:[0-9]{1,3}(@[0-9]{1,10})?:[0-9]{1,2}:[0-9])?"` (`nixos/modules/hardware/video/nvidia.nix`), whose domain group is `{1,10}` digits, the same width this option already uses.
- Chromium browsers receive `--hardware-video-device-path=${...}` through `CHROME_EXTRA_FLAGS`. This is read by the browser binary itself, not by a launcher script: `AppendExtraArgumentsToCommandLine` in `chrome/app/chrome_main_linux.cc` pulls it through `base::Environment` and appends it onto the already-parsed command line, outside any `GOOGLE_CHROME_BRANDING` guard. One setting therefore covers current and future Chromium browsers without per-package wiring, and because it appends, it also outranks the `wrapProgram --add-flags` this repo bakes into its Chromium packages.
- Entries are encoded so that one list element is one Chromium argument: `AppendExtraArgsFromEnvVar` re-splits the variable on whitespace, so an entry containing whitespace is single-quoted (its tokenizer runs `set_quote_chars("\"'")` and trims the outer quotes). The quote is single because `environment.sessionVariables` renders into `/etc/pam/environment` as `NAME   DEFAULT="<value>"` without escaping, so a double quote would close that value early and drop the render-node flag. That file is also line-oriented, so an entry containing a quote character or a raw line break has no encoding and fails an assertion. Two additional classes have the same problem for different reasons: `pam_env(8)` expands braced `${string}`/`@{string}` references inside a `DEFAULT=` value against the environment and PAM items, and nixpkgs rewrites literal `$HOME`/`$USER` for `sessionVariables`, so those forms are rewritten before any browser sees them; bare `$` and `@` remain literal. Its line parser truncates at the first `#`, so an entry containing `#` drops the rest of the record, including the derived flag appended after it. Entries without whitespace, quotes, line breaks, `#`, or those expansion forms are emitted verbatim, so the default value is unchanged. `checks.system76-video-decode-device` pins the accepted half of this encoding (default, whitespace-free, whitespace-quoted, and the append-last ordering) by reading `config.environment.sessionVariables.CHROME_EXTRA_FLAGS` back through the same `extendModules` handle used for the bus-ID table, without forcing `config.assertions`. The rejected half (does a bad entry actually fail the assertion) is not pinned there: `config.assertions` is a roughly 2925-entry whole-system list, and `builtins.tryEval` only catches `throw`/`assert` failures, not a missing-attribute error inside an unrelated entry's message (`nixos/modules/tasks/filesystems.nix`'s fileSystems cycle check has one, confirmed by reproducing the exact failure), so there is no safe way to probe an arbitrary unrelated entry in that list from this check.
- The derived flag is emitted **last**. Chromium parses argv into `base::CommandLine`'s `switches_`, a `std::map` whose `AppendSwitchNative` does an unconditional `operator[]` overwrite, so the last occurrence of a repeated switch wins. Emitting the derived flag last means `system76.gpu.chromeExtraFlags` cannot silently displace it; `videoDecodeDevice` is the supported way to change the node.
- `LIBVA_DRM_DEVICE` and `LIBVA_DRIVER_NAME=iHD` reuse the same option in both `hybrid-sync` and `nvidia-only` modes. This prevents non-Chromium VA-API consumers from depending on render-node probe order. `checks.system76-video-decode-device` forces both modes through `extendModules` and compares `CHROME_EXTRA_FLAGS`/`LIBVA_DRM_DEVICE`/`LIBVA_DRIVER_NAME` against a fixed table for each and reports missing variables as `<unset>` in the mode-specific diagnostic: the `system76` host itself pins `mode = "nvidia-only"` (`modules/system76/hardware-config.nix`), so without this, nothing evaluated here would ever exercise `hybrid-sync`, the option's own default, and a future edit re-wrapping this block in its old `mkIf (mode == "nvidia-only")` would go unnoticed by every other case in the check.

The existing System76 configuration guide now documents `videoDecodeDevice`, the browser flag, the shared libva routing, and the override format. This PR intentionally does not add package-specific overlays or Electron wrappers. Electron and bundled-app-specific flag handling remain outside the browser-wide configuration.

### Scope notes

Two things this deliberately does not do:

- It does not silence the `MESA-LOADER: failed to open dri: .../dri_gbm.so: Permission denied` warning. That is Chromium's GPU sandbox broker refusing a path outside its allowlist. Removing it with `--disable-gpu-sandbox` would trade away the GPU sandbox.
- It does not address the Logseq blank screen, which is an independent rendering issue. `--disable-gpu-compositing` remains the required workaround.

`tpnix` is not brought to parity here on purpose: it sets `gpu.nvidia.vaapi.backend = "nvidia"`, so it routes VA-API through NVDEC by design and this Intel-routing bug class does not apply to it.

## Test plan

### Evaluation

- [x] `nix run path:.#treefmt -- modules/system76/nvidia-gpu.nix modules/system76/nvidia-gpu-checks.nix docs/system76/system76-configuration.md`
- [x] `nix-instantiate --parse modules/system76/nvidia-gpu.nix`
- [x] Default eval resolves `CHROME_EXTRA_FLAGS` to `--hardware-video-device-path=/dev/dri/by-path/pci-0000:00:02.0-render`
- [x] Override eval maps `PCI:0:02:0` to `/dev/dri/by-path/pci-0000:00:02.0-render`
- [x] Override eval maps `PCI:2@1:3:4` to `/dev/dri/by-path/pci-0001:02:03.4-render`
- [x] Bus-ID boundaries: `PCI:255:2:0`, `PCI:0:31:0`, `PCI:0:2:7` accepted; `PCI:256:2:0`, `PCI:0:32:0`, `PCI:0:2:9` throw naming `system76.gpu.intelBusId`; `PCI:0@65536:2:0` widens to `pci-10000:00:02.0-render`
- [x] `checks.system76-video-decode-device` pins the bus-ID boundary table and the `CHROME_EXTRA_FLAGS` encoding (default, whitespace-free, whitespace-quoted, and append-last-ordering cases) so `nix flake check` catches a future regression in either branch: verified by deliberately breaking one golden value in each half, confirming the throw named the mismatched case with its expected/actual strings, then reverting and confirming the derivation path matched the pre-break state
- [x] The check's `videoDecodeDeviceFor` forces its value directly rather than through `builtins.tryEval`, so an accept-row mismatch propagates the real error instead of being flattened into `<eval failure>`; `tryEval` is scoped to the three reject rows only, where a thrown eval is the expected outcome
- [x] `extendModules` eval with a conflicting `chromeExtraFlags` entry keeps the derived flag as the last occurrence
- [x] `extendModules` eval: `[ "--host-resolver-rules=MAP * 127.0.0.1" ]` is emitted quoted, whitespace-free entries and the default are unchanged, and an entry containing a quote character fails the assertion
- [x] `extendModules` eval: an entry containing an embedded `\n` or `\r` fails the same assertion (message names "a quote character or a line break"); a plain-whitespace entry and the unmodified default still pass
- [x] `extendModules` eval: braced `${...}`/`@{...}` and literal `$HOME`/`$USER` entries fail the assertion; bare `$`/`@` entries remain unchanged; a `#` entry fails with the updated message; newline, quote, plain-whitespace, and no-override cases re-verified unaffected
- [x] Attempted a `checks.system76-video-decode-device` case for the reject half of the encoder (does chromeExtraFlags = [ "a\"b" ]/[ "a\nb" ] actually fail the assertion); reproduced `error: attribute 'cycle' missing` from `nixos/modules/tasks/filesystems.nix`'s unrelated fileSystems assertion escaping three different `tryEval` placements (wrapping `!entry.assertion && hasPrefix ...`, the reordered `hasPrefix ... && !entry.assertion`, and the whole per-entry predicate), then confirmed against `lix/libexpr/primops.cc`'s `prim_tryEval` that it only catches `AssertionError`, not the `EvalError` class this hits; reverted the attempt and documented the finding in `modules/system76/nvidia-gpu-checks.nix` instead
- [x] Forced `hybrid-sync` eval exposes the Intel `LIBVA_DRM_DEVICE` and `LIBVA_DRIVER_NAME=iHD`
- [x] `checks.system76-video-decode-device` forces `hybrid-sync` and `nvidia-only` and compares `CHROME_EXTRA_FLAGS`/`LIBVA_DRM_DEVICE`/`LIBVA_DRIVER_NAME` for each against a fixed table: verified by deliberately breaking one golden value, confirming the throw named both modes' mismatch, then reverting and confirming the derivation path matched the pre-break state
- [x] Disputed review claim re-checked against the pinned nixpkgs directly rather than trusted or dismissed on priors: `hardware.nvidia.prime.intelBusId` accepts `PCI:0@65536:2:0` cleanly (`extendModules` eval, both success and value match), and the real `busIDType` regex read from `nixos/modules/hardware/video/nvidia.nix` has a `{1,10}`-digit domain group, not the `{1,3}` the review cited
- [x] `nix flake check path:. --accept-flake-config --no-build --offline`
- [x] `nix develop path:. -c pre-commit run --all-files --hook-stage manual`
- [x] `git diff --check`

### Runtime

Run against `ungoogled-chromium-151.0.7922.137`, the exact package `nixosConfigurations.system76` resolves, to confirm the delivery mechanism rather than only the derived string:

- [x] Flags supplied **only** through `CHROME_EXTRA_FLAGS` with zero argv flags drive the browser: `--headless=old --disable-gpu --no-sandbox --user-data-dir=... --dump-dom` printed the DOM and created the named profile directory, proving a value-carrying switch is parsed from the variable
- [x] Negative control with the variable unset fails on `Missing X server or $DISPLAY`
- [x] The nixpkgs wrapper script contains no reference to `CHROME_EXTRA_FLAGS`, so the mechanism is in the compiled binary; the literal is present in the `ungoogled-chromium`, `google-chrome`, and `brave-origin` ELFs
- [x] Last-occurrence-wins confirmed: a duplicated `--user-data-dir=/tmp/dupA --user-data-dir=/tmp/dupB` creates only `dupB`
- [x] Whitespace encoding, with `--user-data-dir=/tmp/sp ace`: unquoted splits and creates `/tmp/sp`; the quoted whole token creates `/tmp/sp ace`; value-only quoting creates neither, since `TrimString` removes only the trailing quote
- [x] The generated `/etc/pam/environment` line is well formed with a whitespace-bearing entry configured: `CHROME_EXTRA_FLAGS   DEFAULT="'--host-resolver-rules=MAP * 127.0.0.1' --hardware-video-device-path=..."`
- [x] End to end through the rendering step: the value extracted from that generated line, the way `pam_env` strips it, is fed to the browser and keeps `--user-data-dir=/tmp/pam dir` as a single argument