### PR TITLE
feat(apps): add SVG tooling modules

### DIFF
--- a/modules/apps/autotrace.nix
+++ b/modules/apps/autotrace.nix
@@ -1,0 +1,49 @@
+/*
+  Package: autotrace
+  Description: Utility for converting bitmap images into vector graphics.
+  Homepage: nil
+  Documentation: https://github.com/autotrace/autotrace#readme
+  Repository: https://github.com/autotrace/autotrace
+
+  Summary:
+    * Converts bitmap images into SVG, EPS, PDF, DXF, and other vector formats.
+    * Supports outline and centerline tracing, color reduction, and despeckling.
+
+  Options:
+    <input> -output-file <output>: Convert a bitmap image to a vector file.
+    -centerline: Trace centerlines instead of outlines.
+    -color-count <count>: Reduce the number of colors before tracing.
+    --list-input-formats: List supported input formats.
+    --list-output-formats: List supported output formats.
+*/
+_:
+let
+  AutotraceModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.autotrace.extended;
+    in
+    {
+      options.programs.autotrace.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable autotrace.";
+        };
+
+        package = lib.mkPackageOption pkgs "autotrace" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.autotrace = AutotraceModule;
+}

--- a/modules/apps/resvg.nix
+++ b/modules/apps/resvg.nix
@@ -1,0 +1,52 @@
+/*
+  Package: resvg
+  Description: SVG rendering library.
+  Homepage: https://github.com/linebender/resvg
+  Documentation: https://docs.rs/resvg/latest/resvg/
+  Repository: https://github.com/linebender/resvg
+
+  Summary:
+    * Renders static SVG files to PNG through Rust, C, and command-line interfaces.
+    * Provides portable and reproducible rendering for SVG assets and image conversion.
+
+  Options:
+    <in-svg> <out-png>: Render an SVG file to a PNG file.
+    -c: Write the output PNG to stdout.
+    -w, --width <length>: Set the output width in pixels.
+    -h, --height <length>: Set the output height in pixels.
+    -z, --zoom <factor>: Scale the output by a zoom factor.
+    --dpi <dpi>: Set the output resolution.
+    --background <color>: Set a background color instead of transparent output.
+    --stylesheet <path>: Inject a stylesheet while resolving CSS attributes.
+*/
+_:
+let
+  ResvgModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.resvg.extended;
+    in
+    {
+      options.programs.resvg.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable resvg.";
+        };
+
+        package = lib.mkPackageOption pkgs "resvg" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.resvg = ResvgModule;
+}

--- a/modules/apps/svgo.nix
+++ b/modules/apps/svgo.nix
@@ -1,0 +1,50 @@
+/*
+  Package: svgo
+  Description: Node.js tool for optimizing SVG files.
+  Homepage: https://svgo.dev/
+  Documentation: https://svgo.dev/docs/usage/
+  Repository: https://github.com/svg/svgo
+
+  Summary:
+    * Removes redundant SVG metadata, comments, hidden elements, and default attributes without changing rendering.
+    * Simplifies SVG paths and structure to reduce asset size in build and graphics pipelines.
+
+  Options:
+    <input> [<input> ...]: Optimize one or more SVG files.
+    -o, --output <output> [<output> ...]: Write optimized files to the specified paths.
+    -r, --recursive: Process SVG files recursively under a directory.
+    -f, --folder <directory>: Set the directory containing SVG files to process.
+    --config <path>: Load an SVGO configuration file.
+    --help: Show advanced command-line usage.
+*/
+_:
+let
+  SvgoModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.svgo.extended;
+    in
+    {
+      options.programs.svgo.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable svgo.";
+        };
+
+        package = lib.mkPackageOption pkgs "svgo" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.svgo = SvgoModule;
+}

--- a/modules/apps/tsx.nix
+++ b/modules/apps/tsx.nix
@@ -1,0 +1,49 @@
+/*
+  Package: tsx
+  Description: TypeScript Execute (tsx): The easiest way to run TypeScript in Node.js.
+  Homepage: https://tsx.hirok.io/
+  Documentation: https://tsx.hirok.io/getting-started
+  Repository: https://github.com/privatenumber/tsx
+
+  Summary:
+    * Runs TypeScript files directly in Node.js with CommonJS and ESM interoperability.
+    * Supports tsconfig paths, dependency-aware watch mode, shell scripts, and the Node.js test runner.
+
+  Options:
+    <file.ts>: Execute a TypeScript file with Node.js flags and script arguments.
+    watch <file.ts>: Rerun a script whenever its dependencies change.
+    --include <path>: Add files or directories to watch.
+    --exclude <pattern>: Exclude files or directories from watch mode.
+    --test: Run the Node.js test runner with TypeScript support.
+*/
+_:
+let
+  TsxModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.tsx.extended;
+    in
+    {
+      options.programs.tsx.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable tsx.";
+        };
+
+        package = lib.mkPackageOption pkgs "tsx" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.tsx = TsxModule;
+}

--- a/modules/apps/vtracer.nix
+++ b/modules/apps/vtracer.nix
@@ -1,0 +1,54 @@
+/*
+  Package: vtracer
+  Description: Raster to vector graphics converter.
+  Homepage: https://github.com/visioncortex/vtracer
+  Documentation: https://www.visioncortex.org/vtracer-docs/
+  Repository: https://github.com/visioncortex/vtracer
+
+  Summary:
+    * Converts raster images such as PNG and JPEG files into SVG vector graphics.
+    * Traces colored artwork, scans, photographs, blueprints, and pixel art with configurable clustering and curve
+      fitting.
+
+  Options:
+    <input> <output>: Convert a raster input image to an SVG output file.
+    -i, --input <input>: Specify the input raster image.
+    -o, --output <output>: Specify the output SVG file.
+    --preset <preset>: Start from a black-and-white, poster, or photo preset.
+    --clustering <clustering>: Select the region-forming algorithm.
+    --hierarchical <hierarchical>: Select stacked output or a seam-free cutout mosaic.
+    -m, --mode <mode>: Select pixel, polygon, or spline curve fitting.
+    --palette <palette>: Constrain output colors to a comma-separated hex palette.
+    --simplify <tolerance>: Simplify curves within the specified pixel tolerance.
+*/
+_:
+let
+  VtracerModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.vtracer.extended;
+    in
+    {
+      options.programs.vtracer.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable vtracer.";
+        };
+
+        package = lib.mkPackageOption pkgs "vtracer" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.vtracer = VtracerModule;
+}

--- a/modules/apps/vtracer.nix
+++ b/modules/apps/vtracer.nix
@@ -11,15 +11,12 @@
       fitting.
 
   Options:
-    <input> <output>: Convert a raster input image to an SVG output file.
     -i, --input <input>: Specify the input raster image.
     -o, --output <output>: Specify the output SVG file.
     --preset <preset>: Start from a black-and-white, poster, or photo preset.
-    --clustering <clustering>: Select the region-forming algorithm.
+    --colormode <colormode>: Trace in full color or binary black-and-white.
     --hierarchical <hierarchical>: Select stacked output or a seam-free cutout mosaic.
     -m, --mode <mode>: Select pixel, polygon, or spline curve fitting.
-    --palette <palette>: Constrain output colors to a comma-separated hex palette.
-    --simplify <tolerance>: Simplify curves within the specified pixel tolerance.
 */
 _:
 let

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -377,6 +377,7 @@ let
       readpdf.extended.enable = lib.mkOverride 1100 true;
       remmina.extended.enable = lib.mkOverride 1100 true;
       restringer.extended.enable = lib.mkOverride 1100 false; # Produces incorrect results, use webcrack
+      resvg.extended.enable = lib.mkOverride 1100 true;
       rg-fzf.extended.enable = lib.mkOverride 1100 true;
       rip.extended.enable = lib.mkOverride 1100 true;
       ripgrep.extended.enable = lib.mkOverride 1100 true;

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -475,6 +475,7 @@ let
       vlc.extended.enable = lib.mkOverride 1100 false;
       "vscode-fhs".extended.enable = lib.mkOverride 1100 true;
       "vt-cli".extended.enable = lib.mkOverride 1100 true;
+      vtracer.extended.enable = lib.mkOverride 1100 true;
       vulnix.extended.enable = lib.mkOverride 1100 true;
       wafw00f.extended.enable = lib.mkOverride 1100 true;
       wakaru.extended.enable = lib.mkOverride 1100 false;

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -46,6 +46,7 @@ let
       "ast-grep".extended.enable = lib.mkOverride 1100 true;
       atuin.extended.enable = lib.mkOverride 1100 true;
       "autotiling-rs".extended.enable = lib.mkOverride 1100 true;
+      autotrace.extended.enable = lib.mkOverride 1100 true;
       assetfinder.extended.enable = lib.mkOverride 1100 true;
       awscli2.extended.enable = lib.mkOverride 1100 true;
       azd.extended.enable = lib.mkOverride 1100 true;

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -432,6 +432,7 @@ let
       stylua.extended.enable = lib.mkOverride 1100 true;
       subfinder.extended.enable = lib.mkOverride 1100 true;
       subjack.extended.enable = lib.mkOverride 1100 true;
+      svgo.extended.enable = lib.mkOverride 1100 true;
       synchrony.extended.enable = lib.mkOverride 1100 false;
       sysstat.extended.enable = lib.mkOverride 1100 true;
       tailscale.extended.enable = lib.mkOverride 1100 true;

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -453,6 +453,7 @@ let
       "tor-browser".extended.enable = lib.mkOverride 1100 true;
       torsocks.extended.enable = lib.mkOverride 1100 true;
       tlsx.extended.enable = lib.mkOverride 1100 true;
+      tsx.extended.enable = lib.mkOverride 1100 true;
       tweakcc.extended.enable = lib.mkOverride 1100 true;
       "typescript-language-server".extended.enable = lib.mkOverride 1100 false;
       udiskie.extended.enable = lib.mkOverride 1100 true;

--- a/modules/system76/apps-enable.nix
+++ b/modules/system76/apps-enable.nix
@@ -15,7 +15,9 @@
 # re-evaluating module config.
 { config, lib, ... }:
 let
-  appEnable = { };
+  appEnable = {
+    inkscape = true;
+  };
 
   baseline =
     config.flake.lib.nixos._commonAppsBaseline or {


### PR DESCRIPTION
## Summary

- Add package-only NixOS app modules for autotrace, resvg, svgo, tsx, and vtracer.
- Enable the five SVG and TypeScript tools in the shared application baseline.
- Keep Inkscape disabled in the common baseline and enable it only through the System76 host override.
- Preserve separate commits for each added package.

## Test plan

- Repository formatter and applicable pre-commit hooks passed.
- Confirmed the pinned package set exposes autotrace 0.31.10, resvg 0.48.1, svgo 4.0.1, tsx 4.23.12, and vtracer 0.6.15.
- Confirmed the System76 configuration enables Inkscape and the tpnix configuration leaves it disabled.
- Confirmed each added package is enabled and present in the System76 system package set.
- Full validation and testing were completed locally before publication.