### PR TITLE
feat(fonts): adopt MonoLisa v3 Code and Text families

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -206,8 +206,8 @@ load-bearing ones.
   signing).
 - `modules/services/duplicati-r2.nix`: declarative Duplicati backups to Cloudflare
   R2 with runtime-materialized systemd timers.
-- `modules/stylix/stylix.nix`: central theming (OneDark base16, MonoLisa,
-  GTK/Qt/Firefox/mpv).
+- `modules/stylix/stylix.nix`: central theming (OneDark base16, MonoLisaCode
+  for monospace plus MonoLisaText for UI text, GTK/Qt/Firefox/mpv).
 - `modules/csec/wordlists.nix`: opt-in Kali-style `/usr/share/wordlists` symlinks.
 
 ### AI Agents Configuration

--- a/modules/apps/doom-emacs-doomdir/config.el
+++ b/modules/apps/doom-emacs-doomdir/config.el
@@ -29,6 +29,12 @@
 ;; refresh your font settings. If Emacs still can't find your font, it likely
 ;; wasn't installed correctly. Font issues are rarely Doom issues!
 
+;; MonoLisa v3 ships a monospace (Code) and a proportional (Text) family
+;; through the encrypted-archive font pipeline; pair them so variable-pitch
+;; faces get the proportional cut.
+(setq doom-font (font-spec :family "MonoLisaCode" :size 12)
+      doom-variable-pitch-font (font-spec :family "MonoLisaText" :size 12))
+
 ;; There are two ways to load a theme. Both assume the theme is installed and
 ;; available. You can either set `doom-theme' or manually load a theme with the
 ;; `load-theme' function. This is the default:

--- a/modules/apps/doom-emacs-doomdir/config.el
+++ b/modules/apps/doom-emacs-doomdir/config.el
@@ -32,8 +32,8 @@
 ;; MonoLisa v3 ships a monospace (Code) and a proportional (Text) family
 ;; through the encrypted-archive font pipeline; pair them so variable-pitch
 ;; faces get the proportional cut.
-(setq doom-font (font-spec :family "MonoLisaCode" :size 12)
-      doom-variable-pitch-font (font-spec :family "MonoLisaText" :size 12))
+(setq doom-font (font-spec :family "MonoLisaCode" :size 12.0)
+      doom-variable-pitch-font (font-spec :family "MonoLisaText" :size 12.0))
 
 ;; There are two ways to load a theme. Both assume the theme is installed and
 ;; available. You can either set `doom-theme' or manually load a theme with the

--- a/modules/browsers/gecko-chrome/userChrome.css
+++ b/modules/browsers/gecko-chrome/userChrome.css
@@ -1,28 +1,3 @@
-/*
-#Font Settings * {
-	font-family: "MonoLisa Variable" !important;
-	font-variation-settings: "wght" 500 !important;
-	font-feature-settings:
-		"ss01" 1,
-		"ss02" 1,
-		"ss07" 1,
-		"ss08" 1,
-		"ss10" 1,
-		"ss11" 1,
-		"ss15" 1,
-		"ss16" 1,
-		"ss17" 1,
-		"zero" 1,
-		"liga" 1,
-		"calt" 1,
-		"frac" 1,
-		"rlig" 1,
-		"rvrn" 1 !important;
-	line-height: 1.4 !important;
-	font-size: 12px !important;
-}
-*/
-
 /* Hide Tab Toolbar */
 :root {
 	--uc-window-control-width: 0px; /* Space reserved for window controls regular 138px */

--- a/modules/hosts/common/fonts.nix
+++ b/modules/hosts/common/fonts.nix
@@ -155,9 +155,9 @@ let
 
               tar -C "$tmpdir" --strip-components=1 -I zstd -xf "${secretRuntimePath}"
 
-              # Refuse to wipe the installed families unless the archive
-              # carries a payload for each one. A repack missing a single
-              # family would otherwise pass, wipe both, and restore one.
+              # Refuse to install unless the archive carries a payload for each
+              # family. A repack missing one would otherwise swap in a tree
+              # without it and then drop the .old copy that still had it.
               for family in code text; do
                 if [ -z "$(find "$tmpdir/$family" -type f \( -iname '*.ttf' -o -iname '*.otf' \) -print -quit 2>/dev/null)" ]; then
                   echo "MonoLisa archive extracted with no font payload under $family/" >&2
@@ -166,6 +166,7 @@ let
               done
 
               staging="${fontInstallDir}.new"
+              trap 'rm -rf "$tmpdir" "$staging"' EXIT
               rm -rf "$staging"
               install -d -m 0755 "$staging"
               cp -R "$tmpdir"/. "$staging/"

--- a/modules/hosts/common/fonts.nix
+++ b/modules/hosts/common/fonts.nix
@@ -165,6 +165,19 @@ let
                 fi
               done
 
+              # The family strings are the contract between this archive and every
+              # consumer: the generic classes above, the stylix font set, the gecko
+              # profile, and the Doom font-specs. Nothing else checks them, so a
+              # repack whose name tables disagree would drop the whole stack to the
+              # Noto and Liberation fallbacks without failing anything.
+              extractedFamilies="$(find "$tmpdir" -type f \( -iname '*.ttf' -o -iname '*.otf' \) -exec fc-query -f '%{family}\n' {} +)"
+              for wanted in MonoLisaCode MonoLisaText; do
+                if [[ "$extractedFamilies" != *"$wanted"* ]]; then
+                  echo "no extracted face declares the family $wanted" >&2
+                  exit 1
+                fi
+              done
+
               staging="${fontInstallDir}.new"
               # Roll the rotated tree back before cleaning, so an interrupted
               # swap cannot leave the families stranded at .old. The test is

--- a/modules/hosts/common/fonts.nix
+++ b/modules/hosts/common/fonts.nix
@@ -21,6 +21,10 @@ let
 
   # Symbol and icon fallbacks appended after the primary family; the
   # monospace list prefers the Mono variant so glyphs keep cell width.
+  # Every generic class keeps a real text face ahead of these: the MonoLisa
+  # families only exist once monolisa-fonts.service has installed the archive,
+  # and with an icon-only face next in line `fc-match sans-serif:lang=en`
+  # resolves to Symbols Nerd Font, which carries no Latin coverage.
   symbolFallback = [
     "Symbols Nerd Font"
     "Symbols Nerd Font Mono"
@@ -72,9 +76,21 @@ let
 
             fontconfig = {
               defaultFonts = {
-                serif = [ "MonoLisaText" ] ++ symbolFallback;
-                sansSerif = [ "MonoLisaText" ] ++ symbolFallback;
-                monospace = [ "MonoLisaCode" ] ++ monoSymbolFallback;
+                serif = [
+                  "MonoLisaText"
+                  "Noto Serif"
+                ]
+                ++ symbolFallback;
+                sansSerif = [
+                  "MonoLisaText"
+                  "Noto Sans"
+                ]
+                ++ symbolFallback;
+                monospace = [
+                  "MonoLisaCode"
+                  "Liberation Mono"
+                ]
+                ++ monoSymbolFallback;
                 emoji = [
                   "Noto Color Emoji"
                   "Symbols Nerd Font"

--- a/modules/hosts/common/fonts.nix
+++ b/modules/hosts/common/fonts.nix
@@ -155,12 +155,15 @@ let
 
               tar -C "$tmpdir" --strip-components=1 -I zstd -xf "${secretRuntimePath}"
 
-              # Refuse to wipe the installed families for an archive that
-              # extracted without any font payload.
-              if [ -z "$(find "$tmpdir" -type f -name '*.ttf' -print -quit)" ]; then
-                echo "MonoLisa archive extracted with no TTF payload" >&2
-                exit 1
-              fi
+              # Refuse to wipe the installed families unless the archive
+              # carries a payload for each one. A repack missing a single
+              # family would otherwise pass, wipe both, and restore one.
+              for family in code text; do
+                if [ -z "$(find "$tmpdir/$family" -type f \( -iname '*.ttf' -o -iname '*.otf' \) -print -quit 2>/dev/null)" ]; then
+                  echo "MonoLisa archive extracted with no font payload under $family/" >&2
+                  exit 1
+                fi
+              done
 
               install -d -m 0755 "${fontInstallDir}"
               find "${fontInstallDir}" -mindepth 1 -exec rm -rf {} +

--- a/modules/hosts/common/fonts.nix
+++ b/modules/hosts/common/fonts.nix
@@ -166,7 +166,17 @@ let
               done
 
               staging="${fontInstallDir}.new"
-              trap 'rm -rf "$tmpdir" "$staging"' EXIT
+              # Roll the rotated tree back before cleaning: a signal landing
+              # between the two mv calls below would otherwise leave the live
+              # path absent with the only copy parked at .old.
+              cleanup() {
+                rm -rf "$tmpdir" "$staging"
+                if [ ! -e "${fontInstallDir}" ] && [ -d "${fontInstallDir}.old" ]; then
+                  mv "${fontInstallDir}.old" "${fontInstallDir}"
+                fi
+                rm -rf "${fontInstallDir}.old"
+              }
+              trap cleanup EXIT
               rm -rf "$staging"
               install -d -m 0755 "$staging"
               cp -R "$tmpdir"/. "$staging/"

--- a/modules/hosts/common/fonts.nix
+++ b/modules/hosts/common/fonts.nix
@@ -166,12 +166,16 @@ let
               done
 
               staging="${fontInstallDir}.new"
-              # Roll the rotated tree back before cleaning: a signal landing
-              # between the two mv calls below would otherwise leave the live
-              # path absent with the only copy parked at .old.
+              # Roll the rotated tree back before cleaning, so an interrupted
+              # swap cannot leave the families stranded at .old. The test is
+              # emptiness rather than existence, because the tmpfiles rule above
+              # recreates the live path as an empty directory on every boot, and
+              # the empty live path is cleared first so the mv lands on it
+              # instead of nesting inside it.
               cleanup() {
                 rm -rf "$tmpdir" "$staging"
-                if [ ! -e "${fontInstallDir}" ] && [ -d "${fontInstallDir}.old" ]; then
+                if [ -d "${fontInstallDir}.old" ] && [ -z "$(find "${fontInstallDir}" -mindepth 1 -print -quit 2>/dev/null)" ]; then
+                  rm -rf "${fontInstallDir}"
                   mv "${fontInstallDir}.old" "${fontInstallDir}"
                 fi
                 rm -rf "${fontInstallDir}.old"

--- a/modules/hosts/common/fonts.nix
+++ b/modules/hosts/common/fonts.nix
@@ -1,7 +1,9 @@
 # Shared font stack plus the MonoLisa secret-font install pipeline. The
-# install path activates only when the encrypted archive exists and the host
-# registry sets sopsRuntimeReady. Hosts append fontconfig rules through the
-# host.fontconfig.extraRules option declared here.
+# encrypted archive ships MonoLisa v3 as two variable families under
+# monolisa/{code,text}: MonoLisaCode (monospace) and MonoLisaText
+# (proportional). The install path activates only when the encrypted archive
+# exists and the host registry sets sopsRuntimeReady. Hosts append fontconfig
+# rules through the host.fontconfig.extraRules option declared here.
 {
   config,
   lib,
@@ -16,6 +18,21 @@ let
   secretRuntimePath = "/run/secrets/fonts/monolisa.archive";
   fontInstallDir = "/var/lib/fonts/monolisa";
   hostsRegistry = config.flake.lib.nixos.hosts or { };
+
+  # Symbol and icon fallbacks appended after the primary family; the
+  # monospace list prefers the Mono variant so glyphs keep cell width.
+  symbolFallback = [
+    "Symbols Nerd Font"
+    "Symbols Nerd Font Mono"
+    "Font Awesome 6 Free"
+    "Font Awesome 6 Brands"
+  ];
+  monoSymbolFallback = [
+    "Symbols Nerd Font Mono"
+    "Symbols Nerd Font"
+    "Font Awesome 6 Free"
+    "Font Awesome 6 Brands"
+  ];
 
   body =
     {
@@ -55,27 +72,9 @@ let
 
             fontconfig = {
               defaultFonts = {
-                serif = [
-                  "MonoLisa"
-                  "Symbols Nerd Font"
-                  "Symbols Nerd Font Mono"
-                  "Font Awesome 6 Free"
-                  "Font Awesome 6 Brands"
-                ];
-                sansSerif = [
-                  "MonoLisa"
-                  "Symbols Nerd Font"
-                  "Symbols Nerd Font Mono"
-                  "Font Awesome 6 Free"
-                  "Font Awesome 6 Brands"
-                ];
-                monospace = [
-                  "MonoLisa"
-                  "Symbols Nerd Font Mono"
-                  "Symbols Nerd Font"
-                  "Font Awesome 6 Free"
-                  "Font Awesome 6 Brands"
-                ];
+                serif = [ "MonoLisaText" ] ++ symbolFallback;
+                sansSerif = [ "MonoLisaText" ] ++ symbolFallback;
+                monospace = [ "MonoLisaCode" ] ++ monoSymbolFallback;
                 emoji = [
                   "Noto Color Emoji"
                   "Symbols Nerd Font"
@@ -110,7 +109,7 @@ let
           ];
 
           systemd.services.monolisa-fonts = {
-            description = "Install MonoLisa fonts from encrypted archive";
+            description = "Install MonoLisa font families from encrypted archive";
             wantedBy = [ "multi-user.target" ];
             after = installSecretsDeps;
             requires = installSecretsDeps;
@@ -139,6 +138,13 @@ let
               trap 'rm -rf "$tmpdir"' EXIT
 
               tar -C "$tmpdir" --strip-components=1 -I zstd -xf "${secretRuntimePath}"
+
+              # Refuse to wipe the installed families for an archive that
+              # extracted without any font payload.
+              if [ -z "$(find "$tmpdir" -type f -name '*.ttf' -print -quit)" ]; then
+                echo "MonoLisa archive extracted with no TTF payload" >&2
+                exit 1
+              fi
 
               install -d -m 0755 "${fontInstallDir}"
               find "${fontInstallDir}" -mindepth 1 -exec rm -rf {} +

--- a/modules/hosts/common/fonts.nix
+++ b/modules/hosts/common/fonts.nix
@@ -165,14 +165,18 @@ let
                 fi
               done
 
-              install -d -m 0755 "${fontInstallDir}"
-              find "${fontInstallDir}" -mindepth 1 -exec rm -rf {} +
-
-              cp -R "$tmpdir"/. "${fontInstallDir}/"
-
-              find "${fontInstallDir}" -type d -exec chmod 0755 {} +
-              find "${fontInstallDir}" -type f -exec chmod 0644 {} +
-
+              staging="${fontInstallDir}.new"
+              rm -rf "$staging"
+              install -d -m 0755 "$staging"
+              cp -R "$tmpdir"/. "$staging/"
+              find "$staging" -type d -exec chmod 0755 {} +
+              find "$staging" -type f -exec chmod 0644 {} +
+              rm -rf "${fontInstallDir}.old"
+              if [ -d "${fontInstallDir}" ]; then
+                mv "${fontInstallDir}" "${fontInstallDir}.old"
+              fi
+              mv "$staging" "${fontInstallDir}"
+              rm -rf "${fontInstallDir}.old"
               fc-cache -f "${fontInstallDir}"
             '';
           };

--- a/modules/stylix/stylix.nix
+++ b/modules/stylix/stylix.nix
@@ -11,18 +11,23 @@ let
     polarity = lib.mkDefault "dark";
   };
 
-  monoLisaFonts = pkgs: popupSize: {
+  # Shared stylix font set for the NixOS and Home Manager scopes. MonoLisa v3
+  # installs through the hosts-common encrypted-archive pipeline, not a
+  # nixpkgs package, so the package attrs stay empty. Keeping both scopes on
+  # the same set makes stylix's fontconfig defaultFonts injection (mkOrder
+  # 600) agree with the hosts-common lists instead of prepending DejaVu.
+  monoLisaFonts = pkgs: {
     sansSerif = lib.mkDefault {
       package = pkgs.emptyDirectory;
-      name = "MonoLisa";
+      name = "MonoLisaText";
     };
     serif = lib.mkDefault {
       package = pkgs.emptyDirectory;
-      name = "MonoLisa";
+      name = "MonoLisaText";
     };
     monospace = {
       package = pkgs.emptyDirectory;
-      name = "MonoLisa";
+      name = "MonoLisaCode";
     };
     emoji = {
       package = pkgs.noto-fonts-color-emoji;
@@ -31,7 +36,7 @@ let
     sizes = {
       applications = 11;
       desktop = 12;
-      popups = popupSize;
+      popups = 11;
       terminal = 12;
     };
   };
@@ -39,53 +44,62 @@ in
 {
   flake = {
     nixosModules = {
-      base = {
-        imports = [ inputs.stylix.nixosModules.stylix ];
-        stylix = baseTheme // {
-          homeManagerIntegration.autoImport = false;
-          targets = {
-            gnome.enable = false;
-            regreet.enable = false;
-            # Enable Chromium theming (applies to Google Chrome via browser policies)
-            chromium.enable = true;
-            # The NixOS-scope target only enables a nixpkgs overlay that
-            # patches gtksourceview 2/3/4/5 with the generated color scheme.
-            # The hash change forces gtksourceview and every consumer
-            # (planify, inkscape, ...) to rebuild from source on each nixpkgs
-            # bump. The Home Manager target ships the same scheme as
-            # user-scope data files, keeping the theming without rebuilds.
-            gtksourceview.enable = false;
+      base =
+        { pkgs, ... }:
+        {
+          imports = [ inputs.stylix.nixosModules.stylix ];
+          stylix = baseTheme // {
+            fonts = monoLisaFonts pkgs;
+            homeManagerIntegration.autoImport = false;
+            targets = {
+              gnome.enable = false;
+              regreet.enable = false;
+              # Both hosts boot systemd-boot; keep the grub target off so it
+              # can never run grub-mkfont against the empty font packages.
+              grub.enable = false;
+              # Enable Chromium theming (applies to Google Chrome via browser policies)
+              chromium.enable = true;
+              # The NixOS-scope target only enables a nixpkgs overlay that
+              # patches gtksourceview 2/3/4/5 with the generated color scheme.
+              # The hash change forces gtksourceview and every consumer
+              # (planify, inkscape, ...) to rebuild from source on each nixpkgs
+              # bump. The Home Manager target ships the same scheme as
+              # user-scope data files, keeping the theming without rebuilds.
+              gtksourceview.enable = false;
+            };
           };
         };
-      };
 
       # end of nixosModules
     };
 
     homeManagerModules = {
-      base = {
-        imports = [ inputs.stylix.homeModules.stylix ];
-        # Stylix's nixvim home-manager target adds a back-compat setter
-        # `lib.stylix.nixvim.config = ... config.stylix.targets.nixvim.exportedModule`
-        # whose value graph reaches `cfg.enable`, defined as
-        # `config.lib.stylix.mkEnableTargetWith ...`. Evaluating
-        # `home-manager.users.<u>.lib` therefore loops through itself.
-        # Targets under modules/neovim/ (neovim, neovide, nixvim, nvf, vim) are
-        # all unused in this configuration (nixvim theming uses onedark.nvim),
-        # so disabling the whole hm.nix target group is safe and breaks the
-        # cycle without losing functionality.
-        disabledModules = [ "${inputs.stylix}/modules/neovim/hm.nix" ];
-        stylix = baseTheme // {
-          overlays.enable = false;
-          targets = {
-            kde.enable = false;
-            gnome.enable = false;
-            sway.enable = false;
-            river.enable = false;
-            swaylock.enable = false;
+      base =
+        { pkgs, ... }:
+        {
+          imports = [ inputs.stylix.homeModules.stylix ];
+          # Stylix's nixvim home-manager target adds a back-compat setter
+          # `lib.stylix.nixvim.config = ... config.stylix.targets.nixvim.exportedModule`
+          # whose value graph reaches `cfg.enable`, defined as
+          # `config.lib.stylix.mkEnableTargetWith ...`. Evaluating
+          # `home-manager.users.<u>.lib` therefore loops through itself.
+          # Targets under modules/neovim/ (neovim, neovide, nixvim, nvf, vim) are
+          # all unused in this configuration (nixvim theming uses onedark.nvim),
+          # so disabling the whole hm.nix target group is safe and breaks the
+          # cycle without losing functionality.
+          disabledModules = [ "${inputs.stylix}/modules/neovim/hm.nix" ];
+          stylix = baseTheme // {
+            fonts = monoLisaFonts pkgs;
+            overlays.enable = false;
+            targets = {
+              kde.enable = false;
+              gnome.enable = false;
+              sway.enable = false;
+              river.enable = false;
+              swaylock.enable = false;
+            };
           };
         };
-      };
 
       apps.stylix-gui =
         {
@@ -249,9 +263,6 @@ in
           stylix = {
             # Opacity settings for GUI applications
             opacity = lib.genAttrs [ "applications" "desktop" "popups" "terminal" ] (_n: 1.0);
-
-            # Font configuration for GUI applications
-            fonts = monoLisaFonts pkgs 11;
 
             # Icon theme configuration
             icons = {

--- a/modules/stylix/stylix.nix
+++ b/modules/stylix/stylix.nix
@@ -342,7 +342,9 @@ in
                 );
 
             kitty = {
-              settings.font_size = 12;
+              # Track the shared terminal size so a host re-picking
+              # stylix.fonts.sizes.terminal is not silently overridden here.
+              settings.font_size = config.stylix.fonts.sizes.terminal;
               extraConfig = "modify_font cell_height 100%";
             };
           };

--- a/modules/stylix/stylix.nix
+++ b/modules/stylix/stylix.nix
@@ -16,6 +16,8 @@ let
   # nixpkgs package, so the package attrs stay empty. Keeping both scopes on
   # the same set makes stylix's fontconfig defaultFonts injection (mkOrder
   # 600) agree with the hosts-common lists instead of prepending DejaVu.
+  # All four families carry the same mkDefault priority as the baseTheme
+  # values, so a host re-picks any one of them without reaching for mkForce.
   monoLisaFonts = pkgs: {
     sansSerif = lib.mkDefault {
       package = pkgs.emptyDirectory;
@@ -25,11 +27,11 @@ let
       package = pkgs.emptyDirectory;
       name = "MonoLisaText";
     };
-    monospace = {
+    monospace = lib.mkDefault {
       package = pkgs.emptyDirectory;
       name = "MonoLisaCode";
     };
-    emoji = {
+    emoji = lib.mkDefault {
       package = pkgs.noto-fonts-color-emoji;
       name = "Noto Color Emoji";
     };

--- a/modules/stylix/stylix.nix
+++ b/modules/stylix/stylix.nix
@@ -35,7 +35,7 @@ let
       package = pkgs.noto-fonts-color-emoji;
       name = "Noto Color Emoji";
     };
-    sizes = {
+    sizes = lib.mkDefault {
       applications = 11;
       desktop = 12;
       popups = 11;

--- a/modules/tpnix/fonts.nix
+++ b/modules/tpnix/fonts.nix
@@ -1,6 +1,7 @@
 _: {
   configurations.nixos.tpnix.module = {
-    # Prefer Arabic-capable Noto faces ahead of MonoLisa for Arabic text.
+    # Prefer Arabic-capable Noto faces ahead of the MonoLisa families for
+    # Arabic text.
     host.fontconfig.extraRules = ''
       <match target="pattern">
         <test name="lang" compare="contains">

--- a/packages/malimite/default.nix
+++ b/packages/malimite/default.nix
@@ -58,6 +58,9 @@ stdenv.mkDerivation {
     # Create wrapper script that sets up writable working directory
     # Malimite needs to write to malimite.properties and expects DecompilerBridge in cwd
     # Always regenerate config from template to ensure Ghidra path is current
+    # No font flag: FlatSystemProperties reads no defaultFont property, so one is
+    # inert, and the decompiler pane is an RSyntaxTextArea, whose UI delegate
+    # discards any look-and-feel font for its own monospaced default.
     makeWrapper ${temurin-bin-21}/bin/java $out/bin/malimite \
       --add-flags "-Xms2G" \
       --add-flags "-Xmx8G" \
@@ -75,7 +78,6 @@ stdenv.mkDerivation {
       --add-flags "-Dawt.useSystemAAFontSettings=on" \
       --add-flags "-Dsun.java2d.xrender=true" \
       --add-flags "-Dswing.defaultlaf=com.formdev.flatlaf.FlatDarkLaf" \
-      --add-flags "-Dflatlaf.defaultFont=MonoLisaText" \
       --add-flags "-jar $out/share/malimite/${jarName}" \
       --run 'MALIMITE_HOME="$HOME/.local/share/malimite" && \
              mkdir -p "$MALIMITE_HOME" && \

--- a/packages/malimite/default.nix
+++ b/packages/malimite/default.nix
@@ -75,7 +75,7 @@ stdenv.mkDerivation {
       --add-flags "-Dawt.useSystemAAFontSettings=on" \
       --add-flags "-Dsun.java2d.xrender=true" \
       --add-flags "-Dswing.defaultlaf=com.formdev.flatlaf.FlatDarkLaf" \
-      --add-flags "-Dflatlaf.defaultFont=MonoLisa" \
+      --add-flags "-Dflatlaf.defaultFont=MonoLisaText" \
       --add-flags "-jar $out/share/malimite/${jarName}" \
       --run 'MALIMITE_HOME="$HOME/.local/share/malimite" && \
              mkdir -p "$MALIMITE_HOME" && \


### PR DESCRIPTION
## Summary

MonoLisa v3.000 replaces the single static `MonoLisa` family with two variable families: `MonoLisaCode` (monospace) and `MonoLisaText` (proportional). This PR reworks the whole font stack around that split and overhauls the font-related config it touches.

- `modules/hosts/common/fonts.nix`: the encrypted archive now ships the four v3 variable TTFs under `monolisa/{code,text}/`. Generic fontconfig classes point at the split (`MonoLisaText` for serif/sansSerif, `MonoLisaCode` for monospace), each followed by a real text face (`Noto Serif`, `Noto Sans`, `Liberation Mono`) ahead of the symbol/icon fallback tails, which are factored into named lists. That intermediate face matters: with an icon-only font next in line, `fc-match sans-serif:lang=en` resolves to a Nerd Font with no Latin coverage whenever the archive has not been installed yet. The install service refuses to run unless the archive extracts a font payload for both families and those faces declare the `MonoLisaCode` and `MonoLisaText` family names the rest of the stack selects by (checked with `fc-query`, since nothing else validates that contract and a mismatch would silently drop every generic class to the fallbacks), and stages the extracted tree in `monolisa.new` for an atomic swap into `/var/lib/fonts/monolisa` (rotating the previous tree through `monolisa.old`), so an interrupted service or an ENOSPC mid-copy can no longer leave the live directory empty or half-populated. The EXIT handler covers the staging tree as well as the temp dir, and rolls the rotated tree back when the live path is absent, so a run killed between the two `mv` calls restores the previous families instead of leaving the directory empty.
- `modules/stylix/stylix.nix`: one shared MonoLisa font set now applies at both the NixOS and Home Manager scopes (previously only HM `apps.stylix-gui` set fonts). This fixes a pre-existing ordering defect: stylix's fontconfig target injects its font names at `mkOrder 600`, ahead of the hosts-common lists at order 1000, so generic lookups resolved to stylix's DejaVu defaults before MonoLisa. Both scopes agreeing on MonoLisa puts the intended families first. The stylix grub target is disabled explicitly (both hosts boot systemd-boot; it is the one NixOS-scope consumer that would run `grub-mkfont` against the empty font packages). `programs.kitty.settings.font_size` now reads `config.stylix.fonts.sizes.terminal` instead of repeating the literal, so a host re-picking that size is not silently overridden for kitty alone.
- `modules/apps/doom-emacs-doomdir/config.el`: `doom-font` pinned to `MonoLisaCode`, `doom-variable-pitch-font` to `MonoLisaText`, so variable-pitch faces get the proportional cut. Both sizes are the float `12.0`, because `font-spec`'s `:size` is pixels for an integer and points for a float; `12` would render roughly 9pt at 96dpi against a stack that is otherwise in points.
- `modules/tpnix/fonts.nix`: comment only. The Arabic fontconfig rule matches on `lang`, not on a family name, so the Code/Text split needs no XML change there.
- `packages/malimite/default.nix`: the `-Dflatlaf.defaultFont` wrapper flag is removed rather than renamed. Inspecting the shipped `Malimite-1-2.jar` shows FlatLaf's `FlatSystemProperties` reads twelve `flatlaf.*` properties and `defaultFont` is not one of them, and nothing in Malimite's own 265 classes reads it either, so the flag was inert. The decompiler pane is an `RSyntaxTextArea`, whose UI delegate discards look-and-feel fonts for its own monospaced default regardless.
- `modules/browsers/gecko-chrome/userChrome.css`: removed the dead commented-out block referencing `MonoLisa Variable`, a family no archive ever shipped.
- `docs/ONBOARDING.md`: the stylix module description now names both families.
- Secrets submodule (pushed directly to `main` per instructions): `98d420a` + `4976b23` replace the cleartext v3 zips with sops-encrypted artifacts and bump the archive layout.

## Decisions

1. **Everything in `secrets/fonts/` is sops-encrypted again.** The cleartext zips added in secrets `d3e4158` failed the `secrets-no-cleartext` flake check (deny-by-default, `*.zip` is not exempt), and `self.submodules = true` copies the submodule tree into the world-readable store on every flake fetch. `nix flake check` on this branch passes again.
2. **One combined desktop archive** (`fonts/monolisa.tar.zst`, layout `monolisa/{code,text}/`) instead of per-family archives: both families share one purchase, one lifecycle, one secret, one install service.
3. **Webfont bundles kept but not deployed.** No module consumes woff2; they stay archived encrypted as `monolisa-code-webfont.zip` and `monolisa-text-webfont.zip`. The Text bundle was renamed from `monolisa-webfont.zip`, whose name did not match its contents.
4. **No `MonoLisa` compatibility alias.** All references were updated to the new family names instead, per the repo rule to eliminate legacy support.
5. **UI text classes get `MonoLisaText`**, matching the point of the new proportional family; terminals, editors, and generic monospace keep `MonoLisaCode`.
6. **No global fontconfig forcing of MonoLisa stylistic sets** (ss01 etc.). The old userChrome block that experimented with them had been deliberately disabled; feature selection stays an app-level choice.
7. **Existing font packages untouched** (`google-fonts`, `maple-mono.NF`, corefonts, Noto stack): they serve as coverage fallbacks independent of the MonoLisa refresh.
8. **Secrets history still contains the cleartext zips** (private repo). No history rewrite was performed; the prerequisite unpushed secrets commit `d3e4158` was pushed as-is because superproject `main` already recorded its gitlink.
9. **The install script keeps extracting to a tmpfs temp dir before copying into staging**, rather than extracting straight into the staging tree. The payload is 2.93 MiB, so the saved copy is not worth it, and `cp -R` without `-p` is what currently launders ownership to root: GNU tar restores stored uid/gid when run as root, so direct extraction would make root ownership an assumption about how the archive is repacked rather than a property the script enforces.
10. **`monoLisaFonts` keeps `lib.mkDefault` at the family level, not per field.** `stylix.fonts.<family>` and `stylix.fonts.sizes` are flat `mkOption` declarations in upstream stylix, not a `types.submodule`, so `pushDownProperties` already distributes the outer wrapper onto each key before `filterOverrides` runs. A host overriding one field keeps its siblings. Verified by evaluating the pinned `Bad3r/stylix` revision with a simulated per-field host override.

## Test plan

- [x] `nix run path:.#treefmt -- <changed files>` clean
- [x] `sops -d` round-trips of all three encrypted artifacts are byte-identical (sha256 compared against pre-encryption archives)
- [x] `nix eval path:.#nixosConfigurations.{tpnix,system76}.config.fonts.fontconfig.defaultFonts`: MonoLisa families lead every generic class on both hosts
- [x] `nix eval path:.#nixosConfigurations.tpnix.config.home-manager.users.vx.stylix.fonts.{monospace,sansSerif}.name`: `MonoLisaCode` / `MonoLisaText`
- [x] `nix eval path:.#nixosConfigurations.tpnix.config.home-manager.users.vx.programs.kitty.settings.font_size` resolves to `12`, unchanged by the switch to the option reference
- [x] Read the name tables out of the shipped archive: all four faces declare `MonoLisaCode` / `MonoLisaText` unspaced, and the new `fc-query` assertion passes on that archive while rejecting both a foreign-face tree and a `code/`-only tree
- [x] Simulated the install script's four exit paths (success, kill during `cp -R`, kill between the two `mv` calls, kill before the final `rm -rf .old`): the live path ends up present and populated in all four, with no `.new` or `.old` residue
- [x] `shellcheck` on the rendered `monolisa-fonts` unit script exits 0; the rendered script shows `trap 'rm -rf "$tmpdir" "$staging"' EXIT` with `${fontInstallDir}` interpolated and the shell variables left unexpanded
- [x] `nix flake check path:. --accept-flake-config --no-build --offline` exit 0 (includes `secrets-no-cleartext`)
- [x] `nix build path:.#nixosConfigurations.tpnix.config.system.build.toplevel` exit 0 (full closure, includes the Doom Emacs config build)
- [x] `nix eval path:.#nixosConfigurations.system76.config.system.build.toplevel.drvPath` exit 0
- [ ] Post-merge: `./build.sh` switch on a host, then verify `systemctl status monolisa-fonts` and `fc-list | grep -i monolisa` shows both families
- [ ] Post-merge: interrupt `monolisa-fonts.service` mid-copy, rerun it, and confirm `/var/lib/fonts/monolisa` is intact with no `monolisa.new` or `monolisa.old` left behind
