### PR TITLE
feat(apps): add iPhone pairing, file transfer, and backup tooling

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -29,6 +29,7 @@ crypted = "crypted"           # LUKS device mapper name
 wdth = "wdth"                 # CSS font-variation-settings property
 substituters = "substituters" # nix substituters
 ANC = "ANC"                   # Active Noise Cancellation (AirPods)
+udid = "udid"                 # Apple Unique Device Identifier (ifuse -u, idevicepair)
 # Hashes/keys (extend-ignore-re should catch most, but explicit for safety)
 "981DE78A201C2B735FF0B545A3967CCA47D5275F" = "981DE78A201C2B735FF0B545A3967CCA47D5275F"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -187,6 +187,8 @@
   - Scheduled upstream sync workflow installed in each flake-input fork, its conflict behavior, and the installer for adding new forks.
 - [reference/github-labels.md](reference/github-labels.md)
   - GitHub label taxonomy, application rules, and label-family reference for issues and pull requests.
+- [reference/iphone.md](reference/iphone.md)
+  - iPhone pairing, AFC and PTP file transfer, encrypted backups, and USB tethering through the usbmuxd/libimobiledevice stack.
 - [reference/local-mirrors.md](reference/local-mirrors.md)
   - List of repositories mirrored locally via `git-mirror` for offline access and patching.
 - [reference/mcp-tools.md](reference/mcp-tools.md)

--- a/docs/reference/iphone.md
+++ b/docs/reference/iphone.md
@@ -85,6 +85,13 @@ gphoto2 --new --get-all-files
 Keep the phone unlocked for the whole transfer and accept the
 photo-access prompt. HEIC/HEVC files transfer as-is.
 
+PTP goes through libusb rather than usbmuxd, so it needs libgphoto2's
+own udev rules. `modules/apps/gphoto2.nix` installs them and adds the
+owner to the `camera` group those rules hardcode. Neither `gvfs` nor
+`usbmuxd` supplies them. After the first `nixos-rebuild switch` that
+lands this, log out and back in; until the new group is in the
+session, every `gphoto2` device command fails as an ordinary user.
+
 ### Fast paths over the network
 
 - LocalSend (already enabled) works well for everyday-sized files in
@@ -156,9 +163,17 @@ access point.
   `idevicepair unpair && idevicepair pair`.
 - File manager shows app folders but no `DCIM`: trust is incomplete;
   unlock the phone and re-pair.
-- PTP listing fails after an iOS upgrade: stable libgphoto2 has a
-  known listing regression against iOS 27 betas (fixed upstream in
-  git); use the ifuse `DCIM` path until a release lands.
+- `gphoto2` fails on permissions for an ordinary user: the `camera`
+  group is not in the current session; log out and back in after the
+  rebuild that first installs the libgphoto2 udev rules.
+- `gphoto2` reports it cannot claim the USB device: gvfs's gphoto2
+  volume monitor holds the PTP port on detection, with or without a
+  mount; stop it and rerun the transfer with
+  `systemctl --user stop gvfs-gphoto2-volume-monitor.service`.
+- PTP listing fails after an iOS upgrade: libgphoto2 2.5.34 aborts
+  the folder listing with `GP_ERROR_FILE_EXISTS (-103)` on iOS 27
+  betas, which repeat PTP filenames (upstream libgphoto2 issue 1258,
+  open as of 2026-08); use the ifuse `DCIM` path meanwhile.
 - USBGuard is force-disabled in `modules/hosts/common/usbguard.nix`.
   If it is ever re-enabled, allow the device per
   `docs/usbguard/README.md` before usbmuxd can see it.

--- a/docs/reference/iphone.md
+++ b/docs/reference/iphone.md
@@ -56,7 +56,7 @@ path; use it for browsing, not bulk copies.
 mkdir -p ~/mnt/iphone
 ifuse ~/mnt/iphone
 rsync -av --progress ~/mnt/iphone/DCIM/ ~/Pictures/iphone/
-fusermount -u ~/mnt/iphone
+fusermount3 -u ~/mnt/iphone
 ```
 
 Expectations: AFC is protocol-bound at roughly 2-20 MB/s reads and

--- a/docs/reference/iphone.md
+++ b/docs/reference/iphone.md
@@ -130,12 +130,23 @@ sha256sum huge.zip.part-* > SHA256SUMS
 ```sh
 idevicebackup2 encryption on
 idevicebackup2 backup --full ~/backups/iphone
-idevicebackup2 restore --system --settings ~/backups/iphone
 ```
 
 Prefer encrypted backups: they include health and keychain data that
 unencrypted backups omit. The `list` subcommand is broken upstream.
 Full backups of a large phone take hours at AFC-class throughput.
+`backup --full` updates the existing set under `<dir>/<udid>/` in
+place rather than writing a new dated copy.
+
+NOTE: `restore --system --settings` overwrites the phone's current
+system files and settings from this backup and reboots the device
+when done; upstream reboots unless `--no-reboot` is passed. Run it
+only as a deliberate, separate step, never pasted with the backup
+above.
+
+```sh
+idevicebackup2 restore --system --settings ~/backups/iphone
+```
 
 `pymobiledevice3` is the actively developed alternative, including
 selective backups:

--- a/docs/reference/iphone.md
+++ b/docs/reference/iphone.md
@@ -85,12 +85,15 @@ gphoto2 --new --get-all-files
 Keep the phone unlocked for the whole transfer and accept the
 photo-access prompt. HEIC/HEVC files transfer as-is.
 
-PTP goes through libusb rather than usbmuxd, so it needs libgphoto2's
-own udev rules. `modules/apps/gphoto2.nix` installs them and adds the
-owner to the `camera` group those rules hardcode. Neither `gvfs` nor
-`usbmuxd` supplies them. After the first `nixos-rebuild switch` that
-lands this, log out and back in; until the new group is in the
-session, every `gphoto2` device command fails as an ordinary user.
+PTP goes through libusb rather than usbmuxd. A local seat session
+already reaches the device without any repo change: stock systemd
+`70-uaccess.rules` tags any USB device exposing the PTP interface
+class for `uaccess`, and `73-seat-late.rules` ACLs it to the active
+seat. `modules/apps/gphoto2.nix` installs libgphoto2's own rules on
+top, because they are the only source of the `ID_GPHOTO2` property
+gvfs keys on to offer the camera volume, and they group-gate the
+device to `camera`, which is the path for non-seat access such as
+SSH. That group reaches a session only at login.
 
 ### Fast paths over the network
 
@@ -174,9 +177,10 @@ access point.
   `idevicepair unpair && idevicepair pair`.
 - File manager shows app folders but no `DCIM`: trust is incomplete;
   unlock the phone and re-pair.
-- `gphoto2` fails on permissions for an ordinary user: the `camera`
-  group is not in the current session; log out and back in after the
-  rebuild that first installs the libgphoto2 udev rules.
+- `gphoto2` fails on permissions over SSH or from a unit: `uaccess`
+  ACLs the device to the active local seat only, and non-seat access
+  goes through the `camera` group, which reaches a session at login;
+  log in again after the switch that added it.
 - `gphoto2` reports it cannot claim the USB device: gvfs's gphoto2
   volume monitor holds the PTP port on detection, with or without a
   mount; stop it and rerun the transfer with

--- a/docs/reference/iphone.md
+++ b/docs/reference/iphone.md
@@ -132,15 +132,21 @@ sha256sum huge.zip.part-* > SHA256SUMS
 ## Backup
 
 ```sh
-idevicebackup2 encryption on
+mkdir -p ~/backups/iphone
+idevicebackup2 encryption on -i
 idevicebackup2 backup --full ~/backups/iphone
 ```
 
 Prefer encrypted backups: they include health and keychain data that
-unencrypted backups omit. The `list` subcommand is broken upstream.
-Full backups of a large phone take hours at AFC-class throughput.
-`backup --full` updates the existing set under `<dir>/<udid>/` in
-place rather than writing a new dated copy.
+unencrypted backups omit. Any password-handling subcommand needs
+`-i` to prompt, or `BACKUP_PASSWORD_NEW` and `BACKUP_PASSWORD` in
+the environment; with neither it refuses to read a password and
+exits before contacting the device. The tool also never creates the
+top-level backup directory, only the per-device folder inside it.
+The `list` subcommand is broken upstream. Full backups of a large
+phone take hours at AFC-class throughput. `backup --full` updates
+the existing set under `<dir>/<udid>/` in place rather than writing
+a new dated copy.
 
 NOTE: `restore --system --settings` overwrites the phone's current
 system files and settings from this backup and reboots the device
@@ -149,7 +155,7 @@ only as a deliberate, separate step, never pasted with the backup
 above.
 
 ```sh
-idevicebackup2 restore --system --settings ~/backups/iphone
+idevicebackup2 restore --system --settings -i ~/backups/iphone
 ```
 
 `pymobiledevice3` is the actively developed alternative, including

--- a/docs/reference/iphone.md
+++ b/docs/reference/iphone.md
@@ -55,15 +55,16 @@ path; use it for browsing, not bulk copies.
 ```sh
 mkdir -p ~/mnt/iphone
 ifuse ~/mnt/iphone
-rsync -av --progress ~/mnt/iphone/DCIM/ ~/Pictures/iphone/
+rsync -av --partial --progress ~/mnt/iphone/DCIM/ ~/Pictures/iphone/
 fusermount3 -u ~/mnt/iphone
 ```
 
 Expectations: AFC is protocol-bound at roughly 2-20 MB/s reads and
 often 1-2 MB/s writes, regardless of USB 2 or USB 3 hardware. Long
 imports can hit an AFC idle disconnect (known upstream
-libimobiledevice issue); remount and rerun rsync, which resumes where
-it stopped.
+libimobiledevice issue); remount and rerun rsync, which resumes the
+interrupted file rather than recopying it. `--partial` is what makes
+that true: without it rsync discards the in-flight temp file.
 
 ### Per-app documents
 

--- a/docs/reference/iphone.md
+++ b/docs/reference/iphone.md
@@ -1,0 +1,148 @@
+# iPhone Support
+
+Apple ships no iOS tooling for Linux; everything below runs on the
+community stack (libimobiledevice 1.4.0 era, current as of 2026-08).
+The moving parts in this repo:
+
+- `modules/apps/usbmuxd.nix`: the pairing daemon
+  (`services.usbmuxd.extended`), required by every USB path including
+  tethering trust.
+- `modules/apps/libimobiledevice.nix`: `idevicepair`, `ideviceinfo`,
+  `idevicebackup2`, `afcclient`, `idevicesyslog`.
+- `modules/apps/ifuse.nix`: FUSE mounts of the media filesystem and
+  per-app Documents folders.
+- `modules/apps/gphoto2.nix`: scriptable PTP camera-roll import.
+- Already present: the gvfs AFC and gphoto2 backends
+  (`services.gvfs` in `modules/hosts/common/services.nix`) and
+  LocalSend (`modules/apps/localsend.nix`, port 53317).
+
+All are enabled in the common baseline
+(`modules/hosts/common/apps-enable.nix`); per-host `appEnable`
+overrides can opt out, but `libimobiledevice` and `ifuse` assert that
+the usbmuxd daemon stays enabled.
+
+## Pairing And Trust
+
+Connect with a data-capable cable, unlock the phone, then:
+
+```sh
+idevicepair pair      # accept the trust dialog on the phone, run again
+idevicepair validate
+ideviceinfo -k ProductVersion
+```
+
+Major iOS upgrades can invalidate the stored pair record. When
+lockdownd starts refusing connections, reset it:
+
+```sh
+idevicepair unpair && idevicepair pair
+```
+
+## File Transfer
+
+iOS never exposes mass storage. USB access is limited to the media
+area (`DCIM`, `Downloads`, recordings), per-app Documents folders, and
+the read-only PTP camera roll.
+
+### File manager (casual)
+
+After pairing, the device appears in PCManFM/Nemo through gvfs with a
+documents (AFC) and a camera (gphoto2) volume. This is the slowest
+path; use it for browsing, not bulk copies.
+
+### Bulk copies (ifuse + rsync)
+
+```sh
+mkdir -p ~/mnt/iphone
+ifuse ~/mnt/iphone
+rsync -av --progress ~/mnt/iphone/DCIM/ ~/Pictures/iphone/
+fusermount -u ~/mnt/iphone
+```
+
+Expectations: AFC is protocol-bound at roughly 2-20 MB/s reads and
+often 1-2 MB/s writes, regardless of USB 2 or USB 3 hardware. Long
+imports can hit an AFC idle disconnect (known upstream
+libimobiledevice issue); remount and rerun rsync, which resumes where
+it stopped.
+
+### Per-app documents
+
+```sh
+ifuse --list-apps
+ifuse --documents <bundle-id> ~/mnt/iphone
+```
+
+Only apps that opt into file sharing are mountable.
+
+### Camera roll over PTP (gphoto2)
+
+```sh
+gphoto2 --auto-detect
+gphoto2 --get-all-files --filename '%Y%m%d-%H%M%S-%n.%C'
+gphoto2 --new --get-all-files
+```
+
+Keep the phone unlocked for the whole transfer and accept the
+photo-access prompt. HEIC/HEVC files transfer as-is.
+
+### Fast paths over the network
+
+- LocalSend (already enabled) transfers both directions and usually
+  beats USB AFC for large pushes.
+- The iOS Files app has a built-in SMB client (Connect to Server)
+  that mounts any LAN SMB share at Wi-Fi speed.
+
+## Backup
+
+```sh
+idevicebackup2 encryption on
+idevicebackup2 backup --full ~/backups/iphone
+idevicebackup2 restore --system --settings ~/backups/iphone
+```
+
+Prefer encrypted backups: they include health and keychain data that
+unencrypted backups omit. The `list` subcommand is broken upstream.
+Full backups of a large phone take hours at AFC-class throughput.
+
+`pymobiledevice3` is the actively developed alternative, including
+selective backups:
+
+```sh
+nix shell nixpkgs#python3Packages.pymobiledevice3
+pymobiledevice3 backup2 backup --full <dir>
+```
+
+## Tethering
+
+USB: pair once, enable Settings > Personal Hotspot, and the in-kernel
+`ipheth` driver exposes an ethernet interface NetworkManager brings up
+automatically. NCM support (kernel 6.5 onward, with fixes through
+current kernels) removed the historic drop/instability problems; the
+cellular link, not USB, is the bottleneck. Bluetooth PAN via blueman
+is a workable alternative, and the Wi-Fi hotspot behaves as a normal
+access point.
+
+## Troubleshooting
+
+- `idevice_id -l` prints nothing: replug, check
+  `systemctl status usbmuxd`, confirm the phone is unlocked.
+- SSL or lockdownd connection errors: re-pair with
+  `idevicepair unpair && idevicepair pair`.
+- File manager shows app folders but no `DCIM`: trust is incomplete;
+  unlock the phone and re-pair.
+- PTP listing fails after an iOS upgrade: stable libgphoto2 has a
+  known listing regression against iOS 27 betas (fixed upstream in
+  git); use the ifuse `DCIM` path until a release lands.
+- USBGuard is force-disabled in `modules/hosts/common/usbguard.nix`.
+  If it is ever re-enabled, allow the device per
+  `docs/usbguard/README.md` before usbmuxd can see it.
+- Music sync into the native Music app is not possible from Linux;
+  that protocol was never reverse engineered. Use streaming or
+  per-app drops (`ifuse --documents`) into players that manage their
+  own library.
+
+## External References
+
+- `https://libimobiledevice.org/`
+- `https://wiki.archlinux.org/title/IOS`
+- `https://github.com/doronz88/pymobiledevice3`

--- a/docs/reference/iphone.md
+++ b/docs/reference/iphone.md
@@ -87,10 +87,36 @@ photo-access prompt. HEIC/HEVC files transfer as-is.
 
 ### Fast paths over the network
 
-- LocalSend (already enabled) transfers both directions and usually
-  beats USB AFC for large pushes.
+- LocalSend (already enabled) works well for everyday-sized files in
+  both directions, but it has no transfer resume and fails outright
+  on 100 GiB-class archives (observed with a 120 GiB zip). Do not
+  use it for very large files.
 - The iOS Files app has a built-in SMB client (Connect to Server)
   that mounts any LAN SMB share at Wi-Fi speed.
+
+### Very large files (tens of GiB and up)
+
+No iOS transport moves a 100 GiB-class file reliably in one piece:
+LocalSend fails, Files-app SMB copies cannot resume, and iOS
+suspends app-driven transfers when the screen locks. Chunk first;
+then any transport works and every failure is retryable per part:
+
+```sh
+split -b 4G huge.zip huge.zip.part-
+sha256sum huge.zip.part-* > SHA256SUMS
+# after transfer: sha256sum -c SHA256SUMS && cat huge.zip.part-* > huge.zip
+```
+
+- Phone to computer over USB: `ifuse` plus
+  `rsync --partial --progress` resumes across AFC idle disconnects
+  (remount and rerun).
+- Either direction over Wi-Fi: copy the parts through the SMB share
+  with the phone kept awake, or run an SFTP/WebDAV server app on the
+  phone and drive the copy with rclone from the computer, which
+  retries per chunk.
+- Computer to phone over USB is the worst case: AFC writes run at
+  1-2 MB/s, roughly a day for 100 GiB. Prefer a network path in that
+  direction.
 
 ## Backup
 

--- a/modules/apps/gphoto2.nix
+++ b/modules/apps/gphoto2.nix
@@ -19,7 +19,7 @@
   Notes:
     * Talks libgphoto2/libusb directly and does not use usbmuxd; the device must stay unlocked during transfers.
     * PTP access to iOS devices is read-only by design; deleting after transfer is the only write operation iOS permits.
-    * Installs libgphoto2's udev rules and adds the owner to the "camera" group they hardcode; neither gvfs nor usbmuxd supplies them, so without both the CLI only works as root. Group membership needs a fresh login.
+    * Installs libgphoto2's udev rules, the only source of the ID_GPHOTO2 property gvfs keys on to offer the camera volume, and creates the "camera" group they hardcode. Stock systemd 70-uaccess.rules already ACLs PTP-class devices to the active local seat, so the group grant covers non-seat access such as SSH, and only that path needs a fresh login.
     * gvfs runs its own gphoto2 volume monitor against the same libgphoto2; only one process can claim the PTP port, so the monitor has to be stopped before a CLI transfer.
 */
 _:
@@ -59,9 +59,10 @@ let
 
             environment.systemPackages = [ cfg.package ];
 
-            # 40-libgphoto2.rules is generated with `print-camera-list udev-rules
-            # ... group camera` and carries no uaccess tag, so the group and its
-            # membership are both required for non-root PTP access.
+            # The shipped rules set ID_GPHOTO2, which gvfs keys on to offer the
+            # camera volume, and group-gate the device to "camera". Stock
+            # 70-uaccess.rules already ACLs PTP-class devices to the active
+            # seat, so the group covers non-seat access only.
             services.udev.packages = [ pkgs.libgphoto2 ];
             users.groups.camera = { };
           }

--- a/modules/apps/gphoto2.nix
+++ b/modules/apps/gphoto2.nix
@@ -19,6 +19,8 @@
   Notes:
     * Talks libgphoto2/libusb directly and does not use usbmuxd; the device must stay unlocked during transfers.
     * PTP access to iOS devices is read-only by design; deleting after transfer is the only write operation iOS permits.
+    * Installs libgphoto2's udev rules and adds the owner to the "camera" group they hardcode; neither gvfs nor usbmuxd supplies them, so without both the CLI only works as root. Group membership needs a fresh login.
+    * gvfs runs its own gphoto2 volume monitor against the same libgphoto2; only one process can claim the PTP port, so the monitor has to be stopped before a CLI transfer.
 */
 _:
 let
@@ -26,11 +28,13 @@ let
     {
       config,
       lib,
+      metaOwner,
       pkgs,
       ...
     }:
     let
       cfg = config.programs.gphoto2.extended;
+      owner = metaOwner.username or null;
     in
     {
       options.programs.gphoto2.extended = {
@@ -43,9 +47,30 @@ let
         package = lib.mkPackageOption pkgs "gphoto2" { };
       };
 
-      config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
-      };
+      config = lib.mkIf cfg.enable (
+        lib.mkMerge [
+          {
+            assertions = [
+              {
+                assertion = owner != null;
+                message = "gphoto2 module: expected metaOwner.username to be defined";
+              }
+            ];
+
+            environment.systemPackages = [ cfg.package ];
+
+            # 40-libgphoto2.rules is generated with `print-camera-list udev-rules
+            # ... group camera` and carries no uaccess tag, so the group and its
+            # membership are both required for non-root PTP access.
+            services.udev.packages = [ pkgs.libgphoto2 ];
+            users.groups.camera = { };
+          }
+
+          (lib.mkIf (owner != null) {
+            users.users.${owner}.extraGroups = lib.mkAfter [ "camera" ];
+          })
+        ]
+      );
     };
 in
 {

--- a/modules/apps/gphoto2.nix
+++ b/modules/apps/gphoto2.nix
@@ -1,0 +1,53 @@
+/*
+  Package: gphoto2
+  Description: Command-line PTP client for downloading media from cameras and iOS devices.
+  Homepage: https://www.gphoto.org/
+  Documentation: https://www.gphoto.org/doc/
+  Repository: https://github.com/gphoto/gphoto2
+
+  Summary:
+    * Downloads photos and videos over PTP, the protocol iPhones expose for camera-roll access after the on-device photo permission prompt.
+    * Adds a scriptable batch-import path (filename templates, only-new filtering) that the gvfs gphoto2 GUI backend does not offer.
+
+  Options:
+    --auto-detect: List detected cameras and PTP devices.
+    --list-files: Enumerate files on the device storage.
+    --get-all-files: Download everything from the current folder tree.
+    --new: Restrict operations to files not previously downloaded.
+    --filename <pattern>: Name downloads with strftime and counter placeholders.
+
+  Notes:
+    * Talks libgphoto2/libusb directly and does not use usbmuxd; the device must stay unlocked during transfers.
+    * PTP access to iOS devices is read-only by design; deleting after transfer is the only write operation iOS permits.
+*/
+_:
+let
+  Gphoto2Module =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.gphoto2.extended;
+    in
+    {
+      options.programs.gphoto2.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable gphoto2.";
+        };
+
+        package = lib.mkPackageOption pkgs "gphoto2" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.gphoto2 = Gphoto2Module;
+}

--- a/modules/apps/ifuse.nix
+++ b/modules/apps/ifuse.nix
@@ -16,7 +16,7 @@
     -u <udid>: Select a specific device when several are connected.
 
   Notes:
-    * Unmount with fusermount -u <mountpoint>; a locked screen or missing trust record surfaces as a mount error.
+    * Unmount with fusermount3 -u <mountpoint>, matching the libfuse3 ifuse links; a locked screen or missing trust record surfaces as a mount error.
     * AFC throughput is protocol-bound at roughly 2-20 MB/s reads and lower writes regardless of USB generation, so bulk copies pair a plain ifuse mount with rsync instead of the slower gvfs path.
     * Requires the usbmuxd daemon; the module asserts the service is enabled so the dependency fails at eval instead of at runtime.
 */

--- a/modules/apps/ifuse.nix
+++ b/modules/apps/ifuse.nix
@@ -1,0 +1,60 @@
+/*
+  Package: ifuse
+  Description: FUSE filesystem for mounting iPhone and iPad storage over AFC.
+  Homepage: https://libimobiledevice.org/
+  Documentation: https://github.com/libimobiledevice/ifuse#readme
+  Repository: https://github.com/libimobiledevice/ifuse
+
+  Summary:
+    * Mounts the media filesystem (DCIM, Downloads, recordings) of a paired iOS device as a regular directory.
+    * Reaches per-app Documents folders through the house_arrest service for apps that opt into file sharing.
+
+  Options:
+    ifuse <mountpoint>: Mount the device media filesystem.
+    --documents <appid>: Mount the named app's Documents folder instead.
+    --list-apps: List installed apps and their file-sharing capability.
+    -u <udid>: Select a specific device when several are connected.
+
+  Notes:
+    * Unmount with fusermount -u <mountpoint>; a locked screen or missing trust record surfaces as a mount error.
+    * AFC throughput is protocol-bound at roughly 2-20 MB/s reads and lower writes regardless of USB generation, so bulk copies pair a plain ifuse mount with rsync instead of the slower gvfs path.
+    * Requires the usbmuxd daemon; the module asserts the service is enabled so the dependency fails at eval instead of at runtime.
+*/
+_:
+let
+  IfuseModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.ifuse.extended;
+    in
+    {
+      options.programs.ifuse.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable ifuse.";
+        };
+
+        package = lib.mkPackageOption pkgs "ifuse" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = config.services.usbmuxd.enable;
+            message = "programs.ifuse.extended.enable requires the usbmuxd daemon; enable services.usbmuxd.extended.enable.";
+          }
+        ];
+
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.ifuse = IfuseModule;
+}

--- a/modules/apps/libimobiledevice.nix
+++ b/modules/apps/libimobiledevice.nix
@@ -13,7 +13,7 @@
     idevicepair pair: Establish trust with a connected device; run again after accepting the on-device dialog.
     ideviceinfo: Print device identity, iOS version, and lockdown properties.
     idevicebackup2 backup --full <dir>: Create a full backup; "encryption on" first enables encrypted backups.
-    idevicebackup2 restore <dir>: Restore a previously created backup.
+    idevicebackup2 restore <dir>: Restore a previously created backup; --system --settings overwrites device settings and reboots unless --no-reboot is passed.
     afcclient: Interactive AFC shell for the media filesystem; --documents <appid> targets an app sandbox.
     idevicesyslog: Stream the device syslog.
 

--- a/modules/apps/libimobiledevice.nix
+++ b/modules/apps/libimobiledevice.nix
@@ -12,7 +12,8 @@
   Options:
     idevicepair pair: Establish trust with a connected device; run again after accepting the on-device dialog.
     ideviceinfo: Print device identity, iOS version, and lockdown properties.
-    idevicebackup2 backup --full <dir>: Create a full backup; "encryption on" first enables encrypted backups.
+    idevicebackup2 backup --full <dir>: Create a full backup into an existing <dir>; "encryption on -i" first enables encrypted backups.
+    idevicebackup2 -i: Prompt for backup passwords; without it, or BACKUP_PASSWORD/BACKUP_PASSWORD_NEW, password subcommands exit before reaching the device.
     idevicebackup2 restore <dir>: Restore a previously created backup; --system --settings overwrites device settings and reboots unless --no-reboot is passed.
     afcclient: Interactive AFC shell for the media filesystem; --documents <appid> targets an app sandbox.
     idevicesyslog: Stream the device syslog.

--- a/modules/apps/libimobiledevice.nix
+++ b/modules/apps/libimobiledevice.nix
@@ -1,0 +1,61 @@
+/*
+  Package: libimobiledevice
+  Description: Library and CLI suite speaking Apple's native USB protocols to iOS devices.
+  Homepage: https://libimobiledevice.org/
+  Documentation: https://libimobiledevice.org/docs/libimobiledevice/latest/
+  Repository: https://github.com/libimobiledevice/libimobiledevice
+
+  Summary:
+    * Talks lockdownd and its services (AFC, house_arrest, mobilebackup2, syslog_relay) over usbmuxd without jailbreaking.
+    * Ships the idevice* tools used for pairing, device info, full and encrypted backups, crash reports, and developer mode.
+
+  Options:
+    idevicepair pair: Establish trust with a connected device; run again after accepting the on-device dialog.
+    ideviceinfo: Print device identity, iOS version, and lockdown properties.
+    idevicebackup2 backup --full <dir>: Create a full backup; "encryption on" first enables encrypted backups.
+    idevicebackup2 restore <dir>: Restore a previously created backup.
+    afcclient: Interactive AFC shell for the media filesystem; --documents <appid> targets an app sandbox.
+    idevicesyslog: Stream the device syslog.
+
+  Notes:
+    * Every tool needs the usbmuxd daemon; the module asserts the service is enabled so the dependency fails at eval instead of at runtime.
+    * 1.4.0 (2025-10) is the first upstream release since 1.3.0 (2020); re-pair once after a major iOS upgrade when lockdownd rejects the stored record.
+*/
+_:
+let
+  LibimobiledeviceModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.libimobiledevice.extended;
+    in
+    {
+      options.programs.libimobiledevice.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable libimobiledevice.";
+        };
+
+        package = lib.mkPackageOption pkgs "libimobiledevice" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        assertions = [
+          {
+            assertion = config.services.usbmuxd.enable;
+            message = "programs.libimobiledevice.extended.enable requires the usbmuxd daemon; enable services.usbmuxd.extended.enable.";
+          }
+        ];
+
+        environment.systemPackages = [ cfg.package ];
+      };
+    };
+in
+{
+  flake.nixosModules.apps.libimobiledevice = LibimobiledeviceModule;
+}

--- a/modules/apps/usbmuxd.nix
+++ b/modules/apps/usbmuxd.nix
@@ -1,0 +1,53 @@
+/*
+  Package: usbmuxd
+  Description: USB multiplexing daemon that services connections to iOS devices.
+  Homepage: https://libimobiledevice.org/
+  Documentation: https://github.com/libimobiledevice/usbmuxd#readme
+  Repository: https://github.com/libimobiledevice/usbmuxd
+
+  Summary:
+    * Multiplexes TCP-like connections to iPhones and iPads over USB and brokers the pairing records used by lockdownd clients.
+    * Owns the /var/run/usbmuxd socket that every libimobiledevice tool, ifuse mount, and the gvfs AFC backend connect through.
+
+  Options:
+    services.usbmuxd.extended.enable: Run the daemon and install udev rules that grant it access to Apple USB devices (vendor 05ac).
+    services.usbmuxd.extended.package: Select the usbmuxd package; nixpkgs ships a git snapshot because upstream has tagged no release since 2020.
+
+  Notes:
+    * Headless daemon with no user-facing CLI; it starts at boot via multi-user.target and udev is triggered on activation so an already-plugged device is detected without replugging.
+    * Required by the libimobiledevice, ifuse, and gvfs AFC paths; iPhone USB tethering also depends on it for the trust handshake.
+*/
+_:
+let
+  UsbmuxdModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.services.usbmuxd.extended;
+    in
+    {
+      options.services.usbmuxd.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable usbmuxd.";
+        };
+
+        package = lib.mkPackageOption pkgs "usbmuxd" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        services.usbmuxd = {
+          enable = true;
+          inherit (cfg) package;
+        };
+      };
+    };
+in
+{
+  flake.nixosModules.apps.usbmuxd = UsbmuxdModule;
+}

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -536,6 +536,7 @@ let
       pcscd.extended.enable = lib.mkOverride 1100 true;
       "protonmail-bridge".extended.enable = lib.mkOverride 1100 true;
       thinkfan.extended.enable = lib.mkOverride 1100 false;
+      usbmuxd.extended.enable = lib.mkOverride 1100 true;
     };
   };
 in

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -192,6 +192,7 @@ let
       gowitness.extended.enable = lib.mkOverride 1100 true;
       gparted.extended.enable = lib.mkOverride 1100 true;
       "gpg-tui".extended.enable = lib.mkOverride 1100 true;
+      gphoto2.extended.enable = lib.mkOverride 1100 true;
       greenclip.extended.enable = lib.mkOverride 1100 true;
       gwenview.extended.enable = lib.mkOverride 1100 false;
       gzip.extended.enable = lib.mkOverride 1100 true;
@@ -212,6 +213,7 @@ let
       "i3status-rust".extended.enable = lib.mkOverride 1100 true;
       i7z.extended.enable = lib.mkOverride 1100 true;
       iaito.extended.enable = lib.mkOverride 1100 false;
+      ifuse.extended.enable = lib.mkOverride 1100 true;
       inkscape.extended.enable = lib.mkOverride 1100 false;
       intelephense.extended.enable = lib.mkOverride 1100 false;
       iotop.extended.enable = lib.mkOverride 1100 true;
@@ -238,6 +240,7 @@ let
       lazyjournal.extended.enable = lib.mkOverride 1100 true;
       leiningen.extended.enable = lib.mkOverride 1100 false;
       less.extended.enable = lib.mkOverride 1100 true;
+      libimobiledevice.extended.enable = lib.mkOverride 1100 true;
       libnotify.extended.enable = lib.mkOverride 1100 true;
       librsvg.extended.enable = lib.mkOverride 1100 true;
       libreoffice.extended.enable = lib.mkOverride 1100 true;


### PR DESCRIPTION
## Summary

- Adds `modules/apps/usbmuxd.nix` (services namespace, autorandr pattern) and enables it in the common baseline: the gvfs AFC/gphoto2 backends were already compiled in via `services.gvfs`, but no host ran the usbmuxd daemon, so an iPhone never enumerated and the trust handshake could not happen. nixpkgs pins usbmuxd 1.1.1+date=2025-12-06 because upstream has tagged no release since 2020.
- Adds `modules/apps/libimobiledevice.nix` (1.4.0, first upstream release since 2020: idevicepair, ideviceinfo, encrypted idevicebackup2), `modules/apps/ifuse.nix` (1.2.1, FUSE media and per-app Documents mounts), and `modules/apps/gphoto2.nix` (2.5.32, scriptable PTP camera-roll import that the gvfs GUI backend does not provide). libimobiledevice and ifuse assert `config.services.usbmuxd.enable` so a per-host `appEnable` override that disables the daemon fails at eval instead of leaving dead tools installed.
- `modules/apps/gphoto2.nix` also installs libgphoto2's udev rules, creates the `camera` group they hardcode, and adds the owner to it. The rules are the only source of the `ID_GPHOTO2` property `gvfs-gphoto2-volume-monitor` keys on, so without them the camera volume the docs describe under "File manager (casual)" has nothing to key on. They also group-gate the device to `camera`, which is the non-seat path (SSH, units); a local seat session already gets an ACL from stock systemd `70-uaccess.rules`. Follows the `modules/apps/wireshark.nix` group pattern.
- Adds `docs/reference/iphone.md` (pairing and re-pairing, file transfer paths ranked by real AFC throughput, encrypted backup workflow, pymobiledevice3 alternative, tethering, troubleshooting incl. the USBGuard interaction) and indexes it in `docs/index.md`.
- Allowlists `udid` (Apple Unique Device Identifier) in `.typos.toml`; the typos hook otherwise rewrites it to `uuid`.

USB tethering needs no extra module work: the in-kernel ipheth driver handles the data path once usbmuxd services the trust handshake. LocalSend was already enabled for network transfers.

## Review round

- Backup: `restore --system --settings` no longer shares a copy-pasteable block with `backup --full`. Upstream `tools/idevicebackup2.c` clears `RestorePreserveSettings` exactly when `--settings` is passed and leaves `RestoreShouldReboot` set unless `--no-reboot` is passed, so pasting the block whole overwrote settings and system files and rebooted the phone.
- Troubleshooting: adds the `camera`-group re-login requirement and the gvfs gphoto2 volume monitor holding the PTP port (`systemctl --user stop gvfs-gphoto2-volume-monitor.service`), which is the first failure this configuration produces.
- Round 2: corrected the stated reason for the udev rules. Stock systemd already grants the seat user an ACL (`50-udev-default.rules` imports `usb_id`, `70-uaccess.rules` tags `*:060101:*`, `73-seat-late.rules` applies it), verified live via a `user:vx:rw-` ACL on a USB node. The rules stay for `ID_GPHOTO2`/gvfs and the group stays as the non-seat path.
- Round 2: rejected adding `services.udev.extraRules` with `TAG+="uaccess"`. It lands in `99-local.rules`, which sorts after `73-seat-late.rules`, so the tag is never acted on.
- Corrects the iOS 27 PTP listing entry. It claimed the regression was "fixed upstream in git"; libgphoto2 issue 1258 is still open, and the failure is `GP_ERROR_FILE_EXISTS (-103)` on the folder listing.
- ifuse unmount uses `fusermount3 -u`, matching the libfuse3 the pinned ifuse 1.2.1 links. Both wrappers exist on every host via `programs.fuse.enable`, and the FUSE 2 binary was verified to unmount a fuse3 mount cleanly, so this is consistency, not a bug fix.

- Round 3: `mkdir -p ~/backups/iphone` and `-i` added to the backup block. Upstream `stat(backup_directory)` hard-fails on a missing directory, and `encryption` maps to `CMD_CHANGEPW`, whose `!interactive_mode && !backup_password && !newpw` gate made the documented command fail on every run before reaching the device. Restore inherits the same gate.
- Round 3: `--partial` added to the bulk ifuse rsync, which the paragraph below it already claimed as behavior and which the large-file section already used.
- Round 3: the SMB availability finding was declined; it repeats a finding the maintainer already reviewed and resolved.

## Test plan

- `nix run path:.#treefmt` on all changed files (0 diffs).
- `nix eval` of `nixosConfigurations.{system76,tpnix}.config.services.usbmuxd.enable` (both true, package `usbmuxd-1.1.1+date=2025-12-06`).
- `nix eval` confirming libimobiledevice, ifuse, and gphoto2 land in `environment.systemPackages` on both hosts.
- `nix eval` of `config.users.groups.camera.name`, the owner's `extraGroups` (contains `camera`), and `config.services.udev.packages` (contains `libgphoto2-2.5.34`) on both hosts.
- Rule text read from the built store path: the PTP line is `ENV{ID_USB_INTERFACES}=="*:060101:*", ... GROUP="camera"`, with zero `uaccess` matches in the file. The `gvfs-gphoto2-volume-monitor.service` unit name was read from the built gvfs output and confirmed present in `systemctl --user list-unit-files`.
- `ldd` on the pinned `ifuse-1.2.1` resolves `libfuse3.so.4`; `nix-store -q --references` lists `fuse-3.18.2`.
- `nix eval` of both hosts' `config.system.build.toplevel.drvPath` after the changes (forces the assertions; both succeed).
- `pre-commit` hooks pass on every commit (deadnix, nix-parse, statix, treefmt, typos, apps-catalog-sync).
- `nix flake check path:. --accept-flake-config --no-build` fails identically on the base commit 41602808 with the pre-existing `browsers/firefoxpwa-module-eval` fixtures error (`path did not exist in the store during evaluation`), so it cannot gate this change.
- Upstream `tools/idevicebackup2.c` read at tag 1.4.0 for the directory `stat` gate, the `CMD_CHANGEPW` password gate, and the `"dhu:s:inv"` optstring that makes post-subcommand `-i` parse.
- Runtime pairing against a physical device is not exercised here; first use requires `nixos-rebuild switch`, then a fresh login for the `camera` group, then `idevicepair pair` with the phone unlocked.


