### PR TITLE
feat(storage): grant disk-group members capability-wrapped storage diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,8 @@ Modules that apply to every host opted into the registry live under `modules/hos
 
 Common modules contribute to the aggregate `flake.nixosModules.hosts-common` module. `modules/configurations/nixos.nix` imports that aggregate for each host whose registry entry has `shareCommon = true`, before importing the host-specific module so per-host overrides still win.
 
+Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers.
+
 ```nix
 { ... }:
 let

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Modules that apply to every host opted into the registry live under `modules/hos
 
 Common modules contribute to the aggregate `flake.nixosModules.hosts-common` module. `modules/configurations/nixos.nix` imports that aggregate for each host whose registry entry has `shareCommon = true`, before importing the host-specific module so per-host overrides still win.
 
-Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers, including compiled argv filters with audited allowlists that bound those wrappers and the resulting no-sudo operation boundary.
+Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers, including compiled argv filters with audited, grammar-aware allowlists that bound those wrappers and the resulting no-sudo operation boundary.
 
 ```nix
 { ... }:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Modules that apply to every host opted into the registry live under `modules/hos
 
 Common modules contribute to the aggregate `flake.nixosModules.hosts-common` module. `modules/configurations/nixos.nix` imports that aggregate for each host whose registry entry has `shareCommon = true`, before importing the host-specific module so per-host overrides still win.
 
-Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers, including compiled argv filters with audited, grammar-aware allowlists that bound those wrappers and the resulting no-sudo operation boundary.
+Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers, including compiled argv filters with audited, grammar-aware allowlists that fail closed on unsupported and non-device forms while bounding those wrappers and the resulting no-sudo operation boundary.
 
 ```nix
 { ... }:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Modules that apply to every host opted into the registry live under `modules/hos
 
 Common modules contribute to the aggregate `flake.nixosModules.hosts-common` module. `modules/configurations/nixos.nix` imports that aggregate for each host whose registry entry has `shareCommon = true`, before importing the host-specific module so per-host overrides still win.
 
-Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers.
+Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers, including any argv filters that bound those wrappers.
 
 ```nix
 { ... }:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Modules that apply to every host opted into the registry live under `modules/hos
 
 Common modules contribute to the aggregate `flake.nixosModules.hosts-common` module. `modules/configurations/nixos.nix` imports that aggregate for each host whose registry entry has `shareCommon = true`, before importing the host-specific module so per-host overrides still win.
 
-Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers, including compiled argv filters with audited, grammar-aware allowlists that fail closed on unsupported and non-device forms while bounding those wrappers and the resulting no-sudo operation boundary.
+Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers, including compiled argv filters with audited, grammar-aware allowlists that fail closed on unsupported and non-device forms, validate parser-dependent argument boundaries, and bound those wrappers and the resulting no-sudo operation boundary.
 
 ```nix
 { ... }:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,7 @@ Modules that apply to every host opted into the registry live under `modules/hos
 
 Common modules contribute to the aggregate `flake.nixosModules.hosts-common` module. `modules/configurations/nixos.nix` imports that aggregate for each host whose registry entry has `shareCommon = true`, before importing the host-specific module so per-host overrides still win.
 
-Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers, including any argv filters that bound those wrappers.
+Shared device policy that serves multiple optional applications belongs in the common aggregate. For example, `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device permissions while app modules own their packages and capability wrappers, including compiled argv filters with audited allowlists that bound those wrappers and the resulting no-sudo operation boundary.
 
 ```nix
 { ... }:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,7 @@ Shared device policy that serves multiple optional applications belongs in the
 common aggregate. For example,
 `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device
 permissions while app modules own their packages and capability wrappers,
-including compiled argv filters with audited allowlists that bound those
+including compiled argv filters with audited, grammar-aware allowlists that bound those
 wrappers and the resulting no-sudo operation boundary.
 
 ```nix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,11 @@ host-specific module so per-host overrides still win. Every host under
 aborts evaluation for hosts without a registry entry, so a host cannot skip
 the common baseline silently.
 
+Shared device policy that serves multiple optional applications belongs in the
+common aggregate. For example,
+`modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device
+permissions while app modules own their packages and capability wrappers.
+
 ```nix
 { ... }:
 let

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,8 @@ the common baseline silently.
 Shared device policy that serves multiple optional applications belongs in the
 common aggregate. For example,
 `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device
-permissions while app modules own their packages and capability wrappers.
+permissions while app modules own their packages and capability wrappers,
+including any argv filters that bound those wrappers.
 
 ```nix
 { ... }:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,7 +83,8 @@ Shared device policy that serves multiple optional applications belongs in the
 common aggregate. For example,
 `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device
 permissions while app modules own their packages and capability wrappers,
-including any argv filters that bound those wrappers.
+including compiled argv filters with audited allowlists that bound those
+wrappers and the resulting no-sudo operation boundary.
 
 ```nix
 { ... }:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,8 +84,8 @@ common aggregate. For example,
 `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device
 permissions while app modules own their packages and capability wrappers,
 including compiled argv filters with audited, grammar-aware allowlists that fail closed
-on unsupported and non-device forms while bounding those wrappers and the resulting
-no-sudo operation boundary.
+on unsupported and non-device forms, validate parser-dependent argument boundaries,
+and bound those wrappers and the resulting no-sudo operation boundary.
 
 ```nix
 { ... }:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,8 +83,9 @@ Shared device policy that serves multiple optional applications belongs in the
 common aggregate. For example,
 `modules/hosts/common/storage-diagnostics.nix` owns NVMe character-device
 permissions while app modules own their packages and capability wrappers,
-including compiled argv filters with audited, grammar-aware allowlists that bound those
-wrappers and the resulting no-sudo operation boundary.
+including compiled argv filters with audited, grammar-aware allowlists that fail closed
+on unsupported and non-device forms while bounding those wrappers and the resulting
+no-sudo operation boundary.
 
 ```nix
 { ... }:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NixOS Infrastructure as Code using the [Dendritic Pattern](https://github.com/mi
 
 All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists and the resulting no-sudo operation boundary.
+Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists that fail closed on unsupported and non-device forms while bounding the resulting no-sudo operation boundary.
 
 ## Build and Deployment
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NixOS Infrastructure as Code using the [Dendritic Pattern](https://github.com/mi
 
 All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior.
+Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited allowlists and the resulting no-sudo operation boundary.
 
 ## Build and Deployment
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NixOS Infrastructure as Code using the [Dendritic Pattern](https://github.com/mi
 
 All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited allowlists and the resulting no-sudo operation boundary.
+Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists and the resulting no-sudo operation boundary.
 
 ## Build and Deployment
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NixOS Infrastructure as Code using the [Dendritic Pattern](https://github.com/mi
 
 All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists that fail closed on unsupported and non-device forms while bounding the resulting no-sudo operation boundary.
+Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists that fail closed on unsupported and non-device forms, validate parser-dependent argument boundaries, and bound the resulting no-sudo operation boundary.
 
 ## Build and Deployment
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ NixOS Infrastructure as Code using the [Dendritic Pattern](https://github.com/mi
 
 All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled.
+Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior.
 
 ## Build and Deployment
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ NixOS Infrastructure as Code using the [Dendritic Pattern](https://github.com/mi
 
 All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
+Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled.
+
 ## Build and Deployment
 
 This project uses a custom build script, [`build.sh`](build.sh), for validation and deployment:

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -111,8 +111,9 @@ Scope:
       writes, vendor/selective/pending/force/captive/abort tests, and unknown
       forms clear the ambient set and need `sudo`.
     - the `hdparm` wrapper retains capabilities only for short-option clusters made from `-C`, `-g`, `-i`,
-      `-I`, `-t`, and `-T`, plus standalone `--Istdin`. ATA Security, DCO/HPA,
-      raw-sector writes, TRIM, sanitize, firmware, device-setting, unknown,
+      `-I`, `-t`, and `-T`. Standalone input formatting such as `--Istdin`, ATA
+      Security, DCO/HPA, raw-sector writes, TRIM, sanitize, firmware,
+      device-setting, unknown,
       and parameter-bearing options clear the ambient set and need `sudo`.
       Raw block reads and writes remain available through `disk` membership,
       but that does not grant the separate ATA Security, DCO, or HPA control

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -12,6 +12,7 @@ Scope:
   - `modules/security/polkit.nix`
   - `modules/hosts/common/sudo.nix`
   - `modules/hosts/common/boot.nix`
+  - `modules/hosts/common/storage-diagnostics.nix`
   - `modules/apps/smartmontools.nix`
   - `modules/apps/nvme-cli.nix`
   - `modules/apps/hdparm.nix`
@@ -89,7 +90,7 @@ Scope:
   - access:
     - raw block devices (e.g. `/dev/sda`, `/dev/nvme0n1`).
     - NVMe controller and generic char devices (`/dev/nvme0`, `/dev/ng0n1`) via
-      the udev rule in `modules/apps/nvme-cli.nix`.
+      the shared udev rule in `modules/hosts/common/storage-diagnostics.nix`.
     - storage diagnostic wrappers with `CAP_SYS_ADMIN` / `CAP_SYS_RAWIO` for:
       - `smartctl`
       - `nvme`

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -104,17 +104,21 @@ Scope:
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
     - the `smartctl` wrapper is filtered. It retains capabilities only for
-      audited reports, read-only settings and log queries (including bare
-      `-n sleep`, `-n standby`, and `-n idle` power-mode checks), and the standard
-      `offline`, `short`, `long`, and `conveyance` self-tests documented by the
-      module. SMART configuration (`-s`, `-o`, `-S`, and `--set`), log resets or
-      writes, vendor/selective/pending/force/captive/abort tests, and unknown
-      forms clear the ambient set and need `sudo`.
+      audited reports, the documented `-v`/`--vendorattribute` display
+      definitions and `-F`/`--firmwarebug` report workarounds, read-only settings
+      and log queries (including bare `-n sleep`, `-n standby`, and `-n idle`
+      power-mode checks), and the standard `offline`, `short`, `long`, and
+      `conveyance` self-tests documented by the module. SMART configuration
+      (`-s`, `-o`, `-S`, and `--set`), log resets or writes,
+      selective/pending/force/captive/abort tests, and unknown forms clear the
+      ambient set and need `sudo`.
     - the `hdparm` wrapper retains capabilities only for short-option clusters made from `-C`, `-g`, `-i`,
-      `-I`, `-t`, and `-T`. Standalone input formatting such as `--Istdin`, ATA
+      `-I`, `-t`, and `-T`. Standalone input formatting such as `--Istdin` also
+      takes the cleared-capability path, but reads and formats stdin only,
+      opens no device, and needs neither storage capabilities nor `sudo`. ATA
       Security, DCO/HPA, raw-sector writes, TRIM, sanitize, firmware,
-      device-setting, unknown,
-      and parameter-bearing options clear the ambient set and need `sudo`.
+      device-setting, unknown, and parameter-bearing options clear the ambient
+      set and need `sudo`.
       Raw block reads and writes remain available through `disk` membership,
       but that does not grant the separate ATA Security, DCO, or HPA control
       paths.
@@ -128,11 +132,16 @@ Scope:
       the manual page is unavailable. See
       [docs/security/owner-no-sudo-operations.md](owner-no-sudo-operations.md)
       for the allowlist and the `system()` injection sites that motivate it.
-    - the `sedutil-cli` wrapper is also filtered. It retains capabilities only
-      for `--scan`, `--query`, `--isValidSED`, and `--printDefaultPassword`;
-      Opal password, locking-range, PBA, and revert actions clear the ambient
-      set and need `sudo` again. `--printDefaultPassword` exposes the drive
-      MSID and should be treated as credential material.
+    - for the sedutil 1.49.13 parser, the `sedutil-cli` wrapper is also
+      filtered. It retains capabilities only for `--scan` and its JSON output
+      forms, `--query` and its JSON output forms with one device,
+      `--isValidSED <device>`, and `--printDefaultPassword <device>`. Opal
+      password, locking-range, PBA, and revert actions clear the ambient set
+      and need `sudo` again. `--printDefaultPassword` exposes the drive MSID
+      and should be treated as credential material. The filter checks the first
+      action and relies on sedutil's exact and maximum argument checks to reject
+      later actions before dispatch; re-audit a custom package if that parser
+      changes.
 
 ## Additional Owner Groups Added By Other Modules
 

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -100,7 +100,7 @@ Scope:
       - `smartctl`
       - `nvme`
       - `sedutil-cli`
-      - `hdparm` (enabled on system76 and songbird; disabled on tpnix)
+      - `hdparm` (when the hdparm app module is enabled; disabled on tpnix)
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
     - the `smartctl` wrapper remains whole-binary. The `hdparm` wrapper retains

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -16,6 +16,7 @@ Scope:
   - `modules/apps/smartmontools.nix`
   - `modules/apps/nvme-cli.nix`
   - `modules/apps/hdparm.nix`
+  - `modules/apps/sedutil.nix`
 
 ## Groups Assigned To Owner In Baseline Profile
 
@@ -94,6 +95,7 @@ Scope:
     - storage diagnostic wrappers with `CAP_SYS_ADMIN` / `CAP_SYS_RAWIO` for:
       - `smartctl`
       - `nvme`
+      - `sedutil-cli`
       - `hdparm` (when the hdparm app module is enabled; disabled on tpnix)
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
@@ -101,6 +103,9 @@ Scope:
       `nvme format` and `hdparm --security-erase` are passwordless as well.
       Raw writes to the same devices were already possible through group
       membership, so the wrappers do not extend the privilege boundary.
+    - `sedutil-cli` is the exception to that last point: its Opal password and
+      revert subcommands can lock a drive against every later reader,
+      including root, which raw writes cannot do.
 
 ## Additional Owner Groups Added By Other Modules
 

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -43,6 +43,9 @@ Scope:
   - security impact:
     - administrative control path by design.
     - also grants non-root packet capture through capability-wrapped binaries; `airmon-ng` monitor-mode setup is still outside that wrapper surface.
+    - the `tcpdump` wrapper source is an argv filter that refuses `-z`, because
+      `tcpdump.c:3173` `execlp`s the postrotate command with the ambient
+      capability set intact.
 
 - `networkmanager`:
 
@@ -99,10 +102,17 @@ Scope:
       - `hdparm` (when the hdparm app module is enabled; disabled on tpnix)
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
-    - the wrappers are whole-binary, so destructive subcommands such as
-      `nvme format` and `hdparm --security-erase` are passwordless as well.
-      Raw writes to the same devices were already possible through group
+    - the `smartctl`, `sedutil-cli`, and `hdparm` wrappers are whole-binary, so
+      destructive flags such as `hdparm --security-erase` are passwordless as
+      well. Raw writes to the same devices were already possible through group
       membership, so the wrappers do not extend the privilege boundary.
+    - the `nvme` wrapper is not whole-binary. Its source allowlists the
+      read-only diagnostic subcommands and clears the ambient capability set
+      before `execve` for everything else, so `nvme format`, `nvme sanitize`,
+      `nvme fw-commit`, and the vendor plugins run without `CAP_SYS_ADMIN` and
+      need `sudo` again. See
+      [docs/security/owner-no-sudo-operations.md](owner-no-sudo-operations.md)
+      for the allowlist and the `system()` injection sites that motivate it.
     - `sedutil-cli` is the exception to that last point: its Opal password and
       revert subcommands can lock a drive against every later reader,
       including root, which raw writes cannot do.

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -12,6 +12,9 @@ Scope:
   - `modules/security/polkit.nix`
   - `modules/hosts/common/sudo.nix`
   - `modules/hosts/common/boot.nix`
+  - `modules/apps/smartmontools.nix`
+  - `modules/apps/nvme-cli.nix`
+  - `modules/apps/hdparm.nix`
 
 ## Groups Assigned To Owner In Baseline Profile
 
@@ -85,8 +88,18 @@ Scope:
 
   - access:
     - raw block devices (e.g. `/dev/sda`, `/dev/nvme0n1`).
+    - NVMe controller and generic char devices (`/dev/nvme0`, `/dev/ng0n1`) via
+      the udev rule in `modules/apps/nvme-cli.nix`.
+    - storage diagnostic wrappers with `CAP_SYS_ADMIN` / `CAP_SYS_RAWIO` for:
+      - `smartctl`
+      - `nvme`
+      - `hdparm`
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
+    - the wrappers are whole-binary, so destructive subcommands such as
+      `nvme format` and `hdparm --security-erase` are passwordless as well.
+      Raw writes to the same devices were already possible through group
+      membership, so the wrappers do not extend the privilege boundary.
 
 ## Additional Owner Groups Added By Other Modules
 

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -94,7 +94,7 @@ Scope:
     - storage diagnostic wrappers with `CAP_SYS_ADMIN` / `CAP_SYS_RAWIO` for:
       - `smartctl`
       - `nvme`
-      - `hdparm`
+      - `hdparm` (when the hdparm app module is enabled; disabled on tpnix)
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
     - the wrappers are whole-binary, so destructive subcommands such as

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -104,7 +104,8 @@ Scope:
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
     - the `smartctl` wrapper is filtered. It retains capabilities only for
-      audited reports, read-only settings and log queries, and the standard
+      audited reports, read-only settings and log queries (including bare
+      `-n sleep`, `-n standby`, and `-n idle` power-mode checks), and the standard
       `offline`, `short`, `long`, and `conveyance` self-tests documented by the
       module. SMART configuration (`-s`, `-o`, `-S`, and `--set`), log resets or
       writes, vendor/selective/pending/force/captive/abort tests, and unknown

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -102,20 +102,25 @@ Scope:
       - `hdparm` (when the hdparm app module is enabled; disabled on tpnix)
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
-    - the `smartctl`, `sedutil-cli`, and `hdparm` wrappers are whole-binary, so
-      destructive flags such as `hdparm --security-erase` are passwordless as
-      well. Raw writes to the same devices were already possible through group
-      membership, so the wrappers do not extend the privilege boundary.
+    - the `smartctl` and `hdparm` wrappers are whole-binary, so destructive
+      flags such as `hdparm --security-erase` are passwordless as well. Raw
+      writes to the same devices were already possible through group
+      membership, so those wrappers do not extend the privilege boundary.
     - the `nvme` wrapper is not whole-binary. Its source allowlists the
-      read-only diagnostic subcommands and clears the ambient capability set
-      before `execve` for everything else, so `nvme format`, `nvme sanitize`,
-      `nvme fw-commit`, and the vendor plugins run without `CAP_SYS_ADMIN` and
-      need `sudo` again. See
+      read-only diagnostic subcommands plus `device-self-test`, whose options
+      can start or abort a drive self-test, and clears the ambient capability
+      set before `execve` for everything else. `nvme format`, `nvme sanitize`,
+      `nvme fw-commit`, and the vendor plugins therefore run without
+      `CAP_SYS_ADMIN` and need `sudo` again. `nvme help` also runs on the
+      cleared path without the storage capability, although it may fail if
+      the manual page is unavailable. See
       [docs/security/owner-no-sudo-operations.md](owner-no-sudo-operations.md)
       for the allowlist and the `system()` injection sites that motivate it.
-    - `sedutil-cli` is the exception to that last point: its Opal password and
-      revert subcommands can lock a drive against every later reader,
-      including root, which raw writes cannot do.
+    - the `sedutil-cli` wrapper is also filtered. It retains capabilities only
+      for `--scan`, `--query`, `--isValidSED`, and `--printDefaultPassword`;
+      Opal password, locking-range, PBA, and revert actions clear the ambient
+      set and need `sudo` again. `--printDefaultPassword` exposes the drive
+      MSID and should be treated as credential material.
 
 ## Additional Owner Groups Added By Other Modules
 

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -43,9 +43,10 @@ Scope:
   - security impact:
     - administrative control path by design.
     - also grants non-root packet capture through capability-wrapped binaries; `airmon-ng` monitor-mode setup is still outside that wrapper surface.
-    - the `tcpdump` wrapper source is an argv filter that refuses `-z`, because
-      `tcpdump.c:3173` `execlp`s the postrotate command with the ambient
-      capability set intact.
+    - the `tcpdump` wrapper source refuses `-z` for non-root capability-wrapper
+      execution, because `tcpdump.c:3173` `execlp`s the postrotate command with
+      the ambient capability set intact. Root callers retain the normal
+      rotation and compression workflow.
 
 - `networkmanager`:
 
@@ -99,13 +100,17 @@ Scope:
       - `smartctl`
       - `nvme`
       - `sedutil-cli`
-      - `hdparm` (when the hdparm app module is enabled; disabled on tpnix)
+      - `hdparm` (enabled on system76 and songbird; disabled on tpnix)
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
-    - the `smartctl` and `hdparm` wrappers are whole-binary, so destructive
-      flags such as `hdparm --security-erase` are passwordless as well. Raw
-      writes to the same devices were already possible through group
-      membership, so those wrappers do not extend the privilege boundary.
+    - the `smartctl` wrapper remains whole-binary. The `hdparm` wrapper retains
+      capabilities only for short-option clusters made from `-C`, `-g`, `-i`,
+      `-I`, `-t`, and `-T`, plus standalone `--Istdin`. ATA Security, DCO/HPA,
+      raw-sector writes, TRIM, sanitize, firmware, device-setting, unknown,
+      and parameter-bearing options clear the ambient set and need `sudo`.
+      Raw block reads and writes remain available through `disk` membership,
+      but that does not grant the separate ATA Security, DCO, or HPA control
+      paths.
     - the `nvme` wrapper is not whole-binary. Its source allowlists the
       read-only diagnostic subcommands plus `device-self-test`, whose options
       can start or abort a drive self-test, and clears the ambient capability

--- a/docs/security/owner-group-privileges.md
+++ b/docs/security/owner-group-privileges.md
@@ -103,8 +103,13 @@ Scope:
       - `hdparm` (when the hdparm app module is enabled; disabled on tpnix)
   - security impact:
     - full read/write access to storage devices, bypassing filesystem permissions. Allows running tools like `fdisk` without sudo.
-    - the `smartctl` wrapper remains whole-binary. The `hdparm` wrapper retains
-      capabilities only for short-option clusters made from `-C`, `-g`, `-i`,
+    - the `smartctl` wrapper is filtered. It retains capabilities only for
+      audited reports, read-only settings and log queries, and the standard
+      `offline`, `short`, `long`, and `conveyance` self-tests documented by the
+      module. SMART configuration (`-s`, `-o`, `-S`, and `--set`), log resets or
+      writes, vendor/selective/pending/force/captive/abort tests, and unknown
+      forms clear the ambient set and need `sudo`.
+    - the `hdparm` wrapper retains capabilities only for short-option clusters made from `-C`, `-g`, `-i`,
       `-I`, `-t`, and `-T`, plus standalone `--Istdin`. ATA Security, DCO/HPA,
       raw-sector writes, TRIM, sanitize, firmware, device-setting, unknown,
       and parameter-bearing options clear the ambient set and need `sudo`.

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -100,19 +100,23 @@ Scope:
       absent from glibc's `unsecvars.h`.
   - limitation:
     - the `smartctl` wrapper is filtered: it retains capabilities only for
-      audited reports, read-only settings and log queries (including bare
-      `-n sleep`, `-n standby`, and `-n idle` power-mode checks), and the standard
-      `offline`, `short`, `long`, and `conveyance` self-tests documented by the
-      module. SMART configuration (`-s`, `-o`, `-S`, and `--set`), log resets or
-      writes, vendor/selective/pending/force/captive/abort tests, and unknown
-      forms clear the ambient set and need `sudo` again. The filter fails
-      closed when a package update adds an unrecognized option.
+      audited reports, the documented `-v`/`--vendorattribute` display
+      definitions and `-F`/`--firmwarebug` report workarounds, read-only settings
+      and log queries (including bare `-n sleep`, `-n standby`, and `-n idle`
+      power-mode checks), and the standard `offline`, `short`, `long`, and
+      `conveyance` self-tests documented by the module. SMART configuration
+      (`-s`, `-o`, `-S`, and `--set`), log resets or writes,
+      selective/pending/force/captive/abort tests, and unknown forms clear the
+      ambient set and need `sudo` again. The filter fails closed when a package
+      update adds an unrecognized option or argument form.
     - the `hdparm` wrapper is filtered: it retains capabilities only for
       short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`.
-      Standalone input formatting such as `--Istdin`, ATA Security, DCO/HPA,
-      raw-sector writes, TRIM, sanitize, firmware,
-      device-setting, unknown, and parameter-bearing options clear the ambient
-      set and need `sudo` again. `-t` and `-T` are non-media-mutating timing
+      Standalone input formatting such as `--Istdin` also takes the
+      cleared-capability path, but reads and formats stdin only, opens no
+      device, and needs neither storage capabilities nor `sudo`. ATA Security,
+      DCO/HPA, raw-sector writes, TRIM, sanitize, firmware, device-setting,
+      unknown, and parameter-bearing options clear the ambient set and need
+      `sudo` again. `-t` and `-T` are non-media-mutating timing
       diagnostics, but may flush or synchronize caches. The existing `disk`
       membership still permits raw block reads and writes; that does not grant
       the separate ATA Security, DCO, or HPA control paths.
@@ -167,18 +171,22 @@ Scope:
       true, so it takes effect on the next reboot rather than at switch time.
       NVMe drives do not need it.
   - limitation:
-    - the compiled `sedutil-cli` wrapper keeps capabilities only for
-      `--scan`, `--query`, `--isValidSED`, and `--printDefaultPassword`.
-      State-changing actions such as `--initialSetup`, `--setSIDPassword`,
-      `--setLockingRange`, `--loadPBAimage`, `--revertTPer`, and
+    - for the sedutil 1.49.13 parser, the compiled `sedutil-cli` wrapper keeps
+      capabilities only for `--scan` and its JSON output forms, `--query` and
+      its JSON output forms with one device, `--isValidSED <device>`, and
+      `--printDefaultPassword <device>`. State-changing actions such as
+      `--initialSetup`, `--setSIDPassword`, `--setLockingRange`,
+      `--loadPBAimage`, `--revertTPer`, and
       `--yesIreallywanttoERASEALLmydatausingthePSID` clear the ambient set and
       need `sudo` again. The last two erase the drive. `--printDefaultPassword`
       is intentionally allowed and exposes the drive MSID, so treat its output
-      as credential material.
+      as credential material. The filter checks the first action and relies on
+      sedutil's exact and maximum argument checks to reject later actions before
+      dispatch; re-audit a custom package if that parser changes.
     - `sedutil-cli` links a `popen()` helper that execs `/bin/sh -c`. Its target
       pins `PATH` to a store path as defense in depth, and the filter clears
-      ambient capabilities before every non-allowlisted action, so a helper on
-      that path cannot inherit the storage capabilities.
+      ambient capabilities before every non-allowlisted first action, so a
+      helper on that path cannot inherit the storage capabilities.
   - effect on users outside `disk`:
     - the same as the wrappers above. The wrapper file is `root:disk 0510`, so
       PATH lookup skips it and a bare `sedutil-cli` falls through to the
@@ -258,11 +266,15 @@ Scope:
     - the wrapper source is a compiled argv filter whose target is the hdparm
       binary. An empty result means the filter is not bound to the package
       binary.
-  - `strace -f -e trace=prctl /run/wrappers/bin/smartctl -a /dev/null` and
-    `strace -f -e trace=prctl /run/wrappers/bin/smartctl -s off /dev/null`
-    - the report form should execute without `PR_CAP_AMBIENT_CLEAR_ALL`, while
-      the SMART configuration form should show that call before execution.
-      The target device may still reject the diagnostic after the filter test.
+  - `strace -f -e trace=prctl /run/wrappers/bin/smartctl -a /dev/null`,
+    `strace -f -e trace=prctl /run/wrappers/bin/smartctl -v '9,raw24(raw8)' -a /dev/null`,
+    and `strace -f -e trace=prctl /run/wrappers/bin/smartctl --firmwarebug=swapid -a /dev/null`
+    - the report and audited report-modifier forms should execute without
+      `PR_CAP_AMBIENT_CLEAR_ALL`.
+  - `strace -f -e trace=prctl /run/wrappers/bin/smartctl -v 9,bad -a /dev/null`
+    and `strace -f -e trace=prctl /run/wrappers/bin/smartctl -s off /dev/null`
+    - both forms should show `PR_CAP_AMBIENT_CLEAR_ALL` before execution. The
+      target device may still reject a diagnostic after the filter test.
   - `strace -f -e trace=prctl /run/wrappers/bin/hdparm -V`
     - should show `PR_CAP_AMBIENT_CLEAR_ALL` before the non-allowlisted version
       action executes. A missing call means the filter is not clearing

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -60,7 +60,7 @@ Scope:
 - Storage health diagnostics:
   - `smartctl ...`
   - `nvme ...`
-  - `hdparm ...` (enabled on system76 and songbird; disabled on tpnix)
+  - `hdparm ...` (when the hdparm app module is enabled; disabled on tpnix)
   - mechanism:
     - `security.wrappers` with `CAP_SYS_ADMIN` (`nvme`) or `CAP_SYS_ADMIN` plus
       `CAP_SYS_RAWIO` (`smartctl`, `hdparm`)

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -16,6 +16,7 @@ Scope:
   - `modules/apps/smartmontools.nix`
   - `modules/apps/nvme-cli.nix`
   - `modules/apps/hdparm.nix`
+  - `modules/apps/sedutil.nix`
 - shared NVMe char-device udev rule and its retrigger unit:
   - `modules/hosts/common/storage-diagnostics.nix`
 
@@ -100,6 +101,46 @@ Scope:
       searching. A bare `smartctl` therefore falls through to the `0555`
       `/run/current-system/sw/bin/smartctl` and fails at the ioctl exactly as
       it did before the wrappers existed.
+- Self-encrypting drive management:
+  - `sedutil-cli ...`
+  - mechanism:
+    - `security.wrappers` with `CAP_SYS_ADMIN` plus `CAP_SYS_RAWIO`
+    - available to users in the `disk` group
+  - why group membership alone is not enough:
+    - `blk_verify_command()` rejects the SECURITY PROTOCOL IN/OUT and ATA
+      PASS-THROUGH CDBs that `SG_IO` carries without `CAP_SYS_RAWIO`, and that
+      is the only path Opal traffic takes to SATA drives: the Linux backend
+      leaves `PerformATACommand_via_HD` unimplemented, so no `HDIO_*` ioctl is
+      involved.
+    - `nvme_cmd_allowed()` rejects the NVMe security send/receive admin
+      passthrough (`NVME_IOCTL_ADMIN_CMD`) without `CAP_SYS_ADMIN`.
+  - device nodes:
+    - `sedutil-cli` scans `/dev` by device major and keeps only whole-disk
+      block nodes (SCSI 8, 65-71, 128-135, and NVMe 259), so `root:disk 0660`
+      block nodes are all it needs. The NVMe controller char rule in
+      `modules/hosts/common/storage-diagnostics.nix` is not on its path.
+  - kernel prerequisite:
+    - SATA drives additionally need `libata.allow_tpm=1`, documented in
+      `docs/sedutil-cli.8` upstream, because libata otherwise refuses ATA
+      TRUSTED SEND/RECEIVE. `modules/hosts/common/storage-diagnostics.nix` sets
+      it in `boot.kernelParams`, so it takes effect on the next reboot rather
+      than at switch time. NVMe drives do not need it.
+  - limitation:
+    - the wrapper covers the whole binary, so `--initialSetup`,
+      `--setSIDPassword`, `--revertTPer`, and
+      `--yesIreallywanttoERASEALLmydatausingthePSID` are passwordless for
+      `disk` members too. The last two erase the drive, and a mistyped Opal
+      password locks data that `disk` membership cannot recover, so this is a
+      wider failure mode than the raw writes membership already permitted.
+    - the wrapper source pins `PATH`, because a `popen()` helper is linked into
+      `sedutil-cli` and `popen()` execs `/bin/sh -c`. `PATH` is absent from
+      glibc's `unsecvars.h`, so the capability wrapper forwards the caller's
+      value and the ambient capabilities would survive into whatever the shell
+      resolved.
+  - effect on users outside `disk`:
+    - the same as the wrappers above. The wrapper file is `root:disk 0510`, so
+      PATH lookup skips it and a bare `sedutil-cli` falls through to the
+      `environment.systemPackages` copy, which fails at the ioctl.
 - Packet capture:
   - `wireshark`
   - `tcpdump`
@@ -135,7 +176,7 @@ Scope:
       The common host baseline disables the optional wheel systemd
       unit-management rule.
   - `nix eval --json .#nixosConfigurations.$(hostname).config.security.sudo-rs.extraRules | jq`
-  - `getcap /run/wrappers/bin/smartctl /run/wrappers/bin/nvme`
+  - `getcap /run/wrappers/bin/smartctl /run/wrappers/bin/nvme /run/wrappers/bin/sedutil-cli`
     - add `/run/wrappers/bin/hdparm` where the hdparm app module is enabled.
   - `ls -l /dev/nvme0 /dev/ng0n1 /dev/nvme0n1`
     - all three should be group `disk` with mode `0660`.
@@ -147,3 +188,13 @@ Scope:
     - each should print device data instead of `Permission denied` or
       `Operation not permitted`.
     - `hdparm -I /dev/sda` applies only where the hdparm app module is enabled.
+  - `sedutil-cli --scan`
+    - should list whole-disk block nodes instead of reporting no access. A SATA
+      drive reports Opal support only once `libata.allow_tpm=1` is set, which
+      no module in this repo does; check
+      `cat /sys/module/libata/parameters/allow_tpm` before treating a `No`
+      there as a drive capability result.
+  - `strings "$(nix eval --raw .#nixosConfigurations.$(hostname).config.security.wrappers.sedutil-cli.source)" | grep '^PATH='`
+    - the wrapper source is a compiled `makeBinaryWrapper` binary that pins
+      `PATH` to a store path. An empty result means the pin was lost and the
+      ambient capabilities are reachable through a caller-controlled `PATH`.

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -12,6 +12,10 @@ Scope:
   - `modules/hosts/common/sudo.nix`
 - kernel setting affecting `dmesg`:
   - `modules/hosts/common/boot.nix`
+- storage capability wrappers and the NVMe char-device udev rule:
+  - `modules/apps/smartmontools.nix`
+  - `modules/apps/nvme-cli.nix`
+  - `modules/apps/hdparm.nix`
 
 ## Commands That Do Not Require `sudo`
 
@@ -41,11 +45,46 @@ Scope:
     - mechanism:
       - `kernel.dmesg_restrict = 0`
     - available without sudo because `kernel.dmesg_restrict = 0`.
-- Disk management:
-  - `fdisk ...`
+- Partition and device inventory:
+  - `fdisk ...`, `lsblk ...`, `blkid ...`, `parted ...`, `sgdisk ...`, `gdisk ...`
   - mechanism:
     - `disk` group membership
-  - available without sudo because owner is in the `disk` group.
+  - available without sudo because block device nodes are `root:disk 0660` and
+    owner is in the `disk` group.
+- Storage health diagnostics:
+  - `smartctl ...`
+  - `nvme ...`
+  - `hdparm ...`
+  - mechanism:
+    - `security.wrappers` with `CAP_SYS_ADMIN` (`nvme`) or `CAP_SYS_ADMIN` plus
+      `CAP_SYS_RAWIO` (`smartctl`, `hdparm`)
+    - available to users in the `disk` group
+  - why group membership alone is not enough:
+    - `nvme_cmd_allowed()` rejects NVMe admin passthrough
+      (`NVME_IOCTL_ADMIN_CMD`) without `CAP_SYS_ADMIN`, so SMART, error, and
+      firmware logs fail with `Permission denied` even on a device node the
+      caller can open.
+    - the SG_IO command filter rejects ATA passthrough without `CAP_SYS_RAWIO`,
+      which is what makes `smartctl -d sat` report
+      `Read Device Identity failed: Operation not permitted` on SATA disks.
+    - `ata_sas_scsi_ioctl()` requires both capabilities for `HDIO_DRIVE_CMD`,
+      the ioctl behind `hdparm -I`.
+  - NVMe char devices:
+    - a udev rule in `modules/apps/nvme-cli.nix` sets `GROUP="disk"` and
+      `MODE="0660"` on the `nvme` and `nvme-generic` subsystems, because the
+      kernel default of `root:root 0600` on `/dev/nvme0` and `/dev/ng0n1` is a
+      DAC check that no capability in the wrapper set overrides. Only the
+      namespace block nodes (`/dev/nvme0n1`) carry `disk` by default.
+  - limitation:
+    - the wrappers cover whole binaries, so destructive subcommands
+      (`nvme format`, `nvme sanitize`, `hdparm --security-erase`) are
+      passwordless for `disk` members too. `disk` membership already permits raw
+      writes to the same devices, so this widens the blast radius of a typo
+      rather than the privilege boundary.
+  - side effect:
+    - `/run/wrappers/bin` precedes `/run/current-system/sw/bin` in `PATH`, so
+      users outside the `disk` group cannot execute `smartctl`, `nvme`, or
+      `hdparm` at all once wrapped.
 - Packet capture:
   - `wireshark`
   - `tcpdump`
@@ -81,3 +120,9 @@ Scope:
       The common host baseline disables the optional wheel systemd
       unit-management rule.
   - `nix eval --json .#nixosConfigurations.$(hostname).config.security.sudo-rs.extraRules | jq`
+  - `getcap /run/wrappers/bin/smartctl /run/wrappers/bin/nvme /run/wrappers/bin/hdparm`
+  - `ls -l /dev/nvme0 /dev/ng0n1 /dev/nvme0n1`
+    - all three should be group `disk` with mode `0660`.
+  - `smartctl -a /dev/nvme0n1`, `nvme smart-log /dev/nvme0`, `hdparm -I /dev/sda`
+    - each should print device data instead of `Permission denied` or
+      `Operation not permitted`.

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -100,7 +100,8 @@ Scope:
       absent from glibc's `unsecvars.h`.
   - limitation:
     - the `smartctl` wrapper is filtered: it retains capabilities only for
-      audited reports, read-only settings and log queries, and the standard
+      audited reports, read-only settings and log queries (including bare
+      `-n sleep`, `-n standby`, and `-n idle` power-mode checks), and the standard
       `offline`, `short`, `long`, and `conveyance` self-tests documented by the
       module. SMART configuration (`-s`, `-o`, `-S`, and `--set`), log resets or
       writes, vendor/selective/pending/force/captive/abort tests, and unknown

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -48,7 +48,10 @@ Scope:
       - `kernel.dmesg_restrict = 0`
     - available without sudo because `kernel.dmesg_restrict = 0`.
 - Partition and device inventory:
-  - `fdisk ...`, `lsblk ...`, `blkid ...`, `parted ...`, `sgdisk ...`, `gdisk ...`
+  - `fdisk ...`, `lsblk ...`, `blkid ...`
+    - always present: `util-linux` is in the nixpkgs `corePackageNames` base
+      system, not an app module.
+  - `parted ...` (when the parted app module is enabled; disabled on tpnix)
   - mechanism:
     - `disk` group membership
   - available without sudo because block device nodes are `root:disk 0660` and
@@ -56,7 +59,7 @@ Scope:
 - Storage health diagnostics:
   - `smartctl ...`
   - `nvme ...`
-  - `hdparm ...`
+  - `hdparm ...` (when the hdparm app module is enabled; disabled on tpnix)
   - mechanism:
     - `security.wrappers` with `CAP_SYS_ADMIN` (`nvme`) or `CAP_SYS_ADMIN` plus
       `CAP_SYS_RAWIO` (`smartctl`, `hdparm`)
@@ -123,9 +126,11 @@ Scope:
       The common host baseline disables the optional wheel systemd
       unit-management rule.
   - `nix eval --json .#nixosConfigurations.$(hostname).config.security.sudo-rs.extraRules | jq`
-  - `getcap /run/wrappers/bin/smartctl /run/wrappers/bin/nvme /run/wrappers/bin/hdparm`
+  - `getcap /run/wrappers/bin/smartctl /run/wrappers/bin/nvme`
+    - add `/run/wrappers/bin/hdparm` where the hdparm app module is enabled.
   - `ls -l /dev/nvme0 /dev/ng0n1 /dev/nvme0n1`
     - all three should be group `disk` with mode `0660`.
-  - `smartctl -a /dev/nvme0n1`, `nvme smart-log /dev/nvme0`, `hdparm -I /dev/sda`
+  - `smartctl -a /dev/nvme0n1`, `nvme smart-log /dev/nvme0`
     - each should print device data instead of `Permission denied` or
       `Operation not permitted`.
+    - `hdparm -I /dev/sda` applies only where the hdparm app module is enabled.

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -87,12 +87,34 @@ Scope:
       udev applies rules to new uevents only, so nodes enumerated at boot would
       otherwise keep `root:root 0600` until a reboot. `udevadm trigger` needs
       root, which the `disk` members this grant targets do not have.
+  - why the wrapper sources are argv filters:
+    - `security.wrappers` raises the configured capabilities into the process
+      ambient set (`nixos/modules/security/wrappers/wrapper.c:137`). An ambient
+      capability survives `execve` of an ordinary file and lands in the child's
+      effective set, so any subprocess the wrapped binary starts inherits it.
+      The filter is a compiled binary, never a shell script: a capability
+      wrapper is not setuid, so `euid == uid`, bash does not enter privileged
+      mode, and `BASH_ENV` is absent from glibc's `unsecvars.h`.
   - limitation:
-    - the wrappers cover whole binaries, so destructive subcommands
-      (`nvme format`, `nvme sanitize`, `hdparm --security-erase`) are
-      passwordless for `disk` members too. `disk` membership already permits raw
-      writes to the same devices, so this widens the blast radius of a typo
-      rather than the privilege boundary.
+    - the `smartctl` and `hdparm` wrappers cover whole binaries, so destructive
+      flags (`hdparm --security-erase`, `--trim-sector-ranges`,
+      `--make-bad-sector`) are passwordless for `disk` members too. `disk`
+      membership already permits raw writes to the same devices, so this widens
+      the blast radius of a typo rather than the privilege boundary.
+    - the `nvme` wrapper is not whole-binary. Its source allowlists the
+      read-only diagnostic subcommands (`list`, `list-subsys`, `list-ns`,
+      `list-ctrl`, `id-ctrl`, `id-ns`, `ns-descs`, `smart-log`, `error-log`,
+      `fw-log`, `telemetry-log`, `effects-log`, `endurance-log`,
+      `sanitize-log`, `self-test-log`, `supported-log-pages`, `get-log`,
+      `device-self-test`) and clears the ambient set before `execve` for
+      everything else. `nvme format`, `nvme sanitize`, `nvme fw-commit`,
+      `nvme help` and the vendor plugins still run, but with no capability, so
+      they need `sudo` again. The vendor plugins are the reason: they
+      interpolate the caller's `--dir-name` into a shell command string passed
+      to `system()`
+      (`plugins/solidigm/solidigm-internal-logs.c:989`,
+      `plugins/wdc/wdc-nvme.c:4218`, `plugins/micron/micron-nvme.c:249`), which
+      is metacharacter injection that no pinned `PATH` can bound.
   - effect on users outside `disk`:
     - none. The wrapper files are `root:disk 0510`, so a non-member cannot
       execute `/run/wrappers/bin/{smartctl,nvme,hdparm}`, but the app modules
@@ -152,6 +174,14 @@ Scope:
     - a `wireshark` group is also created and assigned to the owner user for tooling or policy that still expects it
   - limitation:
     - monitor-mode setup via `airmon-ng` is not capability-wrapped and still requires elevated setup
+    - the `tcpdump` wrapper source is an argv filter that refuses `-z`.
+      `tcpdump.c:3173` runs the postrotate command through `execlp()`, and the
+      wrapper's ambient `CAP_NET_RAW` and `CAP_NET_ADMIN` land in that child.
+      The filter rejects `-z` in any getopt form (`-z cmd`, `-nz cmd`,
+      `-zcmd`, and after an operand, since glibc `getopt_long` permutes).
+      Compress rotated files as a separate step, or reach the unwrapped
+      `/run/current-system/sw/bin/tcpdump` and accept that it has no
+      capabilities.
   - available without sudo because packet capture is granted through capability-wrapped binaries rather than `sudo`.
 
 ## Commands That Are Passwordless With `sudo-rs`
@@ -198,3 +228,11 @@ Scope:
     - the wrapper source is a compiled `makeBinaryWrapper` binary that pins
       `PATH` to a store path. An empty result means the pin was lost and the
       ambient capabilities are reachable through a caller-controlled `PATH`.
+  - `nvme sanitize-log /dev/nvme0; nvme get-feature /dev/nvme0 -f 4`
+    - the first is allowlisted and should print log data; the second is not, so
+      it should report `Permission denied`. Both succeeding means the argv
+      filter was lost from `security.wrappers.nvme.source`.
+  - `tcpdump -c 1 -C 1 -w /tmp/cap -z /bin/true`
+    - should exit non-zero with `-z is refused by the capability wrapper`.
+      A started capture means the argv filter was lost from
+      `security.wrappers.tcpdump.source`.

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -105,11 +105,14 @@ Scope:
       read-only diagnostic subcommands (`list`, `list-subsys`, `list-ns`,
       `list-ctrl`, `id-ctrl`, `id-ns`, `ns-descs`, `smart-log`, `error-log`,
       `fw-log`, `telemetry-log`, `effects-log`, `endurance-log`,
-      `sanitize-log`, `self-test-log`, `supported-log-pages`, `get-log`,
-      `device-self-test`) and clears the ambient set before `execve` for
-      everything else. `nvme format`, `nvme sanitize`, `nvme fw-commit`,
-      `nvme help` and the vendor plugins still run, but with no capability, so
-      they need `sudo` again. The vendor plugins are the reason: they
+      `sanitize-log`, `self-test-log`, `supported-log-pages`, `get-log`)
+      plus `device-self-test`, whose options can start or abort a drive
+      self-test. It clears the ambient set before `execve` for everything else.
+      `nvme format`, `nvme sanitize`, `nvme fw-commit`, and the vendor plugins
+      still run, but with no capability, so they need `sudo` again.
+      `nvme help` also runs on the cleared path without the storage capability;
+      it may still fail for an ordinary reason such as a missing manual page.
+      The vendor plugins are the reason: they
       interpolate the caller's `--dir-name` into a shell command string passed
       to `system()`
       (`plugins/solidigm/solidigm-internal-logs.c:989`,
@@ -145,20 +148,22 @@ Scope:
     - SATA drives additionally need `libata.allow_tpm=1`, documented in
       `docs/sedutil-cli.8` upstream, because libata otherwise refuses ATA
       TRUSTED SEND/RECEIVE. `modules/hosts/common/storage-diagnostics.nix` sets
-      it in `boot.kernelParams`, so it takes effect on the next reboot rather
-      than at switch time. NVMe drives do not need it.
+      it to `boot.kernelParams` while `programs.sedutil.extended.enable` is
+      true, so it takes effect on the next reboot rather than at switch time.
+      NVMe drives do not need it.
   - limitation:
-    - the wrapper covers the whole binary, so `--initialSetup`,
-      `--setSIDPassword`, `--revertTPer`, and
-      `--yesIreallywanttoERASEALLmydatausingthePSID` are passwordless for
-      `disk` members too. The last two erase the drive, and a mistyped Opal
-      password locks data that `disk` membership cannot recover, so this is a
-      wider failure mode than the raw writes membership already permitted.
-    - the wrapper source pins `PATH`, because a `popen()` helper is linked into
-      `sedutil-cli` and `popen()` execs `/bin/sh -c`. `PATH` is absent from
-      glibc's `unsecvars.h`, so the capability wrapper forwards the caller's
-      value and the ambient capabilities would survive into whatever the shell
-      resolved.
+    - the compiled `sedutil-cli` wrapper keeps capabilities only for
+      `--scan`, `--query`, `--isValidSED`, and `--printDefaultPassword`.
+      State-changing actions such as `--initialSetup`, `--setSIDPassword`,
+      `--setLockingRange`, `--loadPBAimage`, `--revertTPer`, and
+      `--yesIreallywanttoERASEALLmydatausingthePSID` clear the ambient set and
+      need `sudo` again. The last two erase the drive. `--printDefaultPassword`
+      is intentionally allowed and exposes the drive MSID, so treat its output
+      as credential material.
+    - `sedutil-cli` links a `popen()` helper that execs `/bin/sh -c`. Its target
+      pins `PATH` to a store path as defense in depth, and the filter clears
+      ambient capabilities before every non-allowlisted action, so a helper on
+      that path cannot inherit the storage capabilities.
   - effect on users outside `disk`:
     - the same as the wrappers above. The wrapper file is `root:disk 0510`, so
       PATH lookup skips it and a bare `sedutil-cli` falls through to the
@@ -221,13 +226,18 @@ Scope:
   - `sedutil-cli --scan`
     - should list whole-disk block nodes instead of reporting no access. A SATA
       drive reports Opal support only once `libata.allow_tpm=1` is set, which
-      no module in this repo does; check
+      `modules/hosts/common/storage-diagnostics.nix` adds it while sedutil is
+      enabled, for the next reboot after a switch; check
       `cat /sys/module/libata/parameters/allow_tpm` before treating a `No`
       there as a drive capability result.
-  - `strings "$(nix eval --raw .#nixosConfigurations.$(hostname).config.security.wrappers.sedutil-cli.source)" | grep '^PATH='`
-    - the wrapper source is a compiled `makeBinaryWrapper` binary that pins
-      `PATH` to a store path. An empty result means the pin was lost and the
-      ambient capabilities are reachable through a caller-controlled `PATH`.
+  - `strings "$(nix eval --raw .#nixosConfigurations.$(hostname).config.security.wrappers.sedutil-cli.source)" | grep -F 'sedutil-cli-pinned-path/bin/sedutil-cli'`
+    - the wrapper source is a compiled argv filter whose target is the
+      `makeBinaryWrapper` output with a fixed `PATH`. An empty result means the
+      filter is not bound to the pinned target.
+  - `strace -f -e trace=prctl /run/wrappers/bin/sedutil-cli --version`
+    - should show `PR_CAP_AMBIENT_CLEAR_ALL` before the unprivileged `--version`
+      action executes. A missing call means the filter is not clearing
+      capabilities for non-allowlisted actions.
   - `nvme sanitize-log /dev/nvme0; nvme get-feature /dev/nvme0 -f 4`
     - the first is allowlisted and should print log data; the second is not, so
       it should report `Permission denied`. Both succeeding means the argv

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -60,7 +60,7 @@ Scope:
 - Storage health diagnostics:
   - `smartctl ...`
   - `nvme ...`
-  - `hdparm ...` (when the hdparm app module is enabled; disabled on tpnix)
+  - `hdparm ...` (enabled on system76 and songbird; disabled on tpnix)
   - mechanism:
     - `security.wrappers` with `CAP_SYS_ADMIN` (`nvme`) or `CAP_SYS_ADMIN` plus
       `CAP_SYS_RAWIO` (`smartctl`, `hdparm`)
@@ -96,11 +96,15 @@ Scope:
       wrapper is not setuid, so `euid == uid`, bash does not enter privileged
       mode, and `BASH_ENV` is absent from glibc's `unsecvars.h`.
   - limitation:
-    - the `smartctl` and `hdparm` wrappers cover whole binaries, so destructive
-      flags (`hdparm --security-erase`, `--trim-sector-ranges`,
-      `--make-bad-sector`) are passwordless for `disk` members too. `disk`
-      membership already permits raw writes to the same devices, so this widens
-      the blast radius of a typo rather than the privilege boundary.
+    - the `smartctl` wrapper covers the whole binary. The `hdparm` wrapper is
+      filtered: it retains capabilities only for short-option clusters made
+      from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`, plus standalone `--Istdin`.
+      ATA Security, DCO/HPA, raw-sector writes, TRIM, sanitize, firmware,
+      device-setting, unknown, and parameter-bearing options clear the ambient
+      set and need `sudo` again. `-t` and `-T` are non-media-mutating timing
+      diagnostics, but may flush or synchronize caches. The existing `disk`
+      membership still permits raw block reads and writes; that does not grant
+      the separate ATA Security, DCO, or HPA control paths.
     - the `nvme` wrapper is not whole-binary. Its source allowlists the
       read-only diagnostic subcommands (`list`, `list-subsys`, `list-ns`,
       `list-ctrl`, `id-ctrl`, `id-ns`, `ns-descs`, `smart-log`, `error-log`,
@@ -179,13 +183,14 @@ Scope:
     - a `wireshark` group is also created and assigned to the owner user for tooling or policy that still expects it
   - limitation:
     - monitor-mode setup via `airmon-ng` is not capability-wrapped and still requires elevated setup
-    - the `tcpdump` wrapper source is an argv filter that refuses `-z`.
-      `tcpdump.c:3173` runs the postrotate command through `execlp()`, and the
-      wrapper's ambient `CAP_NET_RAW` and `CAP_NET_ADMIN` land in that child.
-      The filter rejects `-z` in any getopt form (`-z cmd`, `-nz cmd`,
-      `-zcmd`, and after an operand, since glibc `getopt_long` permutes).
-      Compress rotated files as a separate step, or reach the unwrapped
-      `/run/current-system/sw/bin/tcpdump` and accept that it has no
+    - the `tcpdump` wrapper source is an argv filter that refuses `-z` for
+      non-root callers. `tcpdump.c:3173` runs the postrotate command through
+      `execlp()`, and the wrapper's ambient `CAP_NET_RAW` and `CAP_NET_ADMIN`
+      land in that child. The filter rejects `-z` in any getopt form (`-z cmd`,
+      `-nz cmd`, `-zcmd`, and after an operand, since glibc `getopt_long`
+      permutes). Root callers retain the normal rotation and compression
+      workflow; non-root callers should compress rotated files separately or
+      reach the unwrapped `/run/current-system/sw/bin/tcpdump` without
       capabilities.
   - available without sudo because packet capture is granted through capability-wrapped binaries rather than `sudo`.
 
@@ -234,6 +239,14 @@ Scope:
     - the wrapper source is a compiled argv filter whose target is the
       `makeBinaryWrapper` output with a fixed `PATH`. An empty result means the
       filter is not bound to the pinned target.
+  - `strings "$(nix eval --raw .#nixosConfigurations.$(hostname).config.security.wrappers.hdparm.source)" | grep -F '/bin/hdparm'`
+    - the wrapper source is a compiled argv filter whose target is the hdparm
+      binary. An empty result means the filter is not bound to the package
+      binary.
+  - `strace -f -e trace=prctl /run/wrappers/bin/hdparm -V`
+    - should show `PR_CAP_AMBIENT_CLEAR_ALL` before the non-allowlisted version
+      action executes. A missing call means the filter is not clearing
+      capabilities for state-changing and unknown options.
   - `strace -f -e trace=prctl /run/wrappers/bin/sedutil-cli --version`
     - should show `PR_CAP_AMBIENT_CLEAR_ALL` before the unprivileged `--version`
       action executes. A missing call means the filter is not clearing
@@ -242,7 +255,11 @@ Scope:
     - the first is allowlisted and should print log data; the second is not, so
       it should report `Permission denied`. Both succeeding means the argv
       filter was lost from `security.wrappers.nvme.source`.
-  - `tcpdump -c 1 -C 1 -w /tmp/cap -z /bin/true`
+  - `tcpdump -c 1 -C 1 -w /tmp/cap -z /bin/true` as a non-root caller
     - should exit non-zero with `-z is refused by the capability wrapper`.
       A started capture means the argv filter was lost from
       `security.wrappers.tcpdump.source`.
+  - `sudo tcpdump -c 1 -C 1 -w /tmp/cap -z /bin/true` as root, with a valid
+    capture target
+    - should not emit the wrapper refusal. A later capture or tcpdump error is
+      from the real root execution path.

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -92,13 +92,22 @@ Scope:
       ambient set (`nixos/modules/security/wrappers/wrapper.c:137`). An ambient
       capability survives `execve` of an ordinary file and lands in the child's
       effective set, so any subprocess the wrapped binary starts inherits it.
-      The filter is a compiled binary, never a shell script: a capability
-      wrapper is not setuid, so `euid == uid`, bash does not enter privileged
-      mode, and `BASH_ENV` is absent from glibc's `unsecvars.h`.
+      Each mixed read/write storage command is fronted by a compiled argv
+      filter. The `smartctl` filter scans the complete argument vector because
+      its `getopt_long` parser permutes options around device operands. A
+      filter is never a shell script: a capability wrapper is not setuid, so
+      `euid == uid`, bash does not enter privileged mode, and `BASH_ENV` is
+      absent from glibc's `unsecvars.h`.
   - limitation:
-    - the `smartctl` wrapper covers the whole binary. The `hdparm` wrapper is
-      filtered: it retains capabilities only for short-option clusters made
-      from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`, plus standalone `--Istdin`.
+    - the `smartctl` wrapper is filtered: it retains capabilities only for
+      audited reports, read-only settings and log queries, and the standard
+      `offline`, `short`, `long`, and `conveyance` self-tests documented by the
+      module. SMART configuration (`-s`, `-o`, `-S`, and `--set`), log resets or
+      writes, vendor/selective/pending/force/captive/abort tests, and unknown
+      forms clear the ambient set and need `sudo` again. The filter fails
+      closed when a package update adds an unrecognized option.
+    - the `hdparm` wrapper is filtered: it retains capabilities only for
+      short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`, plus standalone `--Istdin`.
       ATA Security, DCO/HPA, raw-sector writes, TRIM, sanitize, firmware,
       device-setting, unknown, and parameter-bearing options clear the ambient
       set and need `sudo` again. `-t` and `-T` are non-media-mutating timing
@@ -239,10 +248,19 @@ Scope:
     - the wrapper source is a compiled argv filter whose target is the
       `makeBinaryWrapper` output with a fixed `PATH`. An empty result means the
       filter is not bound to the pinned target.
+  - `strings "$(nix eval --raw .#nixosConfigurations.$(hostname).config.security.wrappers.smartctl.source)" | grep -F '/bin/smartctl'`
+    - the wrapper source is a compiled argv filter whose target is the
+      smartmontools binary. An empty result means the capability-bearing
+      wrapper is not bound to the filtered target.
   - `strings "$(nix eval --raw .#nixosConfigurations.$(hostname).config.security.wrappers.hdparm.source)" | grep -F '/bin/hdparm'`
     - the wrapper source is a compiled argv filter whose target is the hdparm
       binary. An empty result means the filter is not bound to the package
       binary.
+  - `strace -f -e trace=prctl /run/wrappers/bin/smartctl -a /dev/null` and
+    `strace -f -e trace=prctl /run/wrappers/bin/smartctl -s off /dev/null`
+    - the report form should execute without `PR_CAP_AMBIENT_CLEAR_ALL`, while
+      the SMART configuration form should show that call before execution.
+      The target device may still reject the diagnostic after the filter test.
   - `strace -f -e trace=prctl /run/wrappers/bin/hdparm -V`
     - should show `PR_CAP_AMBIENT_CLEAR_ALL` before the non-allowlisted version
       action executes. A missing call means the filter is not clearing

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -108,8 +108,9 @@ Scope:
       forms clear the ambient set and need `sudo` again. The filter fails
       closed when a package update adds an unrecognized option.
     - the `hdparm` wrapper is filtered: it retains capabilities only for
-      short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`, plus standalone `--Istdin`.
-      ATA Security, DCO/HPA, raw-sector writes, TRIM, sanitize, firmware,
+      short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`.
+      Standalone input formatting such as `--Istdin`, ATA Security, DCO/HPA,
+      raw-sector writes, TRIM, sanitize, firmware,
       device-setting, unknown, and parameter-bearing options clear the ambient
       set and need `sudo` again. `-t` and `-T` are non-media-mutating timing
       diagnostics, but may flush or synchronize caches. The existing `disk`

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -16,7 +16,7 @@ Scope:
   - `modules/apps/smartmontools.nix`
   - `modules/apps/nvme-cli.nix`
   - `modules/apps/hdparm.nix`
-- shared NVMe char-device udev rule:
+- shared NVMe char-device udev rule and its retrigger unit:
   - `modules/hosts/common/storage-diagnostics.nix`
 
 ## Commands That Do Not Require `sudo`
@@ -81,6 +81,11 @@ Scope:
       `/dev/nvme0` and `/dev/ng0n1` is a DAC check that no capability in the
       wrapper set overrides. Only the namespace block nodes (`/dev/nvme0n1`)
       carry `disk` by default.
+    - the same module runs a `nvme-char-device-permissions` oneshot that
+      retriggers both subsystems. A switch only restarts `systemd-udevd`, and
+      udev applies rules to new uevents only, so nodes enumerated at boot would
+      otherwise keep `root:root 0600` until a reboot. `udevadm trigger` needs
+      root, which the `disk` members this grant targets do not have.
   - limitation:
     - the wrappers cover whole binaries, so destructive subcommands
       (`nvme format`, `nvme sanitize`, `hdparm --security-erase`) are
@@ -130,6 +135,10 @@ Scope:
     - add `/run/wrappers/bin/hdparm` where the hdparm app module is enabled.
   - `ls -l /dev/nvme0 /dev/ng0n1 /dev/nvme0n1`
     - all three should be group `disk` with mode `0660`.
+  - `systemctl status nvme-char-device-permissions`
+    - should be `active (exited)`. It retriggers the `nvme` and `nvme-generic`
+      subsystems whenever a switch changes the udev rules, so the node
+      ownership above does not wait for a reboot.
   - `smartctl -a /dev/nvme0n1`, `nvme smart-log /dev/nvme0`
     - each should print device data instead of `Permission denied` or
       `Operation not permitted`.

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -92,10 +92,14 @@ Scope:
       passwordless for `disk` members too. `disk` membership already permits raw
       writes to the same devices, so this widens the blast radius of a typo
       rather than the privilege boundary.
-  - side effect:
-    - `/run/wrappers/bin` precedes `/run/current-system/sw/bin` in `PATH`, so
-      users outside the `disk` group cannot execute `smartctl`, `nvme`, or
-      `hdparm` at all once wrapped.
+  - effect on users outside `disk`:
+    - none. The wrapper files are `root:disk 0510`, so a non-member cannot
+      execute `/run/wrappers/bin/{smartctl,nvme,hdparm}`, but the app modules
+      keep the packages in `environment.systemPackages` and PATH lookup (bash,
+      zsh, `execvp`) skips an entry that fails `access(X_OK)` and keeps
+      searching. A bare `smartctl` therefore falls through to the `0555`
+      `/run/current-system/sw/bin/smartctl` and fails at the ioctl exactly as
+      it did before the wrappers existed.
 - Packet capture:
   - `wireshark`
   - `tcpdump`

--- a/docs/security/owner-no-sudo-operations.md
+++ b/docs/security/owner-no-sudo-operations.md
@@ -12,10 +12,12 @@ Scope:
   - `modules/hosts/common/sudo.nix`
 - kernel setting affecting `dmesg`:
   - `modules/hosts/common/boot.nix`
-- storage capability wrappers and the NVMe char-device udev rule:
+- storage capability wrappers:
   - `modules/apps/smartmontools.nix`
   - `modules/apps/nvme-cli.nix`
   - `modules/apps/hdparm.nix`
+- shared NVMe char-device udev rule:
+  - `modules/hosts/common/storage-diagnostics.nix`
 
 ## Commands That Do Not Require `sudo`
 
@@ -70,11 +72,12 @@ Scope:
     - `ata_sas_scsi_ioctl()` requires both capabilities for `HDIO_DRIVE_CMD`,
       the ioctl behind `hdparm -I`.
   - NVMe char devices:
-    - a udev rule in `modules/apps/nvme-cli.nix` sets `GROUP="disk"` and
-      `MODE="0660"` on the `nvme` and `nvme-generic` subsystems, because the
-      kernel default of `root:root 0600` on `/dev/nvme0` and `/dev/ng0n1` is a
-      DAC check that no capability in the wrapper set overrides. Only the
-      namespace block nodes (`/dev/nvme0n1`) carry `disk` by default.
+    - a shared udev rule in `modules/hosts/common/storage-diagnostics.nix` sets
+      `GROUP="disk"` and `MODE="0660"` on the `nvme` and `nvme-generic`
+      subsystems, because the kernel default of `root:root 0600` on
+      `/dev/nvme0` and `/dev/ng0n1` is a DAC check that no capability in the
+      wrapper set overrides. Only the namespace block nodes (`/dev/nvme0n1`)
+      carry `disk` by default.
   - limitation:
     - the wrappers cover whole binaries, so destructive subcommands
       (`nvme format`, `nvme sanitize`, `hdparm --security-erase`) are

--- a/modules/apps/hdparm.nix
+++ b/modules/apps/hdparm.nix
@@ -23,7 +23,7 @@
 
   Notes:
     * `disk` group members run non-media-mutating diagnostics without `sudo` through a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
-    * The compiled argv filter keeps capabilities only for short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`, plus standalone `--Istdin`. State-changing, parameter-bearing, and unknown options clear the ambient set and need `sudo` again.
+    * The compiled argv filter keeps capabilities only for short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`. Standalone input formatting such as `--Istdin`, state-changing, parameter-bearing, and unknown options clear the ambient set and need `sudo` again.
 */
 _:
 let
@@ -39,8 +39,8 @@ let
 
       # hdparm parses short-option clusters itself rather than using getopt,
       # so inspect every argv element. Keep capabilities only for flags that
-      # query device state or run timings; all get/set and unknown options
-      # take the cleared-capability path.
+      # query device state or run timings; standalone input formatting, all
+      # get/set, and unknown options take the cleared-capability path.
       argvFilter = pkgs.writeCBin "hdparm-argv-filter" ''
         #include <stdio.h>
         #include <string.h>
@@ -80,11 +80,8 @@ let
               continue;
             if (strcmp(arg, "--") == 0)
               break;
-            if (arg[1] == '-') {
-              if (i == 1 && argc == 2 && strcmp(arg, "--Istdin") == 0)
-                return 1;
+            if (arg[1] == '-')
               return 0;
-            }
             if (!is_read_only_short_cluster(arg))
               return 0;
             found = 1;

--- a/modules/apps/hdparm.nix
+++ b/modules/apps/hdparm.nix
@@ -19,11 +19,11 @@
   Example Usage:
     * `hdparm -I /dev/sda` -- Inspect drive capabilities and feature set.
     * `hdparm -tT /dev/nvme0n1` -- Benchmark sequential read performance for an NVMe device.
-    * `hdparm -S 120 /dev/sdb` -- Spin down a drive after 10 minutes of inactivity (120 x 5 seconds).
+    * `sudo hdparm -S 120 /dev/sdb` -- Spin down a drive after 10 minutes of inactivity (120 x 5 seconds).
 
   Notes:
-    * `disk` group members run this without `sudo` through a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
-    * The wrapper covers the whole binary, so destructive flags (`--security-erase`, `--trim-sector-ranges`, `--make-bad-sector`) also lose the sudo prompt.
+    * `disk` group members run non-media-mutating diagnostics without `sudo` through a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
+    * The compiled argv filter keeps capabilities only for short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`, plus standalone `--Istdin`. State-changing, parameter-bearing, and unknown options clear the ambient set and need `sudo` again.
 */
 _:
 let
@@ -36,6 +36,77 @@ let
     }:
     let
       cfg = config.programs.hdparm.extended;
+
+      # hdparm parses short-option clusters itself rather than using getopt,
+      # so inspect every argv element. Keep capabilities only for flags that
+      # query device state or run timings; all get/set and unknown options
+      # take the cleared-capability path.
+      argvFilter = pkgs.writeCBin "hdparm-argv-filter" ''
+        #include <stdio.h>
+        #include <string.h>
+        #include <sys/prctl.h>
+        #include <unistd.h>
+
+        static char real_prog[] = "${cfg.package}/bin/hdparm";
+
+        static int is_read_only_short_cluster(const char *arg)
+        {
+          const char *flag;
+
+          if (arg[0] != '-' || arg[1] == '\0' || arg[1] == '-')
+            return 0;
+
+          for (flag = arg + 1; *flag != '\0'; flag++) {
+            if (strchr("CgiItT", *flag) == NULL)
+              return 0;
+          }
+          return 1;
+        }
+
+        static int keeps_capability(int argc, char **argv)
+        {
+          int found = 0;
+          int i;
+
+          if (argc < 2 || argv[1] == NULL)
+            return 0;
+
+          for (i = 1; i < argc; i++) {
+            const char *arg = argv[i];
+
+            if (arg == NULL)
+              return 0;
+            if (arg[0] != '-' || arg[1] == '\0')
+              continue;
+            if (strcmp(arg, "--") == 0)
+              break;
+            if (arg[1] == '-') {
+              if (i == 1 && argc == 2 && strcmp(arg, "--Istdin") == 0)
+                return 1;
+              return 0;
+            }
+            if (!is_read_only_short_cluster(arg))
+              return 0;
+            found = 1;
+          }
+          return found;
+        }
+
+        int main(int argc, char **argv)
+        {
+          if (!keeps_capability(argc, argv) &&
+              prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) != 0) {
+            perror("hdparm: PR_CAP_AMBIENT_CLEAR_ALL");
+            return 126;
+          }
+
+          if (argc > 0)
+            argv[0] = real_prog;
+          execv(real_prog, argv);
+          perror(real_prog);
+          return 127;
+        }
+      '';
     in
     {
       options.programs.hdparm.extended = {
@@ -53,9 +124,10 @@ let
 
         # ata_sas_scsi_ioctl() requires CAP_SYS_ADMIN and CAP_SYS_RAWIO together
         # for HDIO_DRIVE_CMD / HDIO_DRIVE_TASK, so -I and the other identify
-        # paths return EACCES for a plain `disk` member.
+        # paths return EACCES for a plain `disk` member. The filter clears these
+        # capabilities before state-changing or unknown options run.
         security.wrappers.hdparm = {
-          source = "${cfg.package}/bin/hdparm";
+          source = "${argvFilter}/bin/hdparm-argv-filter";
           capabilities = "cap_sys_admin,cap_sys_rawio+ep";
           owner = "root";
           group = "disk";

--- a/modules/apps/hdparm.nix
+++ b/modules/apps/hdparm.nix
@@ -17,9 +17,13 @@
     -y/-Y/-Z <device>: Put the drive into standby, sleep, or sleep mode (requires caution).
 
   Example Usage:
-    * `sudo hdparm -I /dev/sda` -- Inspect drive capabilities and feature set.
-    * `sudo hdparm -tT /dev/nvme0n1` -- Benchmark sequential read performance for an NVMe device.
-    * `sudo hdparm -S 120 /dev/sdb` -- Spin down a drive after 10 minutes of inactivity (120 × 5 seconds).
+    * `hdparm -I /dev/sda` -- Inspect drive capabilities and feature set.
+    * `hdparm -tT /dev/nvme0n1` -- Benchmark sequential read performance for an NVMe device.
+    * `hdparm -S 120 /dev/sdb` -- Spin down a drive after 10 minutes of inactivity (120 x 5 seconds).
+
+  Notes:
+    * `disk` group members run this without `sudo` through a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
+    * The wrapper covers the whole binary, so destructive flags (`--security-erase`, `--trim-sector-ranges`, `--make-bad-sector`) also lose the sudo prompt.
 */
 _:
 let
@@ -46,6 +50,17 @@ let
 
       config = lib.mkIf cfg.enable {
         environment.systemPackages = [ cfg.package ];
+
+        # ata_sas_scsi_ioctl() requires CAP_SYS_ADMIN and CAP_SYS_RAWIO together
+        # for HDIO_DRIVE_CMD / HDIO_DRIVE_TASK, so -I and the other identify
+        # paths return EACCES for a plain `disk` member.
+        security.wrappers.hdparm = {
+          source = "${cfg.package}/bin/hdparm";
+          capabilities = "cap_sys_admin,cap_sys_rawio+ep";
+          owner = "root";
+          group = "disk";
+          permissions = "u+rx,g+x";
+        };
       };
     };
 in

--- a/modules/apps/hdparm.nix
+++ b/modules/apps/hdparm.nix
@@ -13,7 +13,7 @@
     -I <device>: Display detailed drive identification, including firmware and feature support.
     -tT <device>: Perform cached and buffered read timing tests.
     -S <value>: Configure standby (spin-down) timeout.
-    -B <value>: Set Advanced Power Management level (0–255).
+    -B <value>: Set Advanced Power Management level (0-255).
     -y/-Y/-Z <device>: Put the drive into standby, sleep, or sleep mode (requires caution).
 
   Example Usage:

--- a/modules/apps/hdparm.nix
+++ b/modules/apps/hdparm.nix
@@ -23,7 +23,7 @@
 
   Notes:
     * `disk` group members run non-media-mutating diagnostics without `sudo` through a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
-    * The compiled argv filter keeps capabilities only for short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`. Standalone input formatting such as `--Istdin`, state-changing, parameter-bearing, and unknown options clear the ambient set and need `sudo` again.
+    * The compiled argv filter keeps capabilities only for short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`. Standalone input formatting such as `--Istdin` also takes the cleared-capability path, but only reads and formats stdin, opens no device, and needs neither storage capabilities nor `sudo`. State-changing, parameter-bearing, and unknown options clear the ambient set and need `sudo` again.
 */
 _:
 let
@@ -39,8 +39,9 @@ let
 
       # hdparm parses short-option clusters itself rather than using getopt,
       # so inspect every argv element. Keep capabilities only for flags that
-      # query device state or run timings; standalone input formatting, all
-      # get/set, and unknown options take the cleared-capability path.
+      # query device state or run timings; standalone input formatting also
+      # takes the cleared-capability path but needs no device access, while
+      # all get/set and unknown options need sudo again.
       argvFilter = pkgs.writeCBin "hdparm-argv-filter" ''
         #include <stdio.h>
         #include <string.h>

--- a/modules/apps/nvme-cli.nix
+++ b/modules/apps/nvme-cli.nix
@@ -23,7 +23,8 @@
 
   Notes:
     * `disk` group members run this without `sudo`: a capability wrapper supplies CAP_SYS_ADMIN and the shared storage policy opens the controller char nodes.
-    * The wrapper covers the whole binary, so destructive subcommands (`format`, `sanitize`, `fw-commit`) also lose the sudo prompt.
+    * The wrapper source is an argv filter that only keeps the capability for an allowlist of read-only diagnostic subcommands. Every other subcommand still runs, with the ambient set cleared, so `format`, `sanitize`, `fw-commit` and the vendor plugins need `sudo` again.
+    * `nvme help <cmd>` and the vendor plugins are in the cleared path: plugin.c:52 `execlp`s `man`, and the plugins interpolate `--dir-name` into a `system()` string (solidigm-internal-logs.c:989, wdc-nvme.c:4218).
 */
 _:
 let
@@ -36,6 +37,78 @@ let
     }:
     let
       cfg = config.programs."nvme-cli".extended;
+
+      # security.wrappers raises cap_sys_admin into the ambient set
+      # (wrapper.c:137), which survives execve into a file without capabilities,
+      # so it would reach anything nvme runs. The vendor plugins interpolate the
+      # caller's --dir-name into a shell string (solidigm-internal-logs.c:989,
+      # wdc-nvme.c:4218, micron-nvme.c:249), which no PATH can bound, so the
+      # filter drops the ambient set instead. It has to be a compiled binary:
+      # cap wrappers are not setuid, so euid == uid, bash never enters
+      # privileged mode, and BASH_ENV is absent from glibc's unsecvars.h.
+      argvFilter = pkgs.writeCBin "nvme-argv-filter" ''
+        #include <stdio.h>
+        #include <string.h>
+        #include <sys/prctl.h>
+        #include <unistd.h>
+
+        static char real_prog[] = "${cfg.package}/bin/nvme";
+
+        /* nvme.c:11153 dispatches argv[1]. Each name is an exact nvme-builtin.h
+           entry, so handle_plugin's strcmp arm (plugin.c:186) wins before its
+           unique-prefix and plugin-extension arms, and nvme.c holds no
+           system()/popen()/exec* call for any of them to reach. */
+        static const char *const allowed[] = {
+        	"device-self-test",
+        	"effects-log",
+        	"endurance-log",
+        	"error-log",
+        	"fw-log",
+        	"get-log",
+        	"id-ctrl",
+        	"id-ns",
+        	"list",
+        	"list-ctrl",
+        	"list-ns",
+        	"list-subsys",
+        	"ns-descs",
+        	"sanitize-log",
+        	"self-test-log",
+        	"smart-log",
+        	"supported-log-pages",
+        	"telemetry-log",
+        	NULL
+        };
+
+        int main(int argc, char **argv)
+        {
+        	int keep = 0;
+        	int i;
+
+        	/* Compared verbatim. plugin.c:174 strips leading dashes before
+        	   dispatch, so `--smart-log` reaches the same builtin but takes the
+        	   cleared path. */
+        	for (i = 0; argc > 1 && allowed[i] != NULL; i++) {
+        		if (strcmp(argv[1], allowed[i]) == 0) {
+        			keep = 1;
+        			break;
+        		}
+        	}
+
+        	/* An execve after this gets new_permitted = file_caps(0) | ambient(0). */
+        	if (!keep && prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) != 0) {
+        		perror("nvme: PR_CAP_AMBIENT_CLEAR_ALL");
+        		return 126;
+        	}
+
+        	/* execve(2) permits argc == 0, where argv[0] is the NULL terminator. */
+        	if (argc > 0)
+        		argv[0] = real_prog;
+        	execv(real_prog, argv);
+        	perror(real_prog);
+        	return 127;
+        }
+      '';
     in
     {
       options.programs.nvme-cli.extended = {
@@ -55,7 +128,7 @@ let
         # identify CNS values without CAP_SYS_ADMIN, so smart-log, error-log,
         # fw-log and telemetry fail with EACCES for a plain `disk` member.
         security.wrappers.nvme = {
-          source = "${cfg.package}/bin/nvme";
+          source = "${argvFilter}/bin/nvme-argv-filter";
           capabilities = "cap_sys_admin+ep";
           owner = "root";
           group = "disk";

--- a/modules/apps/nvme-cli.nix
+++ b/modules/apps/nvme-cli.nix
@@ -22,7 +22,7 @@
     * `nvme device-self-test /dev/nvme0 --start extended` -- Initiate an extended diagnostic self-test.
 
   Notes:
-    * `disk` group members run this without `sudo`: a capability wrapper supplies CAP_SYS_ADMIN and a udev rule opens the controller char nodes.
+    * `disk` group members run this without `sudo`: a capability wrapper supplies CAP_SYS_ADMIN and the shared storage policy opens the controller char nodes.
     * The wrapper covers the whole binary, so destructive subcommands (`format`, `sanitize`, `fw-commit`) also lose the sudo prompt.
 */
 _:
@@ -61,14 +61,6 @@ let
           group = "disk";
           permissions = "u+rx,g+x";
         };
-
-        # Only the namespace block nodes carry GROUP="disk"; the controller
-        # (/dev/nvme0) and generic (/dev/ng0n1) char nodes ship root:root 0600,
-        # which no capability in the wrapper set overrides.
-        services.udev.extraRules = ''
-          SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", GROUP="disk", MODE="0660"
-          SUBSYSTEM=="nvme-generic", KERNEL=="ng[0-9]*", GROUP="disk", MODE="0660"
-        '';
       };
     };
 in

--- a/modules/apps/nvme-cli.nix
+++ b/modules/apps/nvme-cli.nix
@@ -23,7 +23,7 @@
 
   Notes:
     * `disk` group members run this without `sudo`: a capability wrapper supplies CAP_SYS_ADMIN and the shared storage policy opens the controller char nodes.
-    * The wrapper source is an argv filter that only keeps the capability for an allowlist of read-only diagnostic subcommands. Every other subcommand still runs, with the ambient set cleared, so `format`, `sanitize`, `fw-commit` and the vendor plugins need `sudo` again.
+    * The wrapper source is an argv filter that only keeps the capability for an allowlist of read-only diagnostic subcommands plus `device-self-test`, whose options can start or abort a drive self-test. Every other subcommand still runs, with the ambient set cleared, so `format`, `sanitize`, `fw-commit` and the vendor plugins need `sudo` again.
     * `nvme help <cmd>` and the vendor plugins are in the cleared path: plugin.c:52 `execlp`s `man`, and the plugins interpolate `--dir-name` into a `system()` string (solidigm-internal-logs.c:989, wdc-nvme.c:4218).
 */
 _:

--- a/modules/apps/nvme-cli.nix
+++ b/modules/apps/nvme-cli.nix
@@ -17,9 +17,13 @@
     nvme device-self-test /dev/nvme0 --start short: Run a short self-test.
 
   Example Usage:
-    * `sudo nvme list` -- Discover NVMe devices attached to the system.
-    * `sudo nvme smart-log /dev/nvme0` -- Check drive temperature, media errors, and wear indicators.
-    * `sudo nvme device-self-test /dev/nvme0 --start extended` -- Initiate an extended diagnostic self-test.
+    * `nvme list` -- Discover NVMe devices attached to the system.
+    * `nvme smart-log /dev/nvme0` -- Check drive temperature, media errors, and wear indicators.
+    * `nvme device-self-test /dev/nvme0 --start extended` -- Initiate an extended diagnostic self-test.
+
+  Notes:
+    * `disk` group members run this without `sudo`: a capability wrapper supplies CAP_SYS_ADMIN and a udev rule opens the controller char nodes.
+    * The wrapper covers the whole binary, so destructive subcommands (`format`, `sanitize`, `fw-commit`) also lose the sudo prompt.
 */
 _:
 let
@@ -46,6 +50,25 @@ let
 
       config = lib.mkIf cfg.enable {
         environment.systemPackages = [ cfg.package ];
+
+        # nvme_cmd_allowed() rejects every admin passthrough except a few
+        # identify CNS values without CAP_SYS_ADMIN, so smart-log, error-log,
+        # fw-log and telemetry fail with EACCES for a plain `disk` member.
+        security.wrappers.nvme = {
+          source = "${cfg.package}/bin/nvme";
+          capabilities = "cap_sys_admin+ep";
+          owner = "root";
+          group = "disk";
+          permissions = "u+rx,g+x";
+        };
+
+        # Only the namespace block nodes carry GROUP="disk"; the controller
+        # (/dev/nvme0) and generic (/dev/ng0n1) char nodes ship root:root 0600,
+        # which no capability in the wrapper set overrides.
+        services.udev.extraRules = ''
+          SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", GROUP="disk", MODE="0660"
+          SUBSYSTEM=="nvme-generic", KERNEL=="ng[0-9]*", GROUP="disk", MODE="0660"
+        '';
       };
     };
 in

--- a/modules/apps/sedutil.nix
+++ b/modules/apps/sedutil.nix
@@ -27,7 +27,7 @@
   Notes:
     * `disk` group members run selected `sedutil-cli` diagnostics without `sudo` through a compiled argv filter and a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
     * SATA drives also need `libata.allow_tpm=1` (docs/sedutil-cli.8), set in `modules/hosts/common/storage-diagnostics.nix` while sedutil is enabled and applied on the next reboot. NVMe drives are unaffected.
-    * The filter keeps capabilities only for `--scan`, `--query`, `--isValidSED`, and `--printDefaultPassword`. State-changing actions clear the ambient set and need `sudo` again; `--revertTPer` and `--yesIreallywanttoERASEALLmydatausingthePSID` destroy data.
+    * For the sedutil 1.49.13 parser, the filter keeps capabilities only for `--scan` (with its JSON output forms), `--query` (with its JSON output forms and one device), `--isValidSED <device>`, and `--printDefaultPassword <device>`. State-changing actions clear the ambient set and need `sudo` again; `--revertTPer` and `--yesIreallywanttoERASEALLmydatausingthePSID` destroy data. A custom package must be re-audited if its argument parser changes.
     * `linuxpba` ships in the same package and stays unwrapped, so it still needs `sudo`.
 */
 _:
@@ -58,9 +58,10 @@ let
               --set PATH ${lib.makeBinPath [ pkgs.coreutils ]}
           '';
 
-      # Keep capabilities only for actions whose current implementation reads
-      # device state. All other actions run after clearing the ambient set,
-      # including unknown future actions, so a package update fails closed.
+      # Keep capabilities only for read actions in the sedutil 1.49.13 parser.
+      # Its exact and maximum argument checks reject later actions before
+      # dispatch; unsupported first actions clear the ambient set. Re-audit a
+      # custom package if its argument parser changes.
       argvFilter = pkgs.writeCBin "sedutil-cli-argv-filter" ''
         #include <stdio.h>
         #include <string.h>

--- a/modules/apps/sedutil.nix
+++ b/modules/apps/sedutil.nix
@@ -25,9 +25,9 @@
     * `sedutil-cli --printDefaultPassword /dev/sda` -- Read the factory MSID before taking ownership.
 
   Notes:
-    * `disk` group members run `sedutil-cli` without `sudo` through a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
-    * SATA drives also need `libata.allow_tpm=1` (docs/sedutil-cli.8), set in `modules/hosts/common/storage-diagnostics.nix` and applied on the next reboot. NVMe drives are unaffected.
-    * The wrapper covers the whole binary, so the password and revert subcommands (`--initialSetup`, `--revertTPer`, `--yesIreallywanttoERASEALLmydatausingthePSID`) also lose the sudo prompt, and the last two destroy data.
+    * `disk` group members run selected `sedutil-cli` diagnostics without `sudo` through a compiled argv filter and a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
+    * SATA drives also need `libata.allow_tpm=1` (docs/sedutil-cli.8), set in `modules/hosts/common/storage-diagnostics.nix` while sedutil is enabled and applied on the next reboot. NVMe drives are unaffected.
+    * The filter keeps capabilities only for `--scan`, `--query`, `--isValidSED`, and `--printDefaultPassword`. State-changing actions clear the ambient set and need `sudo` again; `--revertTPer` and `--yesIreallywanttoERASEALLmydatausingthePSID` destroy data.
     * `linuxpba` ships in the same package and stays unwrapped, so it still needs `sudo`.
 */
 _:
@@ -45,8 +45,9 @@ let
       # `Common/system.cpp` links a popen() helper into sedutil-cli, and popen
       # execs `/bin/sh -c`, which resolves command names from PATH. PATH is not
       # in glibc's unsecvars list, so the capability wrapper forwards the
-      # caller's value and the ambient caps would survive into whatever the
-      # shell found. Pinning PATH here removes that lookup from caller control.
+      # caller's value. The argv filter clears ambient capabilities for every
+      # action that could reach the helper, while this fixed PATH remains a
+      # defense-in-depth boundary for the helper lookup.
       pinnedPath =
         pkgs.runCommand "sedutil-cli-pinned-path"
           {
@@ -56,6 +57,55 @@ let
             makeWrapper ${cfg.package}/bin/sedutil-cli "$out/bin/sedutil-cli" \
               --set PATH ${lib.makeBinPath [ pkgs.coreutils ]}
           '';
+
+      # Keep capabilities only for actions whose current implementation reads
+      # device state. All other actions run after clearing the ambient set,
+      # including unknown future actions, so a package update fails closed.
+      argvFilter = pkgs.writeCBin "sedutil-cli-argv-filter" ''
+        #include <stdio.h>
+        #include <string.h>
+        #include <sys/prctl.h>
+        #include <unistd.h>
+
+        static char real_prog[] = "${pinnedPath}/bin/sedutil-cli";
+
+        static const char *const allowed[] = {
+          "--scan",
+          "--query",
+          "--isValidSED",
+          "--printDefaultPassword",
+          NULL
+        };
+
+        static int keeps_capability(int argc, char **argv)
+        {
+          int i;
+
+          if (argc < 2 || argv[1] == NULL)
+            return 0;
+
+          for (i = 0; allowed[i] != NULL; i++) {
+            if (strcmp(argv[1], allowed[i]) == 0)
+              return 1;
+          }
+          return 0;
+        }
+
+        int main(int argc, char **argv)
+        {
+          if (!keeps_capability(argc, argv) &&
+              prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) != 0) {
+            perror("sedutil-cli: PR_CAP_AMBIENT_CLEAR_ALL");
+            return 126;
+          }
+
+          if (argc > 0)
+            argv[0] = real_prog;
+          execv(real_prog, argv);
+          perror(real_prog);
+          return 127;
+        }
+      '';
     in
     {
       options.programs.sedutil.extended = {
@@ -77,7 +127,7 @@ let
         # the NVMe security send/receive admin passthrough without
         # CAP_SYS_ADMIN.
         security.wrappers.sedutil-cli = {
-          source = "${pinnedPath}/bin/sedutil-cli";
+          source = "${argvFilter}/bin/sedutil-cli-argv-filter";
           capabilities = "cap_sys_admin,cap_sys_rawio+ep";
           owner = "root";
           group = "disk";

--- a/modules/apps/sedutil.nix
+++ b/modules/apps/sedutil.nix
@@ -1,0 +1,91 @@
+/*
+  Package: sedutil
+  Description: Command-line manager for TCG Opal 2.0 self-encrypting drives.
+  Homepage: https://www.drivetrust.com
+  Documentation: https://github.com/Drive-Trust-Alliance/sedutil/wiki
+  Repository: https://github.com/Drive-Trust-Alliance/sedutil
+
+  Summary:
+    * Takes ownership of an Opal drive, manages locking ranges, MBR shadowing, and pre-boot authentication images.
+    * Reaches SATA drives through SCSI/ATA translation and NVMe drives through admin security send/receive.
+
+  Options:
+    --scan: List devices and mark the Opal compliant ones.
+    --query <device>: Print the Discovery 0 feature descriptors of a device.
+    --isValidSED <device>: Report whether a device is a self-encrypting drive.
+    --initialSetup <SIDpassword> <device>: Take ownership and set the SID and Admin1 passwords.
+    --setLockingRange <0...n> <RW|RO|LK> <Admin1password> <device>: Change the state of a locking range.
+    --loadPBAimage <Admin1password> <file> <device>: Write a pre-boot authentication image to the MBR shadow area.
+    --revertTPer <SIDpassword> <device>: Restore factory defaults, erasing all data.
+    --printDefaultPassword <device>: Print the drive MSID.
+
+  Example Usage:
+    * `sedutil-cli --scan` -- Discover which attached drives report Opal support.
+    * `sedutil-cli --query /dev/nvme0n1` -- Read the Discovery 0 response of an NVMe drive.
+    * `sedutil-cli --printDefaultPassword /dev/sda` -- Read the factory MSID before taking ownership.
+
+  Notes:
+    * `disk` group members run `sedutil-cli` without `sudo` through a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
+    * SATA drives also need `libata.allow_tpm=1` (docs/sedutil-cli.8), set in `modules/hosts/common/storage-diagnostics.nix` and applied on the next reboot. NVMe drives are unaffected.
+    * The wrapper covers the whole binary, so the password and revert subcommands (`--initialSetup`, `--revertTPer`, `--yesIreallywanttoERASEALLmydatausingthePSID`) also lose the sudo prompt, and the last two destroy data.
+    * `linuxpba` ships in the same package and stays unwrapped, so it still needs `sudo`.
+*/
+_:
+let
+  SedutilModule =
+    {
+      config,
+      lib,
+      pkgs,
+      ...
+    }:
+    let
+      cfg = config.programs.sedutil.extended;
+
+      # `Common/system.cpp` links a popen() helper into sedutil-cli, and popen
+      # execs `/bin/sh -c`, which resolves command names from PATH. PATH is not
+      # in glibc's unsecvars list, so the capability wrapper forwards the
+      # caller's value and the ambient caps would survive into whatever the
+      # shell found. Pinning PATH here removes that lookup from caller control.
+      pinnedPath =
+        pkgs.runCommand "sedutil-cli-pinned-path"
+          {
+            nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+          }
+          ''
+            makeWrapper ${cfg.package}/bin/sedutil-cli "$out/bin/sedutil-cli" \
+              --set PATH ${lib.makeBinPath [ pkgs.coreutils ]}
+          '';
+    in
+    {
+      options.programs.sedutil.extended = {
+        enable = lib.mkOption {
+          type = lib.types.bool;
+          default = false;
+          description = "Whether to enable sedutil.";
+        };
+
+        package = lib.mkPackageOption pkgs "sedutil" { };
+      };
+
+      config = lib.mkIf cfg.enable {
+        environment.systemPackages = [ cfg.package ];
+
+        # Opal traffic leaves through two gated ioctls: blk_verify_command()
+        # rejects the SECURITY PROTOCOL IN/OUT and ATA PASS-THROUGH CDBs that
+        # SG_IO carries without CAP_SYS_RAWIO, and nvme_cmd_allowed() rejects
+        # the NVMe security send/receive admin passthrough without
+        # CAP_SYS_ADMIN.
+        security.wrappers.sedutil-cli = {
+          source = "${pinnedPath}/bin/sedutil-cli";
+          capabilities = "cap_sys_admin,cap_sys_rawio+ep";
+          owner = "root";
+          group = "disk";
+          permissions = "u+rx,g+x";
+        };
+      };
+    };
+in
+{
+  flake.nixosModules.apps.sedutil = SedutilModule;
+}

--- a/modules/apps/smartmontools.nix
+++ b/modules/apps/smartmontools.nix
@@ -16,9 +16,13 @@
     smartd.conf: Configure daemon monitoring intervals and notification methods.
 
   Example Usage:
-    * `sudo smartctl -a /dev/sda` -- Review detailed health metrics and error logs.
-    * `sudo smartctl -t long /dev/sda` -- Initiate an extended self-test (run in background).
+    * `smartctl -a /dev/sda` -- Review detailed health metrics and error logs.
+    * `smartctl -a /dev/nvme0n1` -- Read the NVMe SMART/health, error and self-test logs.
+    * `smartctl -t long /dev/sda` -- Initiate an extended self-test (run in background).
     * Edit `/etc/smartd.conf` to schedule weekly tests and email alerts via `smartd`.
+
+  Notes:
+    * `disk` group members run `smartctl` without `sudo` through a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
 */
 _:
 let
@@ -45,6 +49,17 @@ let
 
       config = lib.mkIf cfg.enable {
         environment.systemPackages = [ cfg.package ];
+
+        # Two separate kernel gates sit in front of SMART data: NVMe admin
+        # passthrough checks CAP_SYS_ADMIN, and the SG_IO command filter that
+        # ATA-over-SAT reads go through checks CAP_SYS_RAWIO.
+        security.wrappers.smartctl = {
+          source = "${cfg.package}/bin/smartctl";
+          capabilities = "cap_sys_admin,cap_sys_rawio+ep";
+          owner = "root";
+          group = "disk";
+          permissions = "u+rx,g+x";
+        };
       };
     };
 in

--- a/modules/apps/smartmontools.nix
+++ b/modules/apps/smartmontools.nix
@@ -23,7 +23,7 @@
 
   Notes:
     * `disk` group members run the audited `smartctl` reports and standard self-tests without `sudo` through a compiled argv filter and a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
-    * The filter retains capabilities for reports, settings reads, and `offline`, `short`, `long`, and `conveyance` self-tests. Configuration, reset, vendor, selective, pending, force, captive, abort, and unknown forms clear the ambient set and need `sudo` again.
+    * The filter retains capabilities for reports, settings reads including `-n sleep|standby|idle[,STATUS[,STATUS2]]`, and `offline`, `short`, `long`, and `conveyance` self-tests. Configuration, reset, vendor, selective, pending, force, captive, abort, and unknown forms clear the ambient set and need `sudo` again.
 */
 _:
 let
@@ -192,8 +192,12 @@ let
 
               if (strcmp(value, "never") == 0)
                 return 1;
-              if (comma == NULL ||
-                  !((strncmp(value, "sleep", (size_t) (comma - value)) == 0 && comma - value == 5) ||
+              /* smartctl makes the status components optional for these modes. */
+              if (comma == NULL)
+                return strcmp(value, "sleep") == 0 ||
+                  strcmp(value, "standby") == 0 ||
+                  strcmp(value, "idle") == 0;
+              if (!((strncmp(value, "sleep", (size_t) (comma - value)) == 0 && comma - value == 5) ||
                     (strncmp(value, "standby", (size_t) (comma - value)) == 0 && comma - value == 7) ||
                     (strncmp(value, "idle", (size_t) (comma - value)) == 0 && comma - value == 4)))
                 return 0;

--- a/modules/apps/smartmontools.nix
+++ b/modules/apps/smartmontools.nix
@@ -13,6 +13,8 @@
     smartctl -a /dev/sdX: Display all SMART information for a drive.
     smartctl -t short /dev/sdX: Start a short self-test.
     smartctl -H /dev/nvme0: Report overall health status.
+    smartctl -v ID,FORMAT /dev/sdX: Select a vendor attribute display format.
+    smartctl -F TYPE /dev/sdX: Apply a documented firmware-bug workaround.
     smartd.conf: Configure daemon monitoring intervals and notification methods.
 
   Example Usage:
@@ -23,7 +25,7 @@
 
   Notes:
     * `disk` group members run the audited `smartctl` reports and standard self-tests without `sudo` through a compiled argv filter and a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
-    * The filter retains capabilities for reports, settings reads including `-n sleep|standby|idle[,STATUS[,STATUS2]]`, and `offline`, `short`, `long`, and `conveyance` self-tests. Configuration, reset, vendor, selective, pending, force, captive, abort, and unknown forms clear the ambient set and need `sudo` again.
+    * The filter retains capabilities for reports, audited `-v`/`--vendorattribute` display definitions, `-F`/`--firmwarebug` report workarounds, settings reads including `-n sleep|standby|idle[,STATUS[,STATUS2]]`, and `offline`, `short`, `long`, and `conveyance` self-tests. Configuration, reset, log-writing, selective, pending, force, captive, abort, and unknown forms clear the ambient set and need `sudo` again.
 */
 _:
 let
@@ -53,8 +55,9 @@ let
           # smartctl combines read-only reports with device-mutating options. Its
           # getopt_long parser permutes options around operands, so the compiled
           # filter scans the complete argv and keeps capabilities only for the
-          # audited reports and standard tests documented above. Unsupported,
-          # state-changing, and future options take the cleared-capability path.
+          # audited reports, report modifiers, and standard tests documented
+          # above. Unsupported, state-changing, and future options take the
+          # cleared-capability path.
           argvFilter = pkgs.writeCBin "smartctl-argv-filter" ''
             #include <ctype.h>
             #include <stdio.h>
@@ -110,6 +113,60 @@ let
               NULL
             };
 
+            /* Keep the documented smartmontools 7.5 format names exact. */
+            static const char *const vendor_format_values[] = {
+              "raw8",
+              "raw16",
+              "raw48",
+              "hex48",
+              "raw56",
+              "hex56",
+              "raw64",
+              "hex64",
+              "raw16(raw16)",
+              "raw16(avg16)",
+              "raw24(raw8)",
+              "raw24/raw24",
+              "raw24/raw32",
+              "sec2hour",
+              "min2hour",
+              "halfmin2hour",
+              "msec24hour32",
+              "tempminmax",
+              "temp10x",
+              NULL
+            };
+
+            static const char *const vendor_legacy_values[] = {
+              "9,halfminutes",
+              "9,minutes",
+              "9,seconds",
+              "9,temp",
+              "192,emergencyretractcyclect",
+              "193,loadunload",
+              "194,10xCelsius",
+              "194,unknown",
+              "197,increasing",
+              "198,offlinescanuncsectorct",
+              "198,increasing",
+              "200,writeerrorcount",
+              "201,detectedtacount",
+              "220,temp",
+              NULL
+            };
+
+            /* swapid is handled outside parse_firmwarebug_def(). */
+            static const char *const firmwarebug_values[] = {
+              "none",
+              "nologdir",
+              "samsung",
+              "samsung2",
+              "samsung3",
+              "xerrorlba",
+              "swapid",
+              NULL
+            };
+
             static int is_one_of(const char *value, const char *const *allowed)
             {
               int i;
@@ -119,6 +176,11 @@ let
                   return 1;
               }
               return 0;
+            }
+
+            static int has_name(const char *name, size_t length, const char *expected)
+            {
+              return length == strlen(expected) && strncmp(name, expected, length) == 0;
             }
 
             static int is_decimal_range(const char *start, const char *end,
@@ -170,6 +232,96 @@ let
                 return 0;
               }
               return 1;
+            }
+
+            static int is_vendor_format(const char *value, size_t length)
+            {
+              int i;
+
+              for (i = 0; vendor_format_values[i] != NULL; i++) {
+                if (has_name(value, length, vendor_format_values[i]))
+                  return 1;
+              }
+              return 0;
+            }
+
+            static int is_vendor_byteorder(const char *value, size_t length)
+            {
+              size_t i;
+
+              if (length == 0 || length > 8)
+                return 0;
+              for (i = 0; i < length; i++) {
+                if (strchr("012345rvwz", value[i]) == NULL)
+                  return 0;
+              }
+              return 1;
+            }
+
+            static int is_vendor_name(const char *value, size_t length)
+            {
+              size_t i;
+
+              if (length == 0 || length > 23)
+                return 0;
+              for (i = 0; i < length; i++) {
+                if (!((value[i] >= 'a' && value[i] <= 'z') ||
+                      (value[i] >= 'A' && value[i] <= 'Z') ||
+                      (value[i] >= '0' && value[i] <= '9') ||
+                      value[i] == '_'))
+                  return 0;
+              }
+              return 1;
+            }
+
+            static int is_vendor_attribute(const char *value)
+            {
+              const char *format;
+              const char *format_end;
+              const char *separator;
+              const char *name;
+              size_t format_length;
+              size_t name_length;
+
+              if (value == NULL || *value == '\0')
+                return 0;
+
+              if (value[0] == 'N') {
+                if (value[1] != ',')
+                  return 0;
+                format = value + 2;
+              } else {
+                const char *id_end = strchr(value, ',');
+
+                if (id_end == NULL)
+                  return 0;
+                if (!is_decimal_range(value, id_end, 255, 1))
+                  return 0;
+                format = id_end + 1;
+              }
+
+              format_end = strchr(format, ',');
+              if (format_end == NULL)
+                format_end = format + strlen(format);
+              if (format == format_end)
+                return 0;
+
+              separator = memchr(format, ':', (size_t) (format_end - format));
+              format_length = separator == NULL ? (size_t) (format_end - format) :
+                (size_t) (separator - format);
+              if (!is_vendor_format(format, format_length))
+                return 0;
+              if (separator != NULL &&
+                  !is_vendor_byteorder(separator + 1,
+                    (size_t) (format_end - separator - 1)))
+                return 0;
+
+              if (format_end[0] == '\0')
+                return 1;
+              name = format_end + 1;
+              name_length = strlen(name);
+              return is_vendor_name(name, name_length) &&
+                strchr(name, ',') == NULL;
             }
 
             static int is_report(const char *value)
@@ -278,6 +430,9 @@ let
                 "wcreorder", "wcache-sct", NULL
               });
               case 'P': return is_one_of(value, preset_values);
+              case 'v': return strcmp(value, "help") == 0 ||
+                is_vendor_attribute(value) || is_one_of(value, vendor_legacy_values);
+              case 'F': return is_one_of(value, firmwarebug_values);
               case 't': return is_one_of(value, (const char *const[]) {
                 "offline", "short", "long", "conveyance", NULL
               });
@@ -297,12 +452,7 @@ let
 
             static int is_short_arg(int option)
             {
-              return strchr("dTbrqnlfgPt", option) != NULL;
-            }
-
-            static int has_name(const char *name, size_t length, const char *expected)
-            {
-              return length == strlen(expected) && strncmp(name, expected, length) == 0;
+              return strchr("dTbrqnlfgPtvF", option) != NULL;
             }
 
             static int long_option(const char *name, size_t length)
@@ -331,6 +481,8 @@ let
               if (has_name(name, length, "format")) return 'f';
               if (has_name(name, length, "presets")) return 'P';
               if (has_name(name, length, "test")) return 't';
+              if (has_name(name, length, "vendorattribute")) return 'v';
+              if (has_name(name, length, "firmwarebug")) return 'F';
               return 0;
             }
 

--- a/modules/apps/smartmontools.nix
+++ b/modules/apps/smartmontools.nix
@@ -22,7 +22,8 @@
     * Edit `/etc/smartd.conf` to schedule weekly tests and email alerts via `smartd`.
 
   Notes:
-    * `disk` group members run `smartctl` without `sudo` through a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
+    * `disk` group members run the audited `smartctl` reports and standard self-tests without `sudo` through a compiled argv filter and a capability wrapper carrying CAP_SYS_ADMIN and CAP_SYS_RAWIO.
+    * The filter retains capabilities for reports, settings reads, and `offline`, `short`, `long`, and `conveyance` self-tests. Configuration, reset, vendor, selective, pending, force, captive, abort, and unknown forms clear the ambient set and need `sudo` again.
 */
 _:
 let
@@ -47,20 +48,406 @@ let
         package = lib.mkPackageOption pkgs "smartmontools" { };
       };
 
-      config = lib.mkIf cfg.enable {
-        environment.systemPackages = [ cfg.package ];
+      config = lib.mkIf cfg.enable (
+        let
+          # smartctl combines read-only reports with device-mutating options. Its
+          # getopt_long parser permutes options around operands, so the compiled
+          # filter scans the complete argv and keeps capabilities only for the
+          # audited reports and standard tests documented above. Unsupported,
+          # state-changing, and future options take the cleared-capability path.
+          argvFilter = pkgs.writeCBin "smartctl-argv-filter" ''
+            #include <ctype.h>
+            #include <stdio.h>
+            #include <string.h>
+            #include <sys/prctl.h>
+            #include <unistd.h>
 
-        # Two separate kernel gates sit in front of SMART data: NVMe admin
-        # passthrough checks CAP_SYS_ADMIN, and the SG_IO command filter that
-        # ATA-over-SAT reads go through checks CAP_SYS_RAWIO.
-        security.wrappers.smartctl = {
-          source = "${cfg.package}/bin/smartctl";
-          capabilities = "cap_sys_admin,cap_sys_rawio+ep";
-          owner = "root";
-          group = "disk";
-          permissions = "u+rx,g+x";
-        };
-      };
+            static char real_prog[] = "${cfg.package}/bin/smartctl";
+
+            enum {
+              opt_identify = 1000,
+              opt_json,
+              opt_scan,
+              opt_scan_open
+            };
+
+            static const char *const quiet_values[] = {
+              "errorsonly",
+              "silent",
+              "noserial",
+              NULL
+            };
+
+            static const char *const tolerance_values[] = {
+              "normal",
+              "conservative",
+              "permissive",
+              "verypermissive",
+              NULL
+            };
+
+            static const char *const badsum_values[] = {
+              "warn",
+              "exit",
+              "ignore",
+              NULL
+            };
+
+            static const char *const preset_values[] = {
+              "use",
+              "ignore",
+              "show",
+              "showall",
+              NULL
+            };
+
+            static const char *const format_values[] = {
+              "old",
+              "brief",
+              "hex",
+              "hex,id",
+              "hex,val",
+              NULL
+            };
+
+            static int is_one_of(const char *value, const char *const *allowed)
+            {
+              int i;
+
+              for (i = 0; allowed[i] != NULL; i++) {
+                if (strcmp(value, allowed[i]) == 0)
+                  return 1;
+              }
+              return 0;
+            }
+
+            static int is_decimal_range(const char *start, const char *end,
+                                        unsigned max, int nonzero)
+            {
+              unsigned number = 0;
+              const unsigned char *p = (const unsigned char *) start;
+
+              if (start == end)
+                return 0;
+              for (; p < (const unsigned char *) end; p++) {
+                if (!isdigit(*p))
+                  return 0;
+                if (number > (max - (*p - '0')) / 10)
+                  return 0;
+                number = number * 10 + (*p - '0');
+              }
+              return !nonzero || number != 0;
+            }
+
+            static int is_decimal(const char *value, unsigned max, int nonzero)
+            {
+              return is_decimal_range(value, value + strlen(value), max, nonzero);
+            }
+
+            static int is_hex_byte(const char *value)
+            {
+              const unsigned char *p = (const unsigned char *) value;
+              int digits = 0;
+
+              if (p[0] != '0' || p[1] != 'x')
+                return 0;
+              for (p += 2; *p != '\0'; p++) {
+                if (!isxdigit(*p) || ++digits > 2)
+                  return 0;
+              }
+              return digits > 0;
+            }
+
+            static int is_device_type(const char *value)
+            {
+              const unsigned char *p = (const unsigned char *) value;
+
+              if (*p == '\0' || *p == '-')
+                return 0;
+              for (; *p != '\0'; p++) {
+                if (isalnum(*p) || strchr("-_.+,/:", *p) != NULL)
+                  continue;
+                return 0;
+              }
+              return 1;
+            }
+
+            static int is_report(const char *value)
+            {
+              const char *comma = strchr(value, ',');
+              size_t length = comma == NULL ? strlen(value) : (size_t) (comma - value);
+
+              if (!((length == strlen("ioctl") && strncmp(value, "ioctl", length) == 0) ||
+                    (length == strlen("ataioctl") && strncmp(value, "ataioctl", length) == 0) ||
+                    (length == strlen("scsiioctl") && strncmp(value, "scsiioctl", length) == 0) ||
+                    (length == strlen("nvmeioctl") && strncmp(value, "nvmeioctl", length) == 0)))
+                return 0;
+              return comma == NULL ||
+                (comma[1] >= '1' && comma[1] <= '4' && comma[2] == '\0');
+            }
+
+            static int is_nocheck(const char *value)
+            {
+              const char *comma = strchr(value, ',');
+
+              if (strcmp(value, "never") == 0)
+                return 1;
+              if (comma == NULL ||
+                  !((strncmp(value, "sleep", (size_t) (comma - value)) == 0 && comma - value == 5) ||
+                    (strncmp(value, "standby", (size_t) (comma - value)) == 0 && comma - value == 7) ||
+                    (strncmp(value, "idle", (size_t) (comma - value)) == 0 && comma - value == 4)))
+                return 0;
+
+              {
+                const char *first = comma + 1;
+                const char *second = strchr(first, ',');
+
+                if (second == NULL)
+                  return is_decimal(first, 255, 0);
+                if (!is_decimal_range(first, second, 255, 0))
+                  return 0;
+                return is_decimal(second + 1, 255, 0);
+              }
+            }
+
+            static int is_log(const char *value)
+            {
+              const char *comma;
+
+              if (is_one_of(value, (const char *const[]) {
+                    "selftest", "selective", "directory", "directory,g", "directory,s",
+                    "background", "sasphy", "sataphy", "genstats", "scterc", "scterc,p",
+                    "scttemp", "scttempsts", "scttemphist", "ssd", "envrep", "farm",
+                    "tapealert", "tapedevstat", "zdevstat", NULL
+                  }))
+                return 1;
+
+              if (strcmp(value, "error") == 0)
+                return 1;
+              if (strncmp(value, "error,", strlen("error,")) == 0)
+                return is_decimal(value + strlen("error,"), 0xffffffffU, 1);
+
+              if (strcmp(value, "xerror") == 0 || strcmp(value, "xerror,error") == 0 ||
+                  strcmp(value, "xselftest") == 0 || strcmp(value, "xselftest,selftest") == 0)
+                return 1;
+              if (strncmp(value, "xerror,", strlen("xerror,")) == 0) {
+                const char *number = value + strlen("xerror,");
+
+                comma = strchr(number, ',');
+                if (comma == NULL)
+                  return is_decimal(number, 0xffffffffU, 1);
+                return is_decimal_range(number, comma, 0xffffffffU, 1) &&
+                  strcmp(comma, ",error") == 0;
+              }
+              if (strncmp(value, "xselftest,", strlen("xselftest,")) == 0) {
+                const char *number = value + strlen("xselftest,");
+
+                comma = strchr(number, ',');
+                if (comma == NULL)
+                  return is_decimal(number, 0xffffffffU, 1);
+                return is_decimal_range(number, comma, 0xffffffffU, 1) &&
+                  strcmp(comma, ",selftest") == 0;
+              }
+              if (strncmp(value, "devstat,", strlen("devstat,")) == 0)
+                return is_decimal(value + strlen("devstat,"), 255, 0) ||
+                  is_hex_byte(value + strlen("devstat,"));
+              if (strncmp(value, "defects,", strlen("defects,")) == 0)
+                return is_decimal(value + strlen("defects,"), 2097119, 0);
+              if (strcmp(value, "devstat") == 0 || strcmp(value, "defects") == 0)
+                return 1;
+              return 0;
+            }
+
+            static int is_safe_value(int option, const char *value)
+            {
+              switch (option) {
+              case 'q': return is_one_of(value, quiet_values);
+              case 'd': return is_device_type(value);
+              case 'T': return is_one_of(value, tolerance_values);
+              case 'b': return is_one_of(value, badsum_values);
+              case 'r': return is_report(value);
+              case 'l': return is_log(value);
+              case 'n': return is_nocheck(value);
+              case 'f': return is_one_of(value, format_values);
+              case 'g': return is_one_of(value, (const char *const[]) {
+                "all", "aam", "apm", "dsn", "lookahead", "security", "wcache", "rcache",
+                "wcreorder", "wcache-sct", NULL
+              });
+              case 'P': return is_one_of(value, preset_values);
+              case 't': return is_one_of(value, (const char *const[]) {
+                "offline", "short", "long", "conveyance", NULL
+              });
+              case opt_json:
+                return *value != '\0' && strspn(value, "cgiosuvy") == strlen(value);
+              case opt_identify:
+                return *value != '\0' && strspn(value, "wnvb") == strlen(value);
+              default:
+                return 0;
+              }
+            }
+
+            static int is_short_noarg(int option)
+            {
+              return strchr("h?ViHcAaxj", option) != NULL;
+            }
+
+            static int is_short_arg(int option)
+            {
+              return strchr("dTbrqnlfgPt", option) != NULL;
+            }
+
+            static int has_name(const char *name, size_t length, const char *expected)
+            {
+              return length == strlen(expected) && strncmp(name, expected, length) == 0;
+            }
+
+            static int long_option(const char *name, size_t length)
+            {
+              if (has_name(name, length, "help") || has_name(name, length, "usage")) return 'h';
+              if (has_name(name, length, "version") || has_name(name, length, "copyright") ||
+                  has_name(name, length, "license")) return 'V';
+              if (has_name(name, length, "info")) return 'i';
+              if (has_name(name, length, "get")) return 'g';
+              if (has_name(name, length, "all")) return 'a';
+              if (has_name(name, length, "xall")) return 'x';
+              if (has_name(name, length, "scan")) return opt_scan;
+              if (has_name(name, length, "scan-open")) return opt_scan_open;
+              if (has_name(name, length, "json")) return opt_json;
+              if (has_name(name, length, "identify")) return opt_identify;
+              if (has_name(name, length, "quietmode")) return 'q';
+              if (has_name(name, length, "device")) return 'd';
+              if (has_name(name, length, "tolerance")) return 'T';
+              if (has_name(name, length, "badsum")) return 'b';
+              if (has_name(name, length, "report")) return 'r';
+              if (has_name(name, length, "health")) return 'H';
+              if (has_name(name, length, "capabilities")) return 'c';
+              if (has_name(name, length, "attributes")) return 'A';
+              if (has_name(name, length, "log")) return 'l';
+              if (has_name(name, length, "nocheck")) return 'n';
+              if (has_name(name, length, "format")) return 'f';
+              if (has_name(name, length, "presets")) return 'P';
+              if (has_name(name, length, "test")) return 't';
+              return 0;
+            }
+
+            static int parse_short(int argc, char **argv, int *index, const char *arg)
+            {
+              const char *option = arg + 1;
+
+              while (*option != '\0') {
+                if (is_short_noarg((unsigned char) *option)) {
+                  option++;
+                  continue;
+                }
+                if (!is_short_arg((unsigned char) *option))
+                  return 0;
+
+                if (option[1] == '\0') {
+                  if (++*index >= argc || argv[*index] == NULL)
+                    return 0;
+                  return is_safe_value((unsigned char) *option, argv[*index]);
+                }
+                return is_safe_value((unsigned char) *option, option + 1);
+              }
+              return 1;
+            }
+
+            static int parse_long(int argc, char **argv, int *index, const char *arg)
+            {
+              const char *name = arg + 2;
+              const char *equals = strchr(name, '=');
+              size_t length = equals == NULL ? strlen(name) : (size_t) (equals - name);
+              int option = long_option(name, length);
+              const char *value;
+
+              if (option == 0)
+                return 0;
+              if (option == opt_scan || option == opt_scan_open || is_short_noarg(option))
+                return equals == NULL;
+              if (option == opt_json || option == opt_identify) {
+                return equals == NULL || is_safe_value(option, equals + 1);
+              }
+              if (!is_short_arg(option))
+                return 0;
+              if (equals == NULL) {
+                if (++*index >= argc || argv[*index] == NULL)
+                  return 0;
+                value = argv[*index];
+              } else {
+                value = equals + 1;
+              }
+              return is_safe_value(option, value);
+            }
+
+            static int keeps_capability(int argc, char **argv)
+            {
+              int found = 0;
+              int operands = 0;
+              int i;
+
+              for (i = 1; i < argc; i++) {
+                const char *arg = argv[i];
+
+                if (arg == NULL)
+                  return 0;
+                if (arg[0] != '-' || arg[1] == '\0') {
+                  if (++operands > 1)
+                    return 0;
+                  continue;
+                }
+                if (arg[1] == '-') {
+                  int j;
+
+                  if (arg[2] == '\0') {
+                    for (j = i + 1; j < argc; j++) {
+                      if (++operands > 1)
+                        return 0;
+                    }
+                    break;
+                  }
+                  if (!parse_long(argc, argv, &i, arg))
+                    return 0;
+                } else if (!parse_short(argc, argv, &i, arg)) {
+                  return 0;
+                }
+                found = 1;
+              }
+              return found;
+            }
+
+            int main(int argc, char **argv)
+            {
+              if (!keeps_capability(argc, argv) &&
+                  prctl(PR_CAP_AMBIENT, PR_CAP_AMBIENT_CLEAR_ALL, 0, 0, 0) != 0) {
+                perror("smartctl: PR_CAP_AMBIENT_CLEAR_ALL");
+                return 126;
+              }
+
+              /* execve(2) permits argc == 0, where argv[0] is the NULL terminator. */
+              if (argc > 0)
+                argv[0] = real_prog;
+              execv(real_prog, argv);
+              perror(real_prog);
+              return 127;
+            }
+          '';
+
+        in
+        {
+          environment.systemPackages = [ cfg.package ];
+
+          # Two separate kernel gates sit in front of SMART data: NVMe admin
+          # passthrough checks CAP_SYS_ADMIN, and the SG_IO command filter that
+          # ATA-over-SAT reads go through checks CAP_SYS_RAWIO.
+          security.wrappers.smartctl = {
+            source = "${argvFilter}/bin/smartctl-argv-filter";
+            capabilities = "cap_sys_admin,cap_sys_rawio+ep";
+            owner = "root";
+            group = "disk";
+            permissions = "u+rx,g+x";
+          };
+        }
+      );
     };
 in
 {

--- a/modules/apps/tcpdump.nix
+++ b/modules/apps/tcpdump.nix
@@ -18,7 +18,7 @@
 
   Notes:
     * Installs a capability wrapper so `wheel` users can capture without invoking `sudo`.
-    * The wrapper source is an argv filter that refuses `-z`: tcpdump.c:3173 `execlp`s the postrotate command and the wrapper's ambient capability set lands in it. Rotate first, then compress as a separate step.
+    * The wrapper source refuses `-z` for non-root callers: tcpdump.c:3173 `execlp`s the postrotate command and the wrapper's ambient capability set lands in it. Root callers retain the normal rotation workflow.
 */
 _:
 let
@@ -34,10 +34,12 @@ let
 
       # security.wrappers raises cap_net_raw and cap_net_admin into the ambient
       # set (wrapper.c:137), which survives execve into a file without
-      # capabilities, so the -z child at tcpdump.c:3173 would inherit both. The
-      # filter has to be a compiled binary: cap wrappers are not setuid, so
-      # euid == uid, bash never enters privileged mode, and BASH_ENV is absent
-      # from glibc's unsecvars.h.
+      # capabilities, so a non-root -z child at tcpdump.c:3173 would inherit
+      # both. Root already has the administrative context that this wrapper
+      # grants, so it keeps the normal -z workflow. The filter has to be a
+      # compiled binary: cap wrappers are not setuid, so euid == uid, bash
+      # never enters privileged mode, and BASH_ENV is absent from glibc's
+      # unsecvars.h.
       argvFilter = pkgs.writeCBin "tcpdump-argv-filter" ''
         #include <stdio.h>
         #include <string.h>
@@ -52,45 +54,45 @@ let
 
         int main(int argc, char **argv)
         {
-        	int i;
+          int i;
 
-        	for (i = 1; i < argc; i++) {
-        		const char *arg = argv[i];
-        		const char *c;
+          for (i = 1; i < argc; i++) {
+            const char *arg = argv[i];
+            const char *c;
 
-        		/* nixpkgs builds against glibc getopt_long, which permutes, so
-        		   an operand does not end option parsing. A lone "-" is an
-        		   operand. */
-        		if (arg[0] != '-' || arg[1] == '\0')
-        			continue;
-        		if (arg[1] == '-') {
-        			if (arg[2] == '\0')
-        				break;
-        			/* longopts[] (tcpdump.c:729) has no alias for -z. A long
-        			   option never consumes the next element here, because
-        			   guessing wrong would hide `--help -z cmd`. */
-        			continue;
-        		}
+            /* nixpkgs builds against glibc getopt_long, which permutes, so
+               an operand does not end option parsing. A lone "-" is an
+               operand. */
+            if (arg[0] != '-' || arg[1] == '\0')
+              continue;
+            if (arg[1] == '-') {
+              if (arg[2] == '\0')
+                break;
+              /* longopts[] (tcpdump.c:729) has no alias for -z. A long
+                 option never consumes the next element here, because
+                 guessing wrong would hide `--help -z cmd`. */
+              continue;
+            }
 
-        		for (c = arg + 1; *c != '\0'; c++) {
-        			if (*c == 'z') {
-        				fputs("tcpdump: -z is refused by the capability wrapper\n", stderr);
-        				return 1;
-        			}
-        			if (strchr(optarg_chars, *c) != NULL) {
-        				if (c[1] == '\0')
-        					i++;
-        				break;
-        			}
-        		}
-        	}
+            for (c = arg + 1; *c != '\0'; c++) {
+              if (*c == 'z' && geteuid() != 0) {
+                fputs("tcpdump: -z is refused by the capability wrapper\n", stderr);
+                return 1;
+              }
+              if (strchr(optarg_chars, *c) != NULL) {
+                if (c[1] == '\0')
+                  i++;
+                break;
+              }
+            }
+          }
 
-        	/* execve(2) permits argc == 0, where argv[0] is the NULL terminator. */
-        	if (argc > 0)
-        		argv[0] = real_prog;
-        	execv(real_prog, argv);
-        	perror(real_prog);
-        	return 127;
+          /* execve(2) permits argc == 0, where argv[0] is the NULL terminator. */
+          if (argc > 0)
+            argv[0] = real_prog;
+          execv(real_prog, argv);
+          perror(real_prog);
+          return 127;
         }
       '';
     in

--- a/modules/apps/tcpdump.nix
+++ b/modules/apps/tcpdump.nix
@@ -18,6 +18,7 @@
 
   Notes:
     * Installs a capability wrapper so `wheel` users can capture without invoking `sudo`.
+    * The wrapper source is an argv filter that refuses `-z`: tcpdump.c:3173 `execlp`s the postrotate command and the wrapper's ambient capability set lands in it. Rotate first, then compress as a separate step.
 */
 _:
 let
@@ -30,6 +31,68 @@ let
     }:
     let
       cfg = config.programs.tcpdump.extended;
+
+      # security.wrappers raises cap_net_raw and cap_net_admin into the ambient
+      # set (wrapper.c:137), which survives execve into a file without
+      # capabilities, so the -z child at tcpdump.c:3173 would inherit both. The
+      # filter has to be a compiled binary: cap wrappers are not setuid, so
+      # euid == uid, bash never enters privileged mode, and BASH_ENV is absent
+      # from glibc's unsecvars.h.
+      argvFilter = pkgs.writeCBin "tcpdump-argv-filter" ''
+        #include <stdio.h>
+        #include <string.h>
+        #include <unistd.h>
+
+        static char real_prog[] = "${cfg.package}/bin/tcpdump";
+
+        /* SHORTOPTS (tcpdump.c:696) expanded, restricted to the ":"-suffixed
+           entries. `b` is a counter (tcpdump.c:1766); listing it would make
+           `-b -z cmd` consume the -z as an argument and let it through. */
+        static const char optarg_chars[] = "BcCEFGijmMQrsTVwWyzZ";
+
+        int main(int argc, char **argv)
+        {
+        	int i;
+
+        	for (i = 1; i < argc; i++) {
+        		const char *arg = argv[i];
+        		const char *c;
+
+        		/* nixpkgs builds against glibc getopt_long, which permutes, so
+        		   an operand does not end option parsing. A lone "-" is an
+        		   operand. */
+        		if (arg[0] != '-' || arg[1] == '\0')
+        			continue;
+        		if (arg[1] == '-') {
+        			if (arg[2] == '\0')
+        				break;
+        			/* longopts[] (tcpdump.c:729) has no alias for -z. A long
+        			   option never consumes the next element here, because
+        			   guessing wrong would hide `--help -z cmd`. */
+        			continue;
+        		}
+
+        		for (c = arg + 1; *c != '\0'; c++) {
+        			if (*c == 'z') {
+        				fputs("tcpdump: -z is refused by the capability wrapper\n", stderr);
+        				return 1;
+        			}
+        			if (strchr(optarg_chars, *c) != NULL) {
+        				if (c[1] == '\0')
+        					i++;
+        				break;
+        			}
+        		}
+        	}
+
+        	/* execve(2) permits argc == 0, where argv[0] is the NULL terminator. */
+        	if (argc > 0)
+        		argv[0] = real_prog;
+        	execv(real_prog, argv);
+        	perror(real_prog);
+        	return 127;
+        }
+      '';
     in
     {
       options.programs.tcpdump.extended = {
@@ -46,7 +109,7 @@ let
         environment.systemPackages = [ cfg.package ];
 
         security.wrappers.tcpdump = {
-          source = "${cfg.package}/bin/tcpdump";
+          source = "${argvFilter}/bin/tcpdump-argv-filter";
           capabilities = "cap_net_raw,cap_net_admin+ep";
           owner = "root";
           group = "wheel";

--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -399,6 +399,7 @@ let
       screenkey.extended.enable = lib.mkOverride 1100 true;
       "searchfox-cli".extended.enable = lib.mkOverride 1100 true;
       seclists.extended.enable = lib.mkOverride 1100 true;
+      sedutil.extended.enable = lib.mkOverride 1100 true;
       selenium.extended.enable = lib.mkOverride 1100 true;
       shellcheck.extended.enable = lib.mkOverride 1100 true;
       shfmt.extended.enable = lib.mkOverride 1100 true;

--- a/modules/hosts/common/storage-diagnostics.nix
+++ b/modules/hosts/common/storage-diagnostics.nix
@@ -1,0 +1,12 @@
+{
+  flake.nixosModules.hosts-common.imports = [
+    {
+      # Keep controller access independent from the optional nvme-cli package:
+      # smartmontools uses the same character devices for controller-level logs.
+      services.udev.extraRules = ''
+        SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", GROUP="disk", MODE="0660"
+        SUBSYSTEM=="nvme-generic", KERNEL=="ng[0-9]*", GROUP="disk", MODE="0660"
+      '';
+    }
+  ];
+}

--- a/modules/hosts/common/storage-diagnostics.nix
+++ b/modules/hosts/common/storage-diagnostics.nix
@@ -7,6 +7,11 @@ let
       ...
     }:
     {
+      # libata refuses ATA TRUSTED SEND/RECEIVE unless this is set, which is the
+      # only path Opal traffic takes to a SATA drive. NVMe goes through admin
+      # security send/receive instead and is unaffected.
+      boot.kernelParams = [ "libata.allow_tpm=1" ];
+
       # Keep controller access independent from the optional nvme-cli package:
       # smartmontools uses the same character devices for controller-level logs.
       services.udev.extraRules = ''

--- a/modules/hosts/common/storage-diagnostics.nix
+++ b/modules/hosts/common/storage-diagnostics.nix
@@ -8,9 +8,10 @@ let
     }:
     {
       # libata refuses ATA TRUSTED SEND/RECEIVE unless this is set, which is the
-      # only path Opal traffic takes to a SATA drive. NVMe goes through admin
-      # security send/receive instead and is unaffected.
-      boot.kernelParams = [ "libata.allow_tpm=1" ];
+      # only path Opal traffic takes to a SATA drive. Keep the host-wide
+      # relaxation tied to its optional sedutil consumer. NVMe goes through
+      # admin security send/receive instead and is unaffected.
+      boot.kernelParams = lib.mkIf config.programs.sedutil.extended.enable [ "libata.allow_tpm=1" ];
 
       # Keep controller access independent from the optional nvme-cli package:
       # smartmontools uses the same character devices for controller-level logs.

--- a/modules/hosts/common/storage-diagnostics.nix
+++ b/modules/hosts/common/storage-diagnostics.nix
@@ -1,5 +1,11 @@
-{
-  flake.nixosModules.hosts-common.imports = [
+_:
+let
+  body =
+    {
+      config,
+      lib,
+      ...
+    }:
     {
       # Keep controller access independent from the optional nvme-cli package:
       # smartmontools uses the same character devices for controller-level logs.
@@ -7,6 +13,28 @@
         SUBSYSTEM=="nvme", KERNEL=="nvme[0-9]*", GROUP="disk", MODE="0660"
         SUBSYSTEM=="nvme-generic", KERNEL=="ng[0-9]*", GROUP="disk", MODE="0660"
       '';
-    }
-  ];
+
+      # A switch only restarts systemd-udevd, and udev applies rules to new
+      # uevents only, so nodes enumerated at boot keep the kernel default
+      # root:root 0600 until a reboot. `udevadm trigger` needs root, which the
+      # `disk` members this grant targets do not have.
+      systemd.services.nvme-char-device-permissions = lib.mkIf config.services.udev.enable {
+        description = "Re-apply udev permissions to existing NVMe character devices";
+        wants = [ "systemd-udevd.service" ];
+        after = [ "systemd-udevd.service" ];
+        wantedBy = [ "multi-user.target" ];
+        restartTriggers = [ config.environment.etc."udev/rules.d".source ];
+        serviceConfig = {
+          Type = "oneshot";
+          RemainAfterExit = true;
+          # `change` reaches udev_node_apply_permissions(); only the SELinux
+          # relabel is add-only. Namespace nodes are SUBSYSTEM=block and stay
+          # untouched, so the root filesystem is never retriggered.
+          ExecStart = "${config.systemd.package}/bin/udevadm trigger --settle --action=change --subsystem-match=nvme --subsystem-match=nvme-generic";
+        };
+      };
+    };
+in
+{
+  flake.nixosModules.hosts-common.imports = [ body ];
 }

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -45,6 +45,8 @@
 
           All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
+          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled.
+
         '';
 
       build =

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -45,7 +45,7 @@
 
           All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior.
+          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited allowlists and the resulting no-sudo operation boundary.
 
         '';
 

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -45,7 +45,7 @@
 
           All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists that fail closed on unsupported and non-device forms while bounding the resulting no-sudo operation boundary.
+          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists that fail closed on unsupported and non-device forms, validate parser-dependent argument boundaries, and bound the resulting no-sudo operation boundary.
 
         '';
 

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -45,7 +45,7 @@
 
           All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled.
+          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior.
 
         '';
 

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -45,7 +45,7 @@
 
           All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited allowlists and the resulting no-sudo operation boundary.
+          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists and the resulting no-sudo operation boundary.
 
         '';
 

--- a/modules/readme.nix
+++ b/modules/readme.nix
@@ -45,7 +45,7 @@
 
           All Nix files are flake-parts modules and are automatically imported via [import-tree](https://github.com/vic/import-tree). Files prefixed with `_` are omitted. No literal path imports are used, so files can be moved and nested freely.
 
-          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists and the resulting no-sudo operation boundary.
+          Shared device policy that serves multiple optional applications belongs in `modules/hosts/common/`, so its permissions do not disappear when one app module is disabled. Optional app modules own their package and capability-wrapper behavior, including compiled argv filters with audited, grammar-aware allowlists that fail closed on unsupported and non-device forms while bounding the resulting no-sudo operation boundary.
 
         '';
 


### PR DESCRIPTION
## Summary

`disk` group membership reaches the namespace block nodes (`fdisk`, `lsblk`, `blkid` already work without
`sudo`) but not the ioctls that carry SMART data. Measured on the running host before this change:

| command | result |
| --- | --- |
| `smartctl -H /dev/nvme0n1` | `NVME_IOCTL_ADMIN_CMD: Permission denied` (exit 4) |
| `nvme smart-log /dev/nvme0n1` | `smart log: Permission denied` |
| `nvme error-log /dev/nvme0n1` | `error log: Permission denied` |
| `nvme smart-log /dev/nvme0` | `/dev/nvme0: Permission denied` (node is root:root 0600) |
| `smartctl -d sat -i /dev/sda` | `Read Device Identity failed: Operation not permitted` |
| `hdparm -I /dev/sda` | prints the device name and nothing else |

Three kernel gates cause this: `nvme_cmd_allowed()` rejects admin passthrough outside a small identify CNS
subset without `CAP_SYS_ADMIN`, the SG_IO command filter rejects ATA passthrough without `CAP_SYS_RAWIO`, and
`ata_sas_scsi_ioctl()` demands both for `HDIO_DRIVE_CMD`.

Wrappers use group `disk` rather than the `wheel` group used by the packet-capture wrappers, because the grant
extends what `disk` already means (raw device access) instead of the administrative path.

## Changes

- `modules/apps/smartmontools.nix`: `smartctl` wrapper, `cap_sys_admin,cap_sys_rawio+ep`, sourced from a compiled argv filter that retains capabilities only for audited reports, read-only settings and log queries, documented `-v`/`--vendorattribute` display definitions, documented `-F`/`--firmwarebug` report workarounds including `swapid`, and standard `offline`, `short`, `long`, and `conveyance` self-tests; state-changing, log-writing, selective, pending, force, captive, abort, unsupported arguments, and unknown forms clear the ambient set.
- `modules/apps/hdparm.nix`: `hdparm` wrapper, `cap_sys_admin,cap_sys_rawio+ep`, sourced from a compiled argv filter that retains capabilities only for short-option clusters made from `-C`, `-g`, `-i`, `-I`, `-t`, and `-T`; standalone input formatting such as `--Istdin` takes the cleared path but reads and formats stdin only, opens no device, and needs neither storage capabilities nor `sudo`; state-changing, parameter-bearing, and unknown forms clear the ambient set.
- `modules/apps/nvme-cli.nix`: `nvme` wrapper, `cap_sys_admin+ep`, sourced from an argv filter (see "Ambient capabilities" below).
- `modules/apps/sedutil.nix`: new module. A compiled `sedutil-cli` argv filter and capability wrapper, `cap_sys_admin,cap_sys_rawio+ep`, retain capabilities only for the verified sedutil 1.49.13 read forms: `--scan` and its JSON output forms, `--query` and its JSON output forms with one device, `--isValidSED <device>`, and `--printDefaultPassword <device>`; the target is a `makeBinaryWrapper` output that pins `PATH`.
- `modules/apps/tcpdump.nix`: existing wrapper now uses an argv filter that refuses `-z` for non-root callers while retaining the normal root workflow.
- `modules/hosts/common/storage-diagnostics.nix`: new. Owns the shared `nvme` / `nvme-generic` udev rule, a oneshot that retriggers those subsystems on a switch, and adds `libata.allow_tpm=1` while sedutil is enabled.
- `modules/hosts/common/apps-enable.nix`: enables `sedutil` at the `mkOverride 1100` baseline.
- `docs/security/owner-no-sudo-operations.md`, `docs/security/owner-group-privileges.md`: record the grants, the reason group membership alone is not enough, and the caveats below.
- `AGENTS.md`, `CLAUDE.md`, `README.md`, `modules/readme.nix`: record that shared device policy belongs in the common aggregate, not in an optional app module, and that parser-dependent capability filters document their argument boundaries.

## Ambient capabilities

`security.wrappers` raises the configured capabilities into the process ambient set
(`nixos/modules/security/wrappers/wrapper.c:137`, `PR_CAP_AMBIENT_RAISE`). Per capabilities(7),
`P'(ambient) = (file is privileged) ? 0 : P(ambient)`, so the set survives `execve` of any file with neither
setuid nor file capabilities and lands in the child's effective set. Two of the wrapped binaries can be made
to exec something the caller chooses:

- `tcpdump -z postrotate-command` is `execlp(zflag, zflag, filename, NULL)` (`tcpdump.c:3173`), forked at
  `:3152` with only `setpriority()` in between. Reproduced live against the deployed wrapper: the child ran as
  uid 1000 with `CapEff=CapAmb=0x3000`. libcap-ng is compiled out of the nixpkgs build, so every
  `HAVE_LIBCAP_NG` self-drop is absent. `execlp` ignores `PATH` when the name has a slash, so pinning `PATH`
  does not help; only argv rejection does.
- `nvme help <cmd>` reaches `execlp("man", ...)` (`plugin.c:52`) with no device involved, and the vendor plugins
  interpolate the caller's `--dir-name` into a shell string passed to `system()`
  (`solidigm-internal-logs.c:989`, `wdc-nvme.c:4218`, `micron-nvme.c:249`). The second is metacharacter
  injection, which no pinned `PATH` can bound.

All five filtered wrapper sources are `pkgs.writeCBin` argv filters. Compiled, never shell scripts: a capability wrapper
is not setuid, so `euid == uid`, bash does not enter privileged mode, and `BASH_ENV` is absent from glibc's
`unsecvars.h`.

- tcpdump: refuses `-z` for non-root callers and execs the real binary otherwise. Root callers retain the normal
  rotation workflow.
- nvme: allowlists 18 diagnostic builtins, including `device-self-test`, whose options can start or abort
  a drive self-test, and calls `PR_CAP_AMBIENT_CLEAR_ALL` before `execve` for everything else. `format`,
  `sanitize`, `fw-commit` and the vendor plugins still run without the capability and need `sudo` again.
  `help` also runs on the cleared path without the storage capability, although it may fail if the manual
  page is unavailable.

`hdparm` and `smartctl` were swept for the same problem. Neither real binary exports `exec*`/`system`/`popen`
symbols; the hdparm and smartctl filters therefore bound direct privileged device operations.
sedutil links a `popen()` helper (`Common/system.cpp:40`), so its compiled filter clears ambient capabilities for
every non-allowlisted first action and its target pins `PATH` as defense in depth. Its first-action decision relies
on sedutil 1.49.13's exact and maximum argument checks, so a custom package or parser change requires a fresh audit.

## Caveats

- The `smartctl` filter retains capabilities only for audited reports, the documented `-v`/`--vendorattribute`
  display definitions, `-F`/`--firmwarebug` report workarounds including `swapid`, read-only settings and log
  queries including bare `-n sleep`, `-n standby`, and `-n idle` power-mode checks, and standard `offline`,
  `short`, `long`, and `conveyance` self-tests. SMART configuration (`-s`, `-o`, `-S`, and `--set`), log resets
  or writes, selective/pending/force/captive/abort tests, unsupported arguments, and unknown forms clear the
  ambient set and need `sudo` again.
- The `hdparm` filter retains capabilities only for non-media-mutating diagnostic flags. Standalone input formatting
  such as `--Istdin` takes the cleared path, but reads and formats stdin only, opens no device, and needs neither
  storage capabilities nor `sudo`. ATA Security, DCO/HPA, raw-sector writes, TRIM, sanitize, firmware,
  device-setting, unknown, and parameter-bearing options clear the ambient set and need `sudo` again. `disk`
  membership still permits raw block reads and writes, but that does not grant the separate ATA Security, DCO, or
  HPA control paths.
- For the sedutil 1.49.13 parser, `sedutil-cli` retains capabilities only for `--scan` and its JSON output forms,
  `--query` and its JSON output forms with one device, `--isValidSED <device>`, and
  `--printDefaultPassword <device>`. State-changing actions clear the ambient set and need `sudo` again.
  `--revertTPer` and `--yesIreallywanttoERASEALLmydatausingthePSID` still erase the drive when run with `sudo`;
  the allowed `--printDefaultPassword` action exposes the drive MSID, so treat its output as credential material.
  The filter checks the first action and relies on sedutil's exact and maximum argument checks to reject later
  actions before dispatch; re-audit a custom package if that parser changes.
- Non-root `tcpdump -z gzip ...` is refused by the capability wrapper. Root or `sudo` callers retain the normal
  rotation and compression workflow; other non-root callers should rotate first and compress separately.
- When sedutil is enabled, `libata.allow_tpm=1` takes effect on the next reboot, not at switch time.
- Wrapping has no effect on users outside `disk`. The wrapper files are `0510`, but the packages stay in
  `environment.systemPackages`, and PATH lookup skips an entry that fails `access(X_OK)` and keeps searching,
  so a bare `smartctl` falls through to the `0555` store binary and fails at the ioctl exactly as before.

## Out of scope

`modules/apps/aircrack-ng.nix` has the same ambient-capability problem and it is worse: all nine wrapped tools
shell-inject through the plain interface-name argument (`lib/osdep/linux.c:1871-1892`), reproduced live.
Tracked separately in #475, since it is unrelated to storage and needs a different fix shape.

Checked and unaffected: `dumpcap` self-drops via `relinquish_privs_except_capture()` (`dumpcap.c:1207`) and is
the model to emulate; `arp-scan-rs` has no subprocess surface.

## Test plan

- `nix run path:.#treefmt -- modules/apps/smartmontools.nix modules/apps/hdparm.nix modules/apps/sedutil.nix docs/security/owner-no-sudo-operations.md docs/security/owner-group-privileges.md AGENTS.md CLAUDE.md modules/readme.nix README.md` (0 changed)
- `nix flake check path:. --accept-flake-config --no-build --offline` (exit 0)
- `nix eval --json` over the active hosts' `security.wrappers`: `nvme`, `smartctl`, and `sedutil-cli` resolve on system76 and tpnix; `hdparm` resolves on system76, while `modules/tpnix/apps-enable.nix:36` deliberately disables it on tpnix. `songbird` is only a planned host and is not part of this branch.
- `nix build` of the `udev/rules.d` derivation: its own `udevadm verify` pass reports `Fail: 0`.
- `udevadm info -q property` confirms the match is scoped correctly: controllers are `SUBSYSTEM=nvme`,
  `/dev/ng*` is `SUBSYSTEM=nvme-generic`, and every namespace/partition node is `SUBSYSTEM=block`, so the rule
  cannot touch block devices. `udevadm trigger --dry-run` over both subsystems matches 5 char devices and
  nothing else.
- nvme ambient-clear branch tested under `unshare -Ur` with `capsh --secbits=3 --caps=cap_sys_admin+eip
  --addamb=cap_sys_admin`: allowlisted argv gives the child `CapPrm/CapEff/CapAmb 0x200000`, non-allowlisted
  and bare argv give `0x0`. `strace` on the built artifact confirms `nvme list` execs with no `prctl` while
  `nvme format` calls `PR_CAP_AMBIENT_CLEAR_ALL` first.
- tcpdump filter rejects `-z /tmp/x`, `-nz /tmp/x`, `-z/tmp/x`, `-b -z /bin/sh`, `host foo -z /bin/sh`,
  `--number -z /bin/sh`, and `-zz` for non-root callers; passes `--version`, `--help`, `-i zt0 -c 1`,
  `-izt0 -c 1`, `-T zzz`, and `-- -z`. Root `-z` execution is permitted for the normal rotation path.
- `nix build --accept-flake-config --offline --no-link --print-out-paths "path:.#nixosConfigurations.system76.config.system.build.toplevel"` and the corresponding `tpnix` target: compile the smartctl filter and both host closures successfully.
- The smartctl filter was tested with `strace -f -e trace=prctl`: audited reports, `-v 9,raw24(raw8)`, `--vendorattribute=9,raw24/raw24`, `-F swapid`, bare power-mode checks, and standard self-tests avoid `PR_CAP_AMBIENT_CLEAR_ALL`; invalid `-v`/`-F` arguments and mixed write/configuration vectors call it first.
- hdparm filter tested with `strace -f -e trace=prctl`: `-tT` avoids `PR_CAP_AMBIENT_CLEAR_ALL`, while `--Istdin` calls it first but does not open a device; non-allowlisted actions also call it first. Mixed and attached options such as `-IN123`, `-Np123`, `-I --security-set-pass`, and unknown options take the cleared path.
- sedutil filter tested with `strace -f -e trace=prctl`: `--version` calls `PR_CAP_AMBIENT_CLEAR_ALL`, while `--query /definitely-not-a-device`, `--scan --json`, and `--query --json /definitely-not-a-device` do not; later action tokens are rejected by sedutil's argument checks before dispatch. The compiled source points to the fixed-`PATH` target.
- Not run: activation. The wrappers, the udev rule and the kernel parameter only take effect after a switch (and a reboot for `libata.allow_tpm=1`), so the table above still needs re-measuring on the host.