### PR TITLE
fix(apps): turn sc-controller off in the common baseline

### DIFF
--- a/modules/hosts/common/apps-enable.nix
+++ b/modules/hosts/common/apps-enable.nix
@@ -405,7 +405,7 @@ let
       s5cmd.extended.enable = lib.mkOverride 1100 true;
       "safeguard-rdp".extended.enable = lib.mkOverride 1100 true;
       samba.extended.enable = lib.mkOverride 1100 true;
-      "sc-controller".extended.enable = lib.mkOverride 1100 true;
+      "sc-controller".extended.enable = lib.mkOverride 1100 false;
       screenkey.extended.enable = lib.mkOverride 1100 true;
       "searchfox-cli".extended.enable = lib.mkOverride 1100 true;
       seclists.extended.enable = lib.mkOverride 1100 true;

--- a/modules/tpnix/apps-enable.nix
+++ b/modules/tpnix/apps-enable.nix
@@ -49,7 +49,6 @@ let
     opendirectorydownloader = false;
     parted = false;
     projectlibre = true;
-    "sc-controller" = false;
     "spec-kit" = false;
     steam = false;
     terraform = false;


### PR DESCRIPTION
## Summary

- Turn `programs.sc-controller.extended.enable` off in the common baseline. Its `scc-daemon` emits a virtual "Microsoft X-Box 360 pad" (045e:028e) through uinput for whatever profile is active, and Steam opens that pad next to the real DualSense hidraw node, so Steam lists an Xbox 360 controller and receives every press twice. Steam Input drives the DualSense natively, so sc-controller becomes a per-host opt-in instead of a default.
- Drop the tpnix override that pinned it to `false`; it would now duplicate the baseline value and trip the no-op override check in `modules/hosts/common/checks.nix`.

## Test plan

- [x] `nix run path:.#treefmt -- modules/hosts/common/apps-enable.nix modules/tpnix/apps-enable.nix` (0 changed)
- [x] `nix eval` of `programs.sc-controller.extended.enable` for songbird, tpnix, and system76: all `false`
- [x] `nix flake check path:. --accept-flake-config --no-build --offline` (exit 0)
- [ ] After switching songbird: `scc-daemon stop`, then confirm Steam lists only the DualSense

https://claude.ai/code/session_01Qqakanxn6qJHzjNkhFo5PY
