### PR TITLE
feat(songbird): declare /portal on disk P, replacing the removed /shared mount

### DIFF
--- a/modules/songbird/hardware-config.nix
+++ b/modules/songbird/hardware-config.nix
@@ -12,7 +12,27 @@ _: {
     }:
     let
       owner = metaOwner.username;
-      ownerGroup = config.users.users.${owner}.group;
+      ownerCfg = config.users.users.${owner};
+      # /portal needs a stable numeric owner. NixOS allocates a free UID for
+      # null, which cannot safely be represented by this static mount option.
+      ownerGroup =
+        if ownerCfg.group == "" then
+          throw "songbird /portal requires users.users.${owner}.group to be set"
+        else
+          ownerCfg.group;
+      ownerUid =
+        if ownerCfg.uid == null then
+          throw "songbird /portal requires users.users.${owner}.uid to be pinned"
+        else
+          ownerCfg.uid;
+      # attrByPath's default covers an absent group, not a present one whose
+      # gid is null (the option default for any group outside ids.gids).
+      ownerGidRaw = lib.attrByPath [ "users" "groups" ownerGroup "gid" ] null config;
+      ownerGid =
+        if ownerGidRaw == null then
+          throw "songbird /portal requires users.groups.${ownerGroup}.gid to be pinned"
+        else
+          ownerGidRaw;
     in
     {
       # Platform configuration (required)
@@ -122,6 +142,27 @@ _: {
             "nofail"
           ];
         };
+
+        # Samsung SSD 970 PRO 512GB (chipset M.2, 0000:82:00.0): plain NTFS
+        # volume labeled "portal", the drive shared with the Windows dual
+        # boot. Kernel ntfs3 with windows_names blocks names Windows cannot
+        # read; nofail keeps a dirty (Windows fast-startup) or absent volume
+        # from blocking boot. The masks are the /boot pair above: uid=/gid=
+        # alone leave the mode at ~current_umask() of whatever mounted the
+        # volume.
+        "/portal" = {
+          device = "/dev/disk/by-uuid/2FF3F415221D0FA3";
+          fsType = "ntfs3";
+          options = [
+            "uid=${toString ownerUid}"
+            "gid=${toString ownerGid}"
+            "fmask=0077"
+            "dmask=0077"
+            "windows_names"
+            "noatime"
+            "nofail"
+          ];
+        };
       };
 
       swapDevices = [ { device = "/dev/mapper/cryptswap"; } ];
@@ -137,22 +178,80 @@ _: {
       # wrote an owner-writable /data onto the root filesystem on any boot where
       # the volume was absent, and anything writing there filled / silently.
 
-      # Conditional, not required: /data is nofail here, but Requires= and
-      # RequiresMountsFor= (which emits its own Requires=) ignore that, so
-      # an absent or unopened drive failed this unit too, and the chown then
-      # landed on the bare mount point data.mount leaves behind on the root
-      # filesystem rather than on the volume. The condition leaves the unit
-      # inactive instead of failed, so recovering the mount by hand needs
-      # `systemctl start data-ownership.service`.
-      systemd.services.data-ownership = {
-        description = "Ensure /data ownership matches primary user";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "data.mount" ];
-        unitConfig.ConditionPathIsMountPoint = "/data";
-        serviceConfig = {
-          Type = "oneshot";
-          ExecStart = "${pkgs.coreutils}/bin/chown ${owner}:${ownerGroup} /data";
-        };
-      };
+      # Enforces operating rule 2 of docs/songbird/nixos-setup.md: /portal
+      # mounted during imaging restores stale NTFS metadata, corrupting the
+      # volume silently, so ExecStartPre aborts the unit on a busy /portal.
+      # Collides with a shipped unit, so NixOS renders this as a drop-in
+      # (asDropinIfExists) rather than a replacement. Remount runs on
+      # ExecStopPost, not ExecStartPost, which nixpkgs skips on any failed
+      # transition. The /run flag marks that this unit performed the unmount,
+      # so remount, and the unprefixed mount command, only ever run for that
+      # transition.
+      systemd.services =
+        let
+          # Flag written only after the unmount succeeds: it is what tells
+          # ExecStopPost a remount is owed, so writing it first would leave
+          # it set on the busy-/portal refusal above, and ExecStopPost then
+          # runs `mount` against a filesystem that was never unmounted and
+          # fails the unit. A failed marker write must still abort the
+          # transition (exit 1): otherwise hibernation proceeds with /portal
+          # mounted again, defeating the whole guard.
+          portalUmountBeforeHibernate = pkgs.writeShellScript "portal-umount-before-hibernate" ''
+            ${pkgs.util-linux}/bin/mountpoint -q /portal || exit 0
+            ${pkgs.util-linux}/bin/umount /portal || exit 1
+            if ${pkgs.coreutils}/bin/touch /run/portal-remount-after-sleep; then
+              exit 0
+            fi
+            echo "songbird: failed to record the hibernate-remount marker after unmounting /portal; remounting and aborting this sleep transition" >&2
+            ${pkgs.util-linux}/bin/mount /portal || echo "songbird: recovery remount of /portal failed; run 'mount /portal' by hand" >&2
+            exit 1
+          '';
+          # Retries cover the volume not being re-enumerated yet on resume;
+          # exhausting them still fails the unit, per the no-"-" note above.
+          portalRemountAfterSleep = pkgs.writeShellScript "portal-remount-after-sleep" ''
+            [ -e /run/portal-remount-after-sleep ] || exit 0
+            ${pkgs.coreutils}/bin/rm -f /run/portal-remount-after-sleep
+            for _ in 1 2 3; do
+              ${pkgs.util-linux}/bin/mount /portal && exit 0
+              ${pkgs.coreutils}/bin/sleep 1
+            done
+            echo "songbird: failed to remount /portal after resume; run 'mount /portal' by hand" >&2
+            exit 1
+          '';
+        in
+        lib.mkMerge [
+          (lib.genAttrs
+            [
+              "systemd-hibernate"
+              "systemd-hybrid-sleep"
+              "systemd-suspend-then-hibernate"
+            ]
+            (_: {
+              serviceConfig = {
+                ExecStartPre = [ portalUmountBeforeHibernate ];
+                ExecStopPost = [ portalRemountAfterSleep ];
+              };
+            })
+          )
+          {
+            # Conditional, not required: /data is nofail here, but Requires= and
+            # RequiresMountsFor= (which emits its own Requires=) ignore that, so
+            # an absent or unopened drive failed this unit too, and the chown then
+            # landed on the bare mount point data.mount leaves behind on the root
+            # filesystem rather than on the volume. The condition leaves the unit
+            # inactive instead of failed, so recovering the mount by hand needs
+            # `systemctl start data-ownership.service`.
+            "data-ownership" = {
+              description = "Ensure /data ownership matches primary user";
+              wantedBy = [ "multi-user.target" ];
+              after = [ "data.mount" ];
+              unitConfig.ConditionPathIsMountPoint = "/data";
+              serviceConfig = {
+                Type = "oneshot";
+                ExecStart = "${pkgs.coreutils}/bin/chown ${owner}:${ownerGroup} /data";
+              };
+            };
+          }
+        ];
     };
 }


### PR DESCRIPTION
## Summary

- Disk W's WDC SN720 relocated from the chipset M.2 slot (`0000:82:00.0`) to `M.2_2` CPU PCIe 4.0 (`0000:03:00.0`) to free that slot for the replacement shared drive.
- A Samsung SSD 970 PRO 512GB now occupies the freed chipset slot as disk P: wiped via the Windows installer, repartitioned to a single GPT NTFS volume labeled `portal` (filesystem UUID `2FF3F415221D0FA3`), manually verified read-write before this change.
- `modules/songbird/hardware-config.nix`: restores the `fileSystems."/portal"` entry, the `uid`/`gid` throw-guard let-bindings, and the pre-hibernation unmount / post-resume remount systemd unit pattern that commit b68362e5 removed on 2026-09-05 (`git log -S/shared -- modules/songbird/hardware-config.nix`), renamed `shared` to `portal` throughout and pointed at the new device and UUID.
- `docs/songbird/project-songbird.md` and `docs/songbird/nixos-setup.md`: replace `/shared`/disk-W-carried-the-shared-volume references with disk P and `/portal` across the inventory tables, decision record, Disk Layout section, the (not-yet-run) Phase N5 BitLocker procedure, Open Items table, and Operating Rules. Historical references (first-boot narration, the `git log -S/shared` search term, the hibernation-unmount mechanism as it existed under the old name) keep the `/shared` name since that is what the removed code and git history actually used.

## Test plan

- [x] `nix run "path:.#treefmt" -- modules/songbird/hardware-config.nix docs/songbird/nixos-setup.md docs/songbird/project-songbird.md`
- [x] `nix eval "path:.#nixosConfigurations.songbird.config" --apply ...`: `fileSystems` includes `/portal` with device `/dev/disk/by-uuid/2FF3F415221D0FA3` and options `uid=1000,gid=100,fmask=0077,dmask=0077,windows_names,noatime,nofail`; `ExecStartPre`/`ExecStopPost` wired on `systemd-hibernate`, `systemd-hybrid-sleep`, and `systemd-suspend-then-hibernate`; `data-ownership` chown unaffected
- [x] `nix flake check "path:." --accept-flake-config --no-build --offline`: one pre-existing, unrelated failure in `checks.x86_64-linux."browsers/firefoxpwa-module-eval"` (a `module-check-fixtures` store path missing under `--no-build`), confirmed present on unmodified `main` too
- [x] `nix build "path:.#nixosConfigurations.songbird.config.system.build.toplevel" --accept-flake-config --no-link --print-out-paths`: built `/nix/store/qasjx9q4pr1s8115qcmz85pajaf4bvnh-nixos-system-songbird-26.11.20260906.3be84a3`
- [ ] Actual `./build.sh -t songbird` switch on the host, and a hibernate/resume round-trip with `/portal` mounted, are left for the user to run

https://claude.ai/code/session_01PPPfAZCuvgqNmh372skZDX